### PR TITLE
Fix potential compiler crashes in TCO and codegen

### DIFF
--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -809,7 +809,10 @@ object AsmCodeGeneration:
       AsmType.getType("[" * at.dimension + componentDescriptor)
     case _: NullType       => AsmUtil.objectType(AsmUtil.JavaLangObject)
     case _: BottomType     => AsmType.VOID_TYPE
-    case _                 => throw new RuntimeException(s"Unsupported type: $tp")
+    case unknown =>
+      // Defensive fallback: unknown types should not reach codegen, but emitting
+      // java.lang.Object keeps the compiler from crashing with an internal error.
+      AsmUtil.objectType(AsmUtil.JavaLangObject)
 
   /**
    * Get the box class name for a given type (for boxed mutable variables)

--- a/src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala
+++ b/src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala
@@ -767,7 +767,12 @@ class MutualRecursionOptimization(config: CompilerConfig)
       }
     }
 
-    rewriteStatement(body).asInstanceOf[StatementBlock]
+    rewriteStatement(body) match {
+      case block: StatementBlock => block
+      case other =>
+        // Body should always be a StatementBlock; wrap defensively to avoid ClassCastException.
+        new StatementBlock(other.location, other)
+    }
   }
 
   /**

--- a/src/main/scala/onion/compiler/optimization/TailCallOptimization.scala
+++ b/src/main/scala/onion/compiler/optimization/TailCallOptimization.scala
@@ -605,7 +605,7 @@ class TailCallOptimization(config: CompilerConfig)
               case None =>
                 trace(s"[TCO transformStatement] Return: No IfStatement found, calling transformTailCall")
                 // No IfStatement found, transform as direct call
-                transformTailCall(ret.term, paramTemps)
+                transformTailCall(ret.term, paramTemps).getOrElse(ret)
             }
           case stmtTerm: StatementTerm =>
             // Explicit return: Return(StatementTerm(IfStatement))
@@ -621,13 +621,13 @@ class TailCallOptimization(config: CompilerConfig)
                 new IfStatement(ifStmt.location, ifStmt.condition, transformedThen, transformedElse)
               case _ =>
                 // Other StatementTerms: fallback to transformTailCall
-                transformTailCall(ret.term, paramTemps)
+                transformTailCall(ret.term, paramTemps).getOrElse(ret)
             }
 
           case _ =>
             trace(s"[TCO transformStatement] Return: Not Begin, calling transformTailCall")
             // Direct tail call (not in Begin)
-            transformTailCall(ret.term, paramTemps)
+            transformTailCall(ret.term, paramTemps).getOrElse(ret)
         }
 
       case block: StatementBlock =>
@@ -677,12 +677,12 @@ class TailCallOptimization(config: CompilerConfig)
                   case None =>
                     trace(s"[TCO transformStatement] No IfStatement found, calling transformTailCall")
                     // No IfStatement found, try to transform as direct call
-                    transformTailCall(setLocal.value, paramTemps)
+                    transformTailCall(setLocal.value, paramTemps).getOrElse(exprStmt)
                 }
               case _ =>
                 trace(s"[TCO transformStatement] Not Begin, calling transformTailCall")
                 // Direct tail call (not in Begin)
-                transformTailCall(setLocal.value, paramTemps)
+                transformTailCall(setLocal.value, paramTemps).getOrElse(exprStmt)
             }
           case _ =>
             trace(s"[TCO transformStatement] No tail call in ExpressionActionStatement")
@@ -710,7 +710,7 @@ class TailCallOptimization(config: CompilerConfig)
   private def transformTailCall(
     term: Term,
     loopVarMapping: IndexedSeq[(Int, Int, Type)]
-  ): ActionStatement = {
+  ): Option[ActionStatement] = {
     // Extract the actual Call from wrapped structures (Begin, StatementTerm, etc.)
     def extractCall(t: Term, depth: Int = 0): Option[Term] = {
       val indent = "  " * depth
@@ -751,11 +751,12 @@ class TailCallOptimization(config: CompilerConfig)
       }
     }
 
-    val actualCall = extractCall(term).getOrElse {
-      throw new RuntimeException(
-        s"transformTailCall: Could not extract Call from term type=${term.getClass.getSimpleName}"
-      )
+    val actualCallOpt = extractCall(term)
+    if (actualCallOpt.isEmpty) {
+      trace(s"[TCO transformTailCall] Could not extract Call from term type=${term.getClass.getSimpleName}, skipping TCO")
+      return None
     }
+    val actualCall = actualCallOpt.get
 
     val newArgs: Array[Term] = actualCall match {
       case call: Call => call.parameters
@@ -769,7 +770,11 @@ class TailCallOptimization(config: CompilerConfig)
 
     val assignments = mutable.ArrayBuffer[ActionStatement]()
 
-    if (newArgs.length == 1) {
+    if (newArgs.length == 0) {
+      // Zero-argument tail call: restart the loop with current variable values
+      trace(s"[TCO transformTailCall] Zero-argument tail call, emitting Continue")
+      return Some(new Continue(null))
+    } else if (newArgs.length == 1) {
       // Single argument: can directly assign to loop variable (no temp needed)
       val (_, loopVarIndex, paramType) = loopVarMapping(0)
       val newValue = newArgs(0)
@@ -808,14 +813,12 @@ class TailCallOptimization(config: CompilerConfig)
         val loopVarAssignment = new SetLocal(null, 0, loopVarIndex, paramType, tempRef)
         assignments += new ExpressionActionStatement(null, loopVarAssignment)
       }
-    } else {
-      throw new RuntimeException("transformTailCall: No arguments in tail call")
     }
 
     // Add continue statement to restart the loop
     assignments += new Continue(null)
 
     // Return a block with all assignments and continue
-    new StatementBlock(null, assignments.toSeq: _*)
+    Some(new StatementBlock(null, assignments.toSeq: _*))
   }
 }

--- a/src/main/scala/onion/compiler/typing/MethodBodySupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodBodySupport.scala
@@ -20,7 +20,7 @@ private[compiler] final class MethodBodySupport(
     block: AST.BlockExpression
   ): Unit = {
     val context = prepareMethodContext(method, args, block)
-    val translatedBlock = addReturnNode(translate(block, context).asInstanceOf[StatementBlock], method.returnType)
+    val translatedBlock = addReturnNode(translate(block, context), method.returnType)
     method.setBlock(translatedBlock)
     method.setFrame(context.getContextFrame)
     reportUnused(context)
@@ -58,7 +58,7 @@ private[compiler] final class MethodBodySupport(
     context: LocalContext
   ): Unit = {
     constructor.superInitializer = initializer
-    constructor.block = addReturnNode(translate(block, context).asInstanceOf[StatementBlock], BasicType.VOID)
+    constructor.block = addReturnNode(translate(block, context), BasicType.VOID)
     constructor.frame = context.getContextFrame
   }
 
@@ -72,7 +72,7 @@ private[compiler] final class MethodBodySupport(
     receiverType: Type
   ): Unit = {
     val context = prepareExtensionContext(staticMethod, node, receiverType)
-    val translatedBlock = addReturnNode(translate(node.block, context).asInstanceOf[StatementBlock], staticMethod.returnType)
+    val translatedBlock = addReturnNode(translate(node.block, context), staticMethod.returnType)
     staticMethod.setBlock(translatedBlock)
     staticMethod.setFrame(context.getContextFrame)
     extMethod.setBlock(translatedBlock)

--- a/src/test/scala/onion/compiler/tools/TailCallOptimizationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TailCallOptimizationSpec.scala
@@ -41,5 +41,28 @@ class TailCallOptimizationSpec extends AbstractShellSpec {
       )
       assert(result.isInstanceOf[Shell.Success])
     }
+
+    it("optimizes a zero-argument static method without crashing") {
+      val result = shell.run(
+        """
+          |class C {
+          |public:
+          |  static var count: Int = 0
+          |  static def loop(): Int {
+          |    if count >= 100000 { return count }
+          |    count = count + 1
+          |    return loop()
+          |  }
+          |  static def main(args: String[]): Int {
+          |    count = 0
+          |    return loop()
+          |  }
+          |}
+          |""".stripMargin,
+        "ZeroArgStaticTCO.on",
+        Array()
+      )
+      assert(Shell.Success(100000) == result)
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR hardens several compiler paths so users are less likely to hit internal compiler errors (ICEs).

## Changes

- **TailCallOptimization**: `transformTailCall` now returns `Option[ActionStatement]` and falls back to the original statement instead of throwing `RuntimeException` when it cannot extract a call. Zero-argument tail calls are now handled by emitting a `continue`.
- **AsmCodeGeneration**: `asmType` falls back to `java.lang.Object` for unknown types instead of throwing `RuntimeException`.
- **MutualRecursionOptimization**: replaced an unsafe `asInstanceOf[StatementBlock]` with a defensive pattern match.
- **MethodBodySupport**: removed unnecessary `asInstanceOf[StatementBlock]` casts.

## Tests

- Added a regression test for zero-argument static tail-call optimization.
- Full test suite passes: `sbt test`.
