### PR TITLE
Fix compilation error message.  Now onionc generate correct messages again.

### DIFF
--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -24,27 +24,27 @@ class SemanticErrorReporter(threshold: Int) {
   private var errorCount: Int = 0
 
   private def format(string: String): String = {
-    return MessageFormat.format(string, new Array[AnyRef](0))
+    return MessageFormat.format(string)
   }
 
   private def format(string: String, arg: String): String = {
-    return MessageFormat.format(string, Array[AnyRef](arg))
+    return MessageFormat.format(string, arg)
   }
 
   private def format(string: String, arg1: String, arg2: String): String = {
-    return MessageFormat.format(string, Array[AnyRef](arg1, arg2))
+    return MessageFormat.format(string, arg1, arg2)
   }
 
   private def format(string: String, arg1: String, arg2: String, arg3: String): String = {
-    return MessageFormat.format(string, Array[AnyRef](arg1, arg2, arg3))
+    return MessageFormat.format(string, arg1, arg2, arg3)
   }
 
   private def format(string: String, arg1: String, arg2: String, arg3: String, arg4: String): String = {
-    return MessageFormat.format(string, Array[AnyRef](arg1, arg2, arg3, arg4))
+    return MessageFormat.format(string, arg1, arg2, arg3, arg4)
   }
 
   private def format(string: String, args: Array[String]): String = {
-    return MessageFormat.format(string, args.asInstanceOf[Array[AnyRef]])
+    return MessageFormat.format(string, args.asInstanceOf[Array[AnyRef]]:_*)
   }
 
   private def message(property: String): String = {

--- a/src/main/scala/onion/compiler/exceptions/CompilationException.scala
+++ b/src/main/scala/onion/compiler/exceptions/CompilationException.scala
@@ -19,7 +19,7 @@ import java.lang.{Iterable => JIterable}
  */
 class CompilationException(val problems_ : JList[CompileError]) extends RuntimeException with JIterable[CompileError] {
 
-  def problems(): JList[CompileError] = Collections.unmodifiableList(problems)
+  def problems(): JList[CompileError] = Collections.unmodifiableList(problems_)
 
   def size(): Int = problems.size();
 

--- a/src/main/scala/onion/compiler/toolbox/Messages.scala
+++ b/src/main/scala/onion/compiler/toolbox/Messages.scala
@@ -15,15 +15,15 @@ import java.util.ResourceBundle
  * Date: 2005/06/17
  */
 object Messages {
-  private val ERROR_MESSAGES: ResourceBundle = ResourceBundle.getBundle("resources.errorMessage")
+  private val ERROR_MESSAGES: ResourceBundle = ResourceBundle.getBundle("errorMessage")
 
   def get(property: String): String =  ERROR_MESSAGES.getString(property)
 
-  def get(property: String, arguments: Array[Any]): String =  MessageFormat.format(get(property), arguments)
+  def get(property: String, arguments: Array[Any]): String =  MessageFormat.format(get(property), arguments.map(_.asInstanceOf[AnyRef]):_*)
 
-  def get(property: String, arg1: Any): String = MessageFormat.format(get(property), Array(arg1))
+  def get(property: String, arg1: Any): String = MessageFormat.format(get(property), arg1.asInstanceOf[AnyRef])
 
-  def get(property: String, arg1: Any, arg2: AnyRef): String =  MessageFormat.format(get(property), Array(arg1, arg2))
+  def get(property: String, arg1: Any, arg2: AnyRef): String =  MessageFormat.format(get(property), arg1.asInstanceOf[AnyRef], arg2)
 
-  def get(property: String, arg1: Any, arg2: AnyRef, arg3: AnyRef): String =  MessageFormat.format(get(property), Array(arg1 ,arg2, arg3))
+  def get(property: String, arg1: Any, arg2: AnyRef, arg3: AnyRef): String =  MessageFormat.format(get(property), arg1.asInstanceOf[AnyRef] ,arg2, arg3)
 }


### PR DESCRIPTION
- This problem was caused by
  - Specification change when calling vararg method in Java
  - When moving from sbt 0.7.x to 0.11.X, didn't handle resources directory correctly.
