### PR TITLE
Improve release process with dynamic versioning and artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,25 +22,48 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'sbt'
+      - name: Resolve version
+        id: version
+        run: |
+          VERSION="$(sbt -error 'print version' | tail -1)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "resolved version: $VERSION"
+      - name: Verify tag matches version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${{ steps.version.outputs.version }}"
+          # Strip leading 'v' from tag for comparison
+          TAG_VERSION="${TAG#v}"
+          if [ "$TAG_VERSION" != "$VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match build version ($VERSION)" >&2
+            exit 1
+          fi
       - name: Test
         run: sbt test
       - name: Build artifacts
         run: sbt assembly dist
       - name: Collect artifacts
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
           mkdir -p release-artifacts
-          FAT_JAR="$(find target -name onion.jar -path '*scala-*' -not -path '*dist*' | head -1)"
+          FAT_JAR="target/scala-3.3.7/onion-${VERSION}.jar"
           test -f "$FAT_JAR"
-          cp "$FAT_JAR" release-artifacts/onion.jar
-          cp target/onion-dist.zip release-artifacts/onion-dist.zip
+          cp "$FAT_JAR" "release-artifacts/onion-${VERSION}.jar"
+          cp "target/onion-dist-${VERSION}.zip" "release-artifacts/onion-dist-${VERSION}.zip"
+      - name: Generate checksums
+        run: |
+          cd release-artifacts
+          sha256sum * > checksums.txt
       - name: Smoke test the fat jar
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
           echo 'IO::println("release smoke test ok")' > /tmp/smoke.on
-          java -cp release-artifacts/onion.jar onion.tools.ScriptRunner /tmp/smoke.on | grep -q "release smoke test ok"
+          java -cp "release-artifacts/onion-${VERSION}.jar" onion.tools.ScriptRunner /tmp/smoke.on | grep -q "release smoke test ok"
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
           PRERELEASE=""
           case "${GITHUB_REF_NAME}" in
             *-M*|*-RC*|*-rc*|*-alpha*|*-beta*) PRERELEASE="--prerelease" ;;
