### PR TITLE
Support primitive type arguments in Java generic interfaces

### DIFF
--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -6,7 +6,7 @@
 
 | # | 次元 | 測定方法 | 現在値（2026-06-26） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | テストスイート | `SBT_OPTS="-Xmx2g" sbt -batch test` | 1191 pass / 0 fail | 0 failed, 0 skipped |
+| 1 | テストスイート | `SBT_OPTS="-Xmx2g" sbt -batch test` | 1193 pass / 0 fail | 0 failed, 0 skipped |
 | 2 | サンプルの健全性 | `SampleProgramsSpec`（すべての `run/*.on` をコンパイル） | 36 / 36 compile | すべてコンパイル、rot なし |
 | 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 5（OrderReport、StatsApp、TodoManager、ShapeProcessor、TextAnalyzer） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -8,7 +8,7 @@ Baseline figures are the ground-truth values as of 2026-06-26 (develop @ 6a2d0e4
 
 | # | Dimension | How to measure | Current (2026-06-26) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | Test suite | `SBT_OPTS="-Xmx2g" sbt -batch test` | 1191 pass / 0 fail | 0 failed, 0 skipped |
+| 1 | Test suite | `SBT_OPTS="-Xmx2g" sbt -batch test` | 1193 pass / 0 fail | 0 failed, 0 skipped |
 | 2 | Sample health | `SampleProgramsSpec` (compiles every `run/*.on`) | 36 / 36 compile | all compile, no rot |
 | 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 5 (OrderReport, StatsApp, TodoManager, ShapeProcessor, TextAnalyzer) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |

--- a/src/main/scala/onion/compiler/backend/asm/BridgeMethodEmitter.scala
+++ b/src/main/scala/onion/compiler/backend/asm/BridgeMethodEmitter.scala
@@ -35,7 +35,7 @@ final class BridgeMethodEmitter(private val codegen: AsmCodeGeneration) {
           val implOpt = classDef.methods.find { m =>
             m.name == rawMethod.name &&
             m.arguments.length == specializedArgs.length &&
-            m.arguments.indices.forall(i => m.arguments(i).name == specializedArgs(i).name)
+            m.arguments.indices.forall(i => isBridgeCompatible(m.arguments(i), specializedArgs(i)))
           }
 
           implOpt.foreach { impl =>
@@ -75,6 +75,30 @@ final class BridgeMethodEmitter(private val codegen: AsmCodeGeneration) {
                 gen.returnValue()
                 gen.endMethod()
           }
+
+  private def isBridgeCompatible(implArg: TypedAST.Type, specializedArg: TypedAST.Type): Boolean = {
+    if implArg.name == specializedArg.name then return true
+    // Allow primitive implementation argument to match boxed specialized arg
+    // (e.g. Int vs Integer) and vice versa.
+    (implArg, specializedArg) match
+      case (bt: TypedAST.BasicType, ct: TypedAST.ClassType) if bt != TypedAST.BasicType.VOID =>
+        ct.name == boxedName(bt)
+      case (ct: TypedAST.ClassType, bt: TypedAST.BasicType) if bt != TypedAST.BasicType.VOID =>
+        ct.name == boxedName(bt)
+      case _ => false
+  }
+
+  private def boxedName(bt: TypedAST.BasicType): String = bt match {
+    case TypedAST.BasicType.BOOLEAN => "java.lang.Boolean"
+    case TypedAST.BasicType.BYTE    => "java.lang.Byte"
+    case TypedAST.BasicType.SHORT   => "java.lang.Short"
+    case TypedAST.BasicType.CHAR    => "java.lang.Character"
+    case TypedAST.BasicType.INT     => "java.lang.Integer"
+    case TypedAST.BasicType.LONG    => "java.lang.Long"
+    case TypedAST.BasicType.FLOAT   => "java.lang.Float"
+    case TypedAST.BasicType.DOUBLE  => "java.lang.Double"
+    case _ => ""
+  }
 
   private def substituteTypeVars(tp: TypedAST.Type, subst: Map[String, TypedAST.Type]): TypedAST.Type = tp match
     case tv: TypeVariableType => subst.getOrElse(tv.name, tv)

--- a/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
+++ b/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
@@ -3,6 +3,7 @@ package onion.compiler.typing
 import onion.compiler.*
 import onion.compiler.TypedAST.*
 import onion.compiler.generics.Erasure
+import onion.compiler.toolbox.Boxing
 
 import scala.collection.mutable
 
@@ -15,6 +16,61 @@ private[compiler] object DuplicationChecks {
 
   private def erasedParamDescriptor(args: Array[Type]): String =
     args.map(Erasure.asmType).map(_.getDescriptor).mkString("(", "", ")")
+
+  private def allErasedParamDescriptors(args: Array[Type], typing: Typing): Set[String] = {
+    val base = erasedParamDescriptor(args)
+    val variants = Set.newBuilder[String]
+    variants += base
+    // For each argument that is a boxed primitive, also generate a descriptor
+    // where that argument uses the primitive form, and vice versa. This lets
+    // a user implement `compare(a: Int, b: Int)` for `Comparator[Int]`.
+    if args.nonEmpty then
+      val perArg = args.map { arg =>
+        val baseDesc = Erasure.asmType(arg).getDescriptor
+        arg match
+          case bt: BasicType if bt != BasicType.VOID =>
+            Set(baseDesc, Erasure.asmType(typing.boxedTypeArgument(bt)).getDescriptor)
+          case ct: ClassType =>
+            val base = Set(baseDesc)
+            Boxing.unboxedType(typing.table_, ct) match
+              case Some(bt) => base + Erasure.asmType(bt).getDescriptor
+              case None => base
+          case _ =>
+            Set(baseDesc)
+      }
+      // Combine descriptors position-wise.
+      def combine(index: Int, current: String): Unit =
+        if index == args.length then
+          variants += current + ")"
+        else
+          perArg(index).foreach(desc => combine(index + 1, current + desc))
+      combine(0, "(")
+    variants.result()
+  }
+
+  private def primitiveAwareSuperType(implArg: Type, contractArg: Type, typing: Typing): Boolean = {
+    if TypeRules.isSuperType(implArg, contractArg) then return true
+    (implArg, contractArg) match
+      case (bt: BasicType, ct: ClassType) if bt != BasicType.VOID &&
+          typing.boxedTypeArgument(bt).name == ct.name =>
+        true
+      case (ct: ClassType, bt: BasicType) if bt != BasicType.VOID &&
+          typing.boxedTypeArgument(bt).name == ct.name =>
+        true
+      case _ => false
+  }
+
+  private def primitiveAwareAssignable(contractType: Type, implType: Type, typing: Typing): Boolean = {
+    if TypeRules.isAssignable(contractType, implType) then return true
+    (contractType, implType) match
+      case (bt: BasicType, ct: ClassType) if bt != BasicType.VOID &&
+          typing.boxedTypeArgument(bt).name == ct.name =>
+        true
+      case (ct: ClassType, bt: BasicType) if bt != BasicType.VOID &&
+          typing.boxedTypeArgument(bt).name == ct.name =>
+        true
+      case _ => false
+  }
 
   def checkOverrideContracts(typing: Typing, clazz: ClassDefinition, fallback: Location): Unit = {
     if clazz.isInterface then return
@@ -54,13 +110,12 @@ private[compiler] object DuplicationChecks {
               typing.report(SemanticError.FINAL_METHOD_OVERRIDE, location, impl.name, paramDescriptor, view.raw.name)
 
             specializedArgs.zip(impl.arguments).foreach { case (arg, implArg) =>
-              val checkedArg = if (!implArg.isBasicType && arg.isBasicType) typing.boxedTypeArgument(arg) else arg
-              if (!TypeRules.isSuperType(implArg, checkedArg)) {
+              if (!primitiveAwareSuperType(implArg, arg, typing)) {
                 typing.report(SemanticError.INCOMPATIBLE_TYPE, location, arg, implArg)
               }
             }
 
-            if (!TypeRules.isAssignable(specializedRet, impl.returnType)) {
+            if (!primitiveAwareAssignable(specializedRet, impl.returnType, typing)) {
               typing.report(SemanticError.INCOMPATIBLE_TYPE, location, specializedRet, impl.returnType)
             }
           }
@@ -116,9 +171,9 @@ private[compiler] object DuplicationChecks {
           // Example: Picker[String].pick(T) → pick(String) (NOT pick(Object))
           val specializedArgs =
             contract.arguments.map(tp => TypeSubstitution.substituteType(tp, viewSubst, emptyMethodSubst, defaultToBound = true))
-          val key = (contract.name, erasedParamDescriptor(specializedArgs))
+          val possibleKeys = allErasedParamDescriptors(specializedArgs, typing).map(desc => (contract.name, desc))
 
-          if !implByErasedParams.contains(key) then
+          if !possibleKeys.exists(implByErasedParams.contains) then
             val paramDescriptor = specializedArgs.map(_.name).mkString(", ")
             typing.report(SemanticError.UNIMPLEMENTED_ABSTRACT_METHOD, fallback, clazz.name, contract.name, paramDescriptor)
       }

--- a/src/test/scala/onion/compiler/tools/JavaGenericsInteropSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaGenericsInteropSpec.scala
@@ -567,6 +567,64 @@ class JavaGenericsInteropSpec extends AbstractShellSpec {
       assert(Shell.Success("a") == result)
     }
 
+    it("supports Comparator[Int] implemented with primitive Int parameters") {
+      val result = shell.run(
+        """
+          |class IntComparator <: Comparator[Int] {
+          |public:
+          |  def compare(a: Int, b: Int): Int {
+          |    return a - b
+          |  }
+          |}
+          |
+          |class ComparatorIntTest {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val list: ArrayList[Int] = new ArrayList[Int]
+          |    list.add(5)
+          |    list.add(1)
+          |    list.add(3)
+          |    Collections::sort(list, new IntComparator())
+          |    return "" + list.get(0) + "," + list.get(1) + "," + list.get(2)
+          |  }
+          |}
+          |""".stripMargin,
+        "ComparatorIntTest.on",
+        Array()
+      )
+      assert(Shell.Success("1,3,5") == result)
+    }
+
+    it("supports Comparator[Double] implemented with primitive Double parameters") {
+      val result = shell.run(
+        """
+          |class DoubleComparator <: Comparator[Double] {
+          |public:
+          |  def compare(a: Double, b: Double): Int {
+          |    if a < b { return -1 }
+          |    if a > b { return 1 }
+          |    return 0
+          |  }
+          |}
+          |
+          |class ComparatorDoubleTest {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val list: ArrayList[Double] = new ArrayList[Double]
+          |    list.add(3.14)
+          |    list.add(1.5)
+          |    list.add(2.0)
+          |    Collections::sort(list, new DoubleComparator())
+          |    return "" + list.get(0) + "," + list.get(1) + "," + list.get(2)
+          |  }
+          |}
+          |""".stripMargin,
+        "ComparatorDoubleTest.on",
+        Array()
+      )
+      assert(Shell.Success("1.5,2.0,3.14") == result)
+    }
+
     it("supports Collections.newSetFromMap") {
       val result = shell.run(
         """


### PR DESCRIPTION
This PR makes primitive type arguments usable with Java generic interfaces such as `Comparator[Int]` and `Comparable[Int]`.

## Problem

Onion already boxes primitive type arguments internally (`Int` -> `Integer`), so `Comparator[Int]` is stored as `Comparator[Integer]`. However, a class implementing the interface with primitive parameters was rejected:

```onion
class IntComparator <: Comparator[Int] {
public:
  def compare(a: Int, b: Int): Int { return a - b }
}
```

Two issues prevented this from working:

1. `checkAbstractMethodImplementation` looked for an implementation whose erased descriptor exactly matched `compare(Integer, Integer)`, missing the primitive implementation `compare(int, int)`.
2. `BridgeMethodEmitter` matched implementations by exact type argument names, so it never generated the JVM bridge from `compare(Object, Object)` to `compare(int, int)`.

## Changes

- `DuplicationChecks.scala`
  - `allErasedParamDescriptors`: generate both boxed and primitive erased descriptors for interface method lookup.
  - `primitiveAwareSuperType` / `primitiveAwareAssignable`: treat a primitive implementation parameter/return as compatible with its boxed contract counterpart.
- `BridgeMethodEmitter.scala`
  - `isBridgeCompatible`: allow an implementation argument to match a specialized interface argument when one is the boxed form of the other.
  - `boxedName`: small helper mapping `BasicType` to wrapper class name.

## Tests

Added two regression tests in `JavaGenericsInteropSpec`:

- `Comparator[Int]` implemented with primitive `Int` parameters and used with `Collections.sort(ArrayList[Int], ...)`
- `Comparator[Double]` implemented with primitive `Double` parameters

## Verification

- `SBT_OPTS="-Xmx2g" sbt -batch test` -> 1193 tests passed, 0 failed
- `mkdocs build --strict` -> no warnings
