### PR TITLE
fix(install): find the versioned assembly jar in --from-source

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,11 @@ if [ "$FROM_SOURCE" = "1" ]; then
   echo ""
   echo "Building onion.jar from source ($SRC_DIR)..."
   (cd "$SRC_DIR" && sbt assembly)
-  JAR_PATH=$(find "$SRC_DIR/target" -name "onion.jar" -path "*scala-*" -not -path "*/dist/*" 2>/dev/null | sort | head -1)
+  # assemblyJarName is "onion-<dynver>.jar" (e.g. onion-0.5.0+3-abcdef12.jar), never
+  # the literal "onion.jar", and old builds from earlier versions can linger in the
+  # same directory, so pick the most recently built match rather than globbing for
+  # a fixed name or trusting alphabetical sort.
+  JAR_PATH=$(ls -t "$SRC_DIR"/target/scala-*/onion-*.jar 2>/dev/null | head -1)
   if [ ! -f "$JAR_PATH" ]; then
     echo "Error: onion.jar not found after build" >&2
     exit 1


### PR DESCRIPTION
## Summary

- \`assembly / assemblyJarName\` (build.sbt) has produced \`onion-<dynver>.jar\` (e.g. \`onion-0.5.0+3-abcdef12.jar\`) for a while, never the literal \`onion.jar\` that \`install.sh --from-source\` globbed for -- so \`--from-source\` always failed with \`Error: onion.jar not found after build\` right after a successful build.
- Old assembly jars from earlier local builds can also sit in the same \`target/scala-*/\` directory, so alphabetical \`sort | head -1\` on a corrected glob would still risk picking a stale one instead of what was just built.
- Switched the lookup to \`ls -t "$SRC_DIR"/target/scala-*/onion-*.jar | head -1\`: matches the real naming convention and picks the most recently built match.

Found while reinstalling locally right after merging #324 (which changed the launcher's main class to \`onion.tools.OnionCli\`) -- unrelated to that feature, this jar-discovery bug predates it and breaks \`--from-source\` regardless of which main class the launcher targets.

## Test plan

- [x] \`./install.sh --from-source\` from this checkout now builds and installs successfully (previously failed every time at the jar-not-found check)
- [x] Verified the reinstalled \`onion\` end to end: \`onion --version\`, and a full \`new -> run -> test -> clean\` project journey