### PR TITLE
fix: move sbt-dynver to com.github.sbt (Maven Central)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")


### PR DESCRIPTION
## Summary
- `project/plugins.sbt` pinned `"com.dwijnand" % "sbt-dynver" % "4.1.1"`, which sbt can only resolve via `repo.scala-sbt.org`'s `sbt-plugin-releases` and `repo.typesafe.com`'s `ivy-releases`. Both hosts are blocked by policy in at least one CI/dev sandbox this project runs in (confirmed: `HTTP/1.1 403 Forbidden` on both, org egress denial, not transient), which makes `sbt compile`/`sbt test` fail before a single source file is touched — see the note left on draft PR #320.
- The `com.dwijnand` org's sbt-dynver was superseded by `com.github.sbt` starting at 5.x, which is fully published on Maven Central (verified `5.0.0`–`5.1.1` all resolve with `200` from `repo1.maven.org`).
- `build.sbt` never calls sbt-dynver's setting keys directly (no `dynverGitDescribeOutput`, no explicit `version :=`); it only relies on the plugin's default auto-plugin behavior to populate `version.value` from the nearest git tag, so the version bump is a drop-in replacement with no other code changes required.
- Verified locally: with the old coordinates, `sbt compile` fails during project-definition loading with a `ResolveException` against the two blocked hosts; with `com.github.sbt % sbt-dynver % 5.1.1`, plugin resolution succeeds entirely from Maven Central and the full suite runs.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2139 tests, 326 suites, 0 failures, 0 canceled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuZoqptdnM1gE6m8YQffh1)_