@@ -48,5 +71,6 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" $PRERELEASE \
             --title "Onion ${GITHUB_REF_NAME}" \
             --generate-notes \
-            release-artifacts/onion.jar \
-            release-artifacts/onion-dist.zip
+            release-artifacts/onion-${VERSION}.jar \
+            release-artifacts/onion-dist-${VERSION}.zip \
+            release-artifacts/checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to Onion are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Automated release versioning via [sbt-dynver](https://github.com/sbt/sbt-dynver).
+- Versioned artifact names for releases (`onion-<version>.jar` and
+  `onion-dist-<version>.zip`).
+- SHA-256 checksums attached to GitHub Releases.
+- `RELEASING.md` documenting the release process.
+
+### Changed
+- Release workflow now verifies that the pushed tag matches the sbt-derived
+  version before publishing artifacts.
+
+## [0.2.0-M14] - 2024-??-??
+
+### Added
+- (Previous milestone changes should be recorded here from release notes.)
+
+## [0.1.0] - 2024-??-??
+
+### Added
+- Initial release.
+
+[Unreleased]: https://github.com/onion-lang/onion/compare/v0.2.0-M14...develop
+[0.2.0-M14]: https://github.com/onion-lang/onion/releases/tag/v0.2.0-M14
+[0.1.0]: https://github.com/onion-lang/onion/releases/tag/releases/0.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,65 @@
+# Releasing Onion
+
+Onion uses **git tags** to drive releases. The version is derived automatically
+from the latest tag by [sbt-dynver](https://github.com/sbt/sbt-dynver), so there
+is no manual `version := ...` line to update in `build.sbt`.
+
+## Release checklist
+
+1. **Make sure `develop` is green.**
+   ```bash
+   sbt test
+   ```
+
+2. **Decide the next version.**
+   Onion follows [Semantic Versioning](https://semver.org/) with milestone and
+   RC pre-releases when needed:
+   - Patch release: `v0.2.1`
+   - Minor release: `v0.3.0`
+   - Milestone: `v0.3.0-M1`
+   - Release candidate: `v0.3.0-RC1`
+
+3. **Update `CHANGELOG.md`.**
+   Add a new section for the release with the date and a summary of user-facing
+   changes, bug fixes, and internal improvements.
+
+4. **Create and push a tag.**
+   ```bash
+   git checkout develop
+   git pull
+   git tag -a v0.2.0 -m "Release v0.2.0"
+   git push origin v0.2.0
+   ```
+
+5. **Let CI do the rest.**
+   The [release workflow](.github/workflows/release.yml) will:
+   - run the test suite,
+   - build the fat jar (`sbt assembly`) and the distribution zip (`sbt dist`),
+   - verify the tag matches the sbt-derived version,
+   - smoke-test the fat jar,
+   - generate SHA-256 checksums,
+   - create a GitHub Release with the artifacts and auto-generated notes.
+
+6. **Verify the release.**
+   - Check the GitHub Release page.
+   - Download `onion-<version>.jar` and confirm:
+     ```bash
+     java -cp onion-<version>.jar onion.tools.ScriptRunner run/Hello.on
+     ```
+
+## Local artifact inspection
+
+To build the same artifacts locally without creating a release:
+
+```bash
+sbt assembly dist
+```
+
+Outputs:
+- `target/scala-3.3.7/onion-<version>.jar` (fat jar)
+- `target/onion-dist-<version>.zip` (distribution archive)
+
+## Hotfix releases
+
+For a hotfix against an already-released version, branch from the release tag,
+apply the fix, and push a new patch tag (e.g. `v0.2.1`).

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ def manifestExtra(artifact: File, classpath: Classpath) = {
   Package.JarManifest(mf)
 }
 
-def distTask(target: File, out: File, artifact: File, classpath: Classpath) = {
+def distTask(target: File, out: File, artifact: File, classpath: Classpath, version: String) = {
   val libs = classpath.map(_.data).filter(isArchive)
   val libdir = out / "lib"
   IO.createDirectory(libdir)
@@ -62,7 +62,7 @@ def distTask(target: File, out: File, artifact: File, classpath: Classpath) = {
   IO.copyFile(artifact, out / "onion.jar")
   IO.copyFile(file("README.md"), out / "README.md")
   val files = (out ** AllPassFilter).get.flatMap(f=> f.relativeTo(out).map(r=>(f, r.getPath)))
-  IO.zip(files, target / "onion-dist.zip", Some(System.currentTimeMillis()))
+  IO.zip(files, target / s"onion-dist-$version.zip", Some(System.currentTimeMillis()))
 }
 
 def javacc(classpath: Classpath, output: File, log: Logger): Seq[File] = {
@@ -95,7 +95,6 @@ def javacc(classpath: Classpath, output: File, log: Logger): Seq[File] = {
 }
 
 lazy val onionSettings = Seq(
-  version := "0.2.0-SNAPSHOT",
   scalaVersion := "3.3.7",
   name := "onion",
   organization := "org.onion_lang",
@@ -150,13 +149,14 @@ lazy val onionSettings = Seq(
     val out = (dist / distPath).value
     val p = (Compile / packageBin).value
     val cp = (Runtime / fullClasspath).value
-    distTask(t, out, p, cp)
+    val v = version.value
+    distTask(t, out, p, cp, v)
   },
   dist / distPath := {
     target.value / "dist"
   },
   Compile / mainClass := Some("onion.tools.CompilerFrontend"),
-  assembly / assemblyJarName := "onion.jar",
+  assembly / assemblyJarName := s"onion-${version.value}.jar",
   assembly / assemblyMergeStrategy := {
     case "module-info.class" => MergeStrategy.discard
     case x =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")


### PR DESCRIPTION
## Summary

Improves Onion's release process by deriving the version from git tags, versioning release artifacts, and adding release documentation.

## Changes

- **Dynamic versioning**: added `sbt-dynver` so `version` is derived from the latest git tag (e.g. `v0.2.0` → `0.2.0`). Removed the hardcoded `version := "0.2.0-SNAPSHOT"` line from `build.sbt`.
- **Versioned artifacts**: the fat jar and distribution zip now include the version in their filenames (`onion-<version>.jar`, `onion-dist-<version>.zip`).
- **Release workflow updates**:
  - Resolves the version from sbt.
  - Verifies the pushed tag matches the sbt-derived version before publishing.
  - Generates SHA-256 checksums for all release artifacts.
  - Attaches the versioned jar, zip, and checksums to the GitHub Release.
- **Documentation**:
  - Added `RELEASING.md` with a step-by-step release checklist.
  - Added `CHANGELOG.md` with an `Unreleased` section for the new release infrastructure.

## Validation

- `sbt test` passes.
- `sbt assembly dist` produces `target/scala-3.3.7/onion-<version>.jar` and `target/onion-dist-<version>.zip`.
