### PR TITLE
Add practical readiness performance benchmarks and policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ target/
 .ivy2/
 .home/
 .xdg/
+.worktrees/
 
 # MkDocs
 site/

--- a/benchmarks/fixtures/automation-project/Generate.java
+++ b/benchmarks/fixtures/automation-project/Generate.java
@@ -1,0 +1,63 @@
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class Generate {
+    private Generate() {}
+
+    public static void main(String[] args) throws Exception {
+        Path root = Path.of(args.length == 0 ? "." : args[0])
+            .toAbsolutePath()
+            .normalize();
+        Files.createDirectories(root);
+        for (int stage = 1; stage <= 19; stage++) {
+            String className = String.format("Stage%02d", stage);
+            StringBuilder source = new StringBuilder();
+            source.append("module readiness.automation\n\n");
+            source.append("class ").append(className).append(" {\n");
+            source.append("public:\n");
+            for (int method = 1; method <= 32; method++) {
+                source.append("  def step")
+                    .append(String.format("%02d", method))
+                    .append("(value: Int): Int {\n");
+                source.append("    return value + ")
+                    .append(stage + method)
+                    .append("\n");
+                source.append("  }\n");
+            }
+            source.append("}\n");
+            Files.writeString(
+                root.resolve(className + ".on"),
+                source,
+                StandardCharsets.UTF_8
+            );
+        }
+
+        StringBuilder pipeline = new StringBuilder();
+        pipeline.append("module readiness.automation\n\n");
+        pipeline.append("class AutomationPipeline {\npublic:\n");
+        pipeline.append("  def run(value: Int): Int {\n");
+        pipeline.append("    var current = value\n");
+        for (int stage = 1; stage <= 19; stage++) {
+            pipeline.append("    current = new ")
+                .append(String.format("Stage%02d", stage))
+                .append("().step01(current)\n");
+        }
+        pipeline.append("    return current\n  }\n");
+        for (int method = 1; method <= 24; method++) {
+            pipeline.append("  def normalize")
+                .append(String.format("%02d", method))
+                .append("(value: Int): Int {\n");
+            pipeline.append("    return value - ")
+                .append(method)
+                .append("\n");
+            pipeline.append("  }\n");
+        }
+        pipeline.append("}\n");
+        Files.writeString(
+            root.resolve("Pipeline.on"),
+            pipeline,
+            StandardCharsets.UTF_8
+        );
+    }
+}

--- a/benchmarks/fixtures/automation-project/Generate.java
+++ b/benchmarks/fixtures/automation-project/Generate.java
@@ -1,6 +1,7 @@
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 
 public final class Generate {
     private Generate() {}
@@ -11,14 +12,14 @@ public final class Generate {
             .normalize();
         Files.createDirectories(root);
         for (int stage = 1; stage <= 19; stage++) {
-            String className = String.format("Stage%02d", stage);
+            String className = String.format(Locale.ROOT, "Stage%02d", stage);
             StringBuilder source = new StringBuilder();
             source.append("module readiness.automation\n\n");
             source.append("class ").append(className).append(" {\n");
             source.append("public:\n");
             for (int method = 1; method <= 32; method++) {
                 source.append("  def step")
-                    .append(String.format("%02d", method))
+                    .append(String.format(Locale.ROOT, "%02d", method))
                     .append("(value: Int): Int {\n");
                 source.append("    return value + ")
                     .append(stage + method)
@@ -40,13 +41,13 @@ public final class Generate {
         pipeline.append("    var current = value\n");
         for (int stage = 1; stage <= 19; stage++) {
             pipeline.append("    current = new ")
-                .append(String.format("Stage%02d", stage))
+                .append(String.format(Locale.ROOT, "Stage%02d", stage))
                 .append("().step01(current)\n");
         }
         pipeline.append("    return current\n  }\n");
         for (int method = 1; method <= 24; method++) {
             pipeline.append("  def normalize")
-                .append(String.format("%02d", method))
+                .append(String.format(Locale.ROOT, "%02d", method))
                 .append("(value: Int): Int {\n");
             pipeline.append("    return value - ")
                 .append(method)

--- a/benchmarks/fixtures/automation-project/Pipeline.on
+++ b/benchmarks/fixtures/automation-project/Pipeline.on
@@ -1,0 +1,100 @@
+module readiness.automation
+
+class AutomationPipeline {
+public:
+  def run(value: Int): Int {
+    var current = value
+    current = new Stage01().step01(current)
+    current = new Stage02().step01(current)
+    current = new Stage03().step01(current)
+    current = new Stage04().step01(current)
+    current = new Stage05().step01(current)
+    current = new Stage06().step01(current)
+    current = new Stage07().step01(current)
+    current = new Stage08().step01(current)
+    current = new Stage09().step01(current)
+    current = new Stage10().step01(current)
+    current = new Stage11().step01(current)
+    current = new Stage12().step01(current)
+    current = new Stage13().step01(current)
+    current = new Stage14().step01(current)
+    current = new Stage15().step01(current)
+    current = new Stage16().step01(current)
+    current = new Stage17().step01(current)
+    current = new Stage18().step01(current)
+    current = new Stage19().step01(current)
+    return current
+  }
+  def normalize01(value: Int): Int {
+    return value - 1
+  }
+  def normalize02(value: Int): Int {
+    return value - 2
+  }
+  def normalize03(value: Int): Int {
+    return value - 3
+  }
+  def normalize04(value: Int): Int {
+    return value - 4
+  }
+  def normalize05(value: Int): Int {
+    return value - 5
+  }
+  def normalize06(value: Int): Int {
+    return value - 6
+  }
+  def normalize07(value: Int): Int {
+    return value - 7
+  }
+  def normalize08(value: Int): Int {
+    return value - 8
+  }
+  def normalize09(value: Int): Int {
+    return value - 9
+  }
+  def normalize10(value: Int): Int {
+    return value - 10
+  }
+  def normalize11(value: Int): Int {
+    return value - 11
+  }
+  def normalize12(value: Int): Int {
+    return value - 12
+  }
+  def normalize13(value: Int): Int {
+    return value - 13
+  }
+  def normalize14(value: Int): Int {
+    return value - 14
+  }
+  def normalize15(value: Int): Int {
+    return value - 15
+  }
+  def normalize16(value: Int): Int {
+    return value - 16
+  }
+  def normalize17(value: Int): Int {
+    return value - 17
+  }
+  def normalize18(value: Int): Int {
+    return value - 18
+  }
+  def normalize19(value: Int): Int {
+    return value - 19
+  }
+  def normalize20(value: Int): Int {
+    return value - 20
+  }
+  def normalize21(value: Int): Int {
+    return value - 21
+  }
+  def normalize22(value: Int): Int {
+    return value - 22
+  }
+  def normalize23(value: Int): Int {
+    return value - 23
+  }
+  def normalize24(value: Int): Int {
+    return value - 24
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage01.on
+++ b/benchmarks/fixtures/automation-project/Stage01.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage01 {
+public:
+  def step01(value: Int): Int {
+    return value + 2
+  }
+  def step02(value: Int): Int {
+    return value + 3
+  }
+  def step03(value: Int): Int {
+    return value + 4
+  }
+  def step04(value: Int): Int {
+    return value + 5
+  }
+  def step05(value: Int): Int {
+    return value + 6
+  }
+  def step06(value: Int): Int {
+    return value + 7
+  }
+  def step07(value: Int): Int {
+    return value + 8
+  }
+  def step08(value: Int): Int {
+    return value + 9
+  }
+  def step09(value: Int): Int {
+    return value + 10
+  }
+  def step10(value: Int): Int {
+    return value + 11
+  }
+  def step11(value: Int): Int {
+    return value + 12
+  }
+  def step12(value: Int): Int {
+    return value + 13
+  }
+  def step13(value: Int): Int {
+    return value + 14
+  }
+  def step14(value: Int): Int {
+    return value + 15
+  }
+  def step15(value: Int): Int {
+    return value + 16
+  }
+  def step16(value: Int): Int {
+    return value + 17
+  }
+  def step17(value: Int): Int {
+    return value + 18
+  }
+  def step18(value: Int): Int {
+    return value + 19
+  }
+  def step19(value: Int): Int {
+    return value + 20
+  }
+  def step20(value: Int): Int {
+    return value + 21
+  }
+  def step21(value: Int): Int {
+    return value + 22
+  }
+  def step22(value: Int): Int {
+    return value + 23
+  }
+  def step23(value: Int): Int {
+    return value + 24
+  }
+  def step24(value: Int): Int {
+    return value + 25
+  }
+  def step25(value: Int): Int {
+    return value + 26
+  }
+  def step26(value: Int): Int {
+    return value + 27
+  }
+  def step27(value: Int): Int {
+    return value + 28
+  }
+  def step28(value: Int): Int {
+    return value + 29
+  }
+  def step29(value: Int): Int {
+    return value + 30
+  }
+  def step30(value: Int): Int {
+    return value + 31
+  }
+  def step31(value: Int): Int {
+    return value + 32
+  }
+  def step32(value: Int): Int {
+    return value + 33
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage02.on
+++ b/benchmarks/fixtures/automation-project/Stage02.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage02 {
+public:
+  def step01(value: Int): Int {
+    return value + 3
+  }
+  def step02(value: Int): Int {
+    return value + 4
+  }
+  def step03(value: Int): Int {
+    return value + 5
+  }
+  def step04(value: Int): Int {
+    return value + 6
+  }
+  def step05(value: Int): Int {
+    return value + 7
+  }
+  def step06(value: Int): Int {
+    return value + 8
+  }
+  def step07(value: Int): Int {
+    return value + 9
+  }
+  def step08(value: Int): Int {
+    return value + 10
+  }
+  def step09(value: Int): Int {
+    return value + 11
+  }
+  def step10(value: Int): Int {
+    return value + 12
+  }
+  def step11(value: Int): Int {
+    return value + 13
+  }
+  def step12(value: Int): Int {
+    return value + 14
+  }
+  def step13(value: Int): Int {
+    return value + 15
+  }
+  def step14(value: Int): Int {
+    return value + 16
+  }
+  def step15(value: Int): Int {
+    return value + 17
+  }
+  def step16(value: Int): Int {
+    return value + 18
+  }
+  def step17(value: Int): Int {
+    return value + 19
+  }
+  def step18(value: Int): Int {
+    return value + 20
+  }
+  def step19(value: Int): Int {
+    return value + 21
+  }
+  def step20(value: Int): Int {
+    return value + 22
+  }
+  def step21(value: Int): Int {
+    return value + 23
+  }
+  def step22(value: Int): Int {
+    return value + 24
+  }
+  def step23(value: Int): Int {
+    return value + 25
+  }
+  def step24(value: Int): Int {
+    return value + 26
+  }
+  def step25(value: Int): Int {
+    return value + 27
+  }
+  def step26(value: Int): Int {
+    return value + 28
+  }
+  def step27(value: Int): Int {
+    return value + 29
+  }
+  def step28(value: Int): Int {
+    return value + 30
+  }
+  def step29(value: Int): Int {
+    return value + 31
+  }
+  def step30(value: Int): Int {
+    return value + 32
+  }
+  def step31(value: Int): Int {
+    return value + 33
+  }
+  def step32(value: Int): Int {
+    return value + 34
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage03.on
+++ b/benchmarks/fixtures/automation-project/Stage03.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage03 {
+public:
+  def step01(value: Int): Int {
+    return value + 4
+  }
+  def step02(value: Int): Int {
+    return value + 5
+  }
+  def step03(value: Int): Int {
+    return value + 6
+  }
+  def step04(value: Int): Int {
+    return value + 7
+  }
+  def step05(value: Int): Int {
+    return value + 8
+  }
+  def step06(value: Int): Int {
+    return value + 9
+  }
+  def step07(value: Int): Int {
+    return value + 10
+  }
+  def step08(value: Int): Int {
+    return value + 11
+  }
+  def step09(value: Int): Int {
+    return value + 12
+  }
+  def step10(value: Int): Int {
+    return value + 13
+  }
+  def step11(value: Int): Int {
+    return value + 14
+  }
+  def step12(value: Int): Int {
+    return value + 15
+  }
+  def step13(value: Int): Int {
+    return value + 16
+  }
+  def step14(value: Int): Int {
+    return value + 17
+  }
+  def step15(value: Int): Int {
+    return value + 18
+  }
+  def step16(value: Int): Int {
+    return value + 19
+  }
+  def step17(value: Int): Int {
+    return value + 20
+  }
+  def step18(value: Int): Int {
+    return value + 21
+  }
+  def step19(value: Int): Int {
+    return value + 22
+  }
+  def step20(value: Int): Int {
+    return value + 23
+  }
+  def step21(value: Int): Int {
+    return value + 24
+  }
+  def step22(value: Int): Int {
+    return value + 25
+  }
+  def step23(value: Int): Int {
+    return value + 26
+  }
+  def step24(value: Int): Int {
+    return value + 27
+  }
+  def step25(value: Int): Int {
+    return value + 28
+  }
+  def step26(value: Int): Int {
+    return value + 29
+  }
+  def step27(value: Int): Int {
+    return value + 30
+  }
+  def step28(value: Int): Int {
+    return value + 31
+  }
+  def step29(value: Int): Int {
+    return value + 32
+  }
+  def step30(value: Int): Int {
+    return value + 33
+  }
+  def step31(value: Int): Int {
+    return value + 34
+  }
+  def step32(value: Int): Int {
+    return value + 35
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage04.on
+++ b/benchmarks/fixtures/automation-project/Stage04.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage04 {
+public:
+  def step01(value: Int): Int {
+    return value + 5
+  }
+  def step02(value: Int): Int {
+    return value + 6
+  }
+  def step03(value: Int): Int {
+    return value + 7
+  }
+  def step04(value: Int): Int {
+    return value + 8
+  }
+  def step05(value: Int): Int {
+    return value + 9
+  }
+  def step06(value: Int): Int {
+    return value + 10
+  }
+  def step07(value: Int): Int {
+    return value + 11
+  }
+  def step08(value: Int): Int {
+    return value + 12
+  }
+  def step09(value: Int): Int {
+    return value + 13
+  }
+  def step10(value: Int): Int {
+    return value + 14
+  }
+  def step11(value: Int): Int {
+    return value + 15
+  }
+  def step12(value: Int): Int {
+    return value + 16
+  }
+  def step13(value: Int): Int {
+    return value + 17
+  }
+  def step14(value: Int): Int {
+    return value + 18
+  }
+  def step15(value: Int): Int {
+    return value + 19
+  }
+  def step16(value: Int): Int {
+    return value + 20
+  }
+  def step17(value: Int): Int {
+    return value + 21
+  }
+  def step18(value: Int): Int {
+    return value + 22
+  }
+  def step19(value: Int): Int {
+    return value + 23
+  }
+  def step20(value: Int): Int {
+    return value + 24
+  }
+  def step21(value: Int): Int {
+    return value + 25
+  }
+  def step22(value: Int): Int {
+    return value + 26
+  }
+  def step23(value: Int): Int {
+    return value + 27
+  }
+  def step24(value: Int): Int {
+    return value + 28
+  }
+  def step25(value: Int): Int {
+    return value + 29
+  }
+  def step26(value: Int): Int {
+    return value + 30
+  }
+  def step27(value: Int): Int {
+    return value + 31
+  }
+  def step28(value: Int): Int {
+    return value + 32
+  }
+  def step29(value: Int): Int {
+    return value + 33
+  }
+  def step30(value: Int): Int {
+    return value + 34
+  }
+  def step31(value: Int): Int {
+    return value + 35
+  }
+  def step32(value: Int): Int {
+    return value + 36
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage05.on
+++ b/benchmarks/fixtures/automation-project/Stage05.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage05 {
+public:
+  def step01(value: Int): Int {
+    return value + 6
+  }
+  def step02(value: Int): Int {
+    return value + 7
+  }
+  def step03(value: Int): Int {
+    return value + 8
+  }
+  def step04(value: Int): Int {
+    return value + 9
+  }
+  def step05(value: Int): Int {
+    return value + 10
+  }
+  def step06(value: Int): Int {
+    return value + 11
+  }
+  def step07(value: Int): Int {
+    return value + 12
+  }
+  def step08(value: Int): Int {
+    return value + 13
+  }
+  def step09(value: Int): Int {
+    return value + 14
+  }
+  def step10(value: Int): Int {
+    return value + 15
+  }
+  def step11(value: Int): Int {
+    return value + 16
+  }
+  def step12(value: Int): Int {
+    return value + 17
+  }
+  def step13(value: Int): Int {
+    return value + 18
+  }
+  def step14(value: Int): Int {
+    return value + 19
+  }
+  def step15(value: Int): Int {
+    return value + 20
+  }
+  def step16(value: Int): Int {
+    return value + 21
+  }
+  def step17(value: Int): Int {
+    return value + 22
+  }
+  def step18(value: Int): Int {
+    return value + 23
+  }
+  def step19(value: Int): Int {
+    return value + 24
+  }
+  def step20(value: Int): Int {
+    return value + 25
+  }
+  def step21(value: Int): Int {
+    return value + 26
+  }
+  def step22(value: Int): Int {
+    return value + 27
+  }
+  def step23(value: Int): Int {
+    return value + 28
+  }
+  def step24(value: Int): Int {
+    return value + 29
+  }
+  def step25(value: Int): Int {
+    return value + 30
+  }
+  def step26(value: Int): Int {
+    return value + 31
+  }
+  def step27(value: Int): Int {
+    return value + 32
+  }
+  def step28(value: Int): Int {
+    return value + 33
+  }
+  def step29(value: Int): Int {
+    return value + 34
+  }
+  def step30(value: Int): Int {
+    return value + 35
+  }
+  def step31(value: Int): Int {
+    return value + 36
+  }
+  def step32(value: Int): Int {
+    return value + 37
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage06.on
+++ b/benchmarks/fixtures/automation-project/Stage06.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage06 {
+public:
+  def step01(value: Int): Int {
+    return value + 7
+  }
+  def step02(value: Int): Int {
+    return value + 8
+  }
+  def step03(value: Int): Int {
+    return value + 9
+  }
+  def step04(value: Int): Int {
+    return value + 10
+  }
+  def step05(value: Int): Int {
+    return value + 11
+  }
+  def step06(value: Int): Int {
+    return value + 12
+  }
+  def step07(value: Int): Int {
+    return value + 13
+  }
+  def step08(value: Int): Int {
+    return value + 14
+  }
+  def step09(value: Int): Int {
+    return value + 15
+  }
+  def step10(value: Int): Int {
+    return value + 16
+  }
+  def step11(value: Int): Int {
+    return value + 17
+  }
+  def step12(value: Int): Int {
+    return value + 18
+  }
+  def step13(value: Int): Int {
+    return value + 19
+  }
+  def step14(value: Int): Int {
+    return value + 20
+  }
+  def step15(value: Int): Int {
+    return value + 21
+  }
+  def step16(value: Int): Int {
+    return value + 22
+  }
+  def step17(value: Int): Int {
+    return value + 23
+  }
+  def step18(value: Int): Int {
+    return value + 24
+  }
+  def step19(value: Int): Int {
+    return value + 25
+  }
+  def step20(value: Int): Int {
+    return value + 26
+  }
+  def step21(value: Int): Int {
+    return value + 27
+  }
+  def step22(value: Int): Int {
+    return value + 28
+  }
+  def step23(value: Int): Int {
+    return value + 29
+  }
+  def step24(value: Int): Int {
+    return value + 30
+  }
+  def step25(value: Int): Int {
+    return value + 31
+  }
+  def step26(value: Int): Int {
+    return value + 32
+  }
+  def step27(value: Int): Int {
+    return value + 33
+  }
+  def step28(value: Int): Int {
+    return value + 34
+  }
+  def step29(value: Int): Int {
+    return value + 35
+  }
+  def step30(value: Int): Int {
+    return value + 36
+  }
+  def step31(value: Int): Int {
+    return value + 37
+  }
+  def step32(value: Int): Int {
+    return value + 38
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage07.on
+++ b/benchmarks/fixtures/automation-project/Stage07.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage07 {
+public:
+  def step01(value: Int): Int {
+    return value + 8
+  }
+  def step02(value: Int): Int {
+    return value + 9
+  }
+  def step03(value: Int): Int {
+    return value + 10
+  }
+  def step04(value: Int): Int {
+    return value + 11
+  }
+  def step05(value: Int): Int {
+    return value + 12
+  }
+  def step06(value: Int): Int {
+    return value + 13
+  }
+  def step07(value: Int): Int {
+    return value + 14
+  }
+  def step08(value: Int): Int {
+    return value + 15
+  }
+  def step09(value: Int): Int {
+    return value + 16
+  }
+  def step10(value: Int): Int {
+    return value + 17
+  }
+  def step11(value: Int): Int {
+    return value + 18
+  }
+  def step12(value: Int): Int {
+    return value + 19
+  }
+  def step13(value: Int): Int {
+    return value + 20
+  }
+  def step14(value: Int): Int {
+    return value + 21
+  }
+  def step15(value: Int): Int {
+    return value + 22
+  }
+  def step16(value: Int): Int {
+    return value + 23
+  }
+  def step17(value: Int): Int {
+    return value + 24
+  }
+  def step18(value: Int): Int {
+    return value + 25
+  }
+  def step19(value: Int): Int {
+    return value + 26
+  }
+  def step20(value: Int): Int {
+    return value + 27
+  }
+  def step21(value: Int): Int {
+    return value + 28
+  }
+  def step22(value: Int): Int {
+    return value + 29
+  }
+  def step23(value: Int): Int {
+    return value + 30
+  }
+  def step24(value: Int): Int {
+    return value + 31
+  }
+  def step25(value: Int): Int {
+    return value + 32
+  }
+  def step26(value: Int): Int {
+    return value + 33
+  }
+  def step27(value: Int): Int {
+    return value + 34
+  }
+  def step28(value: Int): Int {
+    return value + 35
+  }
+  def step29(value: Int): Int {
+    return value + 36
+  }
+  def step30(value: Int): Int {
+    return value + 37
+  }
+  def step31(value: Int): Int {
+    return value + 38
+  }
+  def step32(value: Int): Int {
+    return value + 39
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage08.on
+++ b/benchmarks/fixtures/automation-project/Stage08.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage08 {
+public:
+  def step01(value: Int): Int {
+    return value + 9
+  }
+  def step02(value: Int): Int {
+    return value + 10
+  }
+  def step03(value: Int): Int {
+    return value + 11
+  }
+  def step04(value: Int): Int {
+    return value + 12
+  }
+  def step05(value: Int): Int {
+    return value + 13
+  }
+  def step06(value: Int): Int {
+    return value + 14
+  }
+  def step07(value: Int): Int {
+    return value + 15
+  }
+  def step08(value: Int): Int {
+    return value + 16
+  }
+  def step09(value: Int): Int {
+    return value + 17
+  }
+  def step10(value: Int): Int {
+    return value + 18
+  }
+  def step11(value: Int): Int {
+    return value + 19
+  }
+  def step12(value: Int): Int {
+    return value + 20
+  }
+  def step13(value: Int): Int {
+    return value + 21
+  }
+  def step14(value: Int): Int {
+    return value + 22
+  }
+  def step15(value: Int): Int {
+    return value + 23
+  }
+  def step16(value: Int): Int {
+    return value + 24
+  }
+  def step17(value: Int): Int {
+    return value + 25
+  }
+  def step18(value: Int): Int {
+    return value + 26
+  }
+  def step19(value: Int): Int {
+    return value + 27
+  }
+  def step20(value: Int): Int {
+    return value + 28
+  }
+  def step21(value: Int): Int {
+    return value + 29
+  }
+  def step22(value: Int): Int {
+    return value + 30
+  }
+  def step23(value: Int): Int {
+    return value + 31
+  }
+  def step24(value: Int): Int {
+    return value + 32
+  }
+  def step25(value: Int): Int {
+    return value + 33
+  }
+  def step26(value: Int): Int {
+    return value + 34
+  }
+  def step27(value: Int): Int {
+    return value + 35
+  }
+  def step28(value: Int): Int {
+    return value + 36
+  }
+  def step29(value: Int): Int {
+    return value + 37
+  }
+  def step30(value: Int): Int {
+    return value + 38
+  }
+  def step31(value: Int): Int {
+    return value + 39
+  }
+  def step32(value: Int): Int {
+    return value + 40
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage09.on
+++ b/benchmarks/fixtures/automation-project/Stage09.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage09 {
+public:
+  def step01(value: Int): Int {
+    return value + 10
+  }
+  def step02(value: Int): Int {
+    return value + 11
+  }
+  def step03(value: Int): Int {
+    return value + 12
+  }
+  def step04(value: Int): Int {
+    return value + 13
+  }
+  def step05(value: Int): Int {
+    return value + 14
+  }
+  def step06(value: Int): Int {
+    return value + 15
+  }
+  def step07(value: Int): Int {
+    return value + 16
+  }
+  def step08(value: Int): Int {
+    return value + 17
+  }
+  def step09(value: Int): Int {
+    return value + 18
+  }
+  def step10(value: Int): Int {
+    return value + 19
+  }
+  def step11(value: Int): Int {
+    return value + 20
+  }
+  def step12(value: Int): Int {
+    return value + 21
+  }
+  def step13(value: Int): Int {
+    return value + 22
+  }
+  def step14(value: Int): Int {
+    return value + 23
+  }
+  def step15(value: Int): Int {
+    return value + 24
+  }
+  def step16(value: Int): Int {
+    return value + 25
+  }
+  def step17(value: Int): Int {
+    return value + 26
+  }
+  def step18(value: Int): Int {
+    return value + 27
+  }
+  def step19(value: Int): Int {
+    return value + 28
+  }
+  def step20(value: Int): Int {
+    return value + 29
+  }
+  def step21(value: Int): Int {
+    return value + 30
+  }
+  def step22(value: Int): Int {
+    return value + 31
+  }
+  def step23(value: Int): Int {
+    return value + 32
+  }
+  def step24(value: Int): Int {
+    return value + 33
+  }
+  def step25(value: Int): Int {
+    return value + 34
+  }
+  def step26(value: Int): Int {
+    return value + 35
+  }
+  def step27(value: Int): Int {
+    return value + 36
+  }
+  def step28(value: Int): Int {
+    return value + 37
+  }
+  def step29(value: Int): Int {
+    return value + 38
+  }
+  def step30(value: Int): Int {
+    return value + 39
+  }
+  def step31(value: Int): Int {
+    return value + 40
+  }
+  def step32(value: Int): Int {
+    return value + 41
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage10.on
+++ b/benchmarks/fixtures/automation-project/Stage10.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage10 {
+public:
+  def step01(value: Int): Int {
+    return value + 11
+  }
+  def step02(value: Int): Int {
+    return value + 12
+  }
+  def step03(value: Int): Int {
+    return value + 13
+  }
+  def step04(value: Int): Int {
+    return value + 14
+  }
+  def step05(value: Int): Int {
+    return value + 15
+  }
+  def step06(value: Int): Int {
+    return value + 16
+  }
+  def step07(value: Int): Int {
+    return value + 17
+  }
+  def step08(value: Int): Int {
+    return value + 18
+  }
+  def step09(value: Int): Int {
+    return value + 19
+  }
+  def step10(value: Int): Int {
+    return value + 20
+  }
+  def step11(value: Int): Int {
+    return value + 21
+  }
+  def step12(value: Int): Int {
+    return value + 22
+  }
+  def step13(value: Int): Int {
+    return value + 23
+  }
+  def step14(value: Int): Int {
+    return value + 24
+  }
+  def step15(value: Int): Int {
+    return value + 25
+  }
+  def step16(value: Int): Int {
+    return value + 26
+  }
+  def step17(value: Int): Int {
+    return value + 27
+  }
+  def step18(value: Int): Int {
+    return value + 28
+  }
+  def step19(value: Int): Int {
+    return value + 29
+  }
+  def step20(value: Int): Int {
+    return value + 30
+  }
+  def step21(value: Int): Int {
+    return value + 31
+  }
+  def step22(value: Int): Int {
+    return value + 32
+  }
+  def step23(value: Int): Int {
+    return value + 33
+  }
+  def step24(value: Int): Int {
+    return value + 34
+  }
+  def step25(value: Int): Int {
+    return value + 35
+  }
+  def step26(value: Int): Int {
+    return value + 36
+  }
+  def step27(value: Int): Int {
+    return value + 37
+  }
+  def step28(value: Int): Int {
+    return value + 38
+  }
+  def step29(value: Int): Int {
+    return value + 39
+  }
+  def step30(value: Int): Int {
+    return value + 40
+  }
+  def step31(value: Int): Int {
+    return value + 41
+  }
+  def step32(value: Int): Int {
+    return value + 42
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage11.on
+++ b/benchmarks/fixtures/automation-project/Stage11.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage11 {
+public:
+  def step01(value: Int): Int {
+    return value + 12
+  }
+  def step02(value: Int): Int {
+    return value + 13
+  }
+  def step03(value: Int): Int {
+    return value + 14
+  }
+  def step04(value: Int): Int {
+    return value + 15
+  }
+  def step05(value: Int): Int {
+    return value + 16
+  }
+  def step06(value: Int): Int {
+    return value + 17
+  }
+  def step07(value: Int): Int {
+    return value + 18
+  }
+  def step08(value: Int): Int {
+    return value + 19
+  }
+  def step09(value: Int): Int {
+    return value + 20
+  }
+  def step10(value: Int): Int {
+    return value + 21
+  }
+  def step11(value: Int): Int {
+    return value + 22
+  }
+  def step12(value: Int): Int {
+    return value + 23
+  }
+  def step13(value: Int): Int {
+    return value + 24
+  }
+  def step14(value: Int): Int {
+    return value + 25
+  }
+  def step15(value: Int): Int {
+    return value + 26
+  }
+  def step16(value: Int): Int {
+    return value + 27
+  }
+  def step17(value: Int): Int {
+    return value + 28
+  }
+  def step18(value: Int): Int {
+    return value + 29
+  }
+  def step19(value: Int): Int {
+    return value + 30
+  }
+  def step20(value: Int): Int {
+    return value + 31
+  }
+  def step21(value: Int): Int {
+    return value + 32
+  }
+  def step22(value: Int): Int {
+    return value + 33
+  }
+  def step23(value: Int): Int {
+    return value + 34
+  }
+  def step24(value: Int): Int {
+    return value + 35
+  }
+  def step25(value: Int): Int {
+    return value + 36
+  }
+  def step26(value: Int): Int {
+    return value + 37
+  }
+  def step27(value: Int): Int {
+    return value + 38
+  }
+  def step28(value: Int): Int {
+    return value + 39
+  }
+  def step29(value: Int): Int {
+    return value + 40
+  }
+  def step30(value: Int): Int {
+    return value + 41
+  }
+  def step31(value: Int): Int {
+    return value + 42
+  }
+  def step32(value: Int): Int {
+    return value + 43
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage12.on
+++ b/benchmarks/fixtures/automation-project/Stage12.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage12 {
+public:
+  def step01(value: Int): Int {
+    return value + 13
+  }
+  def step02(value: Int): Int {
+    return value + 14
+  }
+  def step03(value: Int): Int {
+    return value + 15
+  }
+  def step04(value: Int): Int {
+    return value + 16
+  }
+  def step05(value: Int): Int {
+    return value + 17
+  }
+  def step06(value: Int): Int {
+    return value + 18
+  }
+  def step07(value: Int): Int {
+    return value + 19
+  }
+  def step08(value: Int): Int {
+    return value + 20
+  }
+  def step09(value: Int): Int {
+    return value + 21
+  }
+  def step10(value: Int): Int {
+    return value + 22
+  }
+  def step11(value: Int): Int {
+    return value + 23
+  }
+  def step12(value: Int): Int {
+    return value + 24
+  }
+  def step13(value: Int): Int {
+    return value + 25
+  }
+  def step14(value: Int): Int {
+    return value + 26
+  }
+  def step15(value: Int): Int {
+    return value + 27
+  }
+  def step16(value: Int): Int {
+    return value + 28
+  }
+  def step17(value: Int): Int {
+    return value + 29
+  }
+  def step18(value: Int): Int {
+    return value + 30
+  }
+  def step19(value: Int): Int {
+    return value + 31
+  }
+  def step20(value: Int): Int {
+    return value + 32
+  }
+  def step21(value: Int): Int {
+    return value + 33
+  }
+  def step22(value: Int): Int {
+    return value + 34
+  }
+  def step23(value: Int): Int {
+    return value + 35
+  }
+  def step24(value: Int): Int {
+    return value + 36
+  }
+  def step25(value: Int): Int {
+    return value + 37
+  }
+  def step26(value: Int): Int {
+    return value + 38
+  }
+  def step27(value: Int): Int {
+    return value + 39
+  }
+  def step28(value: Int): Int {
+    return value + 40
+  }
+  def step29(value: Int): Int {
+    return value + 41
+  }
+  def step30(value: Int): Int {
+    return value + 42
+  }
+  def step31(value: Int): Int {
+    return value + 43
+  }
+  def step32(value: Int): Int {
+    return value + 44
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage13.on
+++ b/benchmarks/fixtures/automation-project/Stage13.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage13 {
+public:
+  def step01(value: Int): Int {
+    return value + 14
+  }
+  def step02(value: Int): Int {
+    return value + 15
+  }
+  def step03(value: Int): Int {
+    return value + 16
+  }
+  def step04(value: Int): Int {
+    return value + 17
+  }
+  def step05(value: Int): Int {
+    return value + 18
+  }
+  def step06(value: Int): Int {
+    return value + 19
+  }
+  def step07(value: Int): Int {
+    return value + 20
+  }
+  def step08(value: Int): Int {
+    return value + 21
+  }
+  def step09(value: Int): Int {
+    return value + 22
+  }
+  def step10(value: Int): Int {
+    return value + 23
+  }
+  def step11(value: Int): Int {
+    return value + 24
+  }
+  def step12(value: Int): Int {
+    return value + 25
+  }
+  def step13(value: Int): Int {
+    return value + 26
+  }
+  def step14(value: Int): Int {
+    return value + 27
+  }
+  def step15(value: Int): Int {
+    return value + 28
+  }
+  def step16(value: Int): Int {
+    return value + 29
+  }
+  def step17(value: Int): Int {
+    return value + 30
+  }
+  def step18(value: Int): Int {
+    return value + 31
+  }
+  def step19(value: Int): Int {
+    return value + 32
+  }
+  def step20(value: Int): Int {
+    return value + 33
+  }
+  def step21(value: Int): Int {
+    return value + 34
+  }
+  def step22(value: Int): Int {
+    return value + 35
+  }
+  def step23(value: Int): Int {
+    return value + 36
+  }
+  def step24(value: Int): Int {
+    return value + 37
+  }
+  def step25(value: Int): Int {
+    return value + 38
+  }
+  def step26(value: Int): Int {
+    return value + 39
+  }
+  def step27(value: Int): Int {
+    return value + 40
+  }
+  def step28(value: Int): Int {
+    return value + 41
+  }
+  def step29(value: Int): Int {
+    return value + 42
+  }
+  def step30(value: Int): Int {
+    return value + 43
+  }
+  def step31(value: Int): Int {
+    return value + 44
+  }
+  def step32(value: Int): Int {
+    return value + 45
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage14.on
+++ b/benchmarks/fixtures/automation-project/Stage14.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage14 {
+public:
+  def step01(value: Int): Int {
+    return value + 15
+  }
+  def step02(value: Int): Int {
+    return value + 16
+  }
+  def step03(value: Int): Int {
+    return value + 17
+  }
+  def step04(value: Int): Int {
+    return value + 18
+  }
+  def step05(value: Int): Int {
+    return value + 19
+  }
+  def step06(value: Int): Int {
+    return value + 20
+  }
+  def step07(value: Int): Int {
+    return value + 21
+  }
+  def step08(value: Int): Int {
+    return value + 22
+  }
+  def step09(value: Int): Int {
+    return value + 23
+  }
+  def step10(value: Int): Int {
+    return value + 24
+  }
+  def step11(value: Int): Int {
+    return value + 25
+  }
+  def step12(value: Int): Int {
+    return value + 26
+  }
+  def step13(value: Int): Int {
+    return value + 27
+  }
+  def step14(value: Int): Int {
+    return value + 28
+  }
+  def step15(value: Int): Int {
+    return value + 29
+  }
+  def step16(value: Int): Int {
+    return value + 30
+  }
+  def step17(value: Int): Int {
+    return value + 31
+  }
+  def step18(value: Int): Int {
+    return value + 32
+  }
+  def step19(value: Int): Int {
+    return value + 33
+  }
+  def step20(value: Int): Int {
+    return value + 34
+  }
+  def step21(value: Int): Int {
+    return value + 35
+  }
+  def step22(value: Int): Int {
+    return value + 36
+  }
+  def step23(value: Int): Int {
+    return value + 37
+  }
+  def step24(value: Int): Int {
+    return value + 38
+  }
+  def step25(value: Int): Int {
+    return value + 39
+  }
+  def step26(value: Int): Int {
+    return value + 40
+  }
+  def step27(value: Int): Int {
+    return value + 41
+  }
+  def step28(value: Int): Int {
+    return value + 42
+  }
+  def step29(value: Int): Int {
+    return value + 43
+  }
+  def step30(value: Int): Int {
+    return value + 44
+  }
+  def step31(value: Int): Int {
+    return value + 45
+  }
+  def step32(value: Int): Int {
+    return value + 46
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage15.on
+++ b/benchmarks/fixtures/automation-project/Stage15.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage15 {
+public:
+  def step01(value: Int): Int {
+    return value + 16
+  }
+  def step02(value: Int): Int {
+    return value + 17
+  }
+  def step03(value: Int): Int {
+    return value + 18
+  }
+  def step04(value: Int): Int {
+    return value + 19
+  }
+  def step05(value: Int): Int {
+    return value + 20
+  }
+  def step06(value: Int): Int {
+    return value + 21
+  }
+  def step07(value: Int): Int {
+    return value + 22
+  }
+  def step08(value: Int): Int {
+    return value + 23
+  }
+  def step09(value: Int): Int {
+    return value + 24
+  }
+  def step10(value: Int): Int {
+    return value + 25
+  }
+  def step11(value: Int): Int {
+    return value + 26
+  }
+  def step12(value: Int): Int {
+    return value + 27
+  }
+  def step13(value: Int): Int {
+    return value + 28
+  }
+  def step14(value: Int): Int {
+    return value + 29
+  }
+  def step15(value: Int): Int {
+    return value + 30
+  }
+  def step16(value: Int): Int {
+    return value + 31
+  }
+  def step17(value: Int): Int {
+    return value + 32
+  }
+  def step18(value: Int): Int {
+    return value + 33
+  }
+  def step19(value: Int): Int {
+    return value + 34
+  }
+  def step20(value: Int): Int {
+    return value + 35
+  }
+  def step21(value: Int): Int {
+    return value + 36
+  }
+  def step22(value: Int): Int {
+    return value + 37
+  }
+  def step23(value: Int): Int {
+    return value + 38
+  }
+  def step24(value: Int): Int {
+    return value + 39
+  }
+  def step25(value: Int): Int {
+    return value + 40
+  }
+  def step26(value: Int): Int {
+    return value + 41
+  }
+  def step27(value: Int): Int {
+    return value + 42
+  }
+  def step28(value: Int): Int {
+    return value + 43
+  }
+  def step29(value: Int): Int {
+    return value + 44
+  }
+  def step30(value: Int): Int {
+    return value + 45
+  }
+  def step31(value: Int): Int {
+    return value + 46
+  }
+  def step32(value: Int): Int {
+    return value + 47
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage16.on
+++ b/benchmarks/fixtures/automation-project/Stage16.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage16 {
+public:
+  def step01(value: Int): Int {
+    return value + 17
+  }
+  def step02(value: Int): Int {
+    return value + 18
+  }
+  def step03(value: Int): Int {
+    return value + 19
+  }
+  def step04(value: Int): Int {
+    return value + 20
+  }
+  def step05(value: Int): Int {
+    return value + 21
+  }
+  def step06(value: Int): Int {
+    return value + 22
+  }
+  def step07(value: Int): Int {
+    return value + 23
+  }
+  def step08(value: Int): Int {
+    return value + 24
+  }
+  def step09(value: Int): Int {
+    return value + 25
+  }
+  def step10(value: Int): Int {
+    return value + 26
+  }
+  def step11(value: Int): Int {
+    return value + 27
+  }
+  def step12(value: Int): Int {
+    return value + 28
+  }
+  def step13(value: Int): Int {
+    return value + 29
+  }
+  def step14(value: Int): Int {
+    return value + 30
+  }
+  def step15(value: Int): Int {
+    return value + 31
+  }
+  def step16(value: Int): Int {
+    return value + 32
+  }
+  def step17(value: Int): Int {
+    return value + 33
+  }
+  def step18(value: Int): Int {
+    return value + 34
+  }
+  def step19(value: Int): Int {
+    return value + 35
+  }
+  def step20(value: Int): Int {
+    return value + 36
+  }
+  def step21(value: Int): Int {
+    return value + 37
+  }
+  def step22(value: Int): Int {
+    return value + 38
+  }
+  def step23(value: Int): Int {
+    return value + 39
+  }
+  def step24(value: Int): Int {
+    return value + 40
+  }
+  def step25(value: Int): Int {
+    return value + 41
+  }
+  def step26(value: Int): Int {
+    return value + 42
+  }
+  def step27(value: Int): Int {
+    return value + 43
+  }
+  def step28(value: Int): Int {
+    return value + 44
+  }
+  def step29(value: Int): Int {
+    return value + 45
+  }
+  def step30(value: Int): Int {
+    return value + 46
+  }
+  def step31(value: Int): Int {
+    return value + 47
+  }
+  def step32(value: Int): Int {
+    return value + 48
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage17.on
+++ b/benchmarks/fixtures/automation-project/Stage17.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage17 {
+public:
+  def step01(value: Int): Int {
+    return value + 18
+  }
+  def step02(value: Int): Int {
+    return value + 19
+  }
+  def step03(value: Int): Int {
+    return value + 20
+  }
+  def step04(value: Int): Int {
+    return value + 21
+  }
+  def step05(value: Int): Int {
+    return value + 22
+  }
+  def step06(value: Int): Int {
+    return value + 23
+  }
+  def step07(value: Int): Int {
+    return value + 24
+  }
+  def step08(value: Int): Int {
+    return value + 25
+  }
+  def step09(value: Int): Int {
+    return value + 26
+  }
+  def step10(value: Int): Int {
+    return value + 27
+  }
+  def step11(value: Int): Int {
+    return value + 28
+  }
+  def step12(value: Int): Int {
+    return value + 29
+  }
+  def step13(value: Int): Int {
+    return value + 30
+  }
+  def step14(value: Int): Int {
+    return value + 31
+  }
+  def step15(value: Int): Int {
+    return value + 32
+  }
+  def step16(value: Int): Int {
+    return value + 33
+  }
+  def step17(value: Int): Int {
+    return value + 34
+  }
+  def step18(value: Int): Int {
+    return value + 35
+  }
+  def step19(value: Int): Int {
+    return value + 36
+  }
+  def step20(value: Int): Int {
+    return value + 37
+  }
+  def step21(value: Int): Int {
+    return value + 38
+  }
+  def step22(value: Int): Int {
+    return value + 39
+  }
+  def step23(value: Int): Int {
+    return value + 40
+  }
+  def step24(value: Int): Int {
+    return value + 41
+  }
+  def step25(value: Int): Int {
+    return value + 42
+  }
+  def step26(value: Int): Int {
+    return value + 43
+  }
+  def step27(value: Int): Int {
+    return value + 44
+  }
+  def step28(value: Int): Int {
+    return value + 45
+  }
+  def step29(value: Int): Int {
+    return value + 46
+  }
+  def step30(value: Int): Int {
+    return value + 47
+  }
+  def step31(value: Int): Int {
+    return value + 48
+  }
+  def step32(value: Int): Int {
+    return value + 49
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage18.on
+++ b/benchmarks/fixtures/automation-project/Stage18.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage18 {
+public:
+  def step01(value: Int): Int {
+    return value + 19
+  }
+  def step02(value: Int): Int {
+    return value + 20
+  }
+  def step03(value: Int): Int {
+    return value + 21
+  }
+  def step04(value: Int): Int {
+    return value + 22
+  }
+  def step05(value: Int): Int {
+    return value + 23
+  }
+  def step06(value: Int): Int {
+    return value + 24
+  }
+  def step07(value: Int): Int {
+    return value + 25
+  }
+  def step08(value: Int): Int {
+    return value + 26
+  }
+  def step09(value: Int): Int {
+    return value + 27
+  }
+  def step10(value: Int): Int {
+    return value + 28
+  }
+  def step11(value: Int): Int {
+    return value + 29
+  }
+  def step12(value: Int): Int {
+    return value + 30
+  }
+  def step13(value: Int): Int {
+    return value + 31
+  }
+  def step14(value: Int): Int {
+    return value + 32
+  }
+  def step15(value: Int): Int {
+    return value + 33
+  }
+  def step16(value: Int): Int {
+    return value + 34
+  }
+  def step17(value: Int): Int {
+    return value + 35
+  }
+  def step18(value: Int): Int {
+    return value + 36
+  }
+  def step19(value: Int): Int {
+    return value + 37
+  }
+  def step20(value: Int): Int {
+    return value + 38
+  }
+  def step21(value: Int): Int {
+    return value + 39
+  }
+  def step22(value: Int): Int {
+    return value + 40
+  }
+  def step23(value: Int): Int {
+    return value + 41
+  }
+  def step24(value: Int): Int {
+    return value + 42
+  }
+  def step25(value: Int): Int {
+    return value + 43
+  }
+  def step26(value: Int): Int {
+    return value + 44
+  }
+  def step27(value: Int): Int {
+    return value + 45
+  }
+  def step28(value: Int): Int {
+    return value + 46
+  }
+  def step29(value: Int): Int {
+    return value + 47
+  }
+  def step30(value: Int): Int {
+    return value + 48
+  }
+  def step31(value: Int): Int {
+    return value + 49
+  }
+  def step32(value: Int): Int {
+    return value + 50
+  }
+}

--- a/benchmarks/fixtures/automation-project/Stage19.on
+++ b/benchmarks/fixtures/automation-project/Stage19.on
@@ -1,0 +1,101 @@
+module readiness.automation
+
+class Stage19 {
+public:
+  def step01(value: Int): Int {
+    return value + 20
+  }
+  def step02(value: Int): Int {
+    return value + 21
+  }
+  def step03(value: Int): Int {
+    return value + 22
+  }
+  def step04(value: Int): Int {
+    return value + 23
+  }
+  def step05(value: Int): Int {
+    return value + 24
+  }
+  def step06(value: Int): Int {
+    return value + 25
+  }
+  def step07(value: Int): Int {
+    return value + 26
+  }
+  def step08(value: Int): Int {
+    return value + 27
+  }
+  def step09(value: Int): Int {
+    return value + 28
+  }
+  def step10(value: Int): Int {
+    return value + 29
+  }
+  def step11(value: Int): Int {
+    return value + 30
+  }
+  def step12(value: Int): Int {
+    return value + 31
+  }
+  def step13(value: Int): Int {
+    return value + 32
+  }
+  def step14(value: Int): Int {
+    return value + 33
+  }
+  def step15(value: Int): Int {
+    return value + 34
+  }
+  def step16(value: Int): Int {
+    return value + 35
+  }
+  def step17(value: Int): Int {
+    return value + 36
+  }
+  def step18(value: Int): Int {
+    return value + 37
+  }
+  def step19(value: Int): Int {
+    return value + 38
+  }
+  def step20(value: Int): Int {
+    return value + 39
+  }
+  def step21(value: Int): Int {
+    return value + 40
+  }
+  def step22(value: Int): Int {
+    return value + 41
+  }
+  def step23(value: Int): Int {
+    return value + 42
+  }
+  def step24(value: Int): Int {
+    return value + 43
+  }
+  def step25(value: Int): Int {
+    return value + 44
+  }
+  def step26(value: Int): Int {
+    return value + 45
+  }
+  def step27(value: Int): Int {
+    return value + 46
+  }
+  def step28(value: Int): Int {
+    return value + 47
+  }
+  def step29(value: Int): Int {
+    return value + 48
+  }
+  def step30(value: Int): Int {
+    return value + 49
+  }
+  def step31(value: Int): Int {
+    return value + 50
+  }
+  def step32(value: Int): Int {
+    return value + 51
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val dist = taskKey[Unit]("Builds a runnable distribution under target/dist"
 lazy val distPath = settingKey[File]("Output directory used by the dist task")
 
 lazy val runScript = inputKey[Unit]("Runs the ScriptRunner with arguments")
-lazy val bench = inputKey[Unit]("Runs the benchmark suite")
+lazy val bench = inputKey[Unit]("Runs the benchmark suite (compatibility alias)")
+lazy val benchmark = inputKey[Unit]("Runs the versioned readiness benchmark suite")
 
 fullRunInputTask(
   runScript,
@@ -22,6 +23,12 @@ fullRunInputTask(
 
 fullRunInputTask(
   bench,
+  Compile,
+  "onion.tools.BenchmarkRunner"
+)
+
+fullRunInputTask(
+  benchmark,
   Compile,
   "onion.tools.BenchmarkRunner"
 )

--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -217,14 +217,32 @@ The default suite reports six explicit protocols:
 
 Process-cold uses 3 warmups by default; the other protocols use 8. Every
 protocol uses 25 measured iterations and a 30-second iteration timeout.
-`--warmups N` overrides the scenario defaults. The schema-v2 JSON report stores
+`--warmups N` overrides the scenario defaults. The schema-v3 JSON report stores
 the effective configuration beside every scenario so unlike lifecycles are
 never presented as identical measurements. It also retains raw nanosecond
 observations, median and p95 latency, phase timings where available, source
-metrics, and JVM/OS metadata.
+metrics, JVM/OS metadata, assigned memory, and typed absolute-policy checks.
+
+The first practical milestone uses these inclusive latency ceilings:
+
+| Protocol | Median | p95 |
+|---|---:|---:|
+| Fresh `onion Hello.on` process | 1.5 s | 2.5 s |
+| Steady-state compile of `Hello.on` | 150 ms | 300 ms |
+| Steady-state compile of `StatsApp.on` | 750 ms | 1.2 s |
+| Subsequent REPL snippet | 100 ms | 250 ms |
+| 20-file/~2,000-line project | 2.0 s | 3.0 s |
+
+The absolute policy is enforced only when the captured environment exactly
+matches the reference lane: Ubuntu 24.04 x86-64, Eclipse Adoptium Temurin
+JDK 21, two assigned processors, 4 GiB assigned memory, a 2 GiB maximum heap,
+and G1. A breach on that lane fails the benchmark task. On every other
+machine, the checks are `not-applicable` and the overall policy status is
+`informational`; those measurements are useful for profiling but do not count
+as release evidence.
 
 The machine-readable report is written to
-`target/readiness/benchmark-v2.json`. For a quick protocol smoke test:
+`target/readiness/benchmark-v3.json`. For a quick protocol smoke test:
 
 ```bash
 sbt 'benchmark --warmups 0 --iterations 1'

--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -199,11 +199,27 @@ Run the promoted REPL:
 sbt repl
 ```
 
-Run the benchmark suite:
+Run the readiness benchmark suite:
 
 ```bash
-sbt bench
+sbt benchmark
 ```
+
+The default suite measures a fresh Onion compiler inside an already-warmed JVM
+against `run/Hello.on`, `run/TodoManager.on`, and `run/StatsApp.on`. It reports
+raw nanosecond observations, median and p95 latency, phase timings, source
+metrics, and JVM/OS metadata. This is a **steady-state fresh-compiler**
+measurement; it does not include JVM process startup and does not imply a
+persistent compiler cache.
+
+The machine-readable report is written to
+`target/readiness/benchmark-v1.json`. For a quick protocol smoke test:
+
+```bash
+sbt 'benchmark --warmups 0 --iterations 1'
+```
+
+`sbt bench` remains a compatibility alias and accepts the same options.
 
 Emit compile profiles:
 

--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -205,15 +205,26 @@ Run the readiness benchmark suite:
 sbt benchmark
 ```
 
-The default suite measures a fresh Onion compiler inside an already-warmed JVM
-against `run/Hello.on`, `run/TodoManager.on`, and `run/StatsApp.on`. It reports
-raw nanosecond observations, median and p95 latency, phase timings, source
-metrics, and JVM/OS metadata. This is a **steady-state fresh-compiler**
-measurement; it does not include JVM process startup and does not imply a
-persistent compiler cache.
+The default suite reports six explicit protocols:
+
+- steady-state fresh compiler measurements for `run/Hello.on`,
+  `run/TodoManager.on`, and `run/StatsApp.on`;
+- a process-cold `onion run/Hello.on` measurement that includes child-JVM
+  startup and shutdown;
+- submissions to one persistent, growing Onion REPL session; and
+- one compilation of the deterministic 20-file automation fixture under
+  `benchmarks/fixtures/automation-project/`.
+
+Process-cold uses 3 warmups by default; the other protocols use 8. Every
+protocol uses 25 measured iterations and a 30-second iteration timeout.
+`--warmups N` overrides the scenario defaults. The schema-v2 JSON report stores
+the effective configuration beside every scenario so unlike lifecycles are
+never presented as identical measurements. It also retains raw nanosecond
+observations, median and p95 latency, phase timings where available, source
+metrics, and JVM/OS metadata.
 
 The machine-readable report is written to
-`target/readiness/benchmark-v1.json`. For a quick protocol smoke test:
+`target/readiness/benchmark-v2.json`. For a quick protocol smoke test:
 
 ```bash
 sbt 'benchmark --warmups 0 --iterations 1'

--- a/docs/ja/contributing/building.md
+++ b/docs/ja/contributing/building.md
@@ -205,14 +205,24 @@ readiness ベンチマークスイートを実行します:
 sbt benchmark
 ```
 
-デフォルトのスイートは、すでにウォームアップされた JVM 内で毎回新しい
-Onion コンパイラを作成し、`run/Hello.on`、`run/TodoManager.on`、
-`run/StatsApp.on` をコンパイルします。生のナノ秒計測値、中央値、p95
-レイテンシ、フェーズ別時間、ソース規模、JVM/OS メタデータを報告します。
-これは **steady-state fresh-compiler** 計測です。JVM プロセスの起動時間は
-含まず、永続コンパイラキャッシュがあることも意味しません。
+デフォルトスイートは、次の6つの明示的なプロトコルを報告します:
 
-機械可読レポートは `target/readiness/benchmark-v1.json` に書き出されます。
+- `run/Hello.on`、`run/TodoManager.on`、`run/StatsApp.on` に対する
+  steady-state fresh compiler 計測
+- 子 JVM の起動と終了を含む process-cold の
+  `onion run/Hello.on` 計測
+- 1つの永続的かつ状態が増加する Onion REPL セッションへの連続入力
+- `benchmarks/fixtures/automation-project/` にある決定的な20ファイル
+  automation fixture の一括コンパイル
+
+process-cold のデフォルト warmup は3回、その他は8回です。全プロトコルを
+25回計測し、1 iteration の timeout は30秒です。`--warmups N` は各
+scenario のデフォルトを上書きします。schema-v2 JSON は有効な設定を
+scenario ごとに保存するため、異なる lifecycle を同一条件の計測として
+扱いません。また、生のナノ秒計測値、中央値、p95、取得可能なフェーズ別
+時間、ソース規模、JVM/OS メタデータも保持します。
+
+機械可読レポートは `target/readiness/benchmark-v2.json` に書き出されます。
 プロトコルだけを短時間で確認するには次を実行します:
 
 ```bash

--- a/docs/ja/contributing/building.md
+++ b/docs/ja/contributing/building.md
@@ -217,12 +217,31 @@ sbt benchmark
 
 process-cold のデフォルト warmup は3回、その他は8回です。全プロトコルを
 25回計測し、1 iteration の timeout は30秒です。`--warmups N` は各
-scenario のデフォルトを上書きします。schema-v2 JSON は有効な設定を
+scenario のデフォルトを上書きします。schema-v3 JSON は有効な設定を
 scenario ごとに保存するため、異なる lifecycle を同一条件の計測として
 扱いません。また、生のナノ秒計測値、中央値、p95、取得可能なフェーズ別
-時間、ソース規模、JVM/OS メタデータも保持します。
+時間、ソース規模、JVM/OS メタデータ、割り当てメモリ、型付けされた
+絶対性能 policy 判定も保持します。
 
-機械可読レポートは `target/readiness/benchmark-v2.json` に書き出されます。
+最初の実用化マイルストーンでは、次の上限値を境界値を含めて適用します:
+
+| プロトコル | 中央値 | p95 |
+|---|---:|---:|
+| 新規プロセスでの `onion Hello.on` | 1.5 s | 2.5 s |
+| `Hello.on` の steady-state compile | 150 ms | 300 ms |
+| `StatsApp.on` の steady-state compile | 750 ms | 1.2 s |
+| 2回目以降の REPL snippet | 100 ms | 250 ms |
+| 20ファイル・約2,000行のプロジェクト | 2.0 s | 3.0 s |
+
+絶対性能 policy は、取得した環境が reference lane（Ubuntu 24.04
+x86-64、Eclipse Adoptium Temurin JDK 21、割り当て processor 2個、
+割り当てメモリ 4 GiB、最大 heap 2 GiB、G1）と完全に一致する場合だけ
+強制されます。この lane で上限を超えると benchmark task は失敗します。
+それ以外の環境では各判定は `not-applicable`、全体 status は
+`informational` です。この計測は profile には利用できますが、
+release evidence にはなりません。
+
+機械可読レポートは `target/readiness/benchmark-v3.json` に書き出されます。
 プロトコルだけを短時間で確認するには次を実行します:
 
 ```bash

--- a/docs/ja/contributing/building.md
+++ b/docs/ja/contributing/building.md
@@ -199,11 +199,27 @@ sbt 'runScript run/Hello.on'
 sbt repl
 ```
 
-ベンチマークスイートを実行:
+readiness ベンチマークスイートを実行します:
 
 ```bash
-sbt bench
+sbt benchmark
 ```
+
+デフォルトのスイートは、すでにウォームアップされた JVM 内で毎回新しい
+Onion コンパイラを作成し、`run/Hello.on`、`run/TodoManager.on`、
+`run/StatsApp.on` をコンパイルします。生のナノ秒計測値、中央値、p95
+レイテンシ、フェーズ別時間、ソース規模、JVM/OS メタデータを報告します。
+これは **steady-state fresh-compiler** 計測です。JVM プロセスの起動時間は
+含まず、永続コンパイラキャッシュがあることも意味しません。
+
+機械可読レポートは `target/readiness/benchmark-v1.json` に書き出されます。
+プロトコルだけを短時間で確認するには次を実行します:
+
+```bash
+sbt 'benchmark --warmups 0 --iterations 1'
+```
+
+`sbt bench` は互換エイリアスとして残り、同じオプションを受け付けます。
 
 コンパイルプロファイルを出力:
 

--- a/docs/superpowers/plans/2026-07-24-absolute-performance-policy.md
+++ b/docs/superpowers/plans/2026-07-24-absolute-performance-policy.md
@@ -1,0 +1,577 @@
+# Absolute Performance Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the five practical latency ceilings into typed, machine-enforced benchmark policy while keeping non-reference runs useful and informational.
+
+**Architecture:** Extend benchmark environment evidence with the Linux distribution and assigned memory needed for reference-lane detection. A pure `AbsolutePerformancePolicy` evaluates scenario summaries without running benchmarks; schema v3 embeds that evaluation in JSON and text output. The existing runner exits nonzero only for invalid/scenario failures or a policy failure on the detected reference lane.
+
+**Tech Stack:** Scala 3.3.7, ScalaTest 3.2.19, Java management APIs, the existing `onion.Json` renderer, sbt input tasks.
+
+## Global Constraints
+
+- The reference lane is Ubuntu 24.04 x86-64, Temurin JDK 21, two assigned processors, 4 GiB assigned memory, and a 2 GiB maximum heap with G1 for in-process scenarios.
+- Absolute limits are inclusive: a result exactly equal to its median or p95 ceiling passes.
+- The five governed scenario IDs and ceilings come verbatim from the practical-readiness design.
+- A successful non-reference run is `informational`; its absolute checks are `not-applicable`, never `pass`.
+- Missing or failed scenario evidence on a reference lane is `unknown` and fails the policy.
+- All report durations remain integer nanoseconds.
+- The report schema increments from 2 to 3 because environment and policy fields change its public shape.
+- `bench` remains a compatibility alias for `benchmark`.
+- Relative base/head regression comparison is a separate plan because it requires report decoding, two clean revisions, alternating execution, and confirmation rounds.
+
+---
+
+## File Structure
+
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala`
+  captures the additional reference-lane evidence.
+- `src/main/scala/onion/tools/readiness/policy/PerformancePolicy.scala`
+  owns reference requirements, budgets, check statuses, and pure evaluation.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala`
+  embeds the policy evaluation in schema v3.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala`
+  serializes and summarizes the policy evidence.
+- `src/main/scala/onion/tools/BenchmarkRunner.scala`
+  supplies captured evidence and inherits policy-aware exit semantics.
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkMetadataSpec.scala`
+  verifies stable `/etc/os-release` parsing.
+- `src/test/scala/onion/tools/readiness/policy/PerformancePolicySpec.scala`
+  proves reference detection and all policy boundaries.
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala`
+  locks schema v3 JSON and text output.
+- `src/test/scala/onion/tools/BenchmarkRunnerSpec.scala`
+  proves local informational and reference failure behavior.
+- `docs/contributing/building.md` and
+  `docs/ja/contributing/building.md`
+  document policy applicability and schema v3.
+
+---
+
+### Task 1: Capture Reference-Lane Environment Evidence
+
+**Files:**
+- Modify: `src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala`
+- Create: `src/test/scala/onion/tools/readiness/benchmark/BenchmarkMetadataSpec.scala`
+
+**Interfaces:**
+- Produces: `EnvironmentMetadata.osReleaseId: String`
+- Produces: `EnvironmentMetadata.osReleaseVersion: String`
+- Produces: `EnvironmentMetadata.totalMemoryBytes: Long`
+- Produces: `EnvironmentMetadata.parseOsRelease(lines: Seq[String]): (String, String)` with `private[benchmark]` visibility.
+
+- [ ] **Step 1: Write the failing parser and capture tests**
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class BenchmarkMetadataSpec extends AnyFunSpec with Matchers:
+  describe("EnvironmentMetadata.parseOsRelease"):
+    it("extracts and unquotes Ubuntu identity"):
+      EnvironmentMetadata.parseOsRelease(
+        Seq("""ID="ubuntu"""", """VERSION_ID="24.04"""")
+      ) shouldBe ("ubuntu", "24.04")
+
+    it("uses unknown values when release keys are absent"):
+      EnvironmentMetadata.parseOsRelease(Seq("NAME=Linux")) shouldBe
+        ("unknown", "unknown")
+
+  describe("EnvironmentMetadata.capture"):
+    it("captures positive processor, heap, and memory evidence"):
+      val environment = EnvironmentMetadata.capture()
+      environment.processors should be > 0
+      environment.maxHeapBytes should be > 0L
+      environment.totalMemoryBytes should be > 0L
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkMetadataSpec'
+```
+
+Expected: test compilation fails because the three fields and `parseOsRelease` do not exist.
+
+- [ ] **Step 3: Add fields and deterministic capture helpers**
+
+Add these fields after `osArch`:
+
+```scala
+osReleaseId: String,
+osReleaseVersion: String,
+processors: Int,
+totalMemoryBytes: Long,
+```
+
+Add helpers to `EnvironmentMetadata`:
+
+```scala
+private[benchmark] def parseOsRelease(
+  lines: Seq[String]
+): (String, String) =
+  val values = lines.flatMap { line =>
+    line.split("=", 2) match
+      case Array(key, value) =>
+        Some(key -> value.stripPrefix("\"").stripSuffix("\""))
+      case _ => None
+  }.toMap
+  (
+    values.getOrElse("ID", "unknown"),
+    values.getOrElse("VERSION_ID", "unknown")
+  )
+
+private def osRelease(): (String, String) =
+  val path = java.nio.file.Paths.get("/etc/os-release")
+  if java.nio.file.Files.isRegularFile(path) then
+    parseOsRelease(java.nio.file.Files.readAllLines(path).asScala.toSeq)
+  else ("unknown", "unknown")
+
+private def totalMemoryBytes(): Long =
+  ManagementFactory.getOperatingSystemMXBean match
+    case bean: com.sun.management.OperatingSystemMXBean =>
+      bean.getTotalMemorySize
+    case _ => Runtime.getRuntime.maxMemory()
+```
+
+Call both helpers once in `capture()` and populate the new fields.
+
+- [ ] **Step 4: Run the metadata tests to verify GREEN**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkMetadataSpec'
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkMetadataSpec.scala
+git commit -m "Capture benchmark reference environment"
+```
+
+---
+
+### Task 2: Evaluate Absolute Performance Budgets
+
+**Files:**
+- Create: `src/main/scala/onion/tools/readiness/policy/PerformancePolicy.scala`
+- Create: `src/test/scala/onion/tools/readiness/policy/PerformancePolicySpec.scala`
+
+**Interfaces:**
+- Consumes: `EnvironmentMetadata` and `Vector[ScenarioResult]`.
+- Produces: `PolicyCheckStatus`, `PolicyOverallStatus`, `PerformanceBudget`, `AbsolutePerformanceCheck`, `AbsolutePerformanceEvaluation`.
+- Produces: `AbsolutePerformancePolicy.evaluate(environment, scenarios)`.
+
+- [ ] **Step 1: Write failing reference, boundary, non-reference, and missing-evidence tests**
+
+Define test helpers for a qualifying environment and successful scenario, then assert:
+
+```scala
+AbsolutePerformancePolicy.evaluate(reference, passingScenarios)
+  .overallStatus shouldBe PolicyOverallStatus.Pass
+
+AbsolutePerformancePolicy.evaluate(reference, atExactCeilings)
+  .checks.forall(_.status == PolicyCheckStatus.Pass) shouldBe true
+
+AbsolutePerformancePolicy.evaluate(reference, helloMedianOneNanosecondOver)
+  .checks.find(_.scenarioId == "steady-fresh:onionc:hello").value.status shouldBe
+    PolicyCheckStatus.Fail
+
+AbsolutePerformancePolicy.evaluate(
+  reference.copy(processors = 16),
+  passingScenarios
+).overallStatus shouldBe PolicyOverallStatus.Informational
+
+AbsolutePerformancePolicy.evaluate(reference, Vector.empty)
+  .checks.forall(_.status == PolicyCheckStatus.Unknown) shouldBe true
+```
+
+Also vary each reference field independently and assert `isReferenceLane` is false.
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.policy.PerformancePolicySpec'
+```
+
+Expected: test compilation fails because the policy package does not exist.
+
+- [ ] **Step 3: Implement typed statuses, exact budgets, and pure evaluation**
+
+Create:
+
+```scala
+package onion.tools.readiness.policy
+
+import onion.tools.readiness.benchmark.*
+
+enum PolicyCheckStatus(val wireName: String):
+  case Pass extends PolicyCheckStatus("pass")
+  case Fail extends PolicyCheckStatus("fail")
+  case NotApplicable extends PolicyCheckStatus("not-applicable")
+  case Unknown extends PolicyCheckStatus("unknown")
+
+enum PolicyOverallStatus(val wireName: String):
+  case Pass extends PolicyOverallStatus("pass")
+  case Fail extends PolicyOverallStatus("fail")
+  case Informational extends PolicyOverallStatus("informational")
+
+final case class PerformanceBudget(
+  scenarioId: String,
+  medianCeilingNanos: Long,
+  p95CeilingNanos: Long
+)
+
+final case class AbsolutePerformanceCheck(
+  scenarioId: String,
+  status: PolicyCheckStatus,
+  medianNanos: Option[Long],
+  p95Nanos: Option[Long],
+  medianCeilingNanos: Long,
+  p95CeilingNanos: Long,
+  message: String
+)
+
+final case class AbsolutePerformanceEvaluation(
+  referenceLane: Boolean,
+  applicabilityReason: String,
+  checks: Vector[AbsolutePerformanceCheck],
+  overallStatus: PolicyOverallStatus
+)
+```
+
+Use these exact budgets:
+
+```scala
+Vector(
+  PerformanceBudget("process-cold:onion:hello", 1500000000L, 2500000000L),
+  PerformanceBudget("steady-fresh:onionc:hello", 150000000L, 300000000L),
+  PerformanceBudget("steady-fresh:onionc:stats-app", 750000000L, 1200000000L),
+  PerformanceBudget(
+    "persistent-session:repl:growing-state",
+    100000000L,
+    250000000L
+  ),
+  PerformanceBudget(
+    "multi-file:onionc:automation-project",
+    2000000000L,
+    3000000000L
+  )
+)
+```
+
+Reference detection requires:
+
+```scala
+environment.osName == "Linux"
+environment.osReleaseId == "ubuntu"
+environment.osReleaseVersion == "24.04"
+Set("amd64", "x86_64").contains(environment.osArch)
+environment.javaVendor == "Eclipse Adoptium"
+javaMajor(environment.javaVersion).contains(21)
+environment.processors == 2
+environment.totalMemoryBytes == 4L * 1024L * 1024L * 1024L
+environment.maxHeapBytes == 2L * 1024L * 1024L * 1024L
+environment.garbageCollectors.exists(_.startsWith("G1"))
+```
+
+On the reference lane, a check passes only when both actual values are less
+than or equal to their ceilings. Failed/missing summaries produce `unknown`.
+Off the reference lane, every check is `not-applicable` and the overall status
+is `informational`.
+
+- [ ] **Step 4: Run the policy tests to verify GREEN**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.policy.PerformancePolicySpec'
+```
+
+Expected: all policy tests pass, including exact boundary values.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/scala/onion/tools/readiness/policy/PerformancePolicy.scala \
+  src/test/scala/onion/tools/readiness/policy/PerformancePolicySpec.scala
+git commit -m "Add absolute performance policy"
+```
+
+---
+
+### Task 3: Embed Policy Evidence in Benchmark Schema v3
+
+**Files:**
+- Modify: `src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala`
+- Modify: `src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala`
+- Modify: `src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala`
+
+**Interfaces:**
+- Consumes: `AbsolutePerformancePolicy.evaluate`.
+- Produces: `PerformanceBenchmarkReport.policy: AbsolutePerformanceEvaluation`.
+- Produces: schema v3 JSON fields `environment.osReleaseId`,
+  `environment.osReleaseVersion`, `environment.totalMemoryBytes`, and `policy`.
+
+- [ ] **Step 1: Update renderer tests first**
+
+Change the fixture to include the three environment fields and an explicit
+policy evaluation. Assert:
+
+```scala
+PerformanceBenchmarkReport.CurrentSchemaVersion shouldBe 3
+json should include ("\"schemaVersion\": 3")
+json should include ("\"osReleaseId\": \"ubuntu\"")
+json should include ("\"totalMemoryBytes\": 4294967296")
+json should include ("\"overallStatus\": \"pass\"")
+json should include ("\"medianCeilingNanos\": 150000000")
+text should include ("absolute-policy=pass")
+```
+
+- [ ] **Step 2: Run renderer tests to verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkRenderSpec'
+```
+
+Expected: compilation fails because the report has no policy field.
+
+- [ ] **Step 3: Add report policy and render all evidence**
+
+Add:
+
+```scala
+policy: AbsolutePerformanceEvaluation
+```
+
+to `PerformanceBenchmarkReport`, set `CurrentSchemaVersion = 3`, and have
+`create` evaluate:
+
+```scala
+policy = AbsolutePerformancePolicy.evaluate(environment, scenarios)
+```
+
+Make `succeeded` require:
+
+```scala
+failures.isEmpty &&
+  scenarios.forall(_.succeeded) &&
+  policy.overallStatus != PolicyOverallStatus.Fail
+```
+
+Render policy JSON as:
+
+```json
+{
+  "referenceLane": true,
+  "applicabilityReason": "reference environment matched",
+  "overallStatus": "pass",
+  "checks": [
+    {
+      "scenarioId": "steady-fresh:onionc:hello",
+      "status": "pass",
+      "medianNanos": 1000000,
+      "p95Nanos": 1000000,
+      "medianCeilingNanos": 150000000,
+      "p95CeilingNanos": 300000000,
+      "message": "within absolute ceiling"
+    }
+  ]
+}
+```
+
+The text header adds:
+
+```text
+  absolute-policy=pass reference-lane=true
+```
+
+and prints failed or unknown checks beneath it.
+
+- [ ] **Step 4: Run renderer and benchmark tests to verify GREEN**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkRenderSpec onion.tools.readiness.policy.PerformancePolicySpec'
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
+git commit -m "Add policy evidence to benchmark reports"
+```
+
+---
+
+### Task 4: Enforce Reference Failures and Preserve Informational Runs
+
+**Files:**
+- Modify: `src/test/scala/onion/tools/BenchmarkRunnerSpec.scala`
+- Modify: `src/main/scala/onion/tools/BenchmarkRunner.scala`
+- Modify: `src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala`
+- Modify: `src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala`
+
+**Interfaces:**
+- Produces: default report path `target/readiness/benchmark-v3.json`.
+- Preserves: `BenchmarkRunner.main` exit 0 for successful non-reference evidence.
+- Enforces: `PerformanceBenchmarkReport.succeeded == false` for reference-lane
+  budget failures.
+
+- [ ] **Step 1: Write failing report-outcome and default-path tests**
+
+Update the default options expectation:
+
+```scala
+output = Paths.get("target/readiness/benchmark-v3.json")
+```
+
+Add runner-level assertions using constructed reports:
+
+```scala
+informationalReport.policy.overallStatus shouldBe
+  PolicyOverallStatus.Informational
+informationalReport.succeeded shouldBe true
+
+referenceBudgetFailure.policy.overallStatus shouldBe PolicyOverallStatus.Fail
+referenceBudgetFailure.succeeded shouldBe false
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.BenchmarkRunnerSpec onion.tools.readiness.benchmark.BenchmarkOptionsSpec'
+```
+
+Expected: the default still names v2 and report success ignores policy.
+
+- [ ] **Step 3: Update the default and policy-aware construction**
+
+Set:
+
+```scala
+output: Path = Paths.get("target/readiness/benchmark-v3.json")
+```
+
+Capture `EnvironmentMetadata` once in `buildReport`, pass it into
+`PerformanceBenchmarkReport.create`, and rely on the report's policy-aware
+`succeeded` method for the existing `sys.exit(1)` branch.
+
+- [ ] **Step 4: Run runner tests and a real non-reference smoke**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.BenchmarkRunnerSpec onion.tools.readiness.benchmark.* onion.tools.readiness.policy.*'
+sbt 'benchmark --warmups 0 --iterations 1 --output target/readiness/policy-smoke-v3.json'
+```
+
+Expected: tests pass; the smoke exits zero, names all six scenarios, and prints
+`absolute-policy=informational` unless the machine exactly matches the
+reference lane.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/scala/onion/tools/BenchmarkRunner.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala \
+  src/test/scala/onion/tools/BenchmarkRunnerSpec.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala
+git commit -m "Enforce benchmark absolute policy"
+```
+
+---
+
+### Task 5: Document and Fully Verify Absolute Policy
+
+**Files:**
+- Modify: `docs/contributing/building.md`
+- Modify: `docs/ja/contributing/building.md`
+
+**Interfaces:**
+- Documents: schema v3, the five ceilings, exact reference-lane requirements,
+  and informational non-reference behavior.
+
+- [ ] **Step 1: Update both language documents**
+
+Add the same five-row ceiling table to both documents. State that:
+
+- `benchmark-v3.json` records raw timings and typed policy checks;
+- exact reference-lane matches enforce the absolute policy and fail the task on
+  breach;
+- other machines report `not-applicable` checks and an `informational`
+  overall status;
+- informational output is useful for profiling but is not release evidence.
+
+- [ ] **Step 2: Check English/Japanese policy values mechanically**
+
+Run:
+
+```bash
+rg -n "150 ms|300 ms|750 ms|1.2 s|100 ms|250 ms|2.0 s|3.0 s|1.5 s|2.5 s|benchmark-v3" \
+  docs/contributing/building.md docs/ja/contributing/building.md
+```
+
+Expected: every value and `benchmark-v3` occur in both files.
+
+- [ ] **Step 3: Run complete verification**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.* onion.tools.readiness.policy.* onion.tools.BenchmarkRunnerSpec'
+sbt 'benchmark --warmups 0 --iterations 1 --output target/readiness/policy-final-v3.json'
+sbt test
+git diff --check
+```
+
+Expected:
+
+- focused policy/benchmark tests pass;
+- the JSON parses and contains schema 3, six scenarios, five policy checks,
+  and no scenario failures;
+- all repository tests pass with zero failed, canceled, ignored, or pending
+  tests;
+- `git diff --check` emits no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/contributing/building.md docs/ja/contributing/building.md
+git commit -m "Document absolute benchmark policy"
+```
+
+---
+
+## Self-Review
+
+- The plan covers every absolute ceiling, exact boundary behavior,
+  reference-lane evidence, schema rendering, exit semantics, bilingual
+  documentation, and real protocol verification.
+- The plan intentionally excludes relative comparison; that subsystem needs a
+  separate executable plan for decoding, compatibility validation, alternating
+  base/head rounds, and confirmation semantics.
+- The field names and enum values are consistent across policy, report,
+  renderer, runner, tests, and documentation.
+- No production step changes tracked files during a check; only the explicit
+  implementation and documentation commits do so.

--- a/docs/superpowers/plans/2026-07-24-benchmark-measurement-core.md
+++ b/docs/superpowers/plans/2026-07-24-benchmark-measurement-core.md
@@ -1,0 +1,1707 @@
+# Benchmark Measurement Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Onion's ambiguous average-only benchmark with a tested,
+versioned measurement core that reports raw observations, robust statistics,
+phase profiles, environment metadata, and realistic steady-state compiler
+workloads.
+
+**Architecture:** A small benchmark domain model is independent of execution,
+statistics, compiler scenarios, and rendering. `BenchmarkEngine` owns lifecycle,
+warmup, timeout, and failure semantics through injectable clocks and sessions.
+The existing `onion.tools.BenchmarkRunner` becomes a compatibility entry point
+over the new implementation, and `sbt bench` remains available beside the
+clearer `sbt benchmark` task.
+
+**Tech Stack:** Scala 3.3.7, Java 17 APIs, ScalaTest 3.2.19, Onion's existing
+compiler pipeline and `onion.Json`, sbt 1.12.1.
+
+## Global Constraints
+
+- Use Scala 3 indentation style with two spaces and no tabs.
+- Add no third-party dependencies.
+- Store every duration as integer nanoseconds; convert only while rendering.
+- Never label a scenario `cold` or `warm` unless its lifecycle implements that
+  exact meaning.
+- Keep failed and timed-out observations visible; never substitute zero or
+  discard an outlier.
+- Use 8 warmups, 25 measurements, and a 30-second iteration timeout by default.
+- Preserve `sbt 'bench --iterations N --json'` as a supported invocation.
+- Default JSON output is `target/readiness/benchmark-v1.json`.
+- This plan implements steady-state fresh-compiler scenarios only. The
+  process-cold, persistent-REPL, and generated multi-file protocols are the
+  next performance plan and must use the interfaces defined here.
+- Before execution, confirm `java -version` reports JDK 17 or later and
+  `sbt --version` can launch sbt 1.12.1. Install missing tools outside the
+  repository; do not commit tool binaries.
+
+---
+
+## File Map
+
+### New production files
+
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala`
+  owns wire-stable enums and immutable result types.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkStatistics.scala`
+  owns median and nearest-rank p95 calculations.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala`
+  owns warmup, measurement, timeout, partial-result, and session lifecycle.
+- `src/main/scala/onion/tools/readiness/benchmark/CompileWorkload.scala`
+  loads source metadata and computes stable workload hashes.
+- `src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala`
+  adapts `OnionCompiler.compileDetailed` to the benchmark lifecycle.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala`
+  captures Git and JVM/OS environment identity.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala`
+  owns schema-versioned performance report types.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala`
+  owns JSON and text rendering.
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala`
+  parses and validates CLI options without exiting the JVM.
+
+### Modified production files
+
+- `src/main/scala/onion/tools/BenchmarkRunner.scala` becomes the thin
+  compatibility CLI.
+- `build.sbt` adds the `benchmark` input task while retaining `bench`.
+- `docs/contributing/building.md` documents scenario semantics and artifacts.
+- `docs/ja/contributing/building.md` mirrors the command documentation.
+
+### New test files
+
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkStatisticsSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala`
+
+---
+
+### Task 1: Immutable Model and Robust Statistics
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala`
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkStatistics.scala`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/BenchmarkStatisticsSpec.scala`
+
+**Interfaces:**
+
+- Consumes: no project-specific interfaces.
+- Produces:
+  `ScenarioKind`, `ObservationKind`, `FailureCategory`, `SourceMetrics`,
+  `PhaseObservation`, `IterationObservation`, `BenchmarkSummary`,
+  `BenchmarkFailure`, `ScenarioMetadata`, `ScenarioResult`, and
+  `BenchmarkStatistics.summarize(values: Vector[Long])`.
+
+- [ ] **Step 1: Write the failing statistics tests**
+
+Create `BenchmarkStatisticsSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+class BenchmarkStatisticsSpec extends AnyFunSpec with Matchers with OptionValues:
+  describe("BenchmarkStatistics.summarize"):
+    it("calculates median and nearest-rank p95 without dropping observations"):
+      val result = BenchmarkStatistics.summarize(Vector(50L, 10L, 40L, 20L, 30L))
+      result shouldBe Right(
+        BenchmarkSummary(
+          medianNanos = 30L,
+          p95Nanos = 50L,
+          minNanos = 10L,
+          maxNanos = 50L
+        )
+      )
+
+    it("uses the mean of the middle pair for an even observation count"):
+      BenchmarkStatistics.summarize(Vector(7L, 11L)) shouldBe Right(
+        BenchmarkSummary(9L, 11L, 7L, 11L)
+      )
+
+    it("rejects an empty observation set as an invalid measurement"):
+      val result = BenchmarkStatistics.summarize(Vector.empty)
+      result.left.toOption.value.category shouldBe FailureCategory.InvalidMeasurement
+
+    it("rejects a negative duration"):
+      val result = BenchmarkStatistics.summarize(Vector(1L, -1L))
+      result.left.toOption.value.message should include ("negative")
+```
+
+- [ ] **Step 2: Run the new suite and verify it fails**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkStatisticsSpec'
+```
+
+Expected: compilation fails because `BenchmarkStatistics`,
+`BenchmarkSummary`, and `FailureCategory` do not exist.
+
+- [ ] **Step 3: Add the immutable benchmark model**
+
+Create `BenchmarkModel.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+enum ScenarioKind(val wireName: String):
+  case ProcessCold extends ScenarioKind("process-cold")
+  case SteadyFresh extends ScenarioKind("steady-fresh")
+  case PersistentSession extends ScenarioKind("persistent-session")
+  case MultiFile extends ScenarioKind("multi-file")
+
+enum ObservationKind(val wireName: String):
+  case Warmup extends ObservationKind("warmup")
+  case Measurement extends ObservationKind("measurement")
+
+enum FailureCategory(val wireName: String):
+  case InvalidMeasurement extends FailureCategory("invalid-measurement")
+  case ScenarioFailure extends FailureCategory("scenario-failure")
+  case UnstableEnvironment extends FailureCategory("unstable-environment")
+  case BudgetFailure extends FailureCategory("budget-failure")
+
+final case class SourceMetrics(
+  sourceCount: Int,
+  lineCount: Int,
+  byteCount: Long,
+  generatedClasses: Int
+)
+
+final case class PhaseObservation(
+  name: String,
+  elapsedNanos: Long,
+  inputCount: Int,
+  outputCount: Int
+)
+
+final case class IterationObservation(
+  index: Int,
+  kind: ObservationKind,
+  elapsedNanos: Long,
+  phases: Vector[PhaseObservation],
+  sourceMetrics: SourceMetrics,
+  exitCode: Int
+)
+
+final case class BenchmarkSummary(
+  medianNanos: Long,
+  p95Nanos: Long,
+  minNanos: Long,
+  maxNanos: Long
+)
+
+final case class BenchmarkFailure(
+  category: FailureCategory,
+  message: String,
+  iteration: Option[Int] = None
+)
+
+final case class ScenarioMetadata(
+  id: String,
+  kind: ScenarioKind,
+  workload: String,
+  workloadHash: String
+)
+
+final case class ScenarioResult(
+  metadata: ScenarioMetadata,
+  warmups: Vector[IterationObservation],
+  measurements: Vector[IterationObservation],
+  summary: Option[BenchmarkSummary],
+  failure: Option[BenchmarkFailure]
+):
+  def succeeded: Boolean = failure.isEmpty
+```
+
+- [ ] **Step 4: Implement statistics with explicit invalid-input results**
+
+Create `BenchmarkStatistics.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+object BenchmarkStatistics:
+  def summarize(values: Vector[Long]): Either[BenchmarkFailure, BenchmarkSummary] =
+    if values.isEmpty then
+      Left(
+        BenchmarkFailure(
+          FailureCategory.InvalidMeasurement,
+          "cannot summarize an empty observation set"
+        )
+      )
+    else if values.exists(_ < 0L) then
+      Left(
+        BenchmarkFailure(
+          FailureCategory.InvalidMeasurement,
+          "cannot summarize a negative duration"
+        )
+      )
+    else
+      val sorted = values.sorted
+      val median =
+        if sorted.size % 2 == 1 then sorted(sorted.size / 2)
+        else
+          val upper = sorted(sorted.size / 2)
+          val lower = sorted(sorted.size / 2 - 1)
+          lower + (upper - lower) / 2L
+      val rank = (95L * sorted.size + 99L) / 100L
+      val p95 = sorted(rank.toInt - 1)
+      Right(
+        BenchmarkSummary(
+          medianNanos = median,
+          p95Nanos = p95,
+          minNanos = sorted.head,
+          maxNanos = sorted.last
+        )
+      )
+```
+
+- [ ] **Step 5: Run the suite and verify it passes**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkStatisticsSpec'
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 6: Commit the model and statistics**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkStatistics.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkStatisticsSpec.scala
+git commit -m "Add benchmark statistics model"
+```
+
+---
+
+### Task 2: Lifecycle-Aware Measurement Engine
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala`
+
+**Interfaces:**
+
+- Consumes: every model type from Task 1.
+- Produces:
+  `BenchmarkRunConfig`, `IterationPayload`, `NanoClock`,
+  `BenchmarkSession`, `BenchmarkScenario`, `BenchmarkScenarioException`, and
+  `BenchmarkEngine.run(scenario: BenchmarkScenario): ScenarioResult`.
+
+- [ ] **Step 1: Write lifecycle, partial-failure, and timeout tests**
+
+Create `BenchmarkEngineSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+import java.util.concurrent.{CountDownLatch, Executors}
+
+class BenchmarkEngineSpec extends AnyFunSpec with Matchers with OptionValues:
+  private final class SequenceClock(values: Seq[Long]) extends NanoClock:
+    private val iterator = values.iterator
+    override def nanoTime(): Long = iterator.next()
+
+  private def metadata =
+    ScenarioMetadata("steady-fresh:test", ScenarioKind.SteadyFresh, "test", "hash")
+
+  private def payload =
+    IterationPayload(
+      phases = Vector.empty,
+      sourceMetrics = SourceMetrics(1, 1, 1L, 1),
+      exitCode = 0
+    )
+
+  describe("BenchmarkEngine"):
+    it("keeps warmups separate and summarizes only measurements"):
+      var calls = 0
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            calls += 1
+            payload
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(1, 2, 1000L),
+        new SequenceClock(Seq(0L, 5L, 5L, 12L, 12L, 23L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      calls shouldBe 3
+      result.warmups.map(_.elapsedNanos) shouldBe Vector(5L)
+      result.measurements.map(_.elapsedNanos) shouldBe Vector(7L, 11L)
+      result.summary shouldBe Some(BenchmarkSummary(9L, 11L, 7L, 11L))
+      result.failure shouldBe None
+
+    it("returns completed observations when a later iteration fails"):
+      var calls = 0
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            calls += 1
+            if calls == 3 then throw BenchmarkScenarioException("compiler failed")
+            payload
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(1, 2, 1000L),
+        new SequenceClock(Seq(0L, 1L, 1L, 3L, 3L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.warmups.size shouldBe 1
+      result.measurements.size shouldBe 1
+      result.summary shouldBe None
+      result.failure.value.category shouldBe FailureCategory.ScenarioFailure
+      result.failure.value.iteration shouldBe Some(1)
+
+    it("marks an iteration timeout as a scenario failure"):
+      val entered = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            entered.countDown()
+            release.await()
+            payload
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 25L),
+        NanoClock.System,
+        executor
+      )
+      val result =
+        try engine.run(scenario)
+        finally
+          release.countDown()
+          engine.close()
+
+      entered.getCount shouldBe 0L
+      result.failure.value.message should include ("timed out")
+      result.measurements shouldBe empty
+```
+
+- [ ] **Step 2: Run the suite and verify it fails**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkEngineSpec'
+```
+
+Expected: compilation fails because the engine interfaces do not exist.
+
+- [ ] **Step 3: Implement the engine and its injectable boundaries**
+
+Create `BenchmarkEngine.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.util.concurrent.{
+  Callable,
+  ExecutionException,
+  ExecutorService,
+  TimeUnit,
+  TimeoutException
+}
+import scala.util.control.NonFatal
+
+final case class BenchmarkRunConfig(
+  warmupIterations: Int = 8,
+  measuredIterations: Int = 25,
+  timeoutMillis: Long = 30000L
+):
+  require(warmupIterations >= 0, "warmup iterations must be non-negative")
+  require(measuredIterations > 0, "measured iterations must be positive")
+  require(timeoutMillis > 0L, "timeout must be positive")
+
+final case class IterationPayload(
+  phases: Vector[PhaseObservation],
+  sourceMetrics: SourceMetrics,
+  exitCode: Int
+)
+
+trait NanoClock:
+  def nanoTime(): Long
+
+object NanoClock:
+  object System extends NanoClock:
+    override def nanoTime(): Long = java.lang.System.nanoTime()
+
+trait BenchmarkSession extends AutoCloseable:
+  def runIteration(index: Int): IterationPayload
+  override def close(): Unit = ()
+
+trait BenchmarkScenario:
+  def metadata: ScenarioMetadata
+  def open(): BenchmarkSession
+
+final case class BenchmarkScenarioException(message: String)
+  extends RuntimeException(message)
+
+final class BenchmarkEngine(
+  config: BenchmarkRunConfig,
+  clock: NanoClock,
+  executor: ExecutorService
+) extends AutoCloseable:
+  def run(scenario: BenchmarkScenario): ScenarioResult =
+    val warmups = Vector.newBuilder[IterationObservation]
+    val measurements = Vector.newBuilder[IterationObservation]
+    var failure: Option[BenchmarkFailure] = None
+    var session: BenchmarkSession = null
+
+    try
+      session = scenario.open()
+      var index = 0
+      while index < config.warmupIterations && failure.isEmpty do
+        observe(session, index, ObservationKind.Warmup) match
+          case Right(observation) => warmups += observation
+          case Left(problem) => failure = Some(problem)
+        index += 1
+
+      index = 0
+      while index < config.measuredIterations && failure.isEmpty do
+        observe(session, index, ObservationKind.Measurement) match
+          case Right(observation) => measurements += observation
+          case Left(problem) => failure = Some(problem)
+        index += 1
+    catch
+      case NonFatal(error) =>
+        failure = Some(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            messageOf(error)
+          )
+        )
+    finally
+      if session != null then
+        try session.close()
+        catch
+          case NonFatal(error) =>
+            if failure.isEmpty then
+              failure = Some(
+                BenchmarkFailure(
+                  FailureCategory.ScenarioFailure,
+                  s"scenario cleanup failed: ${messageOf(error)}"
+                )
+              )
+
+    val keptWarmups = warmups.result()
+    val keptMeasurements = measurements.result()
+    val summarized =
+      if failure.nonEmpty then Left(failure.get)
+      else BenchmarkStatistics.summarize(keptMeasurements.map(_.elapsedNanos))
+    val finalFailure = failure.orElse(summarized.left.toOption)
+    val summary = summarized.toOption
+
+    ScenarioResult(
+      metadata = scenario.metadata,
+      warmups = keptWarmups,
+      measurements = keptMeasurements,
+      summary = summary,
+      failure = finalFailure
+    )
+
+  private def observe(
+    session: BenchmarkSession,
+    index: Int,
+    kind: ObservationKind
+  ): Either[BenchmarkFailure, IterationObservation] =
+    val future = executor.submit(new Callable[IterationObservation]:
+      override def call(): IterationObservation =
+        val started = clock.nanoTime()
+        val payload = session.runIteration(index)
+        val elapsed = clock.nanoTime() - started
+        if elapsed < 0L then
+          throw BenchmarkScenarioException("clock produced a negative duration")
+        IterationObservation(
+          index = index,
+          kind = kind,
+          elapsedNanos = elapsed,
+          phases = payload.phases,
+          sourceMetrics = payload.sourceMetrics,
+          exitCode = payload.exitCode
+        )
+    )
+
+    try Right(future.get(config.timeoutMillis, TimeUnit.MILLISECONDS))
+    catch
+      case _: TimeoutException =>
+        future.cancel(true)
+        Left(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            s"iteration timed out after ${config.timeoutMillis} ms",
+            Some(index)
+          )
+        )
+      case error: ExecutionException =>
+        Left(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            messageOf(Option(error.getCause).getOrElse(error)),
+            Some(index)
+          )
+        )
+      case _: InterruptedException =>
+        future.cancel(true)
+        Thread.currentThread().interrupt()
+        Left(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            "benchmark thread was interrupted",
+            Some(index)
+          )
+        )
+
+  private def messageOf(error: Throwable): String =
+    Option(error.getMessage)
+      .filter(_.nonEmpty)
+      .getOrElse(error.getClass.getSimpleName)
+
+  override def close(): Unit =
+    executor.shutdownNow()
+```
+
+- [ ] **Step 4: Run engine and statistics tests**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkEngineSpec onion.tools.readiness.benchmark.BenchmarkStatisticsSpec'
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit the lifecycle engine**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala
+git commit -m "Add lifecycle-aware benchmark engine"
+```
+
+---
+
+### Task 3: Realistic Fresh-Compiler Workloads
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/CompileWorkload.scala`
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala`
+
+**Interfaces:**
+
+- Consumes: `BenchmarkScenario`, `BenchmarkSession`, `IterationPayload`,
+  `ScenarioMetadata`, `SourceMetrics`, and `PhaseObservation`.
+- Produces:
+  `CompileWorkload.fromFiles`, `FreshCompileScenario`, and
+  `CompileScenarioCatalog.default(repoRoot)`.
+
+- [ ] **Step 1: Write workload and compiler-adapter tests**
+
+Create `FreshCompileScenarioSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import onion.compiler.{CompilerConfig, WarningLevel}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.util.concurrent.Executors
+
+class FreshCompileScenarioSpec extends AnyFunSpec with Matchers:
+  private def config =
+    CompilerConfig(
+      classPath = Seq("."),
+      superClass = "",
+      encoding = "UTF-8",
+      outputDirectory = "",
+      maxErrorReports = 20,
+      warningLevel = WarningLevel.Off
+    )
+
+  describe("CompileWorkload"):
+    it("counts sources, lines, bytes, and hashes file contents deterministically"):
+      val root = Files.createTempDirectory("onion-benchmark-workload")
+      Files.writeString(root.resolve("One.on"), "val one = 1\n", StandardCharsets.UTF_8)
+      Files.writeString(root.resolve("Two.on"), "val two = 2", StandardCharsets.UTF_8)
+
+      val first = CompileWorkload.fromFiles(
+        root,
+        "fixture",
+        "fixture",
+        Vector("One.on", "Two.on")
+      )
+      val second = CompileWorkload.fromFiles(
+        root,
+        "fixture",
+        "fixture",
+        Vector("One.on", "Two.on")
+      )
+
+      first.sourceCount shouldBe 2
+      first.lineCount shouldBe 2
+      first.byteCount should be > 0L
+      first.workloadHash shouldBe second.workloadHash
+
+  describe("FreshCompileScenario"):
+    it("creates a fresh compiler result with phase and source metadata"):
+      val root = Files.createTempDirectory("onion-benchmark-compile")
+      Files.writeString(
+        root.resolve("Hello.on"),
+        """IO::println("hello")""",
+        StandardCharsets.UTF_8
+      )
+      val workload =
+        CompileWorkload.fromFiles(root, "hello", "hello", Vector("Hello.on"))
+      val scenario = new FreshCompileScenario(workload, config)
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 30000L),
+        NanoClock.System,
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.failure shouldBe None
+      result.measurements should have size 1
+      result.measurements.head.phases.map(_.name) should contain ("Parsing")
+      result.measurements.head.phases.map(_.name) should contain ("BytecodeGeneration")
+      result.measurements.head.sourceMetrics.generatedClasses should be > 0
+
+  describe("CompileScenarioCatalog"):
+    it("uses the actual practical small, medium, and large scripts"):
+      val scenarios = CompileScenarioCatalog.default(Paths.get(".").toAbsolutePath.normalize())
+      scenarios.map(_.metadata.id) shouldBe Vector(
+        "steady-fresh:onionc:hello",
+        "steady-fresh:onionc:todo-manager",
+        "steady-fresh:onionc:stats-app"
+      )
+      scenarios.last.metadata.kind shouldBe ScenarioKind.SteadyFresh
+      scenarios.last.metadata.workload shouldBe "run/StatsApp.on"
+```
+
+- [ ] **Step 2: Run the suite and verify it fails**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.FreshCompileScenarioSpec'
+```
+
+Expected: compilation fails because the workload and scenario adapters do not
+exist.
+
+- [ ] **Step 3: Implement source loading and stable hashing**
+
+Create `CompileWorkload.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.security.MessageDigest
+
+final case class CompileWorkload(
+  id: String,
+  label: String,
+  root: Path,
+  relativeFiles: Vector[String],
+  sourceCount: Int,
+  lineCount: Int,
+  byteCount: Long,
+  workloadHash: String
+):
+  def paths: Vector[Path] = relativeFiles.map(root.resolve)
+
+object CompileWorkload:
+  def fromFiles(
+    root: Path,
+    id: String,
+    label: String,
+    relativeFiles: Vector[String]
+  ): CompileWorkload =
+    require(relativeFiles.nonEmpty, "compile workload requires at least one source")
+    val normalizedRoot = root.toAbsolutePath.normalize()
+    val digest = MessageDigest.getInstance("SHA-256")
+    var lines = 0
+    var bytes = 0L
+
+    relativeFiles.foreach { relative =>
+      val path = normalizedRoot.resolve(relative).normalize()
+      require(path.startsWith(normalizedRoot), s"workload source escapes root: $relative")
+      require(Files.isRegularFile(path), s"workload source does not exist: $relative")
+      val content = Files.readAllBytes(path)
+      digest.update(relative.getBytes(StandardCharsets.UTF_8))
+      digest.update(0.toByte)
+      digest.update(content)
+      bytes += content.length
+      lines += countLines(new String(content, StandardCharsets.UTF_8))
+    }
+
+    CompileWorkload(
+      id = id,
+      label = label,
+      root = normalizedRoot,
+      relativeFiles = relativeFiles,
+      sourceCount = relativeFiles.size,
+      lineCount = lines,
+      byteCount = bytes,
+      workloadHash = digest.digest().map(byte => f"${byte & 0xff}%02x").mkString
+    )
+
+  private def countLines(content: String): Int =
+    if content.isEmpty then 0
+    else content.count(_ == '\n') + (if content.endsWith("\n") then 0 else 1)
+```
+
+- [ ] **Step 4: Implement the fresh-compiler scenario and catalog**
+
+Create `FreshCompileScenario.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import onion.compiler.{
+  CompilerConfig,
+  FileInputSource,
+  OnionCompiler,
+  WarningLevel
+}
+
+final class FreshCompileScenario(
+  workload: CompileWorkload,
+  compilerConfig: CompilerConfig
+) extends BenchmarkScenario:
+  override val metadata: ScenarioMetadata =
+    ScenarioMetadata(
+      id = s"steady-fresh:onionc:${workload.id}",
+      kind = ScenarioKind.SteadyFresh,
+      workload = workload.label,
+      workloadHash = workload.workloadHash
+    )
+
+  override def open(): BenchmarkSession = new BenchmarkSession:
+    override def runIteration(index: Int): IterationPayload =
+      val sources = workload.paths.map(path => new FileInputSource(path.toString))
+      val result = new OnionCompiler(compilerConfig).compileDetailed(sources)
+      if result.hasErrors then
+        val messages = result.allErrors.map(_.message).mkString("; ")
+        throw BenchmarkScenarioException(
+          s"compilation failed for ${workload.label}: $messages"
+        )
+      IterationPayload(
+        phases = result.timings.map { phase =>
+          PhaseObservation(
+            name = phase.name,
+            elapsedNanos = phase.elapsedNanos,
+            inputCount = phase.inputCount,
+            outputCount = phase.outputCount
+          )
+        }.toVector,
+        sourceMetrics = SourceMetrics(
+          sourceCount = workload.sourceCount,
+          lineCount = workload.lineCount,
+          byteCount = workload.byteCount,
+          generatedClasses = result.classes.size
+        ),
+        exitCode = 0
+      )
+
+object CompileScenarioCatalog:
+  def default(repoRoot: java.nio.file.Path): Vector[BenchmarkScenario] =
+    val config = CompilerConfig(
+      classPath = Seq("."),
+      superClass = "",
+      encoding = "UTF-8",
+      outputDirectory = "",
+      maxErrorReports = 20,
+      warningLevel = WarningLevel.Off
+    )
+    Vector(
+      CompileWorkload.fromFiles(
+        repoRoot,
+        "hello",
+        "run/Hello.on",
+        Vector("run/Hello.on")
+      ),
+      CompileWorkload.fromFiles(
+        repoRoot,
+        "todo-manager",
+        "run/TodoManager.on",
+        Vector("run/TodoManager.on")
+      ),
+      CompileWorkload.fromFiles(
+        repoRoot,
+        "stats-app",
+        "run/StatsApp.on",
+        Vector("run/StatsApp.on")
+      )
+    ).map(workload => new FreshCompileScenario(workload, config))
+```
+
+- [ ] **Step 5: Run all measurement-core suites**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkStatisticsSpec onion.tools.readiness.benchmark.BenchmarkEngineSpec onion.tools.readiness.benchmark.FreshCompileScenarioSpec'
+```
+
+Expected: 10 tests pass.
+
+- [ ] **Step 6: Commit the compiler workload adapter**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/CompileWorkload.scala \
+  src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala \
+  src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
+git commit -m "Add practical compiler benchmark scenarios"
+```
+
+---
+
+### Task 4: Versioned Report and Renderers
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala`
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala`
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala`
+
+**Interfaces:**
+
+- Consumes: `BenchmarkRunConfig` and `ScenarioResult`.
+- Produces:
+  `GitMetadata.capture`, `EnvironmentMetadata.capture`,
+  `PerformanceBenchmarkReport.create`, `BenchmarkRender.json`, and
+  `BenchmarkRender.text`.
+
+- [ ] **Step 1: Write schema and rendering tests**
+
+Create `BenchmarkRenderSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import onion.Json
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
+  private val scenario =
+    ScenarioResult(
+      ScenarioMetadata(
+        "steady-fresh:onionc:hello",
+        ScenarioKind.SteadyFresh,
+        "run/Hello.on",
+        "abc"
+      ),
+      warmups = Vector.empty,
+      measurements = Vector(
+        IterationObservation(
+          0,
+          ObservationKind.Measurement,
+          1000000L,
+          Vector(PhaseObservation("Parsing", 100L, 1, 1)),
+          SourceMetrics(1, 1, 10L, 1),
+          0
+        )
+      ),
+      summary = Some(BenchmarkSummary(1000000L, 1000000L, 1000000L, 1000000L)),
+      failure = None
+    )
+
+  private val report =
+    PerformanceBenchmarkReport(
+      schemaVersion = 1,
+      generatedAt = "2026-07-24T00:00:00Z",
+      git = GitMetadata("deadbeef", dirty = false),
+      environment = EnvironmentMetadata(
+        javaVendor = "Eclipse Adoptium",
+        javaVersion = "21",
+        osName = "Linux",
+        osArch = "amd64",
+        processors = 2,
+        maxHeapBytes = 2147483648L,
+        garbageCollectors = Vector("G1 Young Generation", "G1 Old Generation"),
+        jvmArguments = Vector("-Xmx2g")
+      ),
+      runConfig = BenchmarkRunConfig(0, 1, 30000L),
+      scenarios = Vector(scenario),
+      failures = Vector.empty
+    )
+
+  describe("BenchmarkRender"):
+    it("writes schema-versioned JSON with raw nanosecond observations"):
+      val json = BenchmarkRender.json(report)
+      Json.parseOrNull(json) should not be null
+      json should include ("\"schemaVersion\": 1")
+      json should include ("\"elapsedNanos\": 1000000")
+      json should include ("\"kind\": \"steady-fresh\"")
+      json should not include "elapsedMillis"
+
+    it("renders a concise human summary in milliseconds"):
+      val text = BenchmarkRender.text(report)
+      text should include ("steady-fresh:onionc:hello")
+      text should include ("median=1.00ms")
+      text should include ("p95=1.00ms")
+      text should include ("1 measured")
+```
+
+- [ ] **Step 2: Run the suite and verify it fails**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkRenderSpec'
+```
+
+Expected: compilation fails because report and renderer types do not exist.
+
+- [ ] **Step 3: Add Git and environment metadata capture**
+
+Create `BenchmarkMetadata.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.lang.management.ManagementFactory
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+
+final case class GitMetadata(commit: String, dirty: Boolean)
+
+object GitMetadata:
+  def capture(repoRoot: Path): Either[String, GitMetadata] =
+    for
+      commit <- command(repoRoot, "git", "rev-parse", "HEAD")
+      status <- command(repoRoot, "git", "status", "--porcelain")
+    yield GitMetadata(commit.trim, status.trim.nonEmpty)
+
+  private def command(repoRoot: Path, args: String*): Either[String, String] =
+    val process =
+      new ProcessBuilder(args*)
+        .directory(repoRoot.toFile)
+        .redirectErrorStream(true)
+        .start()
+    val output =
+      try new String(process.getInputStream.readAllBytes(), StandardCharsets.UTF_8)
+      finally process.getInputStream.close()
+    val exit = process.waitFor()
+    if exit == 0 then Right(output)
+    else Left(s"${args.mkString(" ")} failed with exit $exit: ${output.trim}")
+
+final case class EnvironmentMetadata(
+  javaVendor: String,
+  javaVersion: String,
+  osName: String,
+  osArch: String,
+  processors: Int,
+  maxHeapBytes: Long,
+  garbageCollectors: Vector[String],
+  jvmArguments: Vector[String]
+)
+
+object EnvironmentMetadata:
+  def capture(): EnvironmentMetadata =
+    import scala.jdk.CollectionConverters.*
+    EnvironmentMetadata(
+      javaVendor = System.getProperty("java.vendor"),
+      javaVersion = System.getProperty("java.version"),
+      osName = System.getProperty("os.name"),
+      osArch = System.getProperty("os.arch"),
+      processors = Runtime.getRuntime.availableProcessors(),
+      maxHeapBytes = Runtime.getRuntime.maxMemory(),
+      garbageCollectors =
+        ManagementFactory.getGarbageCollectorMXBeans.asScala
+          .map(_.getName)
+          .toVector,
+      jvmArguments =
+        ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toVector
+    )
+```
+
+- [ ] **Step 4: Add the versioned report model**
+
+Create `BenchmarkReport.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.time.Instant
+
+final case class PerformanceBenchmarkReport(
+  schemaVersion: Int,
+  generatedAt: String,
+  git: GitMetadata,
+  environment: EnvironmentMetadata,
+  runConfig: BenchmarkRunConfig,
+  scenarios: Vector[ScenarioResult],
+  failures: Vector[BenchmarkFailure]
+):
+  def succeeded: Boolean = failures.isEmpty && scenarios.forall(_.succeeded)
+
+object PerformanceBenchmarkReport:
+  val CurrentSchemaVersion = 1
+
+  def create(
+    git: GitMetadata,
+    environment: EnvironmentMetadata,
+    runConfig: BenchmarkRunConfig,
+    scenarios: Vector[ScenarioResult],
+    failures: Vector[BenchmarkFailure] = Vector.empty
+  ): PerformanceBenchmarkReport =
+    PerformanceBenchmarkReport(
+      schemaVersion = CurrentSchemaVersion,
+      generatedAt = Instant.now().toString,
+      git = git,
+      environment = environment,
+      runConfig = runConfig,
+      scenarios = scenarios,
+      failures = failures
+    )
+```
+
+- [ ] **Step 5: Implement complete JSON and text rendering**
+
+Create `BenchmarkRender.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import onion.Json
+
+import java.util.{ArrayList, LinkedHashMap, List as JList, Map as JMap}
+import scala.jdk.CollectionConverters.*
+
+object BenchmarkRender:
+  def json(report: PerformanceBenchmarkReport): String =
+    Json.stringifyPretty(reportObject(report))
+
+  def text(report: PerformanceBenchmarkReport): String =
+    val lines = Vector.newBuilder[String]
+    lines += s"benchmark schema=${report.schemaVersion} commit=${report.git.commit}"
+    report.failures.foreach { failure =>
+      lines += s"  FAILED [${failure.category.wireName}]: ${failure.message}"
+    }
+    report.scenarios.foreach { scenario =>
+      scenario.summary match
+        case Some(summary) =>
+          lines += f"  ${scenario.metadata.id}%-40s median=${millis(summary.medianNanos)}%.2fms p95=${millis(summary.p95Nanos)}%.2fms ${scenario.measurements.size}%d measured"
+        case None =>
+          val message = scenario.failure.map(_.message).getOrElse("missing summary")
+          lines += s"  ${scenario.metadata.id} FAILED: $message"
+    }
+    lines.result().mkString(System.lineSeparator())
+
+  private def reportObject(report: PerformanceBenchmarkReport): JMap[String, Object] =
+    obj(
+      "schemaVersion" -> Int.box(report.schemaVersion),
+      "generatedAt" -> report.generatedAt,
+      "commit" -> report.git.commit,
+      "dirty" -> Boolean.box(report.git.dirty),
+      "environment" -> obj(
+        "javaVendor" -> report.environment.javaVendor,
+        "javaVersion" -> report.environment.javaVersion,
+        "osName" -> report.environment.osName,
+        "osArch" -> report.environment.osArch,
+        "processors" -> Int.box(report.environment.processors),
+        "maxHeapBytes" -> Long.box(report.environment.maxHeapBytes),
+        "garbageCollectors" -> arr(
+          report.environment.garbageCollectors.map(value => value: Object)
+        ),
+        "jvmArguments" -> arr(
+          report.environment.jvmArguments.map(value => value: Object)
+        )
+      ),
+      "runConfig" -> obj(
+        "warmupIterations" -> Int.box(report.runConfig.warmupIterations),
+        "measuredIterations" -> Int.box(report.runConfig.measuredIterations),
+        "timeoutMillis" -> Long.box(report.runConfig.timeoutMillis)
+      ),
+      "scenarios" -> arr(report.scenarios.map(scenarioObject)),
+      "failures" -> arr(report.failures.map(failureObject))
+    )
+
+  private def scenarioObject(result: ScenarioResult): Object =
+    obj(
+      "id" -> result.metadata.id,
+      "kind" -> result.metadata.kind.wireName,
+      "workload" -> result.metadata.workload,
+      "workloadHash" -> result.metadata.workloadHash,
+      "warmups" -> arr(result.warmups.map(observationObject)),
+      "measurements" -> arr(result.measurements.map(observationObject)),
+      "summary" -> result.summary.map(summaryObject).orNull,
+      "failure" -> result.failure.map(failureObject).orNull
+    )
+
+  private def observationObject(value: IterationObservation): Object =
+    obj(
+      "index" -> Int.box(value.index),
+      "kind" -> value.kind.wireName,
+      "elapsedNanos" -> Long.box(value.elapsedNanos),
+      "exitCode" -> Int.box(value.exitCode),
+      "sourceMetrics" -> obj(
+        "sourceCount" -> Int.box(value.sourceMetrics.sourceCount),
+        "lineCount" -> Int.box(value.sourceMetrics.lineCount),
+        "byteCount" -> Long.box(value.sourceMetrics.byteCount),
+        "generatedClasses" -> Int.box(value.sourceMetrics.generatedClasses)
+      ),
+      "phases" -> arr(value.phases.map { phase =>
+        obj(
+          "name" -> phase.name,
+          "elapsedNanos" -> Long.box(phase.elapsedNanos),
+          "inputCount" -> Int.box(phase.inputCount),
+          "outputCount" -> Int.box(phase.outputCount)
+        )
+      })
+    )
+
+  private def summaryObject(value: BenchmarkSummary): Object =
+    obj(
+      "medianNanos" -> Long.box(value.medianNanos),
+      "p95Nanos" -> Long.box(value.p95Nanos),
+      "minNanos" -> Long.box(value.minNanos),
+      "maxNanos" -> Long.box(value.maxNanos)
+    )
+
+  private def failureObject(value: BenchmarkFailure): Object =
+    obj(
+      "category" -> value.category.wireName,
+      "message" -> value.message,
+      "iteration" -> value.iteration.map(Int.box).orNull
+    )
+
+  private def obj(entries: (String, Object)*): JMap[String, Object] =
+    val result = new LinkedHashMap[String, Object]()
+    entries.foreach { case (key, value) => result.put(key, value) }
+    result
+
+  private def arr(values: Seq[Object]): JList[Object] =
+    val result = new ArrayList[Object]()
+    values.foreach(result.add)
+    result
+
+  private def millis(nanos: Long): Double =
+    nanos.toDouble / 1000000.0
+```
+
+- [ ] **Step 6: Run rendering tests**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkRenderSpec'
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 7: Commit report metadata and rendering**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
+git commit -m "Add versioned benchmark reports"
+```
+
+---
+
+### Task 5: Compatibility CLI and sbt Tasks
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala`
+- Modify: `src/main/scala/onion/tools/BenchmarkRunner.scala`
+- Modify: `build.sbt`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala`
+
+**Interfaces:**
+
+- Consumes: the engine, default catalog, metadata capture, report model, and
+  renderers from Tasks 1–4.
+- Produces:
+  `BenchmarkOptions.parse`, `onion.tools.BenchmarkRunner`, `sbt benchmark`, and
+  the retained `sbt bench` entry point.
+
+- [ ] **Step 1: Write option compatibility and validation tests**
+
+Create `BenchmarkOptionsSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+import java.nio.file.Paths
+
+class BenchmarkOptionsSpec extends AnyFunSpec with Matchers with OptionValues:
+  describe("BenchmarkOptions.parse"):
+    it("uses readiness-safe defaults"):
+      BenchmarkOptions.parse(Array.empty) shouldBe Right(
+        BenchmarkOptions(
+          runConfig = BenchmarkRunConfig(8, 25, 30000L),
+          output = Paths.get("target/readiness/benchmark-v1.json"),
+          stdoutFormat = BenchmarkOutputFormat.Text
+        )
+      )
+
+    it("preserves --iterations and --json compatibility"):
+      val parsed =
+        BenchmarkOptions.parse(Array("--iterations", "3", "--json")).toOption.value
+      parsed.runConfig.measuredIterations shouldBe 3
+      parsed.stdoutFormat shouldBe BenchmarkOutputFormat.Json
+
+    it("accepts explicit warmup, timeout, and output values"):
+      val parsed = BenchmarkOptions.parse(
+        Array(
+          "--warmups", "2",
+          "--timeout-seconds", "5",
+          "--output", "target/custom.json",
+          "--format", "text"
+        )
+      ).toOption.value
+      parsed.runConfig shouldBe BenchmarkRunConfig(2, 25, 5000L)
+      parsed.output shouldBe Paths.get("target/custom.json")
+
+    it("rejects unknown and invalid options"):
+      BenchmarkOptions.parse(Array("--iterations", "0")).left.toOption.value should include ("positive")
+      BenchmarkOptions.parse(Array("--wat")).left.toOption.value should include ("unknown")
+```
+
+- [ ] **Step 2: Run the option suite and verify it fails**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkOptionsSpec'
+```
+
+Expected: compilation fails because option types do not exist.
+
+- [ ] **Step 3: Implement side-effect-free option parsing**
+
+Create `BenchmarkOptions.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.nio.file.{Path, Paths}
+
+enum BenchmarkOutputFormat:
+  case Text
+  case Json
+
+final case class BenchmarkOptions(
+  runConfig: BenchmarkRunConfig = BenchmarkRunConfig(),
+  output: Path = Paths.get("target/readiness/benchmark-v1.json"),
+  stdoutFormat: BenchmarkOutputFormat = BenchmarkOutputFormat.Text
+)
+
+object BenchmarkOptions:
+  def parse(args: Array[String]): Either[String, BenchmarkOptions] =
+    parseAt(args.toVector, 0, BenchmarkOptions())
+
+  private def parseAt(
+    args: Vector[String],
+    index: Int,
+    options: BenchmarkOptions
+  ): Either[String, BenchmarkOptions] =
+    if index >= args.size then Right(options)
+    else
+      args(index) match
+        case "--iterations" =>
+          value(args, index, "--iterations").flatMap { raw =>
+            positiveInt(raw, "iterations").flatMap { count =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(
+                  runConfig = options.runConfig.copy(measuredIterations = count)
+                )
+              )
+            }
+          }
+        case "--warmups" =>
+          value(args, index, "--warmups").flatMap { raw =>
+            nonNegativeInt(raw, "warmups").flatMap { count =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(
+                  runConfig = options.runConfig.copy(warmupIterations = count)
+                )
+              )
+            }
+          }
+        case "--timeout-seconds" =>
+          value(args, index, "--timeout-seconds").flatMap { raw =>
+            positiveInt(raw, "timeout seconds").flatMap { seconds =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(
+                  runConfig = options.runConfig.copy(
+                    timeoutMillis = seconds.toLong * 1000L
+                  )
+                )
+              )
+            }
+          }
+        case "--output" =>
+          value(args, index, "--output").flatMap { path =>
+            parseAt(args, index + 2, options.copy(output = Paths.get(path)))
+          }
+        case "--format" =>
+          value(args, index, "--format").flatMap {
+            case "text" =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(stdoutFormat = BenchmarkOutputFormat.Text)
+              )
+            case "json" =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(stdoutFormat = BenchmarkOutputFormat.Json)
+              )
+            case other => Left(s"unsupported benchmark format: $other")
+          }
+        case "--json" =>
+          parseAt(
+            args,
+            index + 1,
+            options.copy(stdoutFormat = BenchmarkOutputFormat.Json)
+          )
+        case other => Left(s"unknown benchmark option: $other")
+
+  private def value(
+    args: Vector[String],
+    index: Int,
+    option: String
+  ): Either[String, String] =
+    args.lift(index + 1).toRight(s"missing value for $option")
+
+  private def positiveInt(raw: String, label: String): Either[String, Int] =
+    raw.toIntOption.filter(_ > 0).toRight(s"$label must be a positive integer")
+
+  private def nonNegativeInt(raw: String, label: String): Either[String, Int] =
+    raw.toIntOption.filter(_ >= 0).toRight(s"$label must be non-negative")
+```
+
+- [ ] **Step 4: Replace the old benchmark implementation with the thin CLI**
+
+Replace `src/main/scala/onion/tools/BenchmarkRunner.scala` with:
+
+```scala
+package onion.tools
+
+import onion.tools.readiness.benchmark.*
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.Executors
+
+object BenchmarkRunner:
+  def main(args: Array[String]): Unit =
+    BenchmarkOptions.parse(args) match
+      case Left(message) =>
+        Console.err.println(s"benchmark: $message")
+        sys.exit(2)
+      case Right(options) =>
+        val repoRoot = Paths.get("").toAbsolutePath.normalize()
+        val report = buildReport(repoRoot, options)
+        writeJson(options.output, BenchmarkRender.json(report))
+        options.stdoutFormat match
+          case BenchmarkOutputFormat.Text =>
+            println(BenchmarkRender.text(report))
+          case BenchmarkOutputFormat.Json =>
+            println(BenchmarkRender.json(report))
+        if !report.succeeded then sys.exit(1)
+
+  private[onion] def buildReport(
+    repoRoot: Path,
+    options: BenchmarkOptions
+  ): PerformanceBenchmarkReport =
+    val (git, metadataFailures) =
+      GitMetadata.capture(repoRoot) match
+        case Right(value) => (value, Vector.empty)
+        case Left(message) =>
+          (
+            GitMetadata("unknown", dirty = true),
+            Vector(
+              BenchmarkFailure(
+                FailureCategory.InvalidMeasurement,
+                message
+              )
+            )
+          )
+    val executor = Executors.newSingleThreadExecutor()
+    val engine = new BenchmarkEngine(
+      options.runConfig,
+      NanoClock.System,
+      executor
+    )
+    val results =
+      try CompileScenarioCatalog.default(repoRoot).map(engine.run)
+      finally engine.close()
+    PerformanceBenchmarkReport.create(
+      git = git,
+      environment = EnvironmentMetadata.capture(),
+      runConfig = options.runConfig,
+      scenarios = results,
+      failures = metadataFailures
+    )
+
+  private def writeJson(path: Path, content: String): Unit =
+    val parent = path.toAbsolutePath.normalize().getParent
+    if parent != null then Files.createDirectories(parent)
+    Files.writeString(path, content, StandardCharsets.UTF_8)
+```
+
+- [ ] **Step 5: Add the clearer sbt task without removing `bench`**
+
+In `build.sbt`, add the new key next to `bench`:
+
+```scala
+lazy val bench = inputKey[Unit]("Runs the benchmark suite (compatibility alias)")
+lazy val benchmark = inputKey[Unit]("Runs the versioned readiness benchmark suite")
+```
+
+Keep the existing `bench` `fullRunInputTask` and add:
+
+```scala
+fullRunInputTask(
+  benchmark,
+  Compile,
+  "onion.tools.BenchmarkRunner"
+)
+```
+
+- [ ] **Step 6: Run option and benchmark component tests**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.*'
+```
+
+Expected: all measurement-core tests pass.
+
+- [ ] **Step 7: Exercise the one-iteration compatibility paths**
+
+Run:
+
+```bash
+sbt 'bench --warmups 0 --iterations 1 --json --output target/readiness/bench-compat.json'
+sbt 'benchmark --warmups 0 --iterations 1 --format text --output target/readiness/benchmark-v1.json'
+```
+
+Expected:
+
+- both commands exit zero;
+- both compile `Hello.on`, `TodoManager.on`, and `StatsApp.on`;
+- the first prints schema-versioned JSON;
+- the second prints three text summary lines; and
+- both requested JSON files parse successfully and contain
+  `"schemaVersion": 1`.
+
+- [ ] **Step 8: Commit CLI and build integration**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala \
+  src/main/scala/onion/tools/BenchmarkRunner.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala \
+  build.sbt
+git commit -m "Replace benchmark runner with readiness measurements"
+```
+
+---
+
+### Task 6: Contributor Documentation and Final Verification
+
+**Files:**
+
+- Modify: `docs/contributing/building.md`
+- Modify: `docs/ja/contributing/building.md`
+
+**Interfaces:**
+
+- Consumes: `sbt benchmark`, `sbt bench`, the CLI flags, and the JSON artifact
+  path from Task 5.
+- Produces: matching English and Japanese instructions that do not call a
+  JIT-warmed fresh compiler a warm compiler.
+
+- [ ] **Step 1: Add the English benchmark contract**
+
+Replace the short benchmark paragraph in
+`docs/contributing/building.md` with:
+
+````markdown
+Run the readiness benchmark suite:
+
+```bash
+sbt benchmark
+```
+
+The default suite measures a fresh Onion compiler inside an already-warmed JVM
+against `run/Hello.on`, `run/TodoManager.on`, and `run/StatsApp.on`. It reports
+raw nanosecond observations, median and p95 latency, phase timings, source
+metrics, and JVM/OS metadata. This is a **steady-state fresh-compiler**
+measurement; it does not include JVM process startup and does not imply a
+persistent compiler cache.
+
+The machine-readable report is written to
+`target/readiness/benchmark-v1.json`. For a quick protocol smoke test:
+
+```bash
+sbt 'benchmark --warmups 0 --iterations 1'
+```
+
+`sbt bench` remains a compatibility alias and accepts the same options.
+````
+
+- [ ] **Step 2: Add the equivalent Japanese contract**
+
+Replace the corresponding paragraph in
+`docs/ja/contributing/building.md` with:
+
+````markdown
+readiness ベンチマークスイートを実行します:
+
+```bash
+sbt benchmark
+```
+
+デフォルトのスイートは、すでにウォームアップされた JVM 内で毎回新しい
+Onion コンパイラを作成し、`run/Hello.on`、`run/TodoManager.on`、
+`run/StatsApp.on` をコンパイルします。生のナノ秒計測値、中央値、p95
+レイテンシ、フェーズ別時間、ソース規模、JVM/OS メタデータを報告します。
+これは **steady-state fresh-compiler** 計測です。JVM プロセスの起動時間は
+含まず、永続コンパイラキャッシュがあることも意味しません。
+
+機械可読レポートは `target/readiness/benchmark-v1.json` に書き出されます。
+プロトコルだけを短時間で確認するには次を実行します:
+
+```bash
+sbt 'benchmark --warmups 0 --iterations 1'
+```
+
+`sbt bench` は互換エイリアスとして残り、同じオプションを受け付けます。
+````
+
+- [ ] **Step 3: Verify terminology and formatting**
+
+Run:
+
+```bash
+rg -n 'cold-compile|warm-compile|DataClass.on|average-only' \
+  src/main/scala/onion/tools/BenchmarkRunner.scala \
+  src/main/scala/onion/tools/readiness/benchmark \
+  docs/contributing/building.md \
+  docs/ja/contributing/building.md
+git diff --check
+```
+
+Expected: `rg` returns no matches and `git diff --check` reports no errors.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.*'
+sbt test
+sbt 'benchmark --warmups 0 --iterations 1 --output target/readiness/final-smoke.json'
+```
+
+Expected:
+
+- every readiness benchmark test passes;
+- the full test suite has zero failures and zero skipped tests;
+- the smoke benchmark exits zero;
+- `target/readiness/final-smoke.json` exists and parses as JSON; and
+- all three scenario results contain one measured observation and a summary.
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add docs/contributing/building.md docs/ja/contributing/building.md
+git commit -m "Document readiness benchmark semantics"
+```
+
+---
+
+## Completion Checkpoint
+
+Do not start process-cold, persistent-REPL, multi-file, budget-enforcement, or
+compiler-optimization work until this plan's evidence proves:
+
+- raw observations and summaries coexist in the JSON report;
+- warmups do not contribute to summaries;
+- failed and timed-out iterations produce structured partial results;
+- `StatsApp.on`, not `DataClass.on`, is the large practical workload;
+- every scenario name says `steady-fresh`;
+- both sbt entry points work;
+- focused and full tests pass; and
+- the English and Japanese build guides describe the same semantics.
+
+After this checkpoint, write the follow-on performance-protocol plan using the
+interfaces established here. That plan adds process-cold distribution timing,
+a real persistent REPL driver, the deterministic 20-file workload, absolute
+budgets, and base/head comparison.

--- a/docs/superpowers/plans/2026-07-24-performance-scenario-protocols.md
+++ b/docs/superpowers/plans/2026-07-24-performance-scenario-protocols.md
@@ -1,0 +1,1475 @@
+# Performance Scenario Protocols Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend Onion's trustworthy measurement core with honest process-cold,
+persistent-REPL, and deterministic 20-file compilation scenarios whose actual
+per-scenario lifecycle is preserved in schema-versioned reports.
+
+**Architecture:** `JvmRuntime` resolves a child-JVM command from loaded class
+locations without assuming an sbt or distribution layout. Process-cold
+iterations use a cancellable child-process launcher; persistent REPL
+measurements drive one real `onion.tools.Repl` process through its plain prompt
+protocol; the multi-file scenario reuses the compiler adapter against a
+committed deterministic fixture. Scenario-specific warmup counts are resolved
+by the runner and recorded in each result, requiring report schema version 2.
+
+**Tech Stack:** Scala 3.3.7, Java 17 process/concurrency/NIO APIs, ScalaTest
+3.2.19, Onion compiler and REPL, sbt 1.12.1.
+
+## Global Constraints
+
+- Use Scala 3 indentation style with two spaces and no tabs.
+- Add no third-party dependencies.
+- Store every duration as integer nanoseconds.
+- Process-cold scenarios use 3 warmups by default; other scenarios use 8.
+- Every scenario uses 25 measurements and a 30-second iteration timeout by
+  default.
+- `--warmups N` overrides every scenario's default, including process-cold.
+- A process timeout or interruption must forcibly terminate its child process.
+- Persistent-REPL setup is excluded from iteration timing and one real REPL
+  process is retained for the complete scenario.
+- The multi-file fixture contains exactly 20 Onion files and between 1,900 and
+  2,200 lines.
+- Preserve both `sbt bench` and `sbt benchmark`.
+- Increment the performance report schema to 2 and record the effective
+  `BenchmarkRunConfig` inside each scenario result.
+- Benchmark fixture generation may use only the required JDK.
+
+---
+
+## File Map
+
+### New production files
+
+- `src/main/scala/onion/tools/readiness/benchmark/JvmRuntime.scala` resolves
+  the current Java executable and complete child classpath.
+- `src/main/scala/onion/tools/readiness/benchmark/ProcessSupport.scala` owns
+  cancellable child-process execution and output capture.
+- `src/main/scala/onion/tools/readiness/benchmark/ProcessColdScenario.scala`
+  owns fresh-JVM script execution.
+- `src/main/scala/onion/tools/readiness/benchmark/ReplProcess.scala` owns the
+  real REPL prompt protocol.
+- `src/main/scala/onion/tools/readiness/benchmark/PersistentReplScenario.scala`
+  adapts a growing REPL session to `BenchmarkScenario`.
+- `benchmarks/fixtures/automation-project/Generate.java` deterministically
+  regenerates the 20-file fixture.
+- `benchmarks/fixtures/automation-project/Stage01.on` through `Stage19.on`
+  and `Pipeline.on` are generated and committed workload inputs.
+
+### Modified production files
+
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala`
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala`
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala`
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala`
+- `src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala`
+- `src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala`
+- `src/main/scala/onion/tools/BenchmarkRunner.scala`
+- `docs/contributing/building.md`
+- `docs/ja/contributing/building.md`
+
+### New tests
+
+- `src/test/scala/onion/tools/readiness/benchmark/JvmRuntimeSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/ProcessColdScenarioSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/ReplProcessSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/PersistentReplScenarioSpec.scala`
+
+### Modified tests
+
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala`
+- `src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala`
+- `src/test/scala/onion/tools/BenchmarkRunnerSpec.scala`
+
+---
+
+### Task 1: Scenario-Specific Configuration and Schema v2
+
+**Files:**
+
+- Modify:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala`
+- Modify:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala`
+- Modify:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala`
+- Modify:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala`
+- Modify:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala`
+- Modify:
+  `src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala`
+- Modify:
+  `src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala`
+- Modify:
+  `src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala`
+
+**Interfaces:**
+
+- Consumes: `BenchmarkRunConfig`, `BenchmarkScenario`, `ScenarioResult`.
+- Produces:
+  `BenchmarkScenario.defaultWarmupIterations`,
+  `BenchmarkOptions.warmupOverride`, and
+  `ScenarioResult.runConfig`.
+
+- [ ] **Step 1: Write failing effective-configuration tests**
+
+Add to `BenchmarkEngineSpec.scala`:
+
+```scala
+    it("records the effective run configuration in the scenario result"):
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload = payload
+
+      val config = BenchmarkRunConfig(0, 1, 1000L)
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        config,
+        new SequenceClock(Seq(0L, 1L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.runConfig shouldBe config
+```
+
+Extend the explicit warmup test in `BenchmarkOptionsSpec.scala`:
+
+```scala
+      parsed.warmupOverride shouldBe Some(2)
+```
+
+Add to its default test:
+
+```scala
+      BenchmarkOptions.parse(Array.empty).toOption.value.warmupOverride shouldBe None
+```
+
+Extend `BenchmarkRenderSpec.scala`:
+
+```scala
+      json should include ("\"schemaVersion\": 2")
+      json should include ("\"warmupIterations\": 0")
+```
+
+- [ ] **Step 2: Run the affected suites and verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkEngineSpec onion.tools.readiness.benchmark.BenchmarkOptionsSpec onion.tools.readiness.benchmark.BenchmarkRenderSpec'
+```
+
+Expected: compilation fails because `ScenarioResult.runConfig` and
+`BenchmarkOptions.warmupOverride` do not exist, and the schema expectation is
+still version 1.
+
+- [ ] **Step 3: Add effective configuration to scenario results**
+
+In `BenchmarkModel.scala`, add `runConfig` immediately after `metadata`:
+
+```scala
+final case class ScenarioResult(
+  metadata: ScenarioMetadata,
+  runConfig: BenchmarkRunConfig,
+  warmups: Vector[IterationObservation],
+  measurements: Vector[IterationObservation],
+  summary: Option[BenchmarkSummary],
+  failure: Option[BenchmarkFailure]
+):
+  def succeeded: Boolean = failure.isEmpty
+```
+
+In `BenchmarkEngine.run`, pass the engine configuration:
+
+```scala
+    ScenarioResult(
+      metadata = scenario.metadata,
+      runConfig = config,
+      warmups = keptWarmups,
+      measurements = keptMeasurements,
+      summary = summary,
+      failure = finalFailure
+    )
+```
+
+Add this default to `BenchmarkScenario`:
+
+```scala
+  def defaultWarmupIterations: Int = 8
+```
+
+Update every test construction of `ScenarioResult` with its effective
+`BenchmarkRunConfig`.
+
+- [ ] **Step 4: Preserve explicit warmup intent**
+
+Add the final field to `BenchmarkOptions`:
+
+```scala
+  warmupOverride: Option[Int] = None
+```
+
+When parsing `--warmups`, set both values:
+
+```scala
+options.copy(
+  runConfig = options.runConfig.copy(warmupIterations = count),
+  warmupOverride = Some(count)
+)
+```
+
+All other parsing paths retain the field unchanged.
+
+- [ ] **Step 5: Render schema version 2 and per-scenario configs**
+
+Set:
+
+```scala
+  val CurrentSchemaVersion = 2
+```
+
+In `BenchmarkRender.scenarioObject`, add:
+
+```scala
+      "runConfig" -> runConfigObject(result.runConfig),
+```
+
+Extract the existing top-level rendering into:
+
+```scala
+  private def runConfigObject(value: BenchmarkRunConfig): Object =
+    obj(
+      "warmupIterations" -> Int.box(value.warmupIterations),
+      "measuredIterations" -> Int.box(value.measuredIterations),
+      "timeoutMillis" -> Long.box(value.timeoutMillis)
+    )
+```
+
+Use this helper for both the top-level and scenario fields. Update render test
+fixtures and expectations from schema 1 to schema 2.
+
+- [ ] **Step 6: Run the three suites and all readiness benchmark tests**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.BenchmarkEngineSpec onion.tools.readiness.benchmark.BenchmarkOptionsSpec onion.tools.readiness.benchmark.BenchmarkRenderSpec'
+sbt 'testOnly onion.tools.readiness.benchmark.* onion.tools.BenchmarkRunnerSpec'
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala \
+  src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
+git commit -m "Record scenario benchmark configurations"
+```
+
+---
+
+### Task 2: Child JVM and Cancellable Process Boundary
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/JvmRuntime.scala`
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/ProcessSupport.scala`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/JvmRuntimeSpec.scala`
+
+**Interfaces:**
+
+- Consumes: the loaded Onion, Scala, ASM, and JLine classes.
+- Produces:
+  `JvmRuntime.current`,
+  `ProcessLauncher.run(command, workingDirectory, environment)`, and
+  `ProcessOutcome`.
+
+- [ ] **Step 1: Write failing JVM/process tests**
+
+Create `JvmRuntimeSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class JvmRuntimeSpec extends AnyFunSpec with Matchers:
+  describe("JvmRuntime.current"):
+    it("resolves an executable Java command and the loaded Onion classpath"):
+      val runtime = JvmRuntime.current()
+
+      Files.isRegularFile(runtime.javaExecutable) shouldBe true
+      runtime.classPath should include ("scala")
+      runtime.classPath.split(java.io.File.pathSeparator).exists { entry =>
+        entry.contains("classes") || entry.endsWith(".jar")
+      } shouldBe true
+
+  describe("ProcessLauncher.System"):
+    it("captures stdout, stderr, and exit code"):
+      val runtime = JvmRuntime.current()
+      val workingDirectory = Files.createTempDirectory("onion-process-probe")
+      val outcome = ProcessLauncher.System.run(
+        Vector(
+          runtime.javaExecutable.toString,
+          "-version"
+        ),
+        workingDirectory,
+        Map.empty
+      )
+
+      outcome.exitCode shouldBe 0
+      (outcome.stdout + outcome.stderr).toLowerCase should include ("version")
+```
+
+- [ ] **Step 2: Run the suite and verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.JvmRuntimeSpec'
+```
+
+Expected: compilation fails because runtime and process types do not exist.
+
+- [ ] **Step 3: Implement current JVM discovery**
+
+Create `JvmRuntime.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import onion.compiler.OnionCompiler
+import org.jline.terminal.Terminal
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.commons.GeneratorAdapter
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.analysis.Analyzer
+import org.objectweb.asm.util.CheckClassAdapter
+
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+
+final case class JvmRuntime(javaExecutable: Path, classPath: String)
+
+object JvmRuntime:
+  def current(): JvmRuntime =
+    val executableName =
+      if System.getProperty("os.name").toLowerCase.contains("win") then "java.exe"
+      else "java"
+    val executable =
+      Paths.get(System.getProperty("java.home"), "bin", executableName)
+        .toAbsolutePath
+        .normalize()
+    require(Files.isRegularFile(executable), s"Java executable not found: $executable")
+
+    val classes = Vector(
+      classOf[OnionCompiler],
+      classOf[scala.Option[?]],
+      classOf[scala.deriving.Mirror],
+      classOf[ClassReader],
+      classOf[GeneratorAdapter],
+      classOf[ClassNode],
+      classOf[Analyzer[?]],
+      classOf[CheckClassAdapter],
+      classOf[Terminal]
+    )
+    val entries = classes.flatMap(codeLocation).distinct
+    require(entries.nonEmpty, "no child-JVM classpath entries were resolved")
+    JvmRuntime(executable, entries.mkString(File.pathSeparator))
+
+  private def codeLocation(klass: Class[?]): Option[String] =
+    Option(klass.getProtectionDomain)
+      .flatMap(domain => Option(domain.getCodeSource))
+      .flatMap(source => Option(source.getLocation))
+      .map(location => Paths.get(location.toURI).toAbsolutePath.normalize().toString)
+```
+
+- [ ] **Step 4: Implement cancellable process capture**
+
+Create `ProcessSupport.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.concurrent.{Callable, Executors, Future}
+import scala.jdk.CollectionConverters.*
+
+final case class ProcessOutcome(
+  exitCode: Int,
+  stdout: String,
+  stderr: String
+)
+
+trait ProcessLauncher:
+  def run(
+    command: Vector[String],
+    workingDirectory: Path,
+    environment: Map[String, String]
+  ): ProcessOutcome
+
+object ProcessLauncher:
+  object System extends ProcessLauncher:
+    override def run(
+      command: Vector[String],
+      workingDirectory: Path,
+      environment: Map[String, String]
+    ): ProcessOutcome =
+      val builder = new ProcessBuilder(command*)
+        .directory(workingDirectory.toFile)
+      builder.environment().putAll(environment.asJava)
+      val process = builder.start()
+      val readers = Executors.newFixedThreadPool(2, runnable =>
+        val thread = new Thread(runnable, "onion-process-output")
+        thread.setDaemon(true)
+        thread
+      )
+      val stdout = readAsync(readers, process.getInputStream)
+      val stderr = readAsync(readers, process.getErrorStream)
+      try
+        val exitCode = process.waitFor()
+        ProcessOutcome(exitCode, stdout.get(), stderr.get())
+      catch
+        case interrupted: InterruptedException =>
+          process.destroyForcibly()
+          process.waitFor()
+          stdout.cancel(true)
+          stderr.cancel(true)
+          Thread.currentThread().interrupt()
+          throw interrupted
+      finally
+        readers.shutdownNow()
+
+    private def readAsync(
+      readers: java.util.concurrent.ExecutorService,
+      stream: java.io.InputStream
+    ): Future[String] =
+      readers.submit(new Callable[String]:
+        override def call(): String =
+          try new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+          finally stream.close()
+      )
+```
+
+- [ ] **Step 5: Run the suite and focused benchmark tests**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.JvmRuntimeSpec'
+sbt 'testOnly onion.tools.readiness.benchmark.*'
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/JvmRuntime.scala \
+  src/main/scala/onion/tools/readiness/benchmark/ProcessSupport.scala \
+  src/test/scala/onion/tools/readiness/benchmark/JvmRuntimeSpec.scala
+git commit -m "Add child JVM benchmark support"
+```
+
+---
+
+### Task 3: Honest Process-Cold Script Scenario
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/ProcessColdScenario.scala`
+- Create:
+  `src/test/scala/onion/tools/readiness/benchmark/ProcessColdScenarioSpec.scala`
+- Modify:
+  `src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala`
+- Modify:
+  `src/main/scala/onion/tools/BenchmarkRunner.scala`
+- Modify:
+  `src/test/scala/onion/tools/BenchmarkRunnerSpec.scala`
+
+**Interfaces:**
+
+- Consumes: `CompileWorkload`, `JvmRuntime`, `ProcessLauncher`,
+  `BenchmarkScenario`, and `BenchmarkRunConfig`.
+- Produces:
+  `ProcessColdScenario` and
+  `BenchmarkRunner.effectiveConfig(scenario, options)`.
+
+- [ ] **Step 1: Write failing process lifecycle tests**
+
+Create `ProcessColdScenarioSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.concurrent.Executors
+
+class ProcessColdScenarioSpec extends AnyFunSpec with Matchers:
+  describe("ProcessColdScenario"):
+    it("launches a new script-runner process for every iteration"):
+      val root = Files.createTempDirectory("onion-process-cold")
+      Files.writeString(root.resolve("Hello.on"), """IO::println("Hello")""")
+      val workload =
+        CompileWorkload.fromFiles(root, "hello", "Hello.on", Vector("Hello.on"))
+      var launches = 0
+      val launcher = new ProcessLauncher:
+        override def run(
+          command: Vector[String],
+          workingDirectory: java.nio.file.Path,
+          environment: Map[String, String]
+        ): ProcessOutcome =
+          launches += 1
+          ProcessOutcome(0, "Hello\n", "")
+      val runtime = JvmRuntime(root.resolve("java"), "runtime-classpath")
+      val scenario =
+        new ProcessColdScenario(workload, runtime, launcher, "Hello\n")
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(1, 2, 1000L),
+        NanoClock.System,
+        executor
+      )
+
+      val result = try engine.run(scenario) finally engine.close()
+
+      launches shouldBe 3
+      result.failure shouldBe None
+      result.metadata.id shouldBe "process-cold:onion:hello"
+      scenario.defaultWarmupIterations shouldBe 3
+
+    it("fails when a successful process prints the wrong result"):
+      val root = Files.createTempDirectory("onion-process-output")
+      Files.writeString(root.resolve("Hello.on"), """IO::println("Hello")""")
+      val workload =
+        CompileWorkload.fromFiles(root, "hello", "Hello.on", Vector("Hello.on"))
+      val launcher = new ProcessLauncher:
+        override def run(
+          command: Vector[String],
+          workingDirectory: java.nio.file.Path,
+          environment: Map[String, String]
+        ): ProcessOutcome = ProcessOutcome(0, "wrong\n", "")
+      val scenario = new ProcessColdScenario(
+        workload,
+        JvmRuntime(root.resolve("java"), "cp"),
+        launcher,
+        "Hello\n"
+      )
+      val session = scenario.open()
+
+      val thrown = intercept[BenchmarkScenarioException] {
+        session.runIteration(0)
+      }
+      thrown.getMessage should include ("unexpected stdout")
+      session.close()
+```
+
+Add runner configuration tests to `BenchmarkRunnerSpec.scala`:
+
+```scala
+    it("uses three process-cold warmups unless the CLI overrides them"):
+      val processScenario = new BenchmarkScenario:
+        override val metadata =
+          ScenarioMetadata("process", ScenarioKind.ProcessCold, "test", "hash")
+        override def defaultWarmupIterations: Int = 3
+        override def open(): BenchmarkSession =
+          throw new UnsupportedOperationException()
+      val defaults = BenchmarkOptions()
+      BenchmarkRunner.effectiveConfig(processScenario, defaults).warmupIterations shouldBe 3
+      val overrideOptions =
+        BenchmarkOptions.parse(Array("--warmups", "0")).toOption.value
+      BenchmarkRunner.effectiveConfig(
+        processScenario,
+        overrideOptions
+      ).warmupIterations shouldBe 0
+```
+
+- [ ] **Step 2: Run the suites and verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.ProcessColdScenarioSpec onion.tools.BenchmarkRunnerSpec'
+```
+
+Expected: compilation fails because the scenario and effective config do not
+exist.
+
+- [ ] **Step 3: Implement the process-cold scenario**
+
+Create `ProcessColdScenario.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+
+final class ProcessColdScenario(
+  workload: CompileWorkload,
+  runtime: JvmRuntime,
+  launcher: ProcessLauncher,
+  expectedStdout: String
+) extends BenchmarkScenario:
+  override val metadata: ScenarioMetadata =
+    ScenarioMetadata(
+      id = s"process-cold:onion:${workload.id}",
+      kind = ScenarioKind.ProcessCold,
+      workload = workload.label,
+      workloadHash = workload.workloadHash
+    )
+
+  override def defaultWarmupIterations: Int = 3
+
+  override def open(): BenchmarkSession =
+    val workingDirectory = Files.createTempDirectory("onion-process-cold")
+    new BenchmarkSession:
+      override def runIteration(index: Int): IterationPayload =
+        val outcome = launcher.run(
+          Vector(
+            runtime.javaExecutable.toString,
+            "-cp",
+            runtime.classPath,
+            "onion.tools.ScriptRunner",
+            workload.paths.head.toString
+          ),
+          workingDirectory,
+          Map("TERM" -> "dumb")
+        )
+        if outcome.exitCode == 0 && normalize(outcome.stdout) != normalize(expectedStdout) then
+          throw BenchmarkScenarioException(
+            s"unexpected stdout for ${workload.label}: ${outcome.stdout.trim}"
+          )
+        IterationPayload(
+          phases = Vector.empty,
+          sourceMetrics = SourceMetrics(
+            workload.sourceCount,
+            workload.lineCount,
+            workload.byteCount,
+            generatedClasses = 0
+          ),
+          exitCode = outcome.exitCode
+        )
+
+      override def close(): Unit =
+        if Files.exists(workingDirectory) then
+          val entries = Files.walk(workingDirectory)
+          try entries.iterator().asScala.toVector.reverse.foreach(Files.deleteIfExists)
+          finally entries.close()
+
+  private def normalize(value: String): String =
+    value.replace("\r\n", "\n")
+```
+
+- [ ] **Step 4: Resolve and record each scenario's actual config**
+
+Add to `BenchmarkRunner`:
+
+```scala
+  private[onion] def effectiveConfig(
+    scenario: BenchmarkScenario,
+    options: BenchmarkOptions
+  ): BenchmarkRunConfig =
+    options.runConfig.copy(
+      warmupIterations =
+        options.warmupOverride.getOrElse(scenario.defaultWarmupIterations)
+    )
+```
+
+Construct each engine with `effectiveConfig(scenario, options)`, retaining one
+daemon executor per scenario.
+
+- [ ] **Step 5: Run the suites and a real one-iteration process scenario**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.ProcessColdScenarioSpec onion.tools.BenchmarkRunnerSpec'
+```
+
+Then temporarily instantiate the real scenario in its test:
+
+```scala
+    it("runs Hello through a real fresh child JVM"):
+      val repoRoot = java.nio.file.Paths.get(".").toAbsolutePath.normalize()
+      val workload = CompileWorkload.fromFiles(
+        repoRoot,
+        "hello",
+        "run/Hello.on",
+        Vector("run/Hello.on")
+      )
+      val scenario = new ProcessColdScenario(
+        workload,
+        JvmRuntime.current(),
+        ProcessLauncher.System,
+        "Hello\n"
+      )
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 30000L),
+        NanoClock.System,
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+      result.failure shouldBe None
+```
+
+Run the suite again. Expected: all three tests pass and the integration case
+starts a real JVM.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/ProcessColdScenario.scala \
+  src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala \
+  src/main/scala/onion/tools/BenchmarkRunner.scala \
+  src/test/scala/onion/tools/readiness/benchmark/ProcessColdScenarioSpec.scala \
+  src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
+git commit -m "Add process-cold benchmark scenario"
+```
+
+---
+
+### Task 4: Real Persistent REPL Protocol
+
+**Files:**
+
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/ReplProcess.scala`
+- Create:
+  `src/main/scala/onion/tools/readiness/benchmark/PersistentReplScenario.scala`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/ReplProcessSpec.scala`
+- Test:
+  `src/test/scala/onion/tools/readiness/benchmark/PersistentReplScenarioSpec.scala`
+
+**Interfaces:**
+
+- Consumes: `JvmRuntime`, `BenchmarkScenario`, `BenchmarkSession`.
+- Produces:
+  `ReplClient`, `ReplClientFactory`, `ProcessReplClient`, and
+  `PersistentReplScenario`.
+
+- [ ] **Step 1: Write failing protocol and lifecycle tests**
+
+Create `PersistentReplScenarioSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PersistentReplScenarioSpec extends AnyFunSpec with Matchers:
+  describe("PersistentReplScenario"):
+    it("performs setup once and submits growing-state expressions"):
+      val submitted = Vector.newBuilder[String]
+      var closes = 0
+      val factory = new ReplClientFactory:
+        override def open(): ReplClient = new ReplClient:
+          override def submit(code: String): String =
+            submitted += code
+            if code.startsWith("val baseline") then ""
+            else s"res: Int = ${40 + code.split(\" \").last.toInt}"
+          override def close(): Unit = closes += 1
+      val scenario = new PersistentReplScenario(factory, "hash")
+      val session = scenario.open()
+
+      val first = session.runIteration(0)
+      val second = session.runIteration(1)
+      session.close()
+
+      submitted.result() shouldBe Vector(
+        "val baseline = 40",
+        "baseline + 1",
+        "baseline + 2"
+      )
+      first.exitCode shouldBe 0
+      second.sourceMetrics.lineCount shouldBe 3
+      closes shouldBe 1
+      scenario.metadata.kind shouldBe ScenarioKind.PersistentSession
+```
+
+Create `ReplProcessSpec.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class ReplProcessSpec extends AnyFunSpec with Matchers:
+  describe("ProcessReplClient"):
+    it("retains state across submissions to the real Onion REPL"):
+      val workingDirectory = Files.createTempDirectory("onion-repl-process")
+      val client = ProcessReplClient.start(
+        JvmRuntime.current(),
+        workingDirectory,
+        timeoutMillis = 30000L
+      )
+      try
+        client.submit("val baseline = 40")
+        val output = client.submit("baseline + 2")
+        output should include ("res0: Int = 42")
+      finally client.close()
+```
+
+- [ ] **Step 2: Run both suites and verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.PersistentReplScenarioSpec onion.tools.readiness.benchmark.ReplProcessSpec'
+```
+
+Expected: compilation fails because the REPL client interfaces do not exist.
+
+- [ ] **Step 3: Implement the prompt-driven real REPL client**
+
+Create `ReplProcess.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.io.{BufferedWriter, InputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
+trait ReplClient extends AutoCloseable:
+  def submit(code: String): String
+
+trait ReplClientFactory:
+  def open(): ReplClient
+
+final class ProcessReplClient private (
+  process: Process,
+  input: BufferedWriter,
+  stdout: ReplOutputPump,
+  timeoutMillis: Long
+) extends ReplClient:
+  override def submit(code: String): String =
+    try
+      input.write(code)
+      input.newLine()
+      input.flush()
+      stdout.readUntil("onion> ", timeoutMillis)
+    catch
+      case interrupted: InterruptedException =>
+        process.destroyForcibly()
+        Thread.currentThread().interrupt()
+        throw interrupted
+
+  override def close(): Unit =
+    if process.isAlive then
+      try
+        input.write(":quit")
+        input.newLine()
+        input.flush()
+        if !process.waitFor(1L, TimeUnit.SECONDS) then process.destroyForcibly()
+      catch
+        case _: Exception => process.destroyForcibly()
+    input.close()
+
+object ProcessReplClient:
+  def start(
+    runtime: JvmRuntime,
+    workingDirectory: Path,
+    timeoutMillis: Long
+  ): ProcessReplClient =
+    val process =
+      new ProcessBuilder(
+        runtime.javaExecutable.toString,
+        "-cp",
+        runtime.classPath,
+        "onion.tools.Repl"
+      )
+        .directory(workingDirectory.toFile)
+        .start()
+    process.info()
+    val stderr = new ReplOutputPump(process.getErrorStream, "repl-stderr")
+    stderr.start()
+    val stdout = new ReplOutputPump(process.getInputStream, "repl-stdout")
+    stdout.start()
+    val writer =
+      new BufferedWriter(
+        new OutputStreamWriter(process.getOutputStream, StandardCharsets.UTF_8)
+      )
+    val client = new ProcessReplClient(process, writer, stdout, timeoutMillis)
+    try
+      stdout.readUntil("onion> ", timeoutMillis)
+      client
+    catch
+      case error: Throwable =>
+        client.close()
+        throw error
+
+private final class ReplOutputPump(stream: InputStream, name: String):
+  private val End = -1
+  private val queue = new LinkedBlockingQueue[Int]()
+  private val failure = new AtomicReference[Throwable]()
+  private val thread = new Thread(
+    () =>
+      try
+        var next = stream.read()
+        while next >= 0 do
+          queue.put(next)
+          next = stream.read()
+      catch case error: Throwable => failure.set(error)
+      finally
+        queue.offer(End)
+        stream.close(),
+    s"onion-$name"
+  )
+  thread.setDaemon(true)
+
+  def start(): Unit = thread.start()
+
+  def readUntil(marker: String, timeoutMillis: Long): String =
+    val expected = marker.getBytes(StandardCharsets.UTF_8)
+    val bytes = scala.collection.mutable.ArrayBuffer.empty[Byte]
+    val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
+    while !endsWith(bytes, expected) do
+      val remaining = deadline - System.nanoTime()
+      if remaining <= 0L then
+        throw BenchmarkScenarioException(s"REPL prompt timed out after $timeoutMillis ms")
+      val next = queue.poll(remaining, TimeUnit.NANOSECONDS)
+      if next == null then
+        throw BenchmarkScenarioException(s"REPL prompt timed out after $timeoutMillis ms")
+      if next == End then
+        val cause = failure.get()
+        val detail =
+          if cause == null then "end of stream"
+          else Option(cause.getMessage).getOrElse(cause.getClass.getSimpleName)
+        throw BenchmarkScenarioException(s"REPL exited before prompt: $detail")
+      bytes += next.toByte
+    new String(bytes.toArray, StandardCharsets.UTF_8)
+
+  private def endsWith(
+    bytes: scala.collection.mutable.ArrayBuffer[Byte],
+    expected: Array[Byte]
+  ): Boolean =
+    bytes.length >= expected.length &&
+      expected.indices.forall { index =>
+        bytes(bytes.length - expected.length + index) == expected(index)
+      }
+```
+
+- [ ] **Step 4: Implement the persistent scenario**
+
+Create `PersistentReplScenario.scala`:
+
+```scala
+package onion.tools.readiness.benchmark
+
+import java.nio.charset.StandardCharsets
+
+final class PersistentReplScenario(
+  factory: ReplClientFactory,
+  workloadHash: String
+) extends BenchmarkScenario:
+  override val metadata =
+    ScenarioMetadata(
+      "persistent-session:repl:growing-state",
+      ScenarioKind.PersistentSession,
+      "generated growing REPL session",
+      workloadHash
+    )
+
+  override def open(): BenchmarkSession =
+    val client = factory.open()
+    client.submit("val baseline = 40")
+    new BenchmarkSession:
+      private var submission = 0
+      private var bytes = "val baseline = 40".getBytes(StandardCharsets.UTF_8).length
+
+      override def runIteration(index: Int): IterationPayload =
+        submission += 1
+        val code = s"baseline + $submission"
+        bytes += code.getBytes(StandardCharsets.UTF_8).length
+        val output = client.submit(code)
+        val expected = 40 + submission
+        if !output.contains(s"= $expected") then
+          throw BenchmarkScenarioException(
+            s"REPL returned an unexpected result for '$code': ${output.trim}"
+          )
+        IterationPayload(
+          Vector.empty,
+          SourceMetrics(1, submission + 1, bytes, generatedClasses = 1),
+          exitCode = 0
+        )
+
+      override def close(): Unit = client.close()
+```
+
+The production factory in the catalog computes a SHA-256 hash of the literal
+protocol version string `onion-repl-growing-state-v1`, creates a temporary
+working directory, and starts `ProcessReplClient` with the scenario timeout.
+
+- [ ] **Step 5: Run unit and real protocol tests**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.PersistentReplScenarioSpec onion.tools.readiness.benchmark.ReplProcessSpec'
+sbt 'testOnly onion.tools.readiness.benchmark.*'
+```
+
+Expected: both lifecycle and real child-REPL tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  src/main/scala/onion/tools/readiness/benchmark/ReplProcess.scala \
+  src/main/scala/onion/tools/readiness/benchmark/PersistentReplScenario.scala \
+  src/test/scala/onion/tools/readiness/benchmark/ReplProcessSpec.scala \
+  src/test/scala/onion/tools/readiness/benchmark/PersistentReplScenarioSpec.scala
+git commit -m "Add persistent REPL benchmark protocol"
+```
+
+---
+
+### Task 5: Deterministic 20-File Workload and Complete Catalog
+
+**Files:**
+
+- Create:
+  `benchmarks/fixtures/automation-project/Generate.java`
+- Generate and create:
+  `benchmarks/fixtures/automation-project/Stage01.on` through `Stage19.on`
+- Generate and create:
+  `benchmarks/fixtures/automation-project/Pipeline.on`
+- Modify:
+  `src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala`
+- Modify:
+  `src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala`
+
+**Interfaces:**
+
+- Consumes: `CompileWorkload`, `FreshCompileScenario`, `JvmRuntime`.
+- Produces:
+  `CompileScenarioCatalog.default(repoRoot, runtime, timeoutMillis)` containing
+  six scenarios.
+
+- [ ] **Step 1: Write failing fixture and catalog tests**
+
+Replace the catalog test with:
+
+```scala
+    it("contains every honest practical performance protocol"):
+      val root = Paths.get(".").toAbsolutePath.normalize()
+      val scenarios =
+        CompileScenarioCatalog.default(root, JvmRuntime.current(), 30000L)
+      scenarios.map(_.metadata.id) shouldBe Vector(
+        "steady-fresh:onionc:hello",
+        "steady-fresh:onionc:todo-manager",
+        "steady-fresh:onionc:stats-app",
+        "process-cold:onion:hello",
+        "persistent-session:repl:growing-state",
+        "multi-file:onionc:automation-project"
+      )
+      scenarios.last.metadata.kind shouldBe ScenarioKind.MultiFile
+      scenarios.last.metadata.workload shouldBe
+        "benchmarks/fixtures/automation-project"
+```
+
+Add:
+
+```scala
+    it("uses a deterministic 20-file workload of approximately 2,000 lines"):
+      val root = Paths.get(".").toAbsolutePath.normalize()
+      val relativeFiles =
+        (1 to 19).map(index => f"benchmarks/fixtures/automation-project/Stage$index%02d.on").toVector :+
+          "benchmarks/fixtures/automation-project/Pipeline.on"
+      val workload = CompileWorkload.fromFiles(
+        root,
+        "automation-project",
+        "benchmarks/fixtures/automation-project",
+        relativeFiles
+      )
+      workload.sourceCount shouldBe 20
+      workload.lineCount should (be >= 1900 and be <= 2200)
+```
+
+- [ ] **Step 2: Run the suite and verify RED**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.FreshCompileScenarioSpec'
+```
+
+Expected: compilation fails on the new catalog signature or the fixture is
+missing.
+
+- [ ] **Step 3: Add the deterministic JDK-only generator**
+
+Create `benchmarks/fixtures/automation-project/Generate.java`:
+
+```java
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class Generate {
+    private Generate() {}
+
+    public static void main(String[] args) throws Exception {
+        Path root = Path.of(args.length == 0 ? "." : args[0])
+            .toAbsolutePath()
+            .normalize();
+        Files.createDirectories(root);
+        for (int stage = 1; stage <= 19; stage++) {
+            String className = String.format("Stage%02d", stage);
+            StringBuilder source = new StringBuilder();
+            source.append("module readiness.automation\n\n");
+            source.append("class ").append(className).append(" {\n");
+            source.append("public:\n");
+            for (int method = 1; method <= 32; method++) {
+                source.append("  def step")
+                    .append(String.format("%02d", method))
+                    .append("(value: Int): Int {\n");
+                source.append("    return value + ")
+                    .append(stage + method)
+                    .append("\n");
+                source.append("  }\n");
+            }
+            source.append("}\n");
+            Files.writeString(
+                root.resolve(className + ".on"),
+                source,
+                StandardCharsets.UTF_8
+            );
+        }
+
+        StringBuilder pipeline = new StringBuilder();
+        pipeline.append("module readiness.automation\n\n");
+        pipeline.append("class AutomationPipeline {\npublic:\n");
+        pipeline.append("  def run(value: Int): Int {\n");
+        pipeline.append("    var current = value\n");
+        for (int stage = 1; stage <= 19; stage++) {
+            pipeline.append("    current = new ")
+                .append(String.format("Stage%02d", stage))
+                .append("().step01(current)\n");
+        }
+        pipeline.append("    return current\n  }\n");
+        for (int method = 1; method <= 24; method++) {
+            pipeline.append("  def normalize")
+                .append(String.format("%02d", method))
+                .append("(value: Int): Int {\n");
+            pipeline.append("    return value - ")
+                .append(method)
+                .append("\n");
+            pipeline.append("  }\n");
+        }
+        pipeline.append("}\n");
+        Files.writeString(
+            root.resolve("Pipeline.on"),
+            pipeline,
+            StandardCharsets.UTF_8
+        );
+    }
+}
+```
+
+Generate the committed inputs:
+
+```bash
+java benchmarks/fixtures/automation-project/Generate.java \
+  benchmarks/fixtures/automation-project
+```
+
+- [ ] **Step 4: Generalize the compiler adapter**
+
+Add optional constructor fields to `FreshCompileScenario`:
+
+```scala
+  scenarioKind: ScenarioKind = ScenarioKind.SteadyFresh,
+  driver: String = "onionc"
+```
+
+Construct metadata with:
+
+```scala
+      id = s"${scenarioKind.wireName}:$driver:${workload.id}",
+      kind = scenarioKind,
+```
+
+- [ ] **Step 5: Assemble the complete catalog**
+
+Change the catalog signature to:
+
+```scala
+  def default(
+    repoRoot: java.nio.file.Path,
+    runtime: JvmRuntime,
+    timeoutMillis: Long
+  ): Vector[BenchmarkScenario]
+```
+
+Retain the three steady-fresh scenarios, then append:
+
+```scala
+      new ProcessColdScenario(
+        helloWorkload,
+        runtime,
+        ProcessLauncher.System,
+        "Hello\n"
+      ),
+      new PersistentReplScenario(
+        new ReplClientFactory:
+          override def open(): ReplClient =
+            ProcessReplClient.start(
+              runtime,
+              Files.createTempDirectory("onion-repl-benchmark"),
+              timeoutMillis
+            ),
+        sha256("onion-repl-growing-state-v1")
+      ),
+      new FreshCompileScenario(
+        multiFileWorkload,
+        config,
+        ScenarioKind.MultiFile,
+        "onionc"
+      )
+```
+
+Factor SHA-256 string rendering into a package-private helper shared with
+`CompileWorkload`.
+
+- [ ] **Step 6: Compile the fixture and run catalog tests**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.FreshCompileScenarioSpec'
+sbt 'testOnly onion.tools.readiness.benchmark.*'
+```
+
+Expected: the fixture compiles, contains 20 files and 1,900–2,200 lines, and
+the six catalog IDs match exactly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  benchmarks/fixtures/automation-project \
+  src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala \
+  src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
+git commit -m "Add complete practical benchmark catalog"
+```
+
+---
+
+### Task 6: CLI Integration, Documentation, and Full Verification
+
+**Files:**
+
+- Modify: `src/main/scala/onion/tools/BenchmarkRunner.scala`
+- Modify:
+  `src/test/scala/onion/tools/BenchmarkRunnerSpec.scala`
+- Modify: `docs/contributing/building.md`
+- Modify: `docs/ja/contributing/building.md`
+
+**Interfaces:**
+
+- Consumes: schema v2, `JvmRuntime`, the complete catalog, scenario-effective
+  configs, and all renderers.
+- Produces: a six-scenario schema-v2 report from both sbt entry points.
+
+- [ ] **Step 1: Wire the complete catalog and effective configs**
+
+In `BenchmarkRunner.buildReport`, capture `JvmRuntime.current()` inside the
+existing setup-failure boundary and call:
+
+```scala
+CompileScenarioCatalog.default(
+  repoRoot,
+  runtime,
+  options.runConfig.timeoutMillis
+)
+```
+
+Construct each engine with:
+
+```scala
+effectiveConfig(scenario, options)
+```
+
+The setup boundary must still return a structured `InvalidMeasurement` report
+when runtime discovery, fixture loading, or catalog construction fails.
+
+- [ ] **Step 2: Extend runner report tests**
+
+Add a catalog injection boundary:
+
+```scala
+private[onion] def runScenarios(
+  scenarios: Vector[BenchmarkScenario],
+  options: BenchmarkOptions
+): Vector[ScenarioResult]
+```
+
+Test that a fake process-cold scenario receives 3 default warmups and a fake
+steady scenario receives 8, while `--warmups 0` gives both zero. Assert the
+result's recorded `runConfig` for every case.
+
+- [ ] **Step 3: Update English documentation**
+
+Replace the single-protocol description with:
+
+````markdown
+The default suite reports six explicit protocols:
+
+- steady-state fresh compiler measurements for `run/Hello.on`,
+  `run/TodoManager.on`, and `run/StatsApp.on`;
+- a process-cold `onion run/Hello.on` measurement that includes child-JVM
+  startup and shutdown;
+- submissions to one persistent, growing Onion REPL session; and
+- one compilation of the deterministic 20-file automation fixture under
+  `benchmarks/fixtures/automation-project/`.
+
+Process-cold uses 3 warmups by default; the other protocols use 8. Every
+protocol uses 25 measured iterations and a 30-second iteration timeout.
+`--warmups N` overrides the scenario defaults. The schema-v2 JSON report stores
+the effective configuration beside every scenario so unlike lifecycles are
+never presented as identical measurements.
+````
+
+- [ ] **Step 4: Add the equivalent Japanese documentation**
+
+Use:
+
+````markdown
+デフォルトスイートは、次の6つの明示的なプロトコルを報告します:
+
+- `run/Hello.on`、`run/TodoManager.on`、`run/StatsApp.on` に対する
+  steady-state fresh compiler 計測
+- 子 JVM の起動と終了を含む process-cold の
+  `onion run/Hello.on` 計測
+- 1つの永続的かつ状態が増加する Onion REPL セッションへの連続入力
+- `benchmarks/fixtures/automation-project/` にある決定的な20ファイル
+  automation fixture の一括コンパイル
+
+process-cold のデフォルト warmup は3回、その他は8回です。全プロトコルを
+25回計測し、1 iteration の timeout は30秒です。`--warmups N` は各
+scenario のデフォルトを上書きします。schema-v2 JSON は有効な設定を
+scenario ごとに保存するため、異なる lifecycle を同一条件の計測として
+扱いません。
+````
+
+- [ ] **Step 5: Run both one-iteration CLI paths**
+
+Run:
+
+```bash
+sbt 'bench --warmups 0 --iterations 1 --json --output target/readiness/protocol-compat-v2.json'
+sbt 'benchmark --warmups 0 --iterations 1 --format text --output target/readiness/protocol-smoke-v2.json'
+```
+
+Expected:
+
+- both commands exit zero;
+- both reports have `schemaVersion` 2;
+- each report contains exactly six scenario IDs;
+- every scenario has one measurement, an effective run config, and a summary;
+- process-cold starts a child JVM;
+- the REPL result retains setup state; and
+- the multi-file observation reports exactly 20 sources.
+
+- [ ] **Step 6: Validate the report artifacts**
+
+Run:
+
+```bash
+ruby -rjson -e '
+ARGV.each do |path|
+  report = JSON.parse(File.read(path))
+  abort("#{path}: schema") unless report["schemaVersion"] == 2
+  abort("#{path}: scenarios") unless report["scenarios"].length == 6
+  report["scenarios"].each do |scenario|
+    abort("#{path}: config") unless scenario["runConfig"]
+    abort("#{path}: measurement") unless scenario["measurements"].length == 1
+    abort("#{path}: summary") unless scenario["summary"]
+  end
+end
+' target/readiness/protocol-compat-v2.json \
+  target/readiness/protocol-smoke-v2.json
+```
+
+- [ ] **Step 7: Run focused and full verification**
+
+Run:
+
+```bash
+sbt 'testOnly onion.tools.readiness.benchmark.* onion.tools.BenchmarkRunnerSpec'
+sbt test
+git diff --check
+```
+
+Expected: zero failed, canceled, ignored, pending, or skipped tests, and no
+whitespace errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  src/main/scala/onion/tools/BenchmarkRunner.scala \
+  src/test/scala/onion/tools/BenchmarkRunnerSpec.scala \
+  docs/contributing/building.md \
+  docs/ja/contributing/building.md
+git commit -m "Document complete benchmark protocols"
+```
+
+---
+
+## Completion Checkpoint
+
+Do not implement absolute budgets or base/head comparisons until this plan
+proves:
+
+- report schema 2 records the effective run config for every scenario;
+- process-cold iterations launch a new child JVM and have 3 default warmups;
+- child processes are destroyed on interruption;
+- persistent REPL setup is excluded and measurements share one real process;
+- the multi-file fixture is deterministic, exactly 20 files, and approximately
+  2,000 lines;
+- both sbt entry points emit six successful scenario results;
+- English and Japanese documentation name the same lifecycles; and
+- the focused and full suites pass.
+
+The next performance plan adds reference-lane detection, absolute budgets,
+compatible base/head comparison, confirmation rounds, and the first captured
+baseline.

--- a/docs/superpowers/specs/2026-07-24-onion-practical-readiness-design.md
+++ b/docs/superpowers/specs/2026-07-24-onion-practical-readiness-design.md
@@ -1,0 +1,515 @@
+# Onion Practical Readiness Foundation
+
+- **Date:** 2026-07-24
+- **Status:** Approved design
+- **Primary first-milestone workload:** scripts, command-line tools, and data
+  automation
+
+## Purpose
+
+Onion already has a substantial language implementation: a multi-phase JVM
+compiler, a runtime library, a script runner, a REPL, an LSP server, a VS Code
+extension, release automation, hundreds of test suites, a crash corpus, a
+mutation fuzzer, and English and Japanese documentation. The next step is not
+to add features indiscriminately. It is to make the implementation measurably
+usable, fast, documented, installable, and reliable for a defined workload.
+
+The current evidence is not sufficient to make that claim:
+
+- `docs/quality-bar.md` is a dated hand-maintained snapshot. It has no
+  compilation-latency thresholds and some of its documented counts are stale.
+- `BenchmarkRunner` labels a JVM-warmed, fresh-compiler operation as a warm
+  compile, uses `DataClass.on` as a large input even though it is 73 lines, and
+  reports only arithmetic means.
+- The documentation contains 819 `onion` code fences, while
+  `DocExamplesCompileSpec` checks only filename-labelled complete examples
+  under `docs/examples/` and `docs/ja/examples/`.
+- Installation and tooling documentation already contradicts repository
+  capabilities, including the status of the VS Code extension and language
+  server.
+- The main CI workflow runs tests but does not enforce documentation example
+  correctness, release-install journeys, or performance regression limits as
+  first-class readiness dimensions.
+
+This design establishes trustworthy readiness evidence before compiler
+optimization and documentation repair. It is the first independently
+shippable milestone in the broader practical-language program.
+
+## Program Decomposition
+
+The complete practical-language objective is split into five ordered
+milestones:
+
+1. **Readiness foundation.** Establish executable correctness, documentation,
+   performance, packaging, and reporting gates.
+2. **Compilation speed.** Profile realistic workloads, optimize measured
+   bottlenecks, and meet the practical latency budgets in this document.
+3. **Documentation truth and learning path.** Repair contradictions and make
+   install-to-use journeys executable against distribution artifacts.
+4. **Practical developer experience.** Verify compiler, runner, REPL, LSP, VS
+   Code integration, diagnostics, and release archives on supported systems.
+5. **Application reliability.** Exercise representative multi-file
+   applications and establish compatibility and versioning policy.
+
+Each milestone gets its own implementation plan and completion audit. Finishing
+the readiness foundation does not complete the broader objective; it creates
+the evidence required to complete and verify the later milestones.
+
+## Approach
+
+Three approaches were considered:
+
+1. **Readiness gates first (selected).** Make quality and performance claims
+   executable before optimizing or expanding the language.
+2. **User journey first.** Polish installation and tutorials immediately, but
+   risk hiding compiler latency and correctness gaps behind presentation.
+3. **Compiler first.** Optimize immediately, but risk tuning misleading
+   microbenchmarks and leaving documentation claims unverifiable.
+
+The selected approach minimizes speculative work. Performance changes are
+chosen from profiles, documentation work is driven by a complete inventory,
+and every later claim has an authoritative check.
+
+## Scope of This Milestone
+
+The readiness foundation will:
+
+- define stable benchmark workloads and honest execution semantics;
+- retain raw timings and compute robust summary statistics;
+- produce versioned, machine-readable readiness evidence;
+- classify every Onion documentation fence and verify all declared outcomes;
+- express the practical-quality policy as typed, executable rules;
+- provide deterministic checks separately from noisy performance measurements;
+- add pull-request, nightly, and release CI lanes;
+- smoke-test a built distribution in an isolated directory; and
+- capture a trustworthy performance baseline.
+
+This milestone will not:
+
+- introduce compiler caches or incremental compilation before profiles justify
+  them;
+- claim that Onion meets the performance targets merely because measurement
+  exists;
+- rewrite all user documentation before the verifier identifies its exact
+  failures;
+- add unrelated language features; or
+- replace the crash, fuzzing, soundness, and code-generation tests that already
+  exist.
+
+## Architecture
+
+### Package and Artifact Boundaries
+
+Readiness implementation code lives under
+`src/main/scala/onion/tools/readiness/`. It is split into independent units:
+
+- `scenario` owns workload descriptions and execution semantics;
+- `benchmark` owns raw timing collection and statistics;
+- `docs` owns Markdown directive extraction and example execution;
+- `policy` owns readiness requirements and evaluations; and
+- `report` owns versioned JSON and human-readable rendering.
+
+Tests mirror those boundaries under
+`src/test/scala/onion/tools/readiness/`. Dedicated, stable performance inputs
+live under `benchmarks/fixtures/`; they are not mixed with illustrative
+`run/` samples. Reports are written under `target/readiness/` and are never
+treated as source files.
+
+`onion.tools.BenchmarkRunner` remains as a compatibility entry point and
+delegates to the new benchmark package. The existing `bench` task remains an
+alias for the new `benchmark` task during the transition.
+
+### Scenario Catalog
+
+The catalog contains the following distinct scenario kinds:
+
+1. **Process-cold command.** An outer launcher starts a new JVM and invokes the
+   built `onion` or `onionc` command. The duration includes JVM startup,
+   compiler initialization, source I/O, compilation, and command shutdown.
+   Process-cold time cannot be measured by code already running inside that
+   JVM.
+2. **Steady-state fresh compiler.** A warmed benchmark JVM creates a fresh
+   compiler invocation for each measured iteration. This measures JIT-warmed
+   compilation without implying persistent compiler state.
+3. **Persistent session.** Consecutive snippets are submitted to a real REPL
+   session. Setup is excluded and the measured operations include the growing
+   session state.
+4. **Multi-file compilation.** A dedicated 20-file, approximately 2,000-line
+   fixture is compiled as one project to expose scaling and shared-symbol
+   costs.
+
+The single-script catalog uses:
+
+- `run/Hello.on` as the minimal script;
+- `run/TodoManager.on` as the medium practical script; and
+- `run/StatsApp.on` as the large practical script.
+
+Names in reports describe the execution model and workload explicitly, for
+example `process-cold:onion:hello` and
+`steady-fresh:onionc:stats-app`. Terms such as `warm` and `cold` may not appear
+without the corresponding lifecycle definition in scenario metadata.
+
+### Measurement Engine
+
+Every scenario records raw iteration durations in nanoseconds. It also records:
+
+- discarded warmup iterations;
+- median, nearest-rank p95, minimum, and maximum;
+- compiler phase timings where the execution model exposes them;
+- source-file, line, byte, and generated-class counts;
+- exit status and captured failure information;
+- JVM vendor, JVM version, configured heap and garbage collector;
+- operating system, architecture, and assigned processor count;
+- Git commit, dirty-worktree flag, workload hash, and report schema version.
+
+The median is the middle ordered observation, using the mean of the two middle
+observations for an even sample count. The p95 is the observation at
+`ceil(0.95 * n)` in one-based ordered indexing. No sample is removed as an
+outlier. Warmup samples are retained in the report but excluded from summary
+statistics.
+
+Normal in-process scenarios use 8 warmups and 25 measured iterations.
+Process-cold scenarios use 3 discarded launches and 25 measured launches.
+Each iteration has a 30-second timeout. A timeout is a scenario failure, not a
+slow numeric sample.
+
+Timing and execution boundaries are injectable. Unit tests use fake clocks and
+executors to prove lifecycle semantics without depending on wall-clock timing.
+
+### Documentation Verifier
+
+Every fenced block whose language is `onion` must have one HTML directive on
+the immediately preceding non-blank line. The supported forms are:
+
+```text
+<!-- onion-example: compile -->
+<!-- onion-example: run -->
+<!-- onion-example: reject code=E0059 -->
+<!-- onion-example: fragment reason="illustrates an expression in an existing scope" -->
+```
+
+Their meanings are:
+
+- `compile`: the block is a complete program and must compile successfully.
+- `run`: the block is a complete deterministic program and must compile, run,
+  exit successfully, and match its declared output.
+- `reject`: compilation must fail and include the exact declared diagnostic
+  code.
+- `fragment`: the block is intentionally incomplete and has a non-empty,
+  human-readable reason.
+
+A `run` block must be followed by an output declaration and a `text` fence:
+
+````text
+<!-- onion-output: stdout -->
+```text
+expected output
+```
+````
+
+The output fence compares normalized LF line endings exactly. A second
+`onion-output: stderr` block may follow when stderr is part of the example.
+Absent stderr means stderr must be empty. The declared process exit is zero;
+nonzero examples use `reject` and are compile-time examples in this milestone.
+
+Examples execute in a new temporary directory with a five-second timeout.
+They may not depend on an external network service and may access only fixtures
+explicitly copied into that directory. A network example must use a
+test-owned loopback service; the CI documentation job disables non-loopback
+network access. A failure reports the Markdown path and fence line as well as
+the Onion diagnostic location.
+
+Unclassified Onion fences, unknown directives, empty fragment reasons,
+duplicate directives, missing run output, and unsupported output streams are
+validation errors. Nothing is inferred from a filename label or silently
+skipped.
+
+### Documentation Parity
+
+Every published Markdown page in `mkdocs.yml` receives a stable
+`onion_topic` identifier in YAML front matter. The English and Japanese
+navigation trees must contain the same topic identifiers, parent
+relationships, and sibling order. File names may differ. A deliberately
+language-neutral artifact, such as generated API documentation, may be
+referenced by both trees with the same identifier.
+
+The parity check covers the complete published navigation, including
+contributor and design pages. A page cannot be exempted by omission; a
+language-specific note must have a corresponding page that explains the
+language-specific content to the other audience.
+
+Parity proves structure and coverage, not translation quality. Translation
+quality remains a human review responsibility in the documentation milestone.
+
+### Readiness Policy and Commands
+
+`ReadinessPolicy` is the typed authority for thresholds and required checks.
+Human documentation renders stable policy tables from this authority. It does
+not commit fluctuating benchmark results as if they were current forever.
+
+The public development commands are:
+
+- `sbt readinessCheck`: run deterministic tests, documentation verification,
+  sample checks, distribution smoke checks, parity checks, and policy-document
+  freshness checks without modifying tracked files;
+- `sbt benchmark`: run the performance suite and write a versioned JSON report
+  under `target/readiness/`;
+- `sbt readinessReport`: run `readinessCheck` and `benchmark`, then write
+  versioned JSON plus a human-readable report under `target/readiness/`; and
+- `sbt readinessPolicyDocs`: explicitly regenerate the stable policy portion
+  of `docs/quality-bar.md`.
+
+`readinessCheck` renders the expected policy documentation in memory and fails
+when the committed file differs. CI never repairs tracked documentation
+automatically.
+
+`benchmark` and `readinessReport` exit nonzero for invalid measurements and
+scenario failures. On a non-reference machine, absolute budgets are recorded
+as `not-applicable`, the report is informational, and successful measurement
+exits zero. On the detected reference lane, an absolute budget breach exits
+nonzero. Relative comparison always enforces its regression policy when two
+compatible commits were requested.
+
+### Report Data Flow
+
+The authoritative flow is:
+
+```text
+scenarios + documentation + tests + distribution
+  -> isolated runners
+  -> structured component results
+  -> policy evaluation
+  -> versioned JSON + human-readable report
+```
+
+The JSON top level contains:
+
+- `schemaVersion`;
+- `commit`;
+- `dirty`;
+- `generatedAt`;
+- `environment`;
+- `correctness`;
+- `documentation`;
+- `distribution`;
+- `performance`;
+- `policy`;
+- `failures`; and
+- `overallStatus`.
+
+All durations use integer nanoseconds in JSON. Renderers may show milliseconds.
+A breaking shape or semantic change increments `schemaVersion`. Readers reject
+unsupported newer versions instead of guessing.
+
+`overallStatus` is `pass`, `fail`, or `informational`. `informational` is valid
+only when every executed check succeeded and the current environment is not
+eligible for the absolute reference policy.
+
+## Practical Performance Policy
+
+### Reference Lane
+
+Absolute performance is evaluated on:
+
+- Ubuntu 24.04 x86-64;
+- Temurin JDK 21;
+- two assigned processor cores;
+- 4 GiB available memory; and
+- a 2 GiB maximum heap for in-process scenarios.
+
+Process-cold scenarios use the distribution launcher's normal JVM settings.
+In-process scenarios use fixed heap and garbage-collector settings recorded in
+the report. Reports from other environments remain useful but cannot satisfy
+the absolute reference policy.
+
+### Absolute Ceilings
+
+The first practical milestone requires:
+
+| Scenario | Median | p95 |
+|---|---:|---:|
+| Fresh `onion Hello.on` process | 1.5 s | 2.5 s |
+| Steady-state compile of `Hello.on` | 150 ms | 300 ms |
+| Steady-state compile of `StatsApp.on` | 750 ms | 1.2 s |
+| Subsequent REPL snippet | 100 ms | 250 ms |
+| 20-file/~2,000-line project | 2.0 s | 3.0 s |
+
+These are user-experience ceilings, not a description of the current
+implementation. Baseline results determine the work required; they do not
+weaken the ceilings.
+
+### Relative Regression Rule
+
+Head and base run as alternating pairs on the same worker. A scenario is a
+regression when either condition holds:
+
+- head is slower by more than both 10 percent and 20 ms at the median; or
+- head is slower by more than both 20 percent and 50 ms at p95.
+
+A breached scenario runs a second complete round. Repeating the same breach is
+a performance failure. A non-repeating breach is an unstable-environment
+failure and is reported with that category rather than attributed to the code.
+
+Base and head reports are comparable only when schema version, workload hash,
+JVM vendor and major version, OS, architecture, assigned processor count, heap,
+and garbage collector match.
+
+## Failure Semantics
+
+The system uses four failure categories:
+
+1. **Invalid measurement:** malformed configuration, missing workload, empty
+   sample set, incompatible report schema, dirty required checkout, or mixed
+   environments.
+2. **Scenario failure:** compiler crash, unexpected exit, timeout, missing
+   output, or incorrect program result.
+3. **Unstable environment:** a threshold breach does not reproduce in the
+   confirmation round.
+4. **Budget failure:** valid, stable measurements exceed an absolute or
+   relative limit.
+
+The benchmark writes a partial report containing every completed observation
+and failure before exiting nonzero. It never substitutes zero, discards a
+failed iteration, or presents instability as success.
+
+The readiness reporter refuses to merge results from different commits,
+schemas, or incompatible environments. Missing evidence produces `unknown`,
+which fails a required policy item; it never becomes `pass`. A policy item is
+`not-applicable` only when its applicability rule is present and false, such as
+an absolute performance ceiling evaluated on a non-reference machine.
+
+## CI Design
+
+### Pull Requests
+
+Every pull request runs:
+
+- the full ScalaTest suite with zero failed, canceled, ignored, or pending
+  tests;
+- sample compilation and deterministic execution;
+- documentation directive and example verification;
+- English/Japanese topic parity;
+- `mkdocs build --strict`;
+- distribution assembly and isolated smoke checks; and
+- benchmark protocol unit tests.
+
+Changes under compiler, runtime, grammar, build, benchmark fixtures, or command
+launchers also run alternating base/head performance comparisons. Documentation
+only changes do not build two compiler revisions for timing.
+
+### Nightly
+
+Nightly CI runs the complete absolute reference suite, retains the JSON and
+human report artifacts, and retains enough history to inspect trends. A failed
+or unstable run is visible as a failed job with its explicit category.
+
+### Release
+
+Release CI requires all deterministic readiness checks, the absolute
+performance policy, and clean distribution journeys for compiler, runner,
+REPL, and LSP. Existing artifact checksums and fat-JAR smoke tests remain.
+A release is not practical-ready when required evidence is missing, even if
+the ordinary test suite is green.
+
+## Test Design
+
+### Pure Unit Tests
+
+- Parse every supported documentation directive and reject malformed forms.
+- Preserve Markdown source locations through extraction.
+- Calculate median and nearest-rank p95 for odd and even sample counts.
+- Evaluate absolute and relative thresholds at, below, and above boundaries.
+- Encode and decode every report field and reject incompatible schemas.
+- Compare topic identifiers, parents, and order for parity.
+
+### Protocol Tests
+
+- Fake clocks prove warmups are excluded from summaries but retained in raw
+  data.
+- Fake executors prove fresh-process and steady-state scenarios use different
+  lifecycles.
+- Failed and timed-out iterations remain visible and fail the scenario.
+- Incompatible environments cannot be compared.
+- Phase timing totals and compilation totals remain internally consistent.
+- A first breach triggers confirmation; repeated and non-repeated breaches get
+  different categories.
+
+### Compiler-Backed Documentation Tests
+
+- Repository fixtures cover `compile`, `run`, `reject`, and `fragment`.
+- Every repository Onion fence has exactly one valid classification.
+- Every declared example produces its required result.
+- Diagnostics point back to the Markdown fence and underlying Onion location.
+- Network-dependent and nondeterministic examples must be fragments or be
+  rewritten around local fixtures.
+
+### End-to-End Tests
+
+- Build and unpack the distribution in a fresh temporary directory.
+- Invoke `onionc` and execute its generated classes.
+- Invoke `onion` on the practical script corpus.
+- Feed deterministic commands to the REPL and verify state retention.
+- Perform LSP initialize, open, diagnostic, and shutdown exchanges.
+- Generate a complete report and validate it against the current schema and
+  policy.
+
+### Existing Reliability Tests
+
+Mutation fuzzing, the crash-reproducer corpus, code-generation correctness,
+soundness probes, sample tests, and the full existing suite remain required.
+The readiness layer aggregates their results; it does not duplicate or weaken
+them.
+
+## Implementation Order
+
+1. Introduce readiness domain types and pure statistics tests.
+2. Refactor benchmark scenarios behind injectable timing and execution
+   boundaries while preserving the `bench` entry point.
+3. Add honest process-cold, steady-state, REPL, and multi-file workloads.
+4. Add report schema, rendering, and policy evaluation.
+5. Add documentation directive parsing and fixture tests.
+6. Classify all existing Onion fences and make declared outcomes pass.
+7. Add topic identifiers and make the complete English/Japanese navigation
+   trees structurally equivalent.
+8. Add distribution smoke checks and public sbt tasks.
+9. Replace the dated quality snapshot with generated policy documentation.
+10. Add pull-request, nightly, and release CI lanes.
+11. Capture the reference baseline and publish it as a CI artifact.
+12. Start the compilation-speed milestone by profiling the weighted practical
+    scenarios and selecting the largest contributor.
+
+## Readiness-Foundation Completion Evidence
+
+The first milestone is complete only when all of the following evidence exists:
+
+- `sbt readinessCheck` passes from a clean checkout.
+- `sbt benchmark` emits a schema-valid report containing every scenario and all
+  raw observations.
+- `sbt readinessReport` produces internally consistent JSON and human output.
+- Every Onion documentation fence is classified and every non-fragment
+  declaration verifies.
+- The complete published English and Japanese navigation trees have structural
+  topic parity.
+- `mkdocs build --strict` passes.
+- A built distribution completes isolated compiler, runner, REPL, and LSP
+  journeys.
+- Pull-request, nightly, and release workflows implement their specified
+  gates.
+- A reference-lane baseline is captured with environment and workload hashes.
+- `docs/quality-bar.md` contains the current generated policy and no stale
+  hand-maintained status counts.
+
+## Broader Program Completion
+
+The practical-language objective is complete only after later milestone audits
+also prove:
+
+- every absolute compilation and interaction budget passes;
+- the largest measured compile-time bottlenecks have been addressed without
+  correctness regressions;
+- installation, first program, CLI/data application, diagnostics, tooling, and
+  release journeys are current and executable;
+- supported release archives work on Linux, macOS, and Windows;
+- representative multi-file applications pass compatibility and reliability
+  suites; and
+- the versioning and backward-compatibility policy is documented and enforced.

--- a/src/main/scala/onion/tools/BenchmarkRunner.scala
+++ b/src/main/scala/onion/tools/BenchmarkRunner.scala
@@ -4,7 +4,7 @@ import onion.tools.readiness.benchmark.*
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
-import java.util.concurrent.Executors
+import scala.util.control.NonFatal
 
 object BenchmarkRunner:
   def main(args: Array[String]): Unit =
@@ -40,21 +40,36 @@ object BenchmarkRunner:
               )
             )
           )
-    val executor = Executors.newSingleThreadExecutor()
-    val engine = new BenchmarkEngine(
-      options.runConfig,
-      NanoClock.System,
-      executor
-    )
-    val results =
-      try CompileScenarioCatalog.default(repoRoot).map(engine.run)
+    val (scenarios, setupFailures) =
+      try (CompileScenarioCatalog.default(repoRoot), Vector.empty)
+      catch
+        case NonFatal(error) =>
+          (
+            Vector.empty,
+            Vector(
+              BenchmarkFailure(
+                FailureCategory.InvalidMeasurement,
+                Option(error.getMessage)
+                  .filter(_.nonEmpty)
+                  .getOrElse(error.getClass.getSimpleName)
+              )
+            )
+          )
+    val results = scenarios.map { scenario =>
+      val engine = new BenchmarkEngine(
+        options.runConfig,
+        NanoClock.System,
+        BenchmarkExecutor.daemonSingleThread()
+      )
+      try engine.run(scenario)
       finally engine.close()
+    }
     PerformanceBenchmarkReport.create(
       git = git,
       environment = EnvironmentMetadata.capture(),
       runConfig = options.runConfig,
       scenarios = results,
-      failures = metadataFailures
+      failures = metadataFailures ++ setupFailures
     )
 
   private def writeJson(path: Path, content: String): Unit =

--- a/src/main/scala/onion/tools/BenchmarkRunner.scala
+++ b/src/main/scala/onion/tools/BenchmarkRunner.scala
@@ -41,7 +41,16 @@ object BenchmarkRunner:
             )
           )
     val (scenarios, setupFailures) =
-      try (CompileScenarioCatalog.default(repoRoot), Vector.empty)
+      try
+        val runtime = JvmRuntime.current()
+        (
+          CompileScenarioCatalog.default(
+            repoRoot,
+            runtime,
+            options.runConfig.timeoutMillis
+          ),
+          Vector.empty
+        )
       catch
         case NonFatal(error) =>
           (
@@ -55,7 +64,20 @@ object BenchmarkRunner:
               )
             )
           )
-    val results = scenarios.map { scenario =>
+    val results = runScenarios(scenarios, options)
+    PerformanceBenchmarkReport.create(
+      git = git,
+      environment = EnvironmentMetadata.capture(),
+      runConfig = options.runConfig,
+      scenarios = results,
+      failures = metadataFailures ++ setupFailures
+    )
+
+  private[onion] def runScenarios(
+    scenarios: Vector[BenchmarkScenario],
+    options: BenchmarkOptions
+  ): Vector[ScenarioResult] =
+    scenarios.map { scenario =>
       val engine = new BenchmarkEngine(
         effectiveConfig(scenario, options),
         NanoClock.System,
@@ -64,13 +86,6 @@ object BenchmarkRunner:
       try engine.run(scenario)
       finally engine.close()
     }
-    PerformanceBenchmarkReport.create(
-      git = git,
-      environment = EnvironmentMetadata.capture(),
-      runConfig = options.runConfig,
-      scenarios = results,
-      failures = metadataFailures ++ setupFailures
-    )
 
   private[onion] def effectiveConfig(
     scenario: BenchmarkScenario,

--- a/src/main/scala/onion/tools/BenchmarkRunner.scala
+++ b/src/main/scala/onion/tools/BenchmarkRunner.scala
@@ -1,137 +1,63 @@
 package onion.tools
 
-import onion.compiler._
-import onion.compiler.CompilationOutcome.{Failure, Success}
+import onion.tools.readiness.benchmark.*
 
-import java.io.StringReader
-import java.nio.charset.Charset
-import java.nio.file.Paths
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.Executors
 
-object BenchmarkRunner {
-  final case class SampleSet(name: String, files: Seq[String])
-  final case class BenchmarkResult(name: String, elapsedMillis: Double, iterations: Int)
+object BenchmarkRunner:
+  def main(args: Array[String]): Unit =
+    BenchmarkOptions.parse(args) match
+      case Left(message) =>
+        Console.err.println(s"benchmark: $message")
+        sys.exit(2)
+      case Right(options) =>
+        val repoRoot = Paths.get("").toAbsolutePath.normalize()
+        val report = buildReport(repoRoot, options)
+        writeJson(options.output, BenchmarkRender.json(report))
+        options.stdoutFormat match
+          case BenchmarkOutputFormat.Text =>
+            println(BenchmarkRender.text(report))
+          case BenchmarkOutputFormat.Json =>
+            println(BenchmarkRender.json(report))
+        if !report.succeeded then sys.exit(1)
 
-  def main(args: Array[String]): Unit = {
-    val json = args.contains("--json")
-    val iterations = parseIterations(args).getOrElse(3)
-    val runner = new BenchmarkRunner(iterations)
-    val results = runner.run()
-    if (json) println(runner.renderJson(results))
-    else println(runner.renderText(results))
-  }
-
-  private def parseIterations(args: Array[String]): Option[Int] = {
-    args.sliding(2).collectFirst {
-      case Array("--iterations", value) => value.toInt
-    }
-  }
-}
-
-final class BenchmarkRunner(private val iterations: Int) {
-  import BenchmarkRunner._
-
-  private val encoding = Charset.defaultCharset().name()
-  private val repoRoot = Paths.get("").toAbsolutePath.normalize()
-  private val compilerConfig = CompilerConfig(Seq("."), "", encoding, "", 20, warningLevel = WarningLevel.Off)
-  private val sampleSets = Seq(
-    SampleSet("small", Seq("run/Hello.on")),
-    SampleSet("medium", Seq("run/TodoApp.on")),
-    SampleSet("large", Seq("run/DataClass.on"))
-  )
-
-  def run(): Seq[BenchmarkResult] = {
-    val compileResults =
-      sampleSets.flatMap { sample =>
-        Seq(
-          benchmark(s"cold-compile:${sample.name}", iterations)(compileSample(sample)),
-          benchmark(s"warm-compile:${sample.name}", iterations)(compileSample(sample), warmup = true)
-        )
-      }
-
-    compileResults ++ Seq(
-      benchmark("script-run", iterations)(runScript()),
-      benchmark("repl-snippet-eval", iterations)(runReplSnippet())
+  private[onion] def buildReport(
+    repoRoot: Path,
+    options: BenchmarkOptions
+  ): PerformanceBenchmarkReport =
+    val (git, metadataFailures) =
+      GitMetadata.capture(repoRoot) match
+        case Right(value) => (value, Vector.empty)
+        case Left(message) =>
+          (
+            GitMetadata("unknown", dirty = true),
+            Vector(
+              BenchmarkFailure(
+                FailureCategory.InvalidMeasurement,
+                message
+              )
+            )
+          )
+    val executor = Executors.newSingleThreadExecutor()
+    val engine = new BenchmarkEngine(
+      options.runConfig,
+      NanoClock.System,
+      executor
     )
-  }
+    val results =
+      try CompileScenarioCatalog.default(repoRoot).map(engine.run)
+      finally engine.close()
+    PerformanceBenchmarkReport.create(
+      git = git,
+      environment = EnvironmentMetadata.capture(),
+      runConfig = options.runConfig,
+      scenarios = results,
+      failures = metadataFailures
+    )
 
-  def renderText(results: Seq[BenchmarkResult]): String = {
-    val builder = new StringBuilder
-    builder.append("benchmark").append(System.lineSeparator())
-    results.foreach { result =>
-      builder.append(f"  ${result.name}%-24s ${result.elapsedMillis}%.2fms avg (${result.iterations} runs)")
-      builder.append(System.lineSeparator())
-    }
-    builder.toString.trim
-  }
-
-  def renderJson(results: Seq[BenchmarkResult]): String =
-    results.map { result =>
-      s"""{"name":"${result.name}","elapsedMillis":${result.elapsedMillis},"iterations":${result.iterations}}"""
-    }.mkString("[", ",", "]")
-
-  private def benchmark(name: String, iterations: Int)(block: => Unit, warmup: Boolean = false): BenchmarkResult = {
-    if (warmup) block
-    val elapsed = (0 until iterations).map { _ =>
-      val start = System.nanoTime()
-      block
-      (System.nanoTime() - start).toDouble / 1000000.0
-    }.sum / iterations.toDouble
-    BenchmarkResult(name, elapsed, iterations)
-  }
-
-  private def compileSample(sample: SampleSet): Unit = {
-    val sources = sample.files.map(path => new FileInputSource(repoRoot.resolve(path).toString))
-    new OnionCompiler(compilerConfig).compile(sources) match {
-      case Success(_) =>
-      case Failure(errors) =>
-        throw new IllegalStateException(s"Compilation failed for ${sample.name}: ${errors.map(_.message).mkString(", ")}")
-    }
-  }
-
-  private def runScript(): Unit = {
-    val source = repoRoot.resolve("run/Factorial.on").toString
-    new OnionCompiler(compilerConfig).compile(Seq(new FileInputSource(source))) match {
-      case Success(classes) =>
-        captureStdOut {
-          new Shell(classOf[OnionClassLoader].getClassLoader, compilerConfig.classPath).run(classes, Array())
-        }
-      case Failure(errors) =>
-        throw new IllegalStateException(s"Script benchmark failed: ${errors.map(_.message).mkString(", ")}")
-    }
-  }
-
-  private def runReplSnippet(): Unit = {
-    val source =
-      """import {
-        |  java.util.ArrayList;
-        |}
-        |val xs = new ArrayList();
-        |xs.add("hello");
-        |val res0 = {
-        |  xs.size() + 2
-        |}
-        |IO::println("res0 = " + res0)
-        |""".stripMargin
-    new OnionCompiler(compilerConfig).compile(Seq(new StreamInputSource(() => new StringReader(source), "benchmark_repl.on"))) match {
-      case Success(classes) =>
-        captureStdOut {
-          new Shell(classOf[OnionClassLoader].getClassLoader, compilerConfig.classPath).run(classes, Array())
-        }
-      case Failure(errors) =>
-        throw new IllegalStateException(s"REPL benchmark failed: ${errors.map(_.message).mkString(", ")}")
-    }
-  }
-
-  private def captureStdOut[A](block: => A): A = {
-    val original = System.out
-    val buffer = new java.io.ByteArrayOutputStream()
-    val stream = new java.io.PrintStream(buffer, true, encoding)
-    System.setOut(stream)
-    try block
-    finally {
-      stream.flush()
-      System.setOut(original)
-      stream.close()
-    }
-  }
-}
+  private def writeJson(path: Path, content: String): Unit =
+    val parent = path.toAbsolutePath.normalize().getParent
+    if parent != null then Files.createDirectories(parent)
+    Files.writeString(path, content, StandardCharsets.UTF_8)

--- a/src/main/scala/onion/tools/BenchmarkRunner.scala
+++ b/src/main/scala/onion/tools/BenchmarkRunner.scala
@@ -57,7 +57,7 @@ object BenchmarkRunner:
           )
     val results = scenarios.map { scenario =>
       val engine = new BenchmarkEngine(
-        options.runConfig,
+        effectiveConfig(scenario, options),
         NanoClock.System,
         BenchmarkExecutor.daemonSingleThread()
       )
@@ -70,6 +70,15 @@ object BenchmarkRunner:
       runConfig = options.runConfig,
       scenarios = results,
       failures = metadataFailures ++ setupFailures
+    )
+
+  private[onion] def effectiveConfig(
+    scenario: BenchmarkScenario,
+    options: BenchmarkOptions
+  ): BenchmarkRunConfig =
+    options.runConfig.copy(
+      warmupIterations =
+        options.warmupOverride.getOrElse(scenario.defaultWarmupIterations)
     )
 
   private def writeJson(path: Path, content: String): Unit =

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala
@@ -54,6 +54,7 @@ trait BenchmarkSession extends AutoCloseable:
 
 trait BenchmarkScenario:
   def metadata: ScenarioMetadata
+  def defaultWarmupIterations: Int = 8
   def open(): BenchmarkSession
 
 final case class BenchmarkScenarioException(message: String)
@@ -155,6 +156,7 @@ final class BenchmarkEngine(
 
     ScenarioResult(
       metadata = scenario.metadata,
+      runConfig = config,
       warmups = keptWarmups,
       measurements = keptMeasurements,
       summary = summary,

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala
@@ -1,0 +1,166 @@
+package onion.tools.readiness.benchmark
+
+import java.util.concurrent.{
+  Callable,
+  ExecutionException,
+  ExecutorService,
+  TimeUnit,
+  TimeoutException
+}
+import scala.util.control.NonFatal
+
+final case class BenchmarkRunConfig(
+  warmupIterations: Int = 8,
+  measuredIterations: Int = 25,
+  timeoutMillis: Long = 30000L
+):
+  require(warmupIterations >= 0, "warmup iterations must be non-negative")
+  require(measuredIterations > 0, "measured iterations must be positive")
+  require(timeoutMillis > 0L, "timeout must be positive")
+
+final case class IterationPayload(
+  phases: Vector[PhaseObservation],
+  sourceMetrics: SourceMetrics,
+  exitCode: Int
+)
+
+trait NanoClock:
+  def nanoTime(): Long
+
+object NanoClock:
+  object System extends NanoClock:
+    override def nanoTime(): Long = java.lang.System.nanoTime()
+
+trait BenchmarkSession extends AutoCloseable:
+  def runIteration(index: Int): IterationPayload
+  override def close(): Unit = ()
+
+trait BenchmarkScenario:
+  def metadata: ScenarioMetadata
+  def open(): BenchmarkSession
+
+final case class BenchmarkScenarioException(message: String)
+  extends RuntimeException(message)
+
+final class BenchmarkEngine(
+  config: BenchmarkRunConfig,
+  clock: NanoClock,
+  executor: ExecutorService
+) extends AutoCloseable:
+  def run(scenario: BenchmarkScenario): ScenarioResult =
+    val warmups = Vector.newBuilder[IterationObservation]
+    val measurements = Vector.newBuilder[IterationObservation]
+    var failure: Option[BenchmarkFailure] = None
+    var session: BenchmarkSession = null
+
+    try
+      session = scenario.open()
+      var index = 0
+      while index < config.warmupIterations && failure.isEmpty do
+        observe(session, index, ObservationKind.Warmup) match
+          case Right(observation) => warmups += observation
+          case Left(problem) => failure = Some(problem)
+        index += 1
+
+      index = 0
+      while index < config.measuredIterations && failure.isEmpty do
+        observe(session, index, ObservationKind.Measurement) match
+          case Right(observation) => measurements += observation
+          case Left(problem) => failure = Some(problem)
+        index += 1
+    catch
+      case NonFatal(error) =>
+        failure = Some(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            messageOf(error)
+          )
+        )
+    finally
+      if session != null then
+        try session.close()
+        catch
+          case NonFatal(error) =>
+            if failure.isEmpty then
+              failure = Some(
+                BenchmarkFailure(
+                  FailureCategory.ScenarioFailure,
+                  s"scenario cleanup failed: ${messageOf(error)}"
+                )
+              )
+
+    val keptWarmups = warmups.result()
+    val keptMeasurements = measurements.result()
+    val summarized =
+      if failure.nonEmpty then Left(failure.get)
+      else BenchmarkStatistics.summarize(keptMeasurements.map(_.elapsedNanos))
+    val finalFailure = failure.orElse(summarized.left.toOption)
+    val summary = summarized.toOption
+
+    ScenarioResult(
+      metadata = scenario.metadata,
+      warmups = keptWarmups,
+      measurements = keptMeasurements,
+      summary = summary,
+      failure = finalFailure
+    )
+
+  private def observe(
+    session: BenchmarkSession,
+    index: Int,
+    kind: ObservationKind
+  ): Either[BenchmarkFailure, IterationObservation] =
+    val future = executor.submit(new Callable[IterationObservation]:
+      override def call(): IterationObservation =
+        val started = clock.nanoTime()
+        val payload = session.runIteration(index)
+        val elapsed = clock.nanoTime() - started
+        if elapsed < 0L then
+          throw BenchmarkScenarioException("clock produced a negative duration")
+        IterationObservation(
+          index = index,
+          kind = kind,
+          elapsedNanos = elapsed,
+          phases = payload.phases,
+          sourceMetrics = payload.sourceMetrics,
+          exitCode = payload.exitCode
+        )
+    )
+
+    try Right(future.get(config.timeoutMillis, TimeUnit.MILLISECONDS))
+    catch
+      case _: TimeoutException =>
+        future.cancel(true)
+        Left(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            s"iteration timed out after ${config.timeoutMillis} ms",
+            Some(index)
+          )
+        )
+      case error: ExecutionException =>
+        Left(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            messageOf(Option(error.getCause).getOrElse(error)),
+            Some(index)
+          )
+        )
+      case _: InterruptedException =>
+        future.cancel(true)
+        Thread.currentThread().interrupt()
+        Left(
+          BenchmarkFailure(
+            FailureCategory.ScenarioFailure,
+            "benchmark thread was interrupted",
+            Some(index)
+          )
+        )
+
+  private def messageOf(error: Throwable): String =
+    Option(error.getMessage)
+      .filter(_.nonEmpty)
+      .getOrElse(error.getClass.getSimpleName)
+
+  override def close(): Unit =
+    executor.shutdownNow()

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkEngine.scala
@@ -4,9 +4,12 @@ import java.util.concurrent.{
   Callable,
   ExecutionException,
   ExecutorService,
+  Executors,
+  ThreadFactory,
   TimeUnit,
   TimeoutException
 }
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import scala.util.control.NonFatal
 
 final case class BenchmarkRunConfig(
@@ -31,6 +34,20 @@ object NanoClock:
   object System extends NanoClock:
     override def nanoTime(): Long = java.lang.System.nanoTime()
 
+object BenchmarkExecutor:
+  private val threadCount = new AtomicInteger()
+
+  def daemonSingleThread(): ExecutorService =
+    Executors.newSingleThreadExecutor(new ThreadFactory:
+      override def newThread(runnable: Runnable): Thread =
+        val thread = new Thread(
+          runnable,
+          s"onion-benchmark-${threadCount.incrementAndGet()}"
+        )
+        thread.setDaemon(true)
+        thread
+    )
+
 trait BenchmarkSession extends AutoCloseable:
   def runIteration(index: Int): IterationPayload
   override def close(): Unit = ()
@@ -47,26 +64,66 @@ final class BenchmarkEngine(
   clock: NanoClock,
   executor: ExecutorService
 ) extends AutoCloseable:
+  private final case class ObservationProblem(
+    failure: BenchmarkFailure,
+    cleanupDeferred: Boolean
+  )
+
+  private final class SessionCloser(session: BenchmarkSession):
+    private val closed = new AtomicBoolean(false)
+
+    def close(): Option[Throwable] =
+      if closed.compareAndSet(false, true) then
+        try
+          session.close()
+          None
+        catch case NonFatal(error) => Some(error)
+      else None
+
+  private final class IterationControl(closer: SessionCloser):
+    private val closeOnExit = new AtomicBoolean(false)
+    private val finished = new AtomicBoolean(false)
+
+    def deferSessionClose(): Unit =
+      closeOnExit.set(true)
+      if finished.get() then closer.close()
+
+    def markFinished(): Unit =
+      finished.set(true)
+      if closeOnExit.get() then closer.close()
+
+  private final case class BenchmarkObservationException(
+    category: FailureCategory,
+    detail: String
+  ) extends RuntimeException(detail)
+
   def run(scenario: BenchmarkScenario): ScenarioResult =
     val warmups = Vector.newBuilder[IterationObservation]
     val measurements = Vector.newBuilder[IterationObservation]
     var failure: Option[BenchmarkFailure] = None
     var session: BenchmarkSession = null
+    var closer: SessionCloser = null
+    var cleanupDeferred = false
 
     try
       session = scenario.open()
+      closer = new SessionCloser(session)
       var index = 0
       while index < config.warmupIterations && failure.isEmpty do
-        observe(session, index, ObservationKind.Warmup) match
+        observe(session, closer, index, ObservationKind.Warmup) match
           case Right(observation) => warmups += observation
-          case Left(problem) => failure = Some(problem)
+          case Left(problem) =>
+            failure = Some(problem.failure)
+            cleanupDeferred = problem.cleanupDeferred
         index += 1
 
       index = 0
       while index < config.measuredIterations && failure.isEmpty do
-        observe(session, index, ObservationKind.Measurement) match
+        observe(session, closer, index, ObservationKind.Measurement) match
           case Right(observation) => measurements += observation
-          case Left(problem) => failure = Some(problem)
+          case Left(problem) =>
+            failure = Some(problem.failure)
+            cleanupDeferred = problem.cleanupDeferred
         index += 1
     catch
       case NonFatal(error) =>
@@ -77,17 +134,16 @@ final class BenchmarkEngine(
           )
         )
     finally
-      if session != null then
-        try session.close()
-        catch
-          case NonFatal(error) =>
-            if failure.isEmpty then
-              failure = Some(
-                BenchmarkFailure(
-                  FailureCategory.ScenarioFailure,
-                  s"scenario cleanup failed: ${messageOf(error)}"
-                )
+      if closer != null && !cleanupDeferred then
+        closer.close().foreach { error =>
+          if failure.isEmpty then
+            failure = Some(
+              BenchmarkFailure(
+                FailureCategory.ScenarioFailure,
+                s"scenario cleanup failed: ${messageOf(error)}"
               )
+            )
+        }
 
     val keptWarmups = warmups.result()
     val keptMeasurements = measurements.result()
@@ -107,55 +163,105 @@ final class BenchmarkEngine(
 
   private def observe(
     session: BenchmarkSession,
+    closer: SessionCloser,
     index: Int,
     kind: ObservationKind
-  ): Either[BenchmarkFailure, IterationObservation] =
+  ): Either[ObservationProblem, IterationObservation] =
+    val control = new IterationControl(closer)
     val future = executor.submit(new Callable[IterationObservation]:
       override def call(): IterationObservation =
-        val started = clock.nanoTime()
-        val payload = session.runIteration(index)
-        val elapsed = clock.nanoTime() - started
-        if elapsed < 0L then
-          throw BenchmarkScenarioException("clock produced a negative duration")
-        IterationObservation(
-          index = index,
-          kind = kind,
-          elapsedNanos = elapsed,
-          phases = payload.phases,
-          sourceMetrics = payload.sourceMetrics,
-          exitCode = payload.exitCode
-        )
+        try
+          val started = clock.nanoTime()
+          val payload = session.runIteration(index)
+          val elapsed = clock.nanoTime() - started
+          validate(elapsed, payload)
+          IterationObservation(
+            index = index,
+            kind = kind,
+            elapsedNanos = elapsed,
+            phases = payload.phases,
+            sourceMetrics = payload.sourceMetrics,
+            exitCode = payload.exitCode
+          )
+        finally control.markFinished()
     )
 
     try Right(future.get(config.timeoutMillis, TimeUnit.MILLISECONDS))
     catch
       case _: TimeoutException =>
+        control.deferSessionClose()
         future.cancel(true)
         Left(
-          BenchmarkFailure(
-            FailureCategory.ScenarioFailure,
-            s"iteration timed out after ${config.timeoutMillis} ms",
-            Some(index)
+          ObservationProblem(
+            BenchmarkFailure(
+              FailureCategory.ScenarioFailure,
+              s"iteration timed out after ${config.timeoutMillis} ms",
+              Some(index)
+            ),
+            cleanupDeferred = true
           )
         )
       case error: ExecutionException =>
+        val cause = Option(error.getCause).getOrElse(error)
+        val (category, message) = cause match
+          case problem: BenchmarkObservationException =>
+            (problem.category, problem.detail)
+          case _ =>
+            (FailureCategory.ScenarioFailure, messageOf(cause))
         Left(
-          BenchmarkFailure(
-            FailureCategory.ScenarioFailure,
-            messageOf(Option(error.getCause).getOrElse(error)),
-            Some(index)
+          ObservationProblem(
+            BenchmarkFailure(category, message, Some(index)),
+            cleanupDeferred = false
           )
         )
       case _: InterruptedException =>
+        control.deferSessionClose()
         future.cancel(true)
         Thread.currentThread().interrupt()
         Left(
-          BenchmarkFailure(
-            FailureCategory.ScenarioFailure,
-            "benchmark thread was interrupted",
-            Some(index)
+          ObservationProblem(
+            BenchmarkFailure(
+              FailureCategory.ScenarioFailure,
+              "benchmark thread was interrupted",
+              Some(index)
+            ),
+            cleanupDeferred = true
           )
         )
+
+  private def validate(elapsed: Long, payload: IterationPayload): Unit =
+    if elapsed < 0L then
+      throw BenchmarkObservationException(
+        FailureCategory.InvalidMeasurement,
+        "clock produced a negative duration"
+      )
+    if payload.exitCode != 0 then
+      throw BenchmarkObservationException(
+        FailureCategory.ScenarioFailure,
+        s"scenario returned exit code ${payload.exitCode}"
+      )
+    val metrics = payload.sourceMetrics
+    if
+      metrics.sourceCount < 0 ||
+      metrics.lineCount < 0 ||
+      metrics.byteCount < 0L ||
+      metrics.generatedClasses < 0
+    then
+      throw BenchmarkObservationException(
+        FailureCategory.InvalidMeasurement,
+        "scenario returned negative source metrics"
+      )
+    if
+      payload.phases.exists { phase =>
+        phase.elapsedNanos < 0L ||
+        phase.inputCount < 0 ||
+        phase.outputCount < 0
+      }
+    then
+      throw BenchmarkObservationException(
+        FailureCategory.InvalidMeasurement,
+        "scenario returned negative phase measurements"
+      )
 
   private def messageOf(error: Throwable): String =
     Option(error.getMessage)

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala
@@ -2,7 +2,8 @@ package onion.tools.readiness.benchmark
 
 import java.lang.management.ManagementFactory
 import java.nio.charset.StandardCharsets
-import java.nio.file.Path
+import java.nio.file.{Files, Path, Paths}
+import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 
 final case class GitMetadata(commit: String, dirty: Boolean)
@@ -40,7 +41,10 @@ final case class EnvironmentMetadata(
   javaVersion: String,
   osName: String,
   osArch: String,
+  osReleaseId: String = "unknown",
+  osReleaseVersion: String = "unknown",
   processors: Int,
+  totalMemoryBytes: Long = 0L,
   maxHeapBytes: Long,
   garbageCollectors: Vector[String],
   jvmArguments: Vector[String]
@@ -48,13 +52,16 @@ final case class EnvironmentMetadata(
 
 object EnvironmentMetadata:
   def capture(): EnvironmentMetadata =
-    import scala.jdk.CollectionConverters.*
+    val (osReleaseId, osReleaseVersion) = osRelease()
     EnvironmentMetadata(
       javaVendor = System.getProperty("java.vendor"),
       javaVersion = System.getProperty("java.version"),
       osName = System.getProperty("os.name"),
       osArch = System.getProperty("os.arch"),
+      osReleaseId = osReleaseId,
+      osReleaseVersion = osReleaseVersion,
       processors = Runtime.getRuntime.availableProcessors(),
+      totalMemoryBytes = totalMemoryBytes(),
       maxHeapBytes = Runtime.getRuntime.maxMemory(),
       garbageCollectors =
         ManagementFactory.getGarbageCollectorMXBeans.asScala
@@ -63,3 +70,29 @@ object EnvironmentMetadata:
       jvmArguments =
         ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toVector
     )
+
+  private[benchmark] def parseOsRelease(
+    lines: Seq[String]
+  ): (String, String) =
+    val values = lines.flatMap { line =>
+      line.split("=", 2) match
+        case Array(key, value) =>
+          Some(key -> value.stripPrefix("\"").stripSuffix("\""))
+        case _ => None
+    }.toMap
+    (
+      values.getOrElse("ID", "unknown"),
+      values.getOrElse("VERSION_ID", "unknown")
+    )
+
+  private def osRelease(): (String, String) =
+    val release = Paths.get("/etc/os-release")
+    if Files.isRegularFile(release) then
+      parseOsRelease(Files.readAllLines(release).asScala.toSeq)
+    else ("unknown", "unknown")
+
+  private def totalMemoryBytes(): Long =
+    ManagementFactory.getOperatingSystemMXBean match
+      case bean: com.sun.management.OperatingSystemMXBean =>
+        bean.getTotalMemorySize
+      case _ => Runtime.getRuntime.maxMemory()

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala
@@ -3,15 +3,24 @@ package onion.tools.readiness.benchmark
 import java.lang.management.ManagementFactory
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import scala.util.control.NonFatal
 
 final case class GitMetadata(commit: String, dirty: Boolean)
 
 object GitMetadata:
   def capture(repoRoot: Path): Either[String, GitMetadata] =
-    for
-      commit <- command(repoRoot, "git", "rev-parse", "HEAD")
-      status <- command(repoRoot, "git", "status", "--porcelain")
-    yield GitMetadata(commit.trim, status.trim.nonEmpty)
+    try
+      for
+        commit <- command(repoRoot, "git", "rev-parse", "HEAD")
+        status <- command(repoRoot, "git", "status", "--porcelain")
+      yield GitMetadata(commit.trim, status.trim.nonEmpty)
+    catch
+      case NonFatal(error) =>
+        Left(
+          Option(error.getMessage)
+            .filter(_.nonEmpty)
+            .getOrElse(error.getClass.getSimpleName)
+        )
 
   private def command(repoRoot: Path, args: String*): Either[String, String] =
     val process =

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkMetadata.scala
@@ -1,0 +1,56 @@
+package onion.tools.readiness.benchmark
+
+import java.lang.management.ManagementFactory
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+
+final case class GitMetadata(commit: String, dirty: Boolean)
+
+object GitMetadata:
+  def capture(repoRoot: Path): Either[String, GitMetadata] =
+    for
+      commit <- command(repoRoot, "git", "rev-parse", "HEAD")
+      status <- command(repoRoot, "git", "status", "--porcelain")
+    yield GitMetadata(commit.trim, status.trim.nonEmpty)
+
+  private def command(repoRoot: Path, args: String*): Either[String, String] =
+    val process =
+      new ProcessBuilder(args*)
+        .directory(repoRoot.toFile)
+        .redirectErrorStream(true)
+        .start()
+    val output =
+      try new String(process.getInputStream.readAllBytes(), StandardCharsets.UTF_8)
+      finally process.getInputStream.close()
+    val exit = process.waitFor()
+    if exit == 0 then Right(output)
+    else Left(s"${args.mkString(" ")} failed with exit $exit: ${output.trim}")
+
+final case class EnvironmentMetadata(
+  javaVendor: String,
+  javaVersion: String,
+  osName: String,
+  osArch: String,
+  processors: Int,
+  maxHeapBytes: Long,
+  garbageCollectors: Vector[String],
+  jvmArguments: Vector[String]
+)
+
+object EnvironmentMetadata:
+  def capture(): EnvironmentMetadata =
+    import scala.jdk.CollectionConverters.*
+    EnvironmentMetadata(
+      javaVendor = System.getProperty("java.vendor"),
+      javaVersion = System.getProperty("java.version"),
+      osName = System.getProperty("os.name"),
+      osArch = System.getProperty("os.arch"),
+      processors = Runtime.getRuntime.availableProcessors(),
+      maxHeapBytes = Runtime.getRuntime.maxMemory(),
+      garbageCollectors =
+        ManagementFactory.getGarbageCollectorMXBeans.asScala
+          .map(_.getName)
+          .toVector,
+      jvmArguments =
+        ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toVector
+    )

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala
@@ -61,6 +61,7 @@ final case class ScenarioMetadata(
 
 final case class ScenarioResult(
   metadata: ScenarioMetadata,
+  runConfig: BenchmarkRunConfig,
   warmups: Vector[IterationObservation],
   measurements: Vector[IterationObservation],
   summary: Option[BenchmarkSummary],

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkModel.scala
@@ -1,0 +1,69 @@
+package onion.tools.readiness.benchmark
+
+enum ScenarioKind(val wireName: String):
+  case ProcessCold extends ScenarioKind("process-cold")
+  case SteadyFresh extends ScenarioKind("steady-fresh")
+  case PersistentSession extends ScenarioKind("persistent-session")
+  case MultiFile extends ScenarioKind("multi-file")
+
+enum ObservationKind(val wireName: String):
+  case Warmup extends ObservationKind("warmup")
+  case Measurement extends ObservationKind("measurement")
+
+enum FailureCategory(val wireName: String):
+  case InvalidMeasurement extends FailureCategory("invalid-measurement")
+  case ScenarioFailure extends FailureCategory("scenario-failure")
+  case UnstableEnvironment extends FailureCategory("unstable-environment")
+  case BudgetFailure extends FailureCategory("budget-failure")
+
+final case class SourceMetrics(
+  sourceCount: Int,
+  lineCount: Int,
+  byteCount: Long,
+  generatedClasses: Int
+)
+
+final case class PhaseObservation(
+  name: String,
+  elapsedNanos: Long,
+  inputCount: Int,
+  outputCount: Int
+)
+
+final case class IterationObservation(
+  index: Int,
+  kind: ObservationKind,
+  elapsedNanos: Long,
+  phases: Vector[PhaseObservation],
+  sourceMetrics: SourceMetrics,
+  exitCode: Int
+)
+
+final case class BenchmarkSummary(
+  medianNanos: Long,
+  p95Nanos: Long,
+  minNanos: Long,
+  maxNanos: Long
+)
+
+final case class BenchmarkFailure(
+  category: FailureCategory,
+  message: String,
+  iteration: Option[Int] = None
+)
+
+final case class ScenarioMetadata(
+  id: String,
+  kind: ScenarioKind,
+  workload: String,
+  workloadHash: String
+)
+
+final case class ScenarioResult(
+  metadata: ScenarioMetadata,
+  warmups: Vector[IterationObservation],
+  measurements: Vector[IterationObservation],
+  summary: Option[BenchmarkSummary],
+  failure: Option[BenchmarkFailure]
+):
+  def succeeded: Boolean = failure.isEmpty

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala
@@ -1,0 +1,104 @@
+package onion.tools.readiness.benchmark
+
+import java.nio.file.{Path, Paths}
+
+enum BenchmarkOutputFormat:
+  case Text
+  case Json
+
+final case class BenchmarkOptions(
+  runConfig: BenchmarkRunConfig = BenchmarkRunConfig(),
+  output: Path = Paths.get("target/readiness/benchmark-v1.json"),
+  stdoutFormat: BenchmarkOutputFormat = BenchmarkOutputFormat.Text
+)
+
+object BenchmarkOptions:
+  def parse(args: Array[String]): Either[String, BenchmarkOptions] =
+    parseAt(args.toVector, 0, BenchmarkOptions())
+
+  private def parseAt(
+    args: Vector[String],
+    index: Int,
+    options: BenchmarkOptions
+  ): Either[String, BenchmarkOptions] =
+    if index >= args.size then Right(options)
+    else
+      args(index) match
+        case "--iterations" =>
+          value(args, index, "--iterations").flatMap { raw =>
+            positiveInt(raw, "iterations").flatMap { count =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(
+                  runConfig = options.runConfig.copy(measuredIterations = count)
+                )
+              )
+            }
+          }
+        case "--warmups" =>
+          value(args, index, "--warmups").flatMap { raw =>
+            nonNegativeInt(raw, "warmups").flatMap { count =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(
+                  runConfig = options.runConfig.copy(warmupIterations = count)
+                )
+              )
+            }
+          }
+        case "--timeout-seconds" =>
+          value(args, index, "--timeout-seconds").flatMap { raw =>
+            positiveInt(raw, "timeout seconds").flatMap { seconds =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(
+                  runConfig = options.runConfig.copy(
+                    timeoutMillis = seconds.toLong * 1000L
+                  )
+                )
+              )
+            }
+          }
+        case "--output" =>
+          value(args, index, "--output").flatMap { path =>
+            parseAt(args, index + 2, options.copy(output = Paths.get(path)))
+          }
+        case "--format" =>
+          value(args, index, "--format").flatMap {
+            case "text" =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(stdoutFormat = BenchmarkOutputFormat.Text)
+              )
+            case "json" =>
+              parseAt(
+                args,
+                index + 2,
+                options.copy(stdoutFormat = BenchmarkOutputFormat.Json)
+              )
+            case other => Left(s"unsupported benchmark format: $other")
+          }
+        case "--json" =>
+          parseAt(
+            args,
+            index + 1,
+            options.copy(stdoutFormat = BenchmarkOutputFormat.Json)
+          )
+        case other => Left(s"unknown benchmark option: $other")
+
+  private def value(
+    args: Vector[String],
+    index: Int,
+    option: String
+  ): Either[String, String] =
+    args.lift(index + 1).toRight(s"missing value for $option")
+
+  private def positiveInt(raw: String, label: String): Either[String, Int] =
+    raw.toIntOption.filter(_ > 0).toRight(s"$label must be a positive integer")
+
+  private def nonNegativeInt(raw: String, label: String): Either[String, Int] =
+    raw.toIntOption.filter(_ >= 0).toRight(s"$label must be non-negative")

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala
@@ -8,7 +8,7 @@ enum BenchmarkOutputFormat:
 
 final case class BenchmarkOptions(
   runConfig: BenchmarkRunConfig = BenchmarkRunConfig(),
-  output: Path = Paths.get("target/readiness/benchmark-v2.json"),
+  output: Path = Paths.get("target/readiness/benchmark-v3.json"),
   stdoutFormat: BenchmarkOutputFormat = BenchmarkOutputFormat.Text,
   warmupOverride: Option[Int] = None
 )

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkOptions.scala
@@ -8,8 +8,9 @@ enum BenchmarkOutputFormat:
 
 final case class BenchmarkOptions(
   runConfig: BenchmarkRunConfig = BenchmarkRunConfig(),
-  output: Path = Paths.get("target/readiness/benchmark-v1.json"),
-  stdoutFormat: BenchmarkOutputFormat = BenchmarkOutputFormat.Text
+  output: Path = Paths.get("target/readiness/benchmark-v2.json"),
+  stdoutFormat: BenchmarkOutputFormat = BenchmarkOutputFormat.Text,
+  warmupOverride: Option[Int] = None
 )
 
 object BenchmarkOptions:
@@ -43,7 +44,8 @@ object BenchmarkOptions:
                 args,
                 index + 2,
                 options.copy(
-                  runConfig = options.runConfig.copy(warmupIterations = count)
+                  runConfig = options.runConfig.copy(warmupIterations = count),
+                  warmupOverride = Some(count)
                 )
               )
             }

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala
@@ -1,0 +1,116 @@
+package onion.tools.readiness.benchmark
+
+import onion.Json
+
+import java.util.{ArrayList, LinkedHashMap, List as JList, Map as JMap}
+
+object BenchmarkRender:
+  def json(report: PerformanceBenchmarkReport): String =
+    Json.stringifyPretty(reportObject(report))
+
+  def text(report: PerformanceBenchmarkReport): String =
+    val lines = Vector.newBuilder[String]
+    lines += s"benchmark schema=${report.schemaVersion} commit=${report.git.commit}"
+    report.failures.foreach { failure =>
+      lines += s"  FAILED [${failure.category.wireName}]: ${failure.message}"
+    }
+    report.scenarios.foreach { scenario =>
+      scenario.summary match
+        case Some(summary) =>
+          lines += f"  ${scenario.metadata.id}%-40s median=${millis(summary.medianNanos)}%.2fms p95=${millis(summary.p95Nanos)}%.2fms ${scenario.measurements.size}%d measured"
+        case None =>
+          val message = scenario.failure.map(_.message).getOrElse("missing summary")
+          lines += s"  ${scenario.metadata.id} FAILED: $message"
+    }
+    lines.result().mkString(System.lineSeparator())
+
+  private def reportObject(report: PerformanceBenchmarkReport): JMap[String, Object] =
+    obj(
+      "schemaVersion" -> Int.box(report.schemaVersion),
+      "generatedAt" -> report.generatedAt,
+      "commit" -> report.git.commit,
+      "dirty" -> Boolean.box(report.git.dirty),
+      "environment" -> obj(
+        "javaVendor" -> report.environment.javaVendor,
+        "javaVersion" -> report.environment.javaVersion,
+        "osName" -> report.environment.osName,
+        "osArch" -> report.environment.osArch,
+        "processors" -> Int.box(report.environment.processors),
+        "maxHeapBytes" -> Long.box(report.environment.maxHeapBytes),
+        "garbageCollectors" -> arr(
+          report.environment.garbageCollectors.map(value => value: Object)
+        ),
+        "jvmArguments" -> arr(
+          report.environment.jvmArguments.map(value => value: Object)
+        )
+      ),
+      "runConfig" -> obj(
+        "warmupIterations" -> Int.box(report.runConfig.warmupIterations),
+        "measuredIterations" -> Int.box(report.runConfig.measuredIterations),
+        "timeoutMillis" -> Long.box(report.runConfig.timeoutMillis)
+      ),
+      "scenarios" -> arr(report.scenarios.map(scenarioObject)),
+      "failures" -> arr(report.failures.map(failureObject))
+    )
+
+  private def scenarioObject(result: ScenarioResult): Object =
+    obj(
+      "id" -> result.metadata.id,
+      "kind" -> result.metadata.kind.wireName,
+      "workload" -> result.metadata.workload,
+      "workloadHash" -> result.metadata.workloadHash,
+      "warmups" -> arr(result.warmups.map(observationObject)),
+      "measurements" -> arr(result.measurements.map(observationObject)),
+      "summary" -> result.summary.map(summaryObject).orNull,
+      "failure" -> result.failure.map(failureObject).orNull
+    )
+
+  private def observationObject(value: IterationObservation): Object =
+    obj(
+      "index" -> Int.box(value.index),
+      "kind" -> value.kind.wireName,
+      "elapsedNanos" -> Long.box(value.elapsedNanos),
+      "exitCode" -> Int.box(value.exitCode),
+      "sourceMetrics" -> obj(
+        "sourceCount" -> Int.box(value.sourceMetrics.sourceCount),
+        "lineCount" -> Int.box(value.sourceMetrics.lineCount),
+        "byteCount" -> Long.box(value.sourceMetrics.byteCount),
+        "generatedClasses" -> Int.box(value.sourceMetrics.generatedClasses)
+      ),
+      "phases" -> arr(value.phases.map { phase =>
+        obj(
+          "name" -> phase.name,
+          "elapsedNanos" -> Long.box(phase.elapsedNanos),
+          "inputCount" -> Int.box(phase.inputCount),
+          "outputCount" -> Int.box(phase.outputCount)
+        )
+      })
+    )
+
+  private def summaryObject(value: BenchmarkSummary): Object =
+    obj(
+      "medianNanos" -> Long.box(value.medianNanos),
+      "p95Nanos" -> Long.box(value.p95Nanos),
+      "minNanos" -> Long.box(value.minNanos),
+      "maxNanos" -> Long.box(value.maxNanos)
+    )
+
+  private def failureObject(value: BenchmarkFailure): Object =
+    obj(
+      "category" -> value.category.wireName,
+      "message" -> value.message,
+      "iteration" -> value.iteration.map(Int.box).orNull
+    )
+
+  private def obj(entries: (String, Object)*): JMap[String, Object] =
+    val result = new LinkedHashMap[String, Object]()
+    entries.foreach { case (key, value) => result.put(key, value) }
+    result
+
+  private def arr(values: Seq[Object]): JList[Object] =
+    val result = new ArrayList[Object]()
+    values.foreach(result.add)
+    result
+
+  private def millis(nanos: Long): Double =
+    nanos.toDouble / 1000000.0

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala
@@ -44,11 +44,7 @@ object BenchmarkRender:
           report.environment.jvmArguments.map(value => value: Object)
         )
       ),
-      "runConfig" -> obj(
-        "warmupIterations" -> Int.box(report.runConfig.warmupIterations),
-        "measuredIterations" -> Int.box(report.runConfig.measuredIterations),
-        "timeoutMillis" -> Long.box(report.runConfig.timeoutMillis)
-      ),
+      "runConfig" -> runConfigObject(report.runConfig),
       "scenarios" -> arr(report.scenarios.map(scenarioObject)),
       "failures" -> arr(report.failures.map(failureObject))
     )
@@ -59,10 +55,18 @@ object BenchmarkRender:
       "kind" -> result.metadata.kind.wireName,
       "workload" -> result.metadata.workload,
       "workloadHash" -> result.metadata.workloadHash,
+      "runConfig" -> runConfigObject(result.runConfig),
       "warmups" -> arr(result.warmups.map(observationObject)),
       "measurements" -> arr(result.measurements.map(observationObject)),
       "summary" -> result.summary.map(summaryObject).orNull,
       "failure" -> result.failure.map(failureObject).orNull
+    )
+
+  private def runConfigObject(value: BenchmarkRunConfig): Object =
+    obj(
+      "warmupIterations" -> Int.box(value.warmupIterations),
+      "measuredIterations" -> Int.box(value.measuredIterations),
+      "timeoutMillis" -> Long.box(value.timeoutMillis)
     )
 
   private def observationObject(value: IterationObservation): Object =

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkRender.scala
@@ -1,6 +1,11 @@
 package onion.tools.readiness.benchmark
 
 import onion.Json
+import onion.tools.readiness.policy.{
+  AbsolutePerformanceCheck,
+  AbsolutePerformanceEvaluation,
+  PolicyCheckStatus
+}
 
 import java.util.{ArrayList, LinkedHashMap, List as JList, Map as JMap}
 
@@ -11,6 +16,17 @@ object BenchmarkRender:
   def text(report: PerformanceBenchmarkReport): String =
     val lines = Vector.newBuilder[String]
     lines += s"benchmark schema=${report.schemaVersion} commit=${report.git.commit}"
+    lines +=
+      s"  absolute-policy=${report.policy.overallStatus.wireName} reference-lane=${report.policy.referenceLane}"
+    report.policy.checks
+      .filter { check =>
+        check.status == PolicyCheckStatus.Fail ||
+        check.status == PolicyCheckStatus.Unknown
+      }
+      .foreach { check =>
+        lines +=
+          s"    ${check.scenarioId} ${check.status.wireName}: ${check.message}"
+      }
     report.failures.foreach { failure =>
       lines += s"  FAILED [${failure.category.wireName}]: ${failure.message}"
     }
@@ -35,7 +51,10 @@ object BenchmarkRender:
         "javaVersion" -> report.environment.javaVersion,
         "osName" -> report.environment.osName,
         "osArch" -> report.environment.osArch,
+        "osReleaseId" -> report.environment.osReleaseId,
+        "osReleaseVersion" -> report.environment.osReleaseVersion,
         "processors" -> Int.box(report.environment.processors),
+        "totalMemoryBytes" -> Long.box(report.environment.totalMemoryBytes),
         "maxHeapBytes" -> Long.box(report.environment.maxHeapBytes),
         "garbageCollectors" -> arr(
           report.environment.garbageCollectors.map(value => value: Object)
@@ -46,7 +65,27 @@ object BenchmarkRender:
       ),
       "runConfig" -> runConfigObject(report.runConfig),
       "scenarios" -> arr(report.scenarios.map(scenarioObject)),
-      "failures" -> arr(report.failures.map(failureObject))
+      "failures" -> arr(report.failures.map(failureObject)),
+      "policy" -> policyObject(report.policy)
+    )
+
+  private def policyObject(value: AbsolutePerformanceEvaluation): Object =
+    obj(
+      "referenceLane" -> Boolean.box(value.referenceLane),
+      "applicabilityReason" -> value.applicabilityReason,
+      "overallStatus" -> value.overallStatus.wireName,
+      "checks" -> arr(value.checks.map(policyCheckObject))
+    )
+
+  private def policyCheckObject(value: AbsolutePerformanceCheck): Object =
+    obj(
+      "scenarioId" -> value.scenarioId,
+      "status" -> value.status.wireName,
+      "medianNanos" -> value.medianNanos.map(Long.box).orNull,
+      "p95Nanos" -> value.p95Nanos.map(Long.box).orNull,
+      "medianCeilingNanos" -> Long.box(value.medianCeilingNanos),
+      "p95CeilingNanos" -> Long.box(value.p95CeilingNanos),
+      "message" -> value.message
     )
 
   private def scenarioObject(result: ScenarioResult): Object =

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala
@@ -1,0 +1,34 @@
+package onion.tools.readiness.benchmark
+
+import java.time.Instant
+
+final case class PerformanceBenchmarkReport(
+  schemaVersion: Int,
+  generatedAt: String,
+  git: GitMetadata,
+  environment: EnvironmentMetadata,
+  runConfig: BenchmarkRunConfig,
+  scenarios: Vector[ScenarioResult],
+  failures: Vector[BenchmarkFailure]
+):
+  def succeeded: Boolean = failures.isEmpty && scenarios.forall(_.succeeded)
+
+object PerformanceBenchmarkReport:
+  val CurrentSchemaVersion = 1
+
+  def create(
+    git: GitMetadata,
+    environment: EnvironmentMetadata,
+    runConfig: BenchmarkRunConfig,
+    scenarios: Vector[ScenarioResult],
+    failures: Vector[BenchmarkFailure] = Vector.empty
+  ): PerformanceBenchmarkReport =
+    PerformanceBenchmarkReport(
+      schemaVersion = CurrentSchemaVersion,
+      generatedAt = Instant.now().toString,
+      git = git,
+      environment = environment,
+      runConfig = runConfig,
+      scenarios = scenarios,
+      failures = failures
+    )

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala
@@ -14,7 +14,7 @@ final case class PerformanceBenchmarkReport(
   def succeeded: Boolean = failures.isEmpty && scenarios.forall(_.succeeded)
 
 object PerformanceBenchmarkReport:
-  val CurrentSchemaVersion = 1
+  val CurrentSchemaVersion = 2
 
   def create(
     git: GitMetadata,

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkReport.scala
@@ -1,5 +1,10 @@
 package onion.tools.readiness.benchmark
 
+import onion.tools.readiness.policy.{
+  AbsolutePerformanceEvaluation,
+  AbsolutePerformancePolicy,
+  PolicyOverallStatus
+}
 import java.time.Instant
 
 final case class PerformanceBenchmarkReport(
@@ -9,12 +14,16 @@ final case class PerformanceBenchmarkReport(
   environment: EnvironmentMetadata,
   runConfig: BenchmarkRunConfig,
   scenarios: Vector[ScenarioResult],
-  failures: Vector[BenchmarkFailure]
+  failures: Vector[BenchmarkFailure],
+  policy: AbsolutePerformanceEvaluation
 ):
-  def succeeded: Boolean = failures.isEmpty && scenarios.forall(_.succeeded)
+  def succeeded: Boolean =
+    failures.isEmpty &&
+      scenarios.forall(_.succeeded) &&
+      policy.overallStatus != PolicyOverallStatus.Fail
 
 object PerformanceBenchmarkReport:
-  val CurrentSchemaVersion = 2
+  val CurrentSchemaVersion = 3
 
   def create(
     git: GitMetadata,
@@ -30,5 +39,6 @@ object PerformanceBenchmarkReport:
       environment = environment,
       runConfig = runConfig,
       scenarios = scenarios,
-      failures = failures
+      failures = failures,
+      policy = AbsolutePerformancePolicy.evaluate(environment, scenarios)
     )

--- a/src/main/scala/onion/tools/readiness/benchmark/BenchmarkStatistics.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/BenchmarkStatistics.scala
@@ -1,0 +1,36 @@
+package onion.tools.readiness.benchmark
+
+object BenchmarkStatistics:
+  def summarize(values: Vector[Long]): Either[BenchmarkFailure, BenchmarkSummary] =
+    if values.isEmpty then
+      Left(
+        BenchmarkFailure(
+          FailureCategory.InvalidMeasurement,
+          "cannot summarize an empty observation set"
+        )
+      )
+    else if values.exists(_ < 0L) then
+      Left(
+        BenchmarkFailure(
+          FailureCategory.InvalidMeasurement,
+          "cannot summarize a negative duration"
+        )
+      )
+    else
+      val sorted = values.sorted
+      val median =
+        if sorted.size % 2 == 1 then sorted(sorted.size / 2)
+        else
+          val upper = sorted(sorted.size / 2)
+          val lower = sorted(sorted.size / 2 - 1)
+          lower + (upper - lower) / 2L
+      val rank = (95L * sorted.size + 99L) / 100L
+      val p95 = sorted(rank.toInt - 1)
+      Right(
+        BenchmarkSummary(
+          medianNanos = median,
+          p95Nanos = p95,
+          minNanos = sorted.head,
+          maxNanos = sorted.last
+        )
+      )

--- a/src/main/scala/onion/tools/readiness/benchmark/CompileWorkload.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/CompileWorkload.scala
@@ -1,0 +1,57 @@
+package onion.tools.readiness.benchmark
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.security.MessageDigest
+
+final case class CompileWorkload(
+  id: String,
+  label: String,
+  root: Path,
+  relativeFiles: Vector[String],
+  sourceCount: Int,
+  lineCount: Int,
+  byteCount: Long,
+  workloadHash: String
+):
+  def paths: Vector[Path] = relativeFiles.map(root.resolve)
+
+object CompileWorkload:
+  def fromFiles(
+    root: Path,
+    id: String,
+    label: String,
+    relativeFiles: Vector[String]
+  ): CompileWorkload =
+    require(relativeFiles.nonEmpty, "compile workload requires at least one source")
+    val normalizedRoot = root.toAbsolutePath.normalize()
+    val digest = MessageDigest.getInstance("SHA-256")
+    var lines = 0
+    var bytes = 0L
+
+    relativeFiles.foreach { relative =>
+      val path = normalizedRoot.resolve(relative).normalize()
+      require(path.startsWith(normalizedRoot), s"workload source escapes root: $relative")
+      require(Files.isRegularFile(path), s"workload source does not exist: $relative")
+      val content = Files.readAllBytes(path)
+      digest.update(relative.getBytes(StandardCharsets.UTF_8))
+      digest.update(0.toByte)
+      digest.update(content)
+      bytes += content.length
+      lines += countLines(new String(content, StandardCharsets.UTF_8))
+    }
+
+    CompileWorkload(
+      id = id,
+      label = label,
+      root = normalizedRoot,
+      relativeFiles = relativeFiles,
+      sourceCount = relativeFiles.size,
+      lineCount = lines,
+      byteCount = bytes,
+      workloadHash = digest.digest().map(byte => f"${byte & 0xff}%02x").mkString
+    )
+
+  private def countLines(content: String): Int =
+    if content.isEmpty then 0
+    else content.count(_ == '\n') + (if content.endsWith("\n") then 0 else 1)

--- a/src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala
@@ -120,22 +120,30 @@ object CompileScenarioCatalog:
       )
     )
 
-  private def replFactory(
+  private[benchmark] def replFactory(
     runtime: JvmRuntime,
-    timeoutMillis: Long
+    timeoutMillis: Long,
+    startClient: (JvmRuntime, java.nio.file.Path, Long) => ReplClient =
+      ProcessReplClient.start
   ): ReplClientFactory =
     new ReplClientFactory:
       override def open(): ReplClient =
         val workingDirectory =
           Files.createTempDirectory("onion-repl-benchmark")
-        val delegate =
-          ProcessReplClient.start(runtime, workingDirectory, timeoutMillis)
-        new ReplClient:
-          override def submit(code: String): String = delegate.submit(code)
+        try
+          val delegate =
+            startClient(runtime, workingDirectory, timeoutMillis)
+          new ReplClient:
+            override def submit(code: String): String = delegate.submit(code)
 
-          override def close(): Unit =
-            try delegate.close()
-            finally deleteRecursively(workingDirectory)
+            override def close(): Unit =
+              try delegate.close()
+              finally deleteRecursively(workingDirectory)
+        catch
+          case error: Throwable =>
+            try deleteRecursively(workingDirectory)
+            catch case closeError: Throwable => error.addSuppressed(closeError)
+            throw error
 
   private def deleteRecursively(root: java.nio.file.Path): Unit =
     if Files.exists(root) then

--- a/src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala
@@ -6,15 +6,21 @@ import onion.compiler.{
   OnionCompiler,
   WarningLevel
 }
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.security.MessageDigest
+import scala.jdk.CollectionConverters.*
 
 final class FreshCompileScenario(
   workload: CompileWorkload,
-  compilerConfig: CompilerConfig
+  compilerConfig: CompilerConfig,
+  scenarioKind: ScenarioKind = ScenarioKind.SteadyFresh,
+  driver: String = "onionc"
 ) extends BenchmarkScenario:
   override val metadata: ScenarioMetadata =
     ScenarioMetadata(
-      id = s"steady-fresh:onionc:${workload.id}",
-      kind = ScenarioKind.SteadyFresh,
+      id = s"${scenarioKind.wireName}:$driver:${workload.id}",
+      kind = scenarioKind,
       workload = workload.label,
       workloadHash = workload.workloadHash
     )
@@ -48,6 +54,13 @@ final class FreshCompileScenario(
 
 object CompileScenarioCatalog:
   def default(repoRoot: java.nio.file.Path): Vector[BenchmarkScenario] =
+    default(repoRoot, JvmRuntime.current(), 30000L)
+
+  def default(
+    repoRoot: java.nio.file.Path,
+    runtime: JvmRuntime,
+    timeoutMillis: Long
+  ): Vector[BenchmarkScenario] =
     val config = CompilerConfig(
       classPath = Seq("."),
       superClass = "",
@@ -56,23 +69,85 @@ object CompileScenarioCatalog:
       maxErrorReports = 20,
       warningLevel = WarningLevel.Off
     )
+    val hello = CompileWorkload.fromFiles(
+      repoRoot,
+      "hello",
+      "run/Hello.on",
+      Vector("run/Hello.on")
+    )
+    val todoManager = CompileWorkload.fromFiles(
+      repoRoot,
+      "todo-manager",
+      "run/TodoManager.on",
+      Vector("run/TodoManager.on")
+    )
+    val statsApp = CompileWorkload.fromFiles(
+      repoRoot,
+      "stats-app",
+      "run/StatsApp.on",
+      Vector("run/StatsApp.on")
+    )
+    val multiFilePaths =
+      (1 to 19).map { index =>
+        f"benchmarks/fixtures/automation-project/Stage$index%02d.on"
+      }.toVector :+
+        "benchmarks/fixtures/automation-project/Pipeline.on"
+    val multiFile = CompileWorkload.fromFiles(
+      repoRoot,
+      "automation-project",
+      "benchmarks/fixtures/automation-project",
+      multiFilePaths
+    )
     Vector(
-      CompileWorkload.fromFiles(
-        repoRoot,
-        "hello",
-        "run/Hello.on",
-        Vector("run/Hello.on")
+      new FreshCompileScenario(hello, config),
+      new FreshCompileScenario(todoManager, config),
+      new FreshCompileScenario(statsApp, config),
+      new ProcessColdScenario(
+        hello,
+        runtime,
+        ProcessLauncher.System,
+        "Hello\n"
       ),
-      CompileWorkload.fromFiles(
-        repoRoot,
-        "todo-manager",
-        "run/TodoManager.on",
-        Vector("run/TodoManager.on")
+      new PersistentReplScenario(
+        replFactory(runtime, timeoutMillis),
+        hashText("onion-repl-growing-state-v1")
       ),
-      CompileWorkload.fromFiles(
-        repoRoot,
-        "stats-app",
-        "run/StatsApp.on",
-        Vector("run/StatsApp.on")
+      new FreshCompileScenario(
+        multiFile,
+        config,
+        ScenarioKind.MultiFile,
+        "onionc"
       )
-    ).map(workload => new FreshCompileScenario(workload, config))
+    )
+
+  private def replFactory(
+    runtime: JvmRuntime,
+    timeoutMillis: Long
+  ): ReplClientFactory =
+    new ReplClientFactory:
+      override def open(): ReplClient =
+        val workingDirectory =
+          Files.createTempDirectory("onion-repl-benchmark")
+        val delegate =
+          ProcessReplClient.start(runtime, workingDirectory, timeoutMillis)
+        new ReplClient:
+          override def submit(code: String): String = delegate.submit(code)
+
+          override def close(): Unit =
+            try delegate.close()
+            finally deleteRecursively(workingDirectory)
+
+  private def deleteRecursively(root: java.nio.file.Path): Unit =
+    if Files.exists(root) then
+      val entries = Files.walk(root)
+      try
+        entries.iterator().asScala.toVector.reverse.foreach { entry =>
+          Files.deleteIfExists(entry)
+        }
+      finally entries.close()
+
+  private def hashText(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+      .digest(value.getBytes(StandardCharsets.UTF_8))
+      .map(byte => f"${byte & 0xff}%02x")
+      .mkString

--- a/src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/FreshCompileScenario.scala
@@ -1,0 +1,78 @@
+package onion.tools.readiness.benchmark
+
+import onion.compiler.{
+  CompilerConfig,
+  FileInputSource,
+  OnionCompiler,
+  WarningLevel
+}
+
+final class FreshCompileScenario(
+  workload: CompileWorkload,
+  compilerConfig: CompilerConfig
+) extends BenchmarkScenario:
+  override val metadata: ScenarioMetadata =
+    ScenarioMetadata(
+      id = s"steady-fresh:onionc:${workload.id}",
+      kind = ScenarioKind.SteadyFresh,
+      workload = workload.label,
+      workloadHash = workload.workloadHash
+    )
+
+  override def open(): BenchmarkSession = new BenchmarkSession:
+    override def runIteration(index: Int): IterationPayload =
+      val sources = workload.paths.map(path => new FileInputSource(path.toString))
+      val result = new OnionCompiler(compilerConfig).compileDetailed(sources)
+      if result.hasErrors then
+        val messages = result.allErrors.map(_.message).mkString("; ")
+        throw BenchmarkScenarioException(
+          s"compilation failed for ${workload.label}: $messages"
+        )
+      IterationPayload(
+        phases = result.timings.map { phase =>
+          PhaseObservation(
+            name = phase.name,
+            elapsedNanos = phase.elapsedNanos,
+            inputCount = phase.inputCount,
+            outputCount = phase.outputCount
+          )
+        }.toVector,
+        sourceMetrics = SourceMetrics(
+          sourceCount = workload.sourceCount,
+          lineCount = workload.lineCount,
+          byteCount = workload.byteCount,
+          generatedClasses = result.classes.size
+        ),
+        exitCode = 0
+      )
+
+object CompileScenarioCatalog:
+  def default(repoRoot: java.nio.file.Path): Vector[BenchmarkScenario] =
+    val config = CompilerConfig(
+      classPath = Seq("."),
+      superClass = "",
+      encoding = "UTF-8",
+      outputDirectory = "",
+      maxErrorReports = 20,
+      warningLevel = WarningLevel.Off
+    )
+    Vector(
+      CompileWorkload.fromFiles(
+        repoRoot,
+        "hello",
+        "run/Hello.on",
+        Vector("run/Hello.on")
+      ),
+      CompileWorkload.fromFiles(
+        repoRoot,
+        "todo-manager",
+        "run/TodoManager.on",
+        Vector("run/TodoManager.on")
+      ),
+      CompileWorkload.fromFiles(
+        repoRoot,
+        "stats-app",
+        "run/StatsApp.on",
+        Vector("run/StatsApp.on")
+      )
+    ).map(workload => new FreshCompileScenario(workload, config))

--- a/src/main/scala/onion/tools/readiness/benchmark/JvmRuntime.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/JvmRuntime.scala
@@ -1,0 +1,46 @@
+package onion.tools.readiness.benchmark
+
+import onion.compiler.OnionCompiler
+import org.jline.terminal.Terminal
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.commons.GeneratorAdapter
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.analysis.Analyzer
+import org.objectweb.asm.util.CheckClassAdapter
+
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+
+final case class JvmRuntime(javaExecutable: Path, classPath: String)
+
+object JvmRuntime:
+  def current(): JvmRuntime =
+    val executableName =
+      if System.getProperty("os.name").toLowerCase.contains("win") then "java.exe"
+      else "java"
+    val executable =
+      Paths.get(System.getProperty("java.home"), "bin", executableName)
+        .toAbsolutePath
+        .normalize()
+    require(Files.isRegularFile(executable), s"Java executable not found: $executable")
+
+    val classes = Vector(
+      classOf[OnionCompiler],
+      classOf[scala.Option[?]],
+      classOf[scala.deriving.Mirror],
+      classOf[ClassReader],
+      classOf[GeneratorAdapter],
+      classOf[ClassNode],
+      classOf[Analyzer[?]],
+      classOf[CheckClassAdapter],
+      classOf[Terminal]
+    )
+    val entries = classes.flatMap(codeLocation).distinct
+    require(entries.nonEmpty, "no child-JVM classpath entries were resolved")
+    JvmRuntime(executable, entries.mkString(File.pathSeparator))
+
+  private def codeLocation(klass: Class[?]): Option[String] =
+    Option(klass.getProtectionDomain)
+      .flatMap(domain => Option(domain.getCodeSource))
+      .flatMap(source => Option(source.getLocation))
+      .map(location => Paths.get(location.toURI).toAbsolutePath.normalize().toString)

--- a/src/main/scala/onion/tools/readiness/benchmark/PersistentReplScenario.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/PersistentReplScenario.scala
@@ -16,31 +16,45 @@ final class PersistentReplScenario(
 
   override def open(): BenchmarkSession =
     val client = factory.open()
-    client.submit("val baseline = 40")
-    new BenchmarkSession:
-      private var submission = 0
-      private var byteCount =
-        "val baseline = 40".getBytes(StandardCharsets.UTF_8).length.toLong
+    try
+      client.submit("val baseline = 40")
+      new BenchmarkSession:
+        private var submission = 0
+        private var byteCount =
+          "val baseline = 40".getBytes(StandardCharsets.UTF_8).length.toLong
 
-      override def runIteration(index: Int): IterationPayload =
-        submission += 1
-        val code = s"baseline + $submission"
-        byteCount += code.getBytes(StandardCharsets.UTF_8).length
-        val output = client.submit(code)
-        val expected = 40 + submission
-        if !output.contains(s"= $expected") then
-          throw BenchmarkScenarioException(
-            s"REPL returned an unexpected result for '$code': ${output.trim}"
+        override def runIteration(index: Int): IterationPayload =
+          submission += 1
+          val code = s"baseline + $submission"
+          byteCount += code.getBytes(StandardCharsets.UTF_8).length
+          val output = client.submit(code)
+          val expected = 40 + submission
+          if !containsExactResult(output, expected) then
+            throw BenchmarkScenarioException(
+              s"REPL returned an unexpected result for '$code': ${output.trim}"
+            )
+          IterationPayload(
+            Vector.empty,
+            SourceMetrics(
+              sourceCount = 1,
+              lineCount = submission + 1,
+              byteCount = byteCount,
+              generatedClasses = 1
+            ),
+            exitCode = 0
           )
-        IterationPayload(
-          Vector.empty,
-          SourceMetrics(
-            sourceCount = 1,
-            lineCount = submission + 1,
-            byteCount = byteCount,
-            generatedClasses = 1
-          ),
-          exitCode = 0
-        )
 
-      override def close(): Unit = client.close()
+        override def close(): Unit = client.close()
+    catch
+      case error: Throwable =>
+        try client.close()
+        catch case closeError: Throwable => error.addSuppressed(closeError)
+        throw error
+
+  private def containsExactResult(output: String, expected: Int): Boolean =
+    val Result = """^res\d*:\s+[^=]+=\s+(-?\d+)\s*$""".r
+    val withoutAnsi = output.replaceAll("\u001B\\[[;\\d]*m", "")
+    withoutAnsi.linesIterator.exists {
+      case Result(value) => value.toIntOption.contains(expected)
+      case _ => false
+    }

--- a/src/main/scala/onion/tools/readiness/benchmark/PersistentReplScenario.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/PersistentReplScenario.scala
@@ -1,0 +1,46 @@
+package onion.tools.readiness.benchmark
+
+import java.nio.charset.StandardCharsets
+
+final class PersistentReplScenario(
+  factory: ReplClientFactory,
+  workloadHash: String
+) extends BenchmarkScenario:
+  override val metadata =
+    ScenarioMetadata(
+      "persistent-session:repl:growing-state",
+      ScenarioKind.PersistentSession,
+      "generated growing REPL session",
+      workloadHash
+    )
+
+  override def open(): BenchmarkSession =
+    val client = factory.open()
+    client.submit("val baseline = 40")
+    new BenchmarkSession:
+      private var submission = 0
+      private var byteCount =
+        "val baseline = 40".getBytes(StandardCharsets.UTF_8).length.toLong
+
+      override def runIteration(index: Int): IterationPayload =
+        submission += 1
+        val code = s"baseline + $submission"
+        byteCount += code.getBytes(StandardCharsets.UTF_8).length
+        val output = client.submit(code)
+        val expected = 40 + submission
+        if !output.contains(s"= $expected") then
+          throw BenchmarkScenarioException(
+            s"REPL returned an unexpected result for '$code': ${output.trim}"
+          )
+        IterationPayload(
+          Vector.empty,
+          SourceMetrics(
+            sourceCount = 1,
+            lineCount = submission + 1,
+            byteCount = byteCount,
+            generatedClasses = 1
+          ),
+          exitCode = 0
+        )
+
+      override def close(): Unit = client.close()

--- a/src/main/scala/onion/tools/readiness/benchmark/ProcessColdScenario.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/ProcessColdScenario.scala
@@ -39,8 +39,13 @@ final class ProcessColdScenario(
           workingDirectory,
           Map("TERM" -> "dumb")
         )
+        if outcome.exitCode != 0 then
+          throw BenchmarkScenarioException(
+            s"${workload.label} exited with exit code ${outcome.exitCode}; " +
+              s"stdout: ${bounded(outcome.stdout)}; " +
+              s"stderr: ${bounded(outcome.stderr)}"
+          )
         if
-          outcome.exitCode == 0 &&
           normalize(outcome.stdout) != normalize(expectedStdout)
         then
           throw BenchmarkScenarioException(
@@ -68,3 +73,9 @@ final class ProcessColdScenario(
 
   private def normalize(value: String): String =
     value.replace("\r\n", "\n")
+
+  private def bounded(value: String): String =
+    val limit = 2048
+    val normalized = normalize(value).trim
+    if normalized.length <= limit then normalized
+    else normalized.take(limit) + "…"

--- a/src/main/scala/onion/tools/readiness/benchmark/ProcessColdScenario.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/ProcessColdScenario.scala
@@ -1,0 +1,70 @@
+package onion.tools.readiness.benchmark
+
+import java.nio.file.Files
+import scala.jdk.CollectionConverters.*
+
+final class ProcessColdScenario(
+  workload: CompileWorkload,
+  runtime: JvmRuntime,
+  launcher: ProcessLauncher,
+  expectedStdout: String
+) extends BenchmarkScenario:
+  require(
+    workload.sourceCount == 1,
+    "process-cold script scenario requires exactly one source"
+  )
+
+  override val metadata: ScenarioMetadata =
+    ScenarioMetadata(
+      id = s"process-cold:onion:${workload.id}",
+      kind = ScenarioKind.ProcessCold,
+      workload = workload.label,
+      workloadHash = workload.workloadHash
+    )
+
+  override def defaultWarmupIterations: Int = 3
+
+  override def open(): BenchmarkSession =
+    val workingDirectory = Files.createTempDirectory("onion-process-cold")
+    new BenchmarkSession:
+      override def runIteration(index: Int): IterationPayload =
+        val outcome = launcher.run(
+          Vector(
+            runtime.javaExecutable.toString,
+            "-cp",
+            runtime.classPath,
+            "onion.tools.ScriptRunner",
+            workload.paths.head.toString
+          ),
+          workingDirectory,
+          Map("TERM" -> "dumb")
+        )
+        if
+          outcome.exitCode == 0 &&
+          normalize(outcome.stdout) != normalize(expectedStdout)
+        then
+          throw BenchmarkScenarioException(
+            s"unexpected stdout for ${workload.label}: ${outcome.stdout.trim}"
+          )
+        IterationPayload(
+          phases = Vector.empty,
+          sourceMetrics = SourceMetrics(
+            workload.sourceCount,
+            workload.lineCount,
+            workload.byteCount,
+            generatedClasses = 0
+          ),
+          exitCode = outcome.exitCode
+        )
+
+      override def close(): Unit =
+        if Files.exists(workingDirectory) then
+          val entries = Files.walk(workingDirectory)
+          try
+            entries.iterator().asScala.toVector.reverse.foreach { entry =>
+              Files.deleteIfExists(entry)
+            }
+          finally entries.close()
+
+  private def normalize(value: String): String =
+    value.replace("\r\n", "\n")

--- a/src/main/scala/onion/tools/readiness/benchmark/ProcessSupport.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/ProcessSupport.scala
@@ -1,0 +1,63 @@
+package onion.tools.readiness.benchmark
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.concurrent.{Callable, Executors, Future}
+import scala.jdk.CollectionConverters.*
+
+final case class ProcessOutcome(
+  exitCode: Int,
+  stdout: String,
+  stderr: String
+)
+
+trait ProcessLauncher:
+  def run(
+    command: Vector[String],
+    workingDirectory: Path,
+    environment: Map[String, String]
+  ): ProcessOutcome
+
+object ProcessLauncher:
+  object System extends ProcessLauncher:
+    override def run(
+      command: Vector[String],
+      workingDirectory: Path,
+      environment: Map[String, String]
+    ): ProcessOutcome =
+      val builder = new ProcessBuilder(command*)
+        .directory(workingDirectory.toFile)
+      builder.environment().putAll(environment.asJava)
+      val process = builder.start()
+      val readers = Executors.newFixedThreadPool(
+        2,
+        runnable =>
+          val thread = new Thread(runnable, "onion-process-output")
+          thread.setDaemon(true)
+          thread
+      )
+      val stdout = readAsync(readers, process.getInputStream)
+      val stderr = readAsync(readers, process.getErrorStream)
+      try
+        val exitCode = process.waitFor()
+        ProcessOutcome(exitCode, stdout.get(), stderr.get())
+      catch
+        case interrupted: InterruptedException =>
+          process.destroyForcibly()
+          process.waitFor()
+          stdout.cancel(true)
+          stderr.cancel(true)
+          Thread.currentThread().interrupt()
+          throw interrupted
+      finally
+        readers.shutdownNow()
+
+    private def readAsync(
+      readers: java.util.concurrent.ExecutorService,
+      stream: java.io.InputStream
+    ): Future[String] =
+      readers.submit(new Callable[String]:
+        override def call(): String =
+          try new String(stream.readAllBytes(), StandardCharsets.UTF_8)
+          finally stream.close()
+      )

--- a/src/main/scala/onion/tools/readiness/benchmark/ProcessSupport.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/ProcessSupport.scala
@@ -2,7 +2,7 @@ package onion.tools.readiness.benchmark
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
-import java.util.concurrent.{Callable, Executors, Future}
+import java.util.concurrent.{Callable, Executors, Future, TimeUnit}
 import scala.jdk.CollectionConverters.*
 
 final case class ProcessOutcome(
@@ -44,7 +44,16 @@ object ProcessLauncher:
       catch
         case interrupted: InterruptedException =>
           process.destroyForcibly()
-          process.waitFor()
+          try
+            if !process.waitFor(5L, TimeUnit.SECONDS) then
+              interrupted.addSuppressed(
+                new IllegalStateException(
+                  "child process did not terminate after forced destruction"
+                )
+              )
+          catch
+            case cleanupInterrupted: InterruptedException =>
+              interrupted.addSuppressed(cleanupInterrupted)
           stdout.cancel(true)
           stderr.cancel(true)
           Thread.currentThread().interrupt()

--- a/src/main/scala/onion/tools/readiness/benchmark/ReplProcess.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/ReplProcess.scala
@@ -1,0 +1,147 @@
+package onion.tools.readiness.benchmark
+
+import java.io.{BufferedWriter, InputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
+trait ReplClient extends AutoCloseable:
+  def submit(code: String): String
+
+trait ReplClientFactory:
+  def open(): ReplClient
+
+final class ProcessReplClient private (
+  process: Process,
+  input: BufferedWriter,
+  stdout: ReplOutputPump,
+  timeoutMillis: Long
+) extends ReplClient:
+  override def submit(code: String): String =
+    try
+      input.write(code)
+      input.newLine()
+      input.flush()
+      stdout.readUntil("onion> ", timeoutMillis)
+    catch
+      case interrupted: InterruptedException =>
+        process.destroyForcibly()
+        Thread.currentThread().interrupt()
+        throw interrupted
+
+  override def close(): Unit =
+    if process.isAlive then
+      try
+        input.write(":quit")
+        input.newLine()
+        input.flush()
+        if !process.waitFor(1L, TimeUnit.SECONDS) then
+          process.destroyForcibly()
+      catch
+        case _: Exception => process.destroyForcibly()
+    input.close()
+
+object ProcessReplClient:
+  def start(
+    runtime: JvmRuntime,
+    workingDirectory: Path,
+    timeoutMillis: Long
+  ): ProcessReplClient =
+    val builder =
+      new ProcessBuilder(
+        runtime.javaExecutable.toString,
+        "-cp",
+        runtime.classPath,
+        "onion.tools.Repl"
+      )
+        .directory(workingDirectory.toFile)
+    builder.environment().put("TERM", "dumb")
+    val process = builder.start()
+    val stderr = new StreamDrainer(process.getErrorStream, "repl-stderr")
+    stderr.start()
+    val stdout = new ReplOutputPump(process.getInputStream, "repl-stdout")
+    stdout.start()
+    val writer =
+      new BufferedWriter(
+        new OutputStreamWriter(process.getOutputStream, StandardCharsets.UTF_8)
+      )
+    val client = new ProcessReplClient(process, writer, stdout, timeoutMillis)
+    try
+      stdout.readUntil("onion> ", timeoutMillis)
+      client
+    catch
+      case error: Throwable =>
+        client.close()
+        throw error
+
+private final class ReplOutputPump(stream: InputStream, name: String):
+  private val End = -1
+  private val queue = new LinkedBlockingQueue[Int]()
+  private val failure = new AtomicReference[Throwable]()
+  private val thread = new Thread(
+    new Runnable:
+      override def run(): Unit =
+        try
+          var next = stream.read()
+          while next >= 0 do
+            queue.put(next)
+            next = stream.read()
+        catch case error: Throwable => failure.set(error)
+        finally
+          queue.offer(End)
+          stream.close()
+    ,
+    s"onion-$name"
+  )
+  thread.setDaemon(true)
+
+  def start(): Unit = thread.start()
+
+  def readUntil(marker: String, timeoutMillis: Long): String =
+    val expected = marker.getBytes(StandardCharsets.UTF_8)
+    val bytes = scala.collection.mutable.ArrayBuffer.empty[Byte]
+    val deadline =
+      System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
+    while !endsWith(bytes, expected) do
+      val remaining = deadline - System.nanoTime()
+      if remaining <= 0L then
+        throw BenchmarkScenarioException(
+          s"REPL prompt timed out after $timeoutMillis ms"
+        )
+      val next: Integer = queue.poll(remaining, TimeUnit.NANOSECONDS)
+      if next == null then
+        throw BenchmarkScenarioException(
+          s"REPL prompt timed out after $timeoutMillis ms"
+        )
+      if next.intValue() == End then
+        val cause = failure.get()
+        val detail =
+          if cause == null then "end of stream"
+          else Option(cause.getMessage).getOrElse(cause.getClass.getSimpleName)
+        throw BenchmarkScenarioException(s"REPL exited before prompt: $detail")
+      bytes += next.byteValue()
+    new String(bytes.toArray, StandardCharsets.UTF_8)
+
+  private def endsWith(
+    bytes: scala.collection.mutable.ArrayBuffer[Byte],
+    expected: Array[Byte]
+  ): Boolean =
+    bytes.length >= expected.length &&
+      expected.indices.forall { index =>
+        bytes(bytes.length - expected.length + index) == expected(index)
+      }
+
+private final class StreamDrainer(stream: InputStream, name: String):
+  private val thread = new Thread(
+    new Runnable:
+      override def run(): Unit =
+        try
+          while stream.read() >= 0 do ()
+        finally stream.close()
+    ,
+    s"onion-$name"
+  )
+  thread.setDaemon(true)
+
+  def start(): Unit = thread.start()

--- a/src/main/scala/onion/tools/readiness/benchmark/ReplProcess.scala
+++ b/src/main/scala/onion/tools/readiness/benchmark/ReplProcess.scala
@@ -18,29 +18,63 @@ final class ProcessReplClient private (
   stdout: ReplOutputPump,
   timeoutMillis: Long
 ) extends ReplClient:
+  private[benchmark] def awaitPrompt(): String =
+    stdout.readUntil("onion> ", timeoutMillis)
+
   override def submit(code: String): String =
     try
       input.write(code)
       input.newLine()
       input.flush()
-      stdout.readUntil("onion> ", timeoutMillis)
+      awaitPrompt()
     catch
       case interrupted: InterruptedException =>
         process.destroyForcibly()
+        try process.waitFor(1L, TimeUnit.SECONDS)
+        catch
+          case cleanupInterrupted: InterruptedException =>
+            interrupted.addSuppressed(cleanupInterrupted)
         Thread.currentThread().interrupt()
         throw interrupted
 
   override def close(): Unit =
-    if process.isAlive then
-      try
+    var failure: Throwable = null
+    try
+      if process.isAlive then
         input.write(":quit")
         input.newLine()
         input.flush()
         if !process.waitFor(1L, TimeUnit.SECONDS) then
           process.destroyForcibly()
+          if !process.waitFor(1L, TimeUnit.SECONDS) then
+            throw BenchmarkScenarioException(
+              "REPL process did not terminate after forced destruction"
+            )
+    catch
+      case interrupted: InterruptedException =>
+        process.destroyForcibly()
+        try process.waitFor(1L, TimeUnit.SECONDS)
+        catch
+          case cleanupInterrupted: InterruptedException =>
+            interrupted.addSuppressed(cleanupInterrupted)
+        Thread.currentThread().interrupt()
+        failure = interrupted
+      case error: Throwable =>
+        process.destroyForcibly()
+        try
+          if process.isAlive then process.waitFor(1L, TimeUnit.SECONDS)
+        catch
+          case interrupted: InterruptedException =>
+            Thread.currentThread().interrupt()
+            error.addSuppressed(interrupted)
+        failure = error
+    finally
+      try input.close()
       catch
-        case _: Exception => process.destroyForcibly()
-    input.close()
+        case error: Throwable =>
+          if failure == null then failure = error
+          else failure.addSuppressed(error)
+    if failure != null then throw failure
 
 object ProcessReplClient:
   def start(
@@ -58,6 +92,20 @@ object ProcessReplClient:
         .directory(workingDirectory.toFile)
     builder.environment().put("TERM", "dumb")
     val process = builder.start()
+    val client = attach(process, timeoutMillis)
+    try
+      client.awaitPrompt()
+      client
+    catch
+      case error: Throwable =>
+        try client.close()
+        catch case closeError: Throwable => error.addSuppressed(closeError)
+        throw error
+
+  private[benchmark] def attach(
+    process: Process,
+    timeoutMillis: Long
+  ): ProcessReplClient =
     val stderr = new StreamDrainer(process.getErrorStream, "repl-stderr")
     stderr.start()
     val stdout = new ReplOutputPump(process.getInputStream, "repl-stdout")
@@ -66,14 +114,7 @@ object ProcessReplClient:
       new BufferedWriter(
         new OutputStreamWriter(process.getOutputStream, StandardCharsets.UTF_8)
       )
-    val client = new ProcessReplClient(process, writer, stdout, timeoutMillis)
-    try
-      stdout.readUntil("onion> ", timeoutMillis)
-      client
-    catch
-      case error: Throwable =>
-        client.close()
-        throw error
+    new ProcessReplClient(process, writer, stdout, timeoutMillis)
 
 private final class ReplOutputPump(stream: InputStream, name: String):
   private val End = -1

--- a/src/main/scala/onion/tools/readiness/policy/PerformancePolicy.scala
+++ b/src/main/scala/onion/tools/readiness/policy/PerformancePolicy.scala
@@ -1,0 +1,202 @@
+package onion.tools.readiness.policy
+
+import onion.tools.readiness.benchmark.*
+
+enum PolicyCheckStatus(val wireName: String):
+  case Pass extends PolicyCheckStatus("pass")
+  case Fail extends PolicyCheckStatus("fail")
+  case NotApplicable extends PolicyCheckStatus("not-applicable")
+  case Unknown extends PolicyCheckStatus("unknown")
+
+enum PolicyOverallStatus(val wireName: String):
+  case Pass extends PolicyOverallStatus("pass")
+  case Fail extends PolicyOverallStatus("fail")
+  case Informational extends PolicyOverallStatus("informational")
+
+final case class PerformanceBudget(
+  scenarioId: String,
+  medianCeilingNanos: Long,
+  p95CeilingNanos: Long
+)
+
+final case class AbsolutePerformanceCheck(
+  scenarioId: String,
+  status: PolicyCheckStatus,
+  medianNanos: Option[Long],
+  p95Nanos: Option[Long],
+  medianCeilingNanos: Long,
+  p95CeilingNanos: Long,
+  message: String
+)
+
+final case class AbsolutePerformanceEvaluation(
+  referenceLane: Boolean,
+  applicabilityReason: String,
+  checks: Vector[AbsolutePerformanceCheck],
+  overallStatus: PolicyOverallStatus
+)
+
+object AbsolutePerformancePolicy:
+  private val GiB = 1024L * 1024L * 1024L
+
+  val budgets: Vector[PerformanceBudget] = Vector(
+    PerformanceBudget(
+      "process-cold:onion:hello",
+      1500000000L,
+      2500000000L
+    ),
+    PerformanceBudget(
+      "steady-fresh:onionc:hello",
+      150000000L,
+      300000000L
+    ),
+    PerformanceBudget(
+      "steady-fresh:onionc:stats-app",
+      750000000L,
+      1200000000L
+    ),
+    PerformanceBudget(
+      "persistent-session:repl:growing-state",
+      100000000L,
+      250000000L
+    ),
+    PerformanceBudget(
+      "multi-file:onionc:automation-project",
+      2000000000L,
+      3000000000L
+    )
+  )
+
+  def isReferenceLane(environment: EnvironmentMetadata): Boolean =
+    referenceMismatches(environment).isEmpty
+
+  def evaluate(
+    environment: EnvironmentMetadata,
+    scenarios: Vector[ScenarioResult]
+  ): AbsolutePerformanceEvaluation =
+    val mismatches = referenceMismatches(environment)
+    val referenceLane = mismatches.isEmpty
+    val byId = scenarios.map(result => result.metadata.id -> result).toMap
+    val checks = budgets.map { budget =>
+      val scenario = byId.get(budget.scenarioId)
+      val summary = scenario.flatMap(_.summary)
+      if !referenceLane then
+        check(
+          budget,
+          PolicyCheckStatus.NotApplicable,
+          summary,
+          "absolute ceilings require the reference environment"
+        )
+      else
+        scenario match
+          case None =>
+            check(
+              budget,
+              PolicyCheckStatus.Unknown,
+              None,
+              "required scenario evidence is missing"
+            )
+          case Some(result) if result.failure.nonEmpty =>
+            check(
+              budget,
+              PolicyCheckStatus.Unknown,
+              result.summary,
+              s"scenario failed: ${result.failure.get.message}"
+            )
+          case Some(result) =>
+            result.summary match
+              case None =>
+                check(
+                  budget,
+                  PolicyCheckStatus.Unknown,
+                  None,
+                  "required scenario summary is missing"
+                )
+              case Some(value) =>
+                val breaches = Vector(
+                  Option.when(value.medianNanos > budget.medianCeilingNanos)(
+                    "median"
+                  ),
+                  Option.when(value.p95Nanos > budget.p95CeilingNanos)("p95")
+                ).flatten
+                if breaches.isEmpty then
+                  check(
+                    budget,
+                    PolicyCheckStatus.Pass,
+                    Some(value),
+                    "within absolute ceiling"
+                  )
+                else
+                  check(
+                    budget,
+                    PolicyCheckStatus.Fail,
+                    Some(value),
+                    s"${breaches.mkString(" and ")} exceeded absolute ceiling"
+                  )
+    }
+    val overallStatus =
+      if !referenceLane then PolicyOverallStatus.Informational
+      else if checks.exists { value =>
+        value.status == PolicyCheckStatus.Fail ||
+        value.status == PolicyCheckStatus.Unknown
+      }
+      then PolicyOverallStatus.Fail
+      else PolicyOverallStatus.Pass
+    AbsolutePerformanceEvaluation(
+      referenceLane = referenceLane,
+      applicabilityReason =
+        if referenceLane then "reference environment matched"
+        else s"reference environment mismatch: ${mismatches.mkString(", ")}",
+      checks = checks,
+      overallStatus = overallStatus
+    )
+
+  private def check(
+    budget: PerformanceBudget,
+    status: PolicyCheckStatus,
+    summary: Option[BenchmarkSummary],
+    message: String
+  ): AbsolutePerformanceCheck =
+    AbsolutePerformanceCheck(
+      scenarioId = budget.scenarioId,
+      status = status,
+      medianNanos = summary.map(_.medianNanos),
+      p95Nanos = summary.map(_.p95Nanos),
+      medianCeilingNanos = budget.medianCeilingNanos,
+      p95CeilingNanos = budget.p95CeilingNanos,
+      message = message
+    )
+
+  private def referenceMismatches(
+    environment: EnvironmentMetadata
+  ): Vector[String] =
+    Vector(
+      Option.unless(environment.osName == "Linux")("operating system"),
+      Option.unless(environment.osReleaseId == "ubuntu")("distribution"),
+      Option.unless(environment.osReleaseVersion == "24.04")(
+        "distribution version"
+      ),
+      Option.unless(Set("amd64", "x86_64").contains(environment.osArch))(
+        "architecture"
+      ),
+      Option.unless(environment.javaVendor == "Eclipse Adoptium")(
+        "Java vendor"
+      ),
+      Option.unless(javaMajor(environment.javaVersion).contains(21))(
+        "Java major version"
+      ),
+      Option.unless(environment.processors == 2)("assigned processors"),
+      Option.unless(environment.totalMemoryBytes == 4L * GiB)(
+        "assigned memory"
+      ),
+      Option.unless(environment.maxHeapBytes == 2L * GiB)("maximum heap"),
+      Option.unless(
+        environment.garbageCollectors.exists(_.startsWith("G1"))
+      )("garbage collector")
+    ).flatten
+
+  private def javaMajor(version: String): Option[Int] =
+    val parts = version.split("[._-]").toVector
+    parts.headOption.flatMap(_.toIntOption) match
+      case Some(1) => parts.lift(1).flatMap(_.toIntOption)
+      case value => value

--- a/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
+++ b/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
@@ -6,11 +6,18 @@ import onion.tools.readiness.benchmark.{
   BenchmarkRunConfig,
   BenchmarkScenario,
   BenchmarkSession,
+  EnvironmentMetadata,
   FailureCategory,
+  GitMetadata,
   IterationPayload,
+  PerformanceBenchmarkReport,
   ScenarioKind,
   ScenarioMetadata,
   SourceMetrics
+}
+import onion.tools.readiness.policy.{
+  AbsolutePerformanceEvaluation,
+  PolicyOverallStatus
 }
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -18,6 +25,51 @@ import org.scalatest.matchers.should.Matchers
 import java.nio.file.Files
 
 class BenchmarkRunnerSpec extends AnyFunSpec with Matchers:
+  private def report(
+    policyStatus: PolicyOverallStatus,
+    referenceLane: Boolean
+  ): PerformanceBenchmarkReport =
+    PerformanceBenchmarkReport(
+      schemaVersion = PerformanceBenchmarkReport.CurrentSchemaVersion,
+      generatedAt = "2026-07-24T00:00:00Z",
+      git = GitMetadata("deadbeef", dirty = false),
+      environment = EnvironmentMetadata(
+        javaVendor = "test",
+        javaVersion = "21",
+        osName = "Linux",
+        osArch = "amd64",
+        processors = 2,
+        maxHeapBytes = 1L,
+        garbageCollectors = Vector("test"),
+        jvmArguments = Vector.empty
+      ),
+      runConfig = BenchmarkRunConfig(0, 1, 1000L),
+      scenarios = Vector.empty,
+      failures = Vector.empty,
+      policy = AbsolutePerformanceEvaluation(
+        referenceLane = referenceLane,
+        applicabilityReason = "test",
+        checks = Vector.empty,
+        overallStatus = policyStatus
+      )
+    )
+
+  describe("PerformanceBenchmarkReport policy outcome"):
+    it("keeps a successful non-reference report informational"):
+      val result = report(
+        PolicyOverallStatus.Informational,
+        referenceLane = false
+      )
+
+      result.policy.overallStatus shouldBe PolicyOverallStatus.Informational
+      result.succeeded shouldBe true
+
+    it("fails a report whose reference policy failed"):
+      val result = report(PolicyOverallStatus.Fail, referenceLane = true)
+
+      result.policy.overallStatus shouldBe PolicyOverallStatus.Fail
+      result.succeeded shouldBe false
+
   describe("BenchmarkRunner.buildReport"):
     it("returns a structured invalid-measurement report when workloads are missing"):
       val root = Files.createTempDirectory("onion-benchmark-missing-workloads")

--- a/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
+++ b/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
@@ -1,0 +1,33 @@
+package onion.tools
+
+import onion.tools.readiness.benchmark.{
+  BenchmarkOptions,
+  BenchmarkOutputFormat,
+  BenchmarkRunConfig,
+  FailureCategory
+}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class BenchmarkRunnerSpec extends AnyFunSpec with Matchers:
+  describe("BenchmarkRunner.buildReport"):
+    it("returns a structured invalid-measurement report when workloads are missing"):
+      val root = Files.createTempDirectory("onion-benchmark-missing-workloads")
+      val options = BenchmarkOptions(
+        runConfig = BenchmarkRunConfig(0, 1, 1000L),
+        output = root.resolve("report.json"),
+        stdoutFormat = BenchmarkOutputFormat.Text
+      )
+
+      val report = BenchmarkRunner.buildReport(root, options)
+
+      report.succeeded shouldBe false
+      report.scenarios shouldBe empty
+      report.failures.map(_.category) should contain (
+        FailureCategory.InvalidMeasurement
+      )
+      report.failures.map(_.message).mkString(" ") should include (
+        "workload source does not exist"
+      )

--- a/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
+++ b/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
@@ -4,7 +4,11 @@ import onion.tools.readiness.benchmark.{
   BenchmarkOptions,
   BenchmarkOutputFormat,
   BenchmarkRunConfig,
-  FailureCategory
+  BenchmarkScenario,
+  BenchmarkSession,
+  FailureCategory,
+  ScenarioKind,
+  ScenarioMetadata
 }
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -31,3 +35,23 @@ class BenchmarkRunnerSpec extends AnyFunSpec with Matchers:
       report.failures.map(_.message).mkString(" ") should include (
         "workload source does not exist"
       )
+
+    it("uses scenario warmups unless the CLI overrides them"):
+      val processScenario = new BenchmarkScenario:
+        override val metadata =
+          ScenarioMetadata("process", ScenarioKind.ProcessCold, "test", "hash")
+        override def defaultWarmupIterations: Int = 3
+        override def open(): BenchmarkSession =
+          throw new UnsupportedOperationException()
+
+      BenchmarkRunner.effectiveConfig(
+        processScenario,
+        BenchmarkOptions()
+      ).warmupIterations shouldBe 3
+
+      val overrideOptions =
+        BenchmarkOptions.parse(Array("--warmups", "0")).toOption.get
+      BenchmarkRunner.effectiveConfig(
+        processScenario,
+        overrideOptions
+      ).warmupIterations shouldBe 0

--- a/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
+++ b/src/test/scala/onion/tools/BenchmarkRunnerSpec.scala
@@ -7,8 +7,10 @@ import onion.tools.readiness.benchmark.{
   BenchmarkScenario,
   BenchmarkSession,
   FailureCategory,
+  IterationPayload,
   ScenarioKind,
-  ScenarioMetadata
+  ScenarioMetadata,
+  SourceMetrics
 }
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -55,3 +57,34 @@ class BenchmarkRunnerSpec extends AnyFunSpec with Matchers:
         processScenario,
         overrideOptions
       ).warmupIterations shouldBe 0
+
+    it("runs and records each scenario with its effective configuration"):
+      def scenario(
+        id: String,
+        kind: ScenarioKind,
+        warmups: Int
+      ): BenchmarkScenario =
+        new BenchmarkScenario:
+          override val metadata =
+            ScenarioMetadata(id, kind, "test", "hash")
+          override def defaultWarmupIterations: Int = warmups
+          override def open(): BenchmarkSession = new BenchmarkSession:
+            override def runIteration(index: Int): IterationPayload =
+              IterationPayload(
+                Vector.empty,
+                SourceMetrics(1, 1, 1L, 1),
+                0
+              )
+
+      val scenarios = Vector(
+        scenario("process", ScenarioKind.ProcessCold, 3),
+        scenario("steady", ScenarioKind.SteadyFresh, 8)
+      )
+      val options = BenchmarkOptions(
+        runConfig = BenchmarkRunConfig(8, 1, 1000L)
+      )
+
+      val results = BenchmarkRunner.runScenarios(scenarios, options)
+
+      results.map(_.runConfig.warmupIterations) shouldBe Vector(3, 8)
+      results.map(_.warmups.size) shouldBe Vector(3, 8)

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala
@@ -4,7 +4,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues
 
-import java.util.concurrent.{CountDownLatch, Executors}
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
 
 class BenchmarkEngineSpec extends AnyFunSpec with Matchers with OptionValues:
   private final class SequenceClock(values: Seq[Long]) extends NanoClock:
@@ -95,3 +96,80 @@ class BenchmarkEngineSpec extends AnyFunSpec with Matchers with OptionValues:
       entered.getCount shouldBe 0L
       result.failure.value.message should include ("timed out")
       result.measurements shouldBe empty
+
+    it("defers session cleanup when a timed-out iteration ignores interruption"):
+      val entered = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+      val closed = new CountDownLatch(1)
+      val running = new AtomicBoolean(false)
+      val closeWhileRunning = new AtomicBoolean(false)
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            running.set(true)
+            entered.countDown()
+            while release.getCount > 0L do
+              try release.await(10L, TimeUnit.MILLISECONDS)
+              catch case _: InterruptedException => ()
+            running.set(false)
+            payload
+
+          override def close(): Unit =
+            closeWhileRunning.set(running.get())
+            closed.countDown()
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 25L),
+        NanoClock.System,
+        executor
+      )
+      val result =
+        try
+          val observed = engine.run(scenario)
+          entered.getCount shouldBe 0L
+          closeWhileRunning.get() shouldBe false
+          observed
+        finally
+          release.countDown()
+          engine.close()
+
+      closed.await(1L, TimeUnit.SECONDS) shouldBe true
+      result.failure.value.message should include ("timed out")
+
+    it("rejects nonzero scenario exit codes"):
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            payload.copy(exitCode = 7)
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 1000L),
+        new SequenceClock(Seq(0L, 1L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.measurements shouldBe empty
+      result.failure.value.category shouldBe FailureCategory.ScenarioFailure
+      result.failure.value.message should include ("exit code 7")
+
+    it("classifies invalid timing data as an invalid measurement"):
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload = payload
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 1000L),
+        new SequenceClock(Seq(2L, 1L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.measurements shouldBe empty
+      result.failure.value.category shouldBe FailureCategory.InvalidMeasurement

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala
@@ -173,3 +173,20 @@ class BenchmarkEngineSpec extends AnyFunSpec with Matchers with OptionValues:
 
       result.measurements shouldBe empty
       result.failure.value.category shouldBe FailureCategory.InvalidMeasurement
+
+    it("records the effective run configuration in the scenario result"):
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload = payload
+
+      val config = BenchmarkRunConfig(0, 1, 1000L)
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        config,
+        new SequenceClock(Seq(0L, 1L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.runConfig shouldBe config

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkEngineSpec.scala
@@ -1,0 +1,97 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+import java.util.concurrent.{CountDownLatch, Executors}
+
+class BenchmarkEngineSpec extends AnyFunSpec with Matchers with OptionValues:
+  private final class SequenceClock(values: Seq[Long]) extends NanoClock:
+    private val iterator = values.iterator
+    override def nanoTime(): Long = iterator.next()
+
+  private def metadata =
+    ScenarioMetadata("steady-fresh:test", ScenarioKind.SteadyFresh, "test", "hash")
+
+  private def payload =
+    IterationPayload(
+      phases = Vector.empty,
+      sourceMetrics = SourceMetrics(1, 1, 1L, 1),
+      exitCode = 0
+    )
+
+  describe("BenchmarkEngine"):
+    it("keeps warmups separate and summarizes only measurements"):
+      var calls = 0
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            calls += 1
+            payload
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(1, 2, 1000L),
+        new SequenceClock(Seq(0L, 5L, 5L, 12L, 12L, 23L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      calls shouldBe 3
+      result.warmups.map(_.elapsedNanos) shouldBe Vector(5L)
+      result.measurements.map(_.elapsedNanos) shouldBe Vector(7L, 11L)
+      result.summary shouldBe Some(BenchmarkSummary(9L, 11L, 7L, 11L))
+      result.failure shouldBe None
+
+    it("returns completed observations when a later iteration fails"):
+      var calls = 0
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            calls += 1
+            if calls == 3 then throw BenchmarkScenarioException("compiler failed")
+            payload
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(1, 2, 1000L),
+        new SequenceClock(Seq(0L, 1L, 1L, 3L, 3L)),
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.warmups.size shouldBe 1
+      result.measurements.size shouldBe 1
+      result.summary shouldBe None
+      result.failure.value.category shouldBe FailureCategory.ScenarioFailure
+      result.failure.value.iteration shouldBe Some(1)
+
+    it("marks an iteration timeout as a scenario failure"):
+      val entered = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+      val scenario = new BenchmarkScenario:
+        override val metadata: ScenarioMetadata = BenchmarkEngineSpec.this.metadata
+        override def open(): BenchmarkSession = new BenchmarkSession:
+          override def runIteration(index: Int): IterationPayload =
+            entered.countDown()
+            release.await()
+            payload
+
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 25L),
+        NanoClock.System,
+        executor
+      )
+      val result =
+        try engine.run(scenario)
+        finally
+          release.countDown()
+          engine.close()
+
+      entered.getCount shouldBe 0L
+      result.failure.value.message should include ("timed out")
+      result.measurements shouldBe empty

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkMetadataSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkMetadataSpec.scala
@@ -1,0 +1,23 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class BenchmarkMetadataSpec extends AnyFunSpec with Matchers:
+  describe("EnvironmentMetadata.parseOsRelease"):
+    it("extracts and unquotes Ubuntu identity"):
+      EnvironmentMetadata.parseOsRelease(
+        Seq("""ID="ubuntu"""", """VERSION_ID="24.04"""")
+      ) shouldBe ("ubuntu", "24.04")
+
+    it("uses unknown values when release keys are absent"):
+      EnvironmentMetadata.parseOsRelease(Seq("NAME=Linux")) shouldBe
+        ("unknown", "unknown")
+
+  describe("EnvironmentMetadata.capture"):
+    it("captures positive processor, heap, and memory evidence"):
+      val environment = EnvironmentMetadata.capture()
+
+      environment.processors should be > 0
+      environment.maxHeapBytes should be > 0L
+      environment.totalMemoryBytes should be > 0L

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala
@@ -12,10 +12,11 @@ class BenchmarkOptionsSpec extends AnyFunSpec with Matchers with OptionValues:
       BenchmarkOptions.parse(Array.empty) shouldBe Right(
         BenchmarkOptions(
           runConfig = BenchmarkRunConfig(8, 25, 30000L),
-          output = Paths.get("target/readiness/benchmark-v1.json"),
+          output = Paths.get("target/readiness/benchmark-v2.json"),
           stdoutFormat = BenchmarkOutputFormat.Text
         )
       )
+      BenchmarkOptions.parse(Array.empty).toOption.value.warmupOverride shouldBe None
 
     it("preserves --iterations and --json compatibility"):
       val parsed =
@@ -34,6 +35,7 @@ class BenchmarkOptionsSpec extends AnyFunSpec with Matchers with OptionValues:
       ).toOption.value
       parsed.runConfig shouldBe BenchmarkRunConfig(2, 25, 5000L)
       parsed.output shouldBe Paths.get("target/custom.json")
+      parsed.warmupOverride shouldBe Some(2)
 
     it("rejects unknown and invalid options"):
       BenchmarkOptions.parse(Array("--iterations", "0")).left.toOption.value should include ("positive")

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala
@@ -12,7 +12,7 @@ class BenchmarkOptionsSpec extends AnyFunSpec with Matchers with OptionValues:
       BenchmarkOptions.parse(Array.empty) shouldBe Right(
         BenchmarkOptions(
           runConfig = BenchmarkRunConfig(8, 25, 30000L),
-          output = Paths.get("target/readiness/benchmark-v2.json"),
+          output = Paths.get("target/readiness/benchmark-v3.json"),
           stdoutFormat = BenchmarkOutputFormat.Text
         )
       )

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkOptionsSpec.scala
@@ -1,0 +1,40 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+import java.nio.file.Paths
+
+class BenchmarkOptionsSpec extends AnyFunSpec with Matchers with OptionValues:
+  describe("BenchmarkOptions.parse"):
+    it("uses readiness-safe defaults"):
+      BenchmarkOptions.parse(Array.empty) shouldBe Right(
+        BenchmarkOptions(
+          runConfig = BenchmarkRunConfig(8, 25, 30000L),
+          output = Paths.get("target/readiness/benchmark-v1.json"),
+          stdoutFormat = BenchmarkOutputFormat.Text
+        )
+      )
+
+    it("preserves --iterations and --json compatibility"):
+      val parsed =
+        BenchmarkOptions.parse(Array("--iterations", "3", "--json")).toOption.value
+      parsed.runConfig.measuredIterations shouldBe 3
+      parsed.stdoutFormat shouldBe BenchmarkOutputFormat.Json
+
+    it("accepts explicit warmup, timeout, and output values"):
+      val parsed = BenchmarkOptions.parse(
+        Array(
+          "--warmups", "2",
+          "--timeout-seconds", "5",
+          "--output", "target/custom.json",
+          "--format", "text"
+        )
+      ).toOption.value
+      parsed.runConfig shouldBe BenchmarkRunConfig(2, 25, 5000L)
+      parsed.output shouldBe Paths.get("target/custom.json")
+
+    it("rejects unknown and invalid options"):
+      BenchmarkOptions.parse(Array("--iterations", "0")).left.toOption.value should include ("positive")
+      BenchmarkOptions.parse(Array("--wat")).left.toOption.value should include ("unknown")

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
@@ -1,6 +1,12 @@
 package onion.tools.readiness.benchmark
 
 import onion.Json
+import onion.tools.readiness.policy.{
+  AbsolutePerformanceCheck,
+  AbsolutePerformanceEvaluation,
+  PolicyCheckStatus,
+  PolicyOverallStatus
+}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -31,7 +37,7 @@ class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
 
   private val report =
     PerformanceBenchmarkReport(
-      schemaVersion = 2,
+      schemaVersion = PerformanceBenchmarkReport.CurrentSchemaVersion,
       generatedAt = "2026-07-24T00:00:00Z",
       git = GitMetadata("deadbeef", dirty = false),
       environment = EnvironmentMetadata(
@@ -39,26 +45,50 @@ class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
         javaVersion = "21",
         osName = "Linux",
         osArch = "amd64",
+        osReleaseId = "ubuntu",
+        osReleaseVersion = "24.04",
         processors = 2,
+        totalMemoryBytes = 4294967296L,
         maxHeapBytes = 2147483648L,
         garbageCollectors = Vector("G1 Young Generation", "G1 Old Generation"),
         jvmArguments = Vector("-Xmx2g")
       ),
       runConfig = BenchmarkRunConfig(0, 1, 30000L),
       scenarios = Vector(scenario),
-      failures = Vector.empty
+      failures = Vector.empty,
+      policy = AbsolutePerformanceEvaluation(
+        referenceLane = true,
+        applicabilityReason = "reference environment matched",
+        checks = Vector(
+          AbsolutePerformanceCheck(
+            scenarioId = "steady-fresh:onionc:hello",
+            status = PolicyCheckStatus.Pass,
+            medianNanos = Some(1000000L),
+            p95Nanos = Some(1000000L),
+            medianCeilingNanos = 150000000L,
+            p95CeilingNanos = 300000000L,
+            message = "within absolute ceiling"
+          )
+        ),
+        overallStatus = PolicyOverallStatus.Pass
+      )
     )
 
   describe("BenchmarkRender"):
     it("writes schema-versioned JSON with raw nanosecond observations"):
       val json = BenchmarkRender.json(report)
       Json.parseOrNull(json) should not be null
-      PerformanceBenchmarkReport.CurrentSchemaVersion shouldBe 2
-      json should include ("\"schemaVersion\": 2")
+      PerformanceBenchmarkReport.CurrentSchemaVersion shouldBe 3
+      json should include ("\"schemaVersion\": 3")
       json should include ("\"elapsedNanos\": 1000000")
       json should include ("\"kind\": \"steady-fresh\"")
       json should include ("\"runConfig\"")
       json should include ("\"warmupIterations\": 0")
+      json should include ("\"osReleaseId\": \"ubuntu\"")
+      json should include ("\"osReleaseVersion\": \"24.04\"")
+      json should include ("\"totalMemoryBytes\": 4294967296")
+      json should include ("\"overallStatus\": \"pass\"")
+      json should include ("\"medianCeilingNanos\": 150000000")
       json should not include "elapsedMillis"
 
     it("renders a concise human summary in milliseconds"):
@@ -67,3 +97,5 @@ class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
       text should include ("median=1.00ms")
       text should include ("p95=1.00ms")
       text should include ("1 measured")
+      text should include ("absolute-policy=pass")
+      text should include ("reference-lane=true")

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
@@ -1,0 +1,65 @@
+package onion.tools.readiness.benchmark
+
+import onion.Json
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
+  private val scenario =
+    ScenarioResult(
+      ScenarioMetadata(
+        "steady-fresh:onionc:hello",
+        ScenarioKind.SteadyFresh,
+        "run/Hello.on",
+        "abc"
+      ),
+      warmups = Vector.empty,
+      measurements = Vector(
+        IterationObservation(
+          0,
+          ObservationKind.Measurement,
+          1000000L,
+          Vector(PhaseObservation("Parsing", 100L, 1, 1)),
+          SourceMetrics(1, 1, 10L, 1),
+          0
+        )
+      ),
+      summary = Some(BenchmarkSummary(1000000L, 1000000L, 1000000L, 1000000L)),
+      failure = None
+    )
+
+  private val report =
+    PerformanceBenchmarkReport(
+      schemaVersion = 1,
+      generatedAt = "2026-07-24T00:00:00Z",
+      git = GitMetadata("deadbeef", dirty = false),
+      environment = EnvironmentMetadata(
+        javaVendor = "Eclipse Adoptium",
+        javaVersion = "21",
+        osName = "Linux",
+        osArch = "amd64",
+        processors = 2,
+        maxHeapBytes = 2147483648L,
+        garbageCollectors = Vector("G1 Young Generation", "G1 Old Generation"),
+        jvmArguments = Vector("-Xmx2g")
+      ),
+      runConfig = BenchmarkRunConfig(0, 1, 30000L),
+      scenarios = Vector(scenario),
+      failures = Vector.empty
+    )
+
+  describe("BenchmarkRender"):
+    it("writes schema-versioned JSON with raw nanosecond observations"):
+      val json = BenchmarkRender.json(report)
+      Json.parseOrNull(json) should not be null
+      json should include ("\"schemaVersion\": 1")
+      json should include ("\"elapsedNanos\": 1000000")
+      json should include ("\"kind\": \"steady-fresh\"")
+      json should not include "elapsedMillis"
+
+    it("renders a concise human summary in milliseconds"):
+      val text = BenchmarkRender.text(report)
+      text should include ("steady-fresh:onionc:hello")
+      text should include ("median=1.00ms")
+      text should include ("p95=1.00ms")
+      text should include ("1 measured")

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkRenderSpec.scala
@@ -13,6 +13,7 @@ class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
         "run/Hello.on",
         "abc"
       ),
+      runConfig = BenchmarkRunConfig(0, 1, 30000L),
       warmups = Vector.empty,
       measurements = Vector(
         IterationObservation(
@@ -30,7 +31,7 @@ class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
 
   private val report =
     PerformanceBenchmarkReport(
-      schemaVersion = 1,
+      schemaVersion = 2,
       generatedAt = "2026-07-24T00:00:00Z",
       git = GitMetadata("deadbeef", dirty = false),
       environment = EnvironmentMetadata(
@@ -52,9 +53,12 @@ class BenchmarkRenderSpec extends AnyFunSpec with Matchers:
     it("writes schema-versioned JSON with raw nanosecond observations"):
       val json = BenchmarkRender.json(report)
       Json.parseOrNull(json) should not be null
-      json should include ("\"schemaVersion\": 1")
+      PerformanceBenchmarkReport.CurrentSchemaVersion shouldBe 2
+      json should include ("\"schemaVersion\": 2")
       json should include ("\"elapsedNanos\": 1000000")
       json should include ("\"kind\": \"steady-fresh\"")
+      json should include ("\"runConfig\"")
+      json should include ("\"warmupIterations\": 0")
       json should not include "elapsedMillis"
 
     it("renders a concise human summary in milliseconds"):

--- a/src/test/scala/onion/tools/readiness/benchmark/BenchmarkStatisticsSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/BenchmarkStatisticsSpec.scala
@@ -1,0 +1,31 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+class BenchmarkStatisticsSpec extends AnyFunSpec with Matchers with OptionValues:
+  describe("BenchmarkStatistics.summarize"):
+    it("calculates median and nearest-rank p95 without dropping observations"):
+      val result = BenchmarkStatistics.summarize(Vector(50L, 10L, 40L, 20L, 30L))
+      result shouldBe Right(
+        BenchmarkSummary(
+          medianNanos = 30L,
+          p95Nanos = 50L,
+          minNanos = 10L,
+          maxNanos = 50L
+        )
+      )
+
+    it("uses the mean of the middle pair for an even observation count"):
+      BenchmarkStatistics.summarize(Vector(7L, 11L)) shouldBe Right(
+        BenchmarkSummary(9L, 11L, 7L, 11L)
+      )
+
+    it("rejects an empty observation set as an invalid measurement"):
+      val result = BenchmarkStatistics.summarize(Vector.empty)
+      result.left.toOption.value.category shouldBe FailureCategory.InvalidMeasurement
+
+    it("rejects a negative duration"):
+      val result = BenchmarkStatistics.summarize(Vector(1L, -1L))
+      result.left.toOption.value.message should include ("negative")

--- a/src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.Executors
+import scala.jdk.CollectionConverters.*
 
 class FreshCompileScenarioSpec extends AnyFunSpec with Matchers:
   private def config =
@@ -118,3 +119,47 @@ class FreshCompileScenarioSpec extends AnyFunSpec with Matchers:
       result.measurements should have size 1
       result.measurements.head.sourceMetrics.sourceCount shouldBe 20
       result.measurements.head.sourceMetrics.lineCount shouldBe 2019
+
+    it("removes a temporary REPL directory when process startup fails"):
+      var capturedDirectory: java.nio.file.Path = null
+      val factory = CompileScenarioCatalog.replFactory(
+        JvmRuntime.current(),
+        1000L,
+        (_, directory, _) =>
+          capturedDirectory = directory
+          throw BenchmarkScenarioException("startup failed")
+      )
+
+      intercept[BenchmarkScenarioException] {
+        factory.open()
+      }
+
+      capturedDirectory should not be null
+      Files.exists(capturedDirectory) shouldBe false
+
+    it("regenerates byte-identical fixture files under a non-English locale"):
+      val root = Paths.get(".").toAbsolutePath.normalize()
+      val generated = Files.createTempDirectory("onion-fixture-locale")
+      val process = new ProcessBuilder(
+        JvmRuntime.current().javaExecutable.toString,
+        "-Duser.language=ar",
+        "-Duser.country=EG",
+        root.resolve(
+          "benchmarks/fixtures/automation-project/Generate.java"
+        ).toString,
+        generated.toString
+      ).start()
+      process.waitFor() shouldBe 0
+
+      val expectedRoot =
+        root.resolve("benchmarks/fixtures/automation-project")
+      val expectedFiles =
+        Files.list(expectedRoot)
+      try
+        expectedFiles.iterator().asScala
+          .filter(path => path.toString.endsWith(".on"))
+          .foreach { expected =>
+            val actual = generated.resolve(expected.getFileName)
+            Files.readAllBytes(actual) shouldBe Files.readAllBytes(expected)
+          }
+      finally expectedFiles.close()

--- a/src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
@@ -1,0 +1,80 @@
+package onion.tools.readiness.benchmark
+
+import onion.compiler.{CompilerConfig, WarningLevel}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.util.concurrent.Executors
+
+class FreshCompileScenarioSpec extends AnyFunSpec with Matchers:
+  private def config =
+    CompilerConfig(
+      classPath = Seq("."),
+      superClass = "",
+      encoding = "UTF-8",
+      outputDirectory = "",
+      maxErrorReports = 20,
+      warningLevel = WarningLevel.Off
+    )
+
+  describe("CompileWorkload"):
+    it("counts sources, lines, bytes, and hashes file contents deterministically"):
+      val root = Files.createTempDirectory("onion-benchmark-workload")
+      Files.writeString(root.resolve("One.on"), "val one = 1\n", StandardCharsets.UTF_8)
+      Files.writeString(root.resolve("Two.on"), "val two = 2", StandardCharsets.UTF_8)
+
+      val first = CompileWorkload.fromFiles(
+        root,
+        "fixture",
+        "fixture",
+        Vector("One.on", "Two.on")
+      )
+      val second = CompileWorkload.fromFiles(
+        root,
+        "fixture",
+        "fixture",
+        Vector("One.on", "Two.on")
+      )
+
+      first.sourceCount shouldBe 2
+      first.lineCount shouldBe 2
+      first.byteCount should be > 0L
+      first.workloadHash shouldBe second.workloadHash
+
+  describe("FreshCompileScenario"):
+    it("creates a fresh compiler result with phase and source metadata"):
+      val root = Files.createTempDirectory("onion-benchmark-compile")
+      Files.writeString(
+        root.resolve("Hello.on"),
+        """IO::println("hello")""",
+        StandardCharsets.UTF_8
+      )
+      val workload =
+        CompileWorkload.fromFiles(root, "hello", "hello", Vector("Hello.on"))
+      val scenario = new FreshCompileScenario(workload, config)
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 30000L),
+        NanoClock.System,
+        executor
+      )
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.failure shouldBe None
+      result.measurements should have size 1
+      result.measurements.head.phases.map(_.name) should contain ("Parsing")
+      result.measurements.head.phases.map(_.name) should contain ("BytecodeGeneration")
+      result.measurements.head.sourceMetrics.generatedClasses should be > 0
+
+  describe("CompileScenarioCatalog"):
+    it("uses the actual practical small, medium, and large scripts"):
+      val scenarios = CompileScenarioCatalog.default(Paths.get(".").toAbsolutePath.normalize())
+      scenarios.map(_.metadata.id) shouldBe Vector(
+        "steady-fresh:onionc:hello",
+        "steady-fresh:onionc:todo-manager",
+        "steady-fresh:onionc:stats-app"
+      )
+      scenarios.last.metadata.kind shouldBe ScenarioKind.SteadyFresh
+      scenarios.last.metadata.workload shouldBe "run/StatsApp.on"

--- a/src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/FreshCompileScenarioSpec.scala
@@ -69,12 +69,52 @@ class FreshCompileScenarioSpec extends AnyFunSpec with Matchers:
       result.measurements.head.sourceMetrics.generatedClasses should be > 0
 
   describe("CompileScenarioCatalog"):
-    it("uses the actual practical small, medium, and large scripts"):
-      val scenarios = CompileScenarioCatalog.default(Paths.get(".").toAbsolutePath.normalize())
+    it("contains every honest practical performance protocol"):
+      val root = Paths.get(".").toAbsolutePath.normalize()
+      val scenarios =
+        CompileScenarioCatalog.default(root, JvmRuntime.current(), 30000L)
       scenarios.map(_.metadata.id) shouldBe Vector(
         "steady-fresh:onionc:hello",
         "steady-fresh:onionc:todo-manager",
-        "steady-fresh:onionc:stats-app"
+        "steady-fresh:onionc:stats-app",
+        "process-cold:onion:hello",
+        "persistent-session:repl:growing-state",
+        "multi-file:onionc:automation-project"
       )
-      scenarios.last.metadata.kind shouldBe ScenarioKind.SteadyFresh
-      scenarios.last.metadata.workload shouldBe "run/StatsApp.on"
+      scenarios.last.metadata.kind shouldBe ScenarioKind.MultiFile
+      scenarios.last.metadata.workload shouldBe
+        "benchmarks/fixtures/automation-project"
+
+    it("uses a deterministic 20-file workload of approximately 2,000 lines"):
+      val root = Paths.get(".").toAbsolutePath.normalize()
+      val relativeFiles =
+        (1 to 19).map { index =>
+          f"benchmarks/fixtures/automation-project/Stage$index%02d.on"
+        }.toVector :+
+          "benchmarks/fixtures/automation-project/Pipeline.on"
+      val workload = CompileWorkload.fromFiles(
+        root,
+        "automation-project",
+        "benchmarks/fixtures/automation-project",
+        relativeFiles
+      )
+      workload.sourceCount shouldBe 20
+      workload.lineCount should (be >= 1900 and be <= 2200)
+
+    it("compiles the complete deterministic multi-file fixture"):
+      val root = Paths.get(".").toAbsolutePath.normalize()
+      val scenario =
+        CompileScenarioCatalog.default(root, JvmRuntime.current(), 30000L).last
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 30000L),
+        NanoClock.System,
+        executor
+      )
+
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.failure shouldBe None
+      result.measurements should have size 1
+      result.measurements.head.sourceMetrics.sourceCount shouldBe 20
+      result.measurements.head.sourceMetrics.lineCount shouldBe 2019

--- a/src/test/scala/onion/tools/readiness/benchmark/JvmRuntimeSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/JvmRuntimeSpec.scala
@@ -1,0 +1,33 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class JvmRuntimeSpec extends AnyFunSpec with Matchers:
+  describe("JvmRuntime.current"):
+    it("resolves an executable Java command and the loaded Onion classpath"):
+      val runtime = JvmRuntime.current()
+
+      Files.isRegularFile(runtime.javaExecutable) shouldBe true
+      runtime.classPath should include ("scala")
+      runtime.classPath.split(java.io.File.pathSeparator).exists { entry =>
+        entry.contains("classes") || entry.endsWith(".jar")
+      } shouldBe true
+
+  describe("ProcessLauncher.System"):
+    it("captures stdout, stderr, and exit code"):
+      val runtime = JvmRuntime.current()
+      val workingDirectory = Files.createTempDirectory("onion-process-probe")
+      val outcome = ProcessLauncher.System.run(
+        Vector(
+          runtime.javaExecutable.toString,
+          "-version"
+        ),
+        workingDirectory,
+        Map.empty
+      )
+
+      outcome.exitCode shouldBe 0
+      (outcome.stdout + outcome.stderr).toLowerCase should include ("version")

--- a/src/test/scala/onion/tools/readiness/benchmark/PersistentReplScenarioSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/PersistentReplScenarioSpec.scala
@@ -1,0 +1,33 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PersistentReplScenarioSpec extends AnyFunSpec with Matchers:
+  describe("PersistentReplScenario"):
+    it("performs setup once and submits growing-state expressions"):
+      val submitted = Vector.newBuilder[String]
+      var closes = 0
+      val factory = new ReplClientFactory:
+        override def open(): ReplClient = new ReplClient:
+          override def submit(code: String): String =
+            submitted += code
+            if code.startsWith("val baseline") then ""
+            else s"res: Int = ${40 + code.split(" ").last.toInt}"
+          override def close(): Unit = closes += 1
+      val scenario = new PersistentReplScenario(factory, "hash")
+      val session = scenario.open()
+
+      val first = session.runIteration(0)
+      val second = session.runIteration(1)
+      session.close()
+
+      submitted.result() shouldBe Vector(
+        "val baseline = 40",
+        "baseline + 1",
+        "baseline + 2"
+      )
+      first.exitCode shouldBe 0
+      second.sourceMetrics.lineCount shouldBe 3
+      closes shouldBe 1
+      scenario.metadata.kind shouldBe ScenarioKind.PersistentSession

--- a/src/test/scala/onion/tools/readiness/benchmark/PersistentReplScenarioSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/PersistentReplScenarioSpec.scala
@@ -31,3 +31,35 @@ class PersistentReplScenarioSpec extends AnyFunSpec with Matchers:
       second.sourceMetrics.lineCount shouldBe 3
       closes shouldBe 1
       scenario.metadata.kind shouldBe ScenarioKind.PersistentSession
+
+    it("closes the client when session setup fails"):
+      var closes = 0
+      val factory = new ReplClientFactory:
+        override def open(): ReplClient = new ReplClient:
+          override def submit(code: String): String =
+            throw BenchmarkScenarioException("setup failed")
+          override def close(): Unit = closes += 1
+
+      intercept[BenchmarkScenarioException] {
+        new PersistentReplScenario(factory, "hash").open()
+      }
+
+      closes shouldBe 1
+
+    it("rejects a result whose value only starts with the expected digits"):
+      var submissions = 0
+      val factory = new ReplClientFactory:
+        override def open(): ReplClient = new ReplClient:
+          override def submit(code: String): String =
+            submissions += 1
+            if submissions == 1 then ""
+            else "res0: Int = 410\nonion> "
+          override def close(): Unit = ()
+      val session = new PersistentReplScenario(factory, "hash").open()
+
+      val thrown = intercept[BenchmarkScenarioException] {
+        session.runIteration(0)
+      }
+
+      thrown.getMessage should include ("unexpected result")
+      session.close()

--- a/src/test/scala/onion/tools/readiness/benchmark/ProcessColdScenarioSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/ProcessColdScenarioSpec.scala
@@ -1,0 +1,92 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.Executors
+
+class ProcessColdScenarioSpec extends AnyFunSpec with Matchers:
+  describe("ProcessColdScenario"):
+    it("launches a new script-runner process for every iteration"):
+      val root = Files.createTempDirectory("onion-process-cold")
+      Files.writeString(root.resolve("Hello.on"), """IO::println("Hello")""")
+      val workload =
+        CompileWorkload.fromFiles(root, "hello", "Hello.on", Vector("Hello.on"))
+      var launches = 0
+      val launcher = new ProcessLauncher:
+        override def run(
+          command: Vector[String],
+          workingDirectory: java.nio.file.Path,
+          environment: Map[String, String]
+        ): ProcessOutcome =
+          launches += 1
+          ProcessOutcome(0, "Hello\n", "")
+      val runtime = JvmRuntime(root.resolve("java"), "runtime-classpath")
+      val scenario =
+        new ProcessColdScenario(workload, runtime, launcher, "Hello\n")
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(1, 2, 1000L),
+        NanoClock.System,
+        executor
+      )
+
+      val result = try engine.run(scenario) finally engine.close()
+
+      launches shouldBe 3
+      result.failure shouldBe None
+      result.metadata.id shouldBe "process-cold:onion:hello"
+      scenario.defaultWarmupIterations shouldBe 3
+
+    it("fails when a successful process prints the wrong result"):
+      val root = Files.createTempDirectory("onion-process-output")
+      Files.writeString(root.resolve("Hello.on"), """IO::println("Hello")""")
+      val workload =
+        CompileWorkload.fromFiles(root, "hello", "Hello.on", Vector("Hello.on"))
+      val launcher = new ProcessLauncher:
+        override def run(
+          command: Vector[String],
+          workingDirectory: java.nio.file.Path,
+          environment: Map[String, String]
+        ): ProcessOutcome = ProcessOutcome(0, "wrong\n", "")
+      val scenario = new ProcessColdScenario(
+        workload,
+        JvmRuntime(root.resolve("java"), "cp"),
+        launcher,
+        "Hello\n"
+      )
+      val session = scenario.open()
+
+      val thrown = intercept[BenchmarkScenarioException] {
+        session.runIteration(0)
+      }
+      thrown.getMessage should include ("unexpected stdout")
+      session.close()
+
+    it("runs Hello through a real fresh child JVM"):
+      val repoRoot = Paths.get(".").toAbsolutePath.normalize()
+      val workload = CompileWorkload.fromFiles(
+        repoRoot,
+        "hello",
+        "run/Hello.on",
+        Vector("run/Hello.on")
+      )
+      val scenario = new ProcessColdScenario(
+        workload,
+        JvmRuntime.current(),
+        ProcessLauncher.System,
+        "Hello\n"
+      )
+      val executor = Executors.newSingleThreadExecutor()
+      val engine = new BenchmarkEngine(
+        BenchmarkRunConfig(0, 1, 30000L),
+        NanoClock.System,
+        executor
+      )
+
+      val result = try engine.run(scenario) finally engine.close()
+
+      result.failure shouldBe None
+      result.measurements should have size 1

--- a/src/test/scala/onion/tools/readiness/benchmark/ProcessColdScenarioSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/ProcessColdScenarioSpec.scala
@@ -65,6 +65,35 @@ class ProcessColdScenarioSpec extends AnyFunSpec with Matchers:
       thrown.getMessage should include ("unexpected stdout")
       session.close()
 
+    it("retains bounded child output when the process exits nonzero"):
+      val root = Files.createTempDirectory("onion-process-failure")
+      Files.writeString(root.resolve("Hello.on"), """IO::println("Hello")""")
+      val workload =
+        CompileWorkload.fromFiles(root, "hello", "Hello.on", Vector("Hello.on"))
+      val launcher = new ProcessLauncher:
+        override def run(
+          command: Vector[String],
+          workingDirectory: java.nio.file.Path,
+          environment: Map[String, String]
+        ): ProcessOutcome =
+          ProcessOutcome(7, "partial output\n", "compiler exploded\n")
+      val scenario = new ProcessColdScenario(
+        workload,
+        JvmRuntime(root.resolve("java"), "cp"),
+        launcher,
+        "Hello\n"
+      )
+      val session = scenario.open()
+
+      val thrown = intercept[BenchmarkScenarioException] {
+        session.runIteration(0)
+      }
+
+      thrown.getMessage should include ("exit code 7")
+      thrown.getMessage should include ("partial output")
+      thrown.getMessage should include ("compiler exploded")
+      session.close()
+
     it("runs Hello through a real fresh child JVM"):
       val repoRoot = Paths.get(".").toAbsolutePath.normalize()
       val workload = CompileWorkload.fromFiles(

--- a/src/test/scala/onion/tools/readiness/benchmark/ReplProcessSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/ReplProcessSpec.scala
@@ -3,9 +3,43 @@ package onion.tools.readiness.benchmark
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  InputStream,
+  OutputStream
+}
 import java.nio.file.Files
+import java.util.concurrent.TimeUnit
 
 class ReplProcessSpec extends AnyFunSpec with Matchers:
+  private final class StubbornProcess extends Process:
+    private val input = new ByteArrayInputStream(Array.emptyByteArray)
+    private val error = new ByteArrayInputStream(Array.emptyByteArray)
+    private val output = new ByteArrayOutputStream()
+    var waits = 0
+    var forciblyDestroyed = false
+    private var alive = true
+
+    override def getOutputStream(): OutputStream = output
+    override def getInputStream(): InputStream = input
+    override def getErrorStream(): InputStream = error
+    override def waitFor(): Int =
+      alive = false
+      0
+    override def waitFor(timeout: Long, unit: TimeUnit): Boolean =
+      waits += 1
+      if forciblyDestroyed then alive = false
+      !alive
+    override def exitValue(): Int =
+      if alive then throw new IllegalThreadStateException()
+      0
+    override def destroy(): Unit = ()
+    override def destroyForcibly(): Process =
+      forciblyDestroyed = true
+      this
+    override def isAlive(): Boolean = alive
+
   describe("ProcessReplClient"):
     it("retains state across submissions to the real Onion REPL"):
       val workingDirectory = Files.createTempDirectory("onion-repl-process")
@@ -19,3 +53,13 @@ class ReplProcessSpec extends AnyFunSpec with Matchers:
         val output = client.submit("baseline + 2")
         output should include ("res0: Int = 42")
       finally client.close()
+
+    it("waits for a forcibly destroyed REPL before returning from close"):
+      val process = new StubbornProcess()
+      val client = ProcessReplClient.attach(process, timeoutMillis = 1000L)
+
+      client.close()
+
+      process.forciblyDestroyed shouldBe true
+      process.waits shouldBe 2
+      process.isAlive shouldBe false

--- a/src/test/scala/onion/tools/readiness/benchmark/ReplProcessSpec.scala
+++ b/src/test/scala/onion/tools/readiness/benchmark/ReplProcessSpec.scala
@@ -1,0 +1,21 @@
+package onion.tools.readiness.benchmark
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class ReplProcessSpec extends AnyFunSpec with Matchers:
+  describe("ProcessReplClient"):
+    it("retains state across submissions to the real Onion REPL"):
+      val workingDirectory = Files.createTempDirectory("onion-repl-process")
+      val client = ProcessReplClient.start(
+        JvmRuntime.current(),
+        workingDirectory,
+        timeoutMillis = 30000L
+      )
+      try
+        client.submit("val baseline = 40")
+        val output = client.submit("baseline + 2")
+        output should include ("res0: Int = 42")
+      finally client.close()

--- a/src/test/scala/onion/tools/readiness/policy/PerformancePolicySpec.scala
+++ b/src/test/scala/onion/tools/readiness/policy/PerformancePolicySpec.scala
@@ -1,0 +1,179 @@
+package onion.tools.readiness.policy
+
+import onion.tools.readiness.benchmark.*
+import org.scalatest.OptionValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PerformancePolicySpec
+    extends AnyFunSpec
+    with Matchers
+    with OptionValues:
+  private val fourGiB = 4L * 1024L * 1024L * 1024L
+  private val twoGiB = 2L * 1024L * 1024L * 1024L
+
+  private val reference =
+    EnvironmentMetadata(
+      javaVendor = "Eclipse Adoptium",
+      javaVersion = "21.0.11",
+      osName = "Linux",
+      osArch = "amd64",
+      osReleaseId = "ubuntu",
+      osReleaseVersion = "24.04",
+      processors = 2,
+      totalMemoryBytes = fourGiB,
+      maxHeapBytes = twoGiB,
+      garbageCollectors = Vector("G1 Young Generation", "G1 Old Generation"),
+      jvmArguments = Vector("-Xmx2g", "-XX:+UseG1GC")
+    )
+
+  private def scenario(
+    budget: PerformanceBudget,
+    medianNanos: Long = -1L,
+    p95Nanos: Long = -1L,
+    failure: Option[BenchmarkFailure] = None
+  ): ScenarioResult =
+    val kind =
+      if budget.scenarioId.startsWith("process-cold") then ScenarioKind.ProcessCold
+      else if budget.scenarioId.startsWith("persistent-session") then
+        ScenarioKind.PersistentSession
+      else if budget.scenarioId.startsWith("multi-file") then ScenarioKind.MultiFile
+      else ScenarioKind.SteadyFresh
+    val median =
+      if medianNanos < 0L then budget.medianCeilingNanos else medianNanos
+    val p95 = if p95Nanos < 0L then budget.p95CeilingNanos else p95Nanos
+    ScenarioResult(
+      metadata = ScenarioMetadata(
+        budget.scenarioId,
+        kind,
+        "test workload",
+        "hash"
+      ),
+      runConfig = BenchmarkRunConfig(0, 1, 30000L),
+      warmups = Vector.empty,
+      measurements = Vector.empty,
+      summary =
+        if failure.isEmpty then Some(BenchmarkSummary(median, p95, median, p95))
+        else None,
+      failure = failure
+    )
+
+  private def atCeilings: Vector[ScenarioResult] =
+    AbsolutePerformancePolicy.budgets.map(scenario(_))
+
+  describe("AbsolutePerformancePolicy reference lane"):
+    it("recognizes only the complete reference environment"):
+      AbsolutePerformancePolicy.isReferenceLane(reference) shouldBe true
+
+      val nonReference = Vector(
+        reference.copy(osName = "Mac OS X"),
+        reference.copy(osReleaseId = "debian"),
+        reference.copy(osReleaseVersion = "22.04"),
+        reference.copy(osArch = "aarch64"),
+        reference.copy(javaVendor = "Oracle Corporation"),
+        reference.copy(javaVersion = "17.0.12"),
+        reference.copy(processors = 3),
+        reference.copy(totalMemoryBytes = fourGiB + 1L),
+        reference.copy(maxHeapBytes = twoGiB - 1L),
+        reference.copy(garbageCollectors = Vector("ZGC"))
+      )
+
+      nonReference.foreach { environment =>
+        withClue(environment) {
+          AbsolutePerformancePolicy.isReferenceLane(environment) shouldBe false
+        }
+      }
+
+  describe("AbsolutePerformancePolicy.evaluate"):
+    it("passes every result exactly at its inclusive ceiling"):
+      val result =
+        AbsolutePerformancePolicy.evaluate(reference, atCeilings)
+
+      result.referenceLane shouldBe true
+      result.overallStatus shouldBe PolicyOverallStatus.Pass
+      result.checks should have size 5
+      all(result.checks.map(_.status)) shouldBe PolicyCheckStatus.Pass
+
+    it("fails a median that exceeds its ceiling by one nanosecond"):
+      val hello =
+        AbsolutePerformancePolicy.budgets
+          .find(_.scenarioId == "steady-fresh:onionc:hello")
+          .value
+      val scenarios =
+        atCeilings.map {
+          case result if result.metadata.id == hello.scenarioId =>
+            scenario(hello, medianNanos = hello.medianCeilingNanos + 1L)
+          case result => result
+        }
+
+      val result =
+        AbsolutePerformancePolicy.evaluate(reference, scenarios)
+      val check = result.checks.find(_.scenarioId == hello.scenarioId).value
+
+      result.overallStatus shouldBe PolicyOverallStatus.Fail
+      check.status shouldBe PolicyCheckStatus.Fail
+      check.message should include ("median")
+
+    it("fails a p95 that exceeds its ceiling by one nanosecond"):
+      val repl =
+        AbsolutePerformancePolicy.budgets
+          .find(_.scenarioId.startsWith("persistent-session"))
+          .value
+      val scenarios =
+        atCeilings.map {
+          case result if result.metadata.id == repl.scenarioId =>
+            scenario(repl, p95Nanos = repl.p95CeilingNanos + 1L)
+          case result => result
+        }
+
+      val check =
+        AbsolutePerformancePolicy
+          .evaluate(reference, scenarios)
+          .checks
+          .find(_.scenarioId == repl.scenarioId)
+          .value
+
+      check.status shouldBe PolicyCheckStatus.Fail
+      check.message should include ("p95")
+
+    it("marks every absolute check not-applicable off the reference lane"):
+      val result =
+        AbsolutePerformancePolicy.evaluate(
+          reference.copy(processors = 16),
+          atCeilings
+        )
+
+      result.referenceLane shouldBe false
+      result.overallStatus shouldBe PolicyOverallStatus.Informational
+      all(result.checks.map(_.status)) shouldBe
+        PolicyCheckStatus.NotApplicable
+
+    it("fails with unknown checks when reference evidence is missing"):
+      val result =
+        AbsolutePerformancePolicy.evaluate(reference, Vector.empty)
+
+      result.overallStatus shouldBe PolicyOverallStatus.Fail
+      all(result.checks.map(_.status)) shouldBe PolicyCheckStatus.Unknown
+
+    it("marks a failed reference scenario unknown"):
+      val budget = AbsolutePerformancePolicy.budgets.head
+      val failure = BenchmarkFailure(
+        FailureCategory.ScenarioFailure,
+        "child failed"
+      )
+      val scenarios =
+        atCeilings.map {
+          case result if result.metadata.id == budget.scenarioId =>
+            scenario(budget, failure = Some(failure))
+          case result => result
+        }
+
+      val check =
+        AbsolutePerformancePolicy
+          .evaluate(reference, scenarios)
+          .checks
+          .find(_.scenarioId == budget.scenarioId)
+          .value
+
+      check.status shouldBe PolicyCheckStatus.Unknown
+      check.message should include ("child failed")


### PR DESCRIPTION
## Summary

- replace the legacy benchmark runner with a lifecycle-aware readiness measurement engine
- add six practical protocols: three steady-fresh compilations, process-cold script launch, persistent REPL interaction, and a deterministic 20-file project
- emit schema-v3 JSON with raw observations, phase/source/environment metadata, structured failures, and per-scenario run configuration
- add typed absolute performance ceilings with strict reference-lane detection and informational non-reference behavior
- document the protocols and policy in English and Japanese
- include the governing readiness design and executable implementation plans

## Why

Onion had useful compiler tests and profiling hooks, but no reproducible evidence for user-visible compile/startup/REPL latency and no machine-enforced performance policy. This PR establishes the measurement and absolute-policy foundation required before optimization work or release-readiness claims.

## User/developer impact

- `sbt benchmark` runs all six protocols; `sbt bench` remains compatible
- reports default to `target/readiness/benchmark-v3.json`
- reference-lane ceiling breaches fail the task
- other machines produce successful `informational` reports with absolute checks marked `not-applicable`

## Validation

Completed on Temurin JDK 21 in the isolated worktree:

- full suite: 338 suites / 2,189 tests, 0 failures, 0 errors, 0 skipped
- focused readiness suite: 12 suites / 50 tests, all passed
- real six-protocol smoke: schema 3, 6 scenarios, 5 policy checks, 0 scenario failures; correctly classified the 16-core host as non-reference/informational
- deterministic 20-file fixture regenerated byte-identically under an Arabic locale
- `git diff --check` passed

The latest attempt to repeat the focused suite was blocked before sbt started because WSL removed the temporary `/tmp/onion-toolchain` JDK and no system `java` is installed. The successful complete runs above were performed against the same code state; CI should provide the fresh independent run.

## Follow-ups

This is intentionally a foundation PR. Relative base/head comparison with confirmation rounds, executable documentation verification, distribution journeys, readiness aggregation/CI lanes, and profile-driven compiler optimization remain follow-up milestones.