### PR TITLE
docs(stdlib): document Json's *Or defaulted accessors (en + ja)

### DIFF
--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -347,6 +347,14 @@ val text = Json::stringify(m)                           // {"x":1}
 
 `getString` / `getInt` / `getLong` / `getDouble` / `getFloat` / `getBoolean` / `getShort` / `getByte` でキーから型別に取得します（見つからない・型不一致のときは null）。
 
+これらはボックス化された値を返すため、見つからない場合の null をそのまま非 null なプリミティブへ代入すると NullPointerException になります。`getStringOr` / `getIntOr` / `getLongOr` / `getDoubleOr` / `getFloatOr` / `getBooleanOr(obj, key, default)` はフォールバック値付きでプリミティブを返すので、キーが無くても NPE になりません:
+
+```onion
+val obj = Json::parse("{}")
+Json::getIntOr(obj, "missing", 42)      // 42（NPE にならない）
+Json::getStringOr(obj, "name", "anon")  // "anon"
+```
+
 ## Yaml モジュール
 
 YAML（flat block mapping のサブセット）のパースとシリアライズ。中間表現は Json と共通です。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -741,6 +741,18 @@ val v = Json::value(jsonText)
 v["users"][0]["name"].asString()
 ```
 
+The plain `getString`/`getInt`/`getLong`/`getDouble`/`getFloat`/`getBoolean`/`getShort`/`getByte`
+return a boxed value that is `null` when the key is missing or has the wrong type — assigning
+that straight into a non-null primitive throws `NullPointerException`. `getStringOr`/`getIntOr`/
+`getLongOr`/`getDoubleOr`/`getFloatOr`/`getBooleanOr(obj, key, default)` return a primitive with
+an explicit fallback instead:
+
+```onion
+val obj = Json::parse("{}")
+Json::getIntOr(obj, "missing", 42)     // 42, no NPE
+Json::getStringOr(obj, "name", "anon") // "anon"
+```
+
 ## Yaml Module
 
 YAML serialization and parsing for flat block-mapping documents


### PR DESCRIPTION
## Summary
- `getStringOr`/`getIntOr`/`getLongOr`/`getDoubleOr`/`getFloatOr`/`getBooleanOr` were added to `onion.Json` in #318 (and are covered by `CHANGELOG.md` + `JsonDefaultedAccessorSpec`), but were never added to the stdlib reference docs.
- Documents them in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, next to the plain accessors they complement, with a short example of the NPE they avoid.

## Why draft
This session's sandbox could not run the required verification command
(`SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test`):
`sbt` had to be installed from scratch, and once installed, plugin
resolution for `sbt-dynver` failed because it is only published on
`repo.scala-sbt.org` / `repo.typesafe.com`, both rejected with 403 by this
session's egress proxy (organization policy denial, not a transient error).
This blocks `sbt compile`/`sbt test` for **any** change in this repo from
this sandbox, not just this one.

Per the maintainer routine's rules, changes are never merged without a
green test run confirmed by an actual command, so this is left as a draft
for a human (or a session with working network access to those hosts) to
verify and merge.

## Test plan
- [ ] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` (blocked in this sandbox, see above)
- [x] Manual review of the added Markdown (renders as plain prose + two fenced `onion` blocks, no new anchors/links)


---
_Generated by [Claude Code](https://claude.ai/code/session_012wc3vk88VQyv9dKPwuR9FJ)_