### PR TITLE
Update language spec for primitive generic type arguments

### DIFF
--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -93,6 +93,29 @@ val         var         when        while
 `record Pair[A, B](first: A, second: B)`。ワイルドカード `?`、`? extends T`、
 `? super T` を型引数として受け入れます。
 
+### ジェネリクス
+
+`[]` 構文の消去ベースジェネリクス: `class Box[T]`、`def first[T](xs: List[T]): T`、
+`record Pair[A, B](first: A, second: B)`。ワイルドカード `?`、`? extends T`、
+`? super T` を型引数として受け入れます。
+
+プリミティブ型も型引数として使えます。内部ではボックス化されます
+（`Int` -> `Integer`）ので、`Comparator[Int]` のような Java 汎用インターフェースを
+プリミティブなパラメータ型で実装できます。コンパイラは消去されたボックス化された
+契約とプリミティブ実装の間のブリッジを生成します。
+
+```onion
+class IntComparator <: Comparator[Int] {
+public:
+  def compare(a: Int, b: Int): Int {
+    return a - b
+  }
+}
+
+val nums: ArrayList[Int] = [5, 1, 3]
+Collections::sort(nums, new IntComparator())
+```
+
 型パラメータの null 性は Kotlin に従います。
 
 - 裸の `[T]` は nullable 型引数を受け入れ（`Box[String?]`）。ジェネリック本体では

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -98,6 +98,23 @@ Erasure-based generics with `[]` syntax: `class Box[T]`, `def first[T](xs: List[
 `record Pair[A, B](first: A, second: B)`. Wildcards `?`, `? extends T`,
 `? super T` are accepted in type arguments.
 
+Primitive types can be used as type arguments. They are boxed internally
+(`Int` -> `Integer`), so Onion code can implement Java generic interfaces such as
+`Comparator[Int]` using primitive parameter types. The compiler generates the
+necessary bridges between the erased boxed contract and the primitive implementation.
+
+```onion
+class IntComparator <: Comparator[Int] {
+public:
+  def compare(a: Int, b: Int): Int {
+    return a - b
+  }
+}
+
+val nums: ArrayList[Int] = [5, 1, 3]
+Collections::sort(nums, new IntComparator())
+```
+
 Type-parameter nullability follows Kotlin:
 
 - Bare `[T]` accepts nullable type arguments (`Box[String?]`); values of


### PR DESCRIPTION
Updates the language specification to match the current implementation now that PR #173 is merged.

## Changes

- `docs/reference/specification.md`
  - Added the missing explanation that primitive types can be used as type arguments.
  - Added an example of implementing `Comparator[Int]` with primitive `Int` parameters.

- `docs/ja/reference/specification.md`
  - Restored the missing `### ジェネリクス` section heading.
  - Added the same primitive-type-argument explanation and example in Japanese.

## Verification

- `mkdocs build --strict` passes with no warnings.
