### PR TITLE
fix(typing): warn (W0015) when a boxed platform value unboxes to a non-null primitive (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A boxed platform value unboxed to a non-null primitive now warns (W0015, #318).**
+  `Json::getInt(obj, key)` (and the other `Json::get*` accessors) return a boxed Java value
+  (`Integer`, `Long`, ...) that is `null` when the key is missing. Assigning or passing it where a
+  non-null primitive (`Int`, `Long`, ...) is expected silently unboxed it, so a missing key threw a
+  raw `NullPointerException` instead of a clear diagnostic. `processAssignable` now emits `W0015`
+  at that unboxing site, mirroring the existing `W0012` null-to-non-nullable trade-off (values from
+  Java stay unchecked but get a warning); use `Json::getIntOr(obj, key, default)` or check the
+  boxed accessor's result for null to avoid it. Suppressible with `--Wno W0015` /
+  `--Wno platform-unboxing`.
 - **A convention-over-configuration project workflow: `onion new/build/run/test/clean`.**
   `onion new hello` scaffolds a manifest (`onion.toml`), `src/`, and `tests/`; `onion build`
   compiles and caches the result under `target/` (invalidated by a SHA-256 fingerprint over the

--- a/src/main/scala/onion/compiler/Warning.scala
+++ b/src/main/scala/onion/compiler/Warning.scala
@@ -35,6 +35,7 @@ enum WarningCategory(val code: String, val description: String):
   case NullToNonNullable   extends WarningCategory("W0012", "Null assigned to non-nullable type")
   case SuspiciousInterpolation extends WarningCategory("W0013", "Suspicious string interpolation syntax")
   case DiscardedTopLevelStmts extends WarningCategory("W0014", "Top-level statements ignored because a main is defined")
+  case PlatformUnboxing     extends WarningCategory("W0015", "Boxed platform value implicitly unboxed to a non-null primitive")
 
 object WarningCategory:
   private val aliases: Map[String, WarningCategory] = Map(
@@ -53,7 +54,8 @@ object WarningCategory:
     "unchecked-cast" -> WarningCategory.UncheckedCast,
     "null-to-non-nullable" -> WarningCategory.NullToNonNullable,
     "suspicious-interpolation" -> WarningCategory.SuspiciousInterpolation,
-    "discarded-toplevel" -> WarningCategory.DiscardedTopLevelStmts
+    "discarded-toplevel" -> WarningCategory.DiscardedTopLevelStmts,
+    "platform-unboxing" -> WarningCategory.PlatformUnboxing
   )
 
   def fromString(value: String): Option[WarningCategory] =

--- a/src/main/scala/onion/compiler/WarningReporter.scala
+++ b/src/main/scala/onion/compiler/WarningReporter.scala
@@ -100,6 +100,12 @@ class WarningReporter(
       s"$count top-level $plural ignored because a main is defined; move the code into main to run it")
   }
 
+  def platformUnboxing(location: Location, boxedTypeName: String, primitiveTypeName: String): Unit = {
+    report(WarningCategory.PlatformUnboxing, location,
+      s"boxed value of type '$boxedTypeName' is implicitly unboxed to non-null '$primitiveTypeName'; " +
+        s"if the platform value can be null (e.g. a missing Json key), this throws a NullPointerException at runtime")
+  }
+
   def getWarnings: Seq[CompileWarning] = warnings.toSeq
 
   def hasWarnings: Boolean = warnings.nonEmpty

--- a/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
+++ b/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
@@ -108,6 +108,12 @@ private[compiler] final class AssignabilitySupport(
       }
       val boxedType = Boxing.boxedType(bodyContext.table, targetBasicType)
       if (TypeRules.isAssignable(boxedType, actual.`type`)) {
+        // The source is a boxed reference (typically a Java-interop platform
+        // value, e.g. Json::getInt's Integer) with no Onion-tracked
+        // nullability; unboxing it to a non-null primitive crashes with a raw
+        // NPE if the value is actually null (#318). Mirrors the W0012
+        // null-to-non-nullable trade-off above: warn rather than block.
+        bodyContext.warningReporter.platformUnboxing(node.location, actual.`type`.displayName, targetBasicType.displayName)
         return Boxing.unboxing(bodyContext.table, actual, targetBasicType)
       }
     }

--- a/src/test/scala/onion/compiler/tools/PlatformUnboxingWarningSpec.scala
+++ b/src/test/scala/onion/compiler/tools/PlatformUnboxingWarningSpec.scala
@@ -1,0 +1,72 @@
+package onion.compiler.tools
+
+import onion.compiler.{CompilerConfig, OnionCompiler, StreamInputSource, WarningLevel}
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * Tests for W0015 (issue #318): a boxed platform value (e.g. Json::getInt's
+ * Integer, null when the key is missing) implicitly unboxed to a non-null
+ * primitive warns, since the unboxing throws a raw NullPointerException at
+ * runtime rather than surfacing the absence.
+ */
+class PlatformUnboxingWarningSpec extends AnyFunSpec {
+
+  private def compileWarnings(source: String, level: WarningLevel = WarningLevel.On) = {
+    val config = CompilerConfig(Seq("."), null, "UTF-8", "", 10, warningLevel = level)
+    new OnionCompiler(config)
+      .compileDetailed(Seq(new StreamInputSource(() => new StringReader(source), "W.on")))
+  }
+
+  describe("W0015 platform unboxing") {
+    it("warns when Json::getInt (boxed Integer) is assigned to a non-null Int") {
+      val result = compileWarnings(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val obj = Json::parse("{}")
+          |    val n: Int = Json::getInt(obj, "missing")
+          |    return n
+          |  }
+          |}
+          |""".stripMargin)
+      assert(!result.hasErrors)
+      val w15 = result.diagnostics.warnings.filter(_.category.code == "W0015")
+      assert(w15.length == 1, s"expected 1 W0015, got: ${result.diagnostics.warnings.map(_.message)}")
+    }
+
+    it("does not warn for the defaulted accessor (already primitive)") {
+      val result = compileWarnings(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val obj = Json::parse("{}")
+          |    val n: Int = Json::getIntOr(obj, "missing", 0)
+          |    return n
+          |  }
+          |}
+          |""".stripMargin)
+      assert(!result.hasErrors)
+      assert(result.diagnostics.warnings.filter(_.category.code == "W0015").isEmpty)
+    }
+
+    it("fails compilation under warnings-as-errors") {
+      val result = compileWarnings(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val obj = Json::parse("{}")
+          |    val n: Int = Json::getInt(obj, "missing")
+          |    return n
+          |  }
+          |}
+          |""".stripMargin,
+        WarningLevel.Error)
+      assert(result.hasErrors)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `Json::getInt`/`getDouble`/`getBoolean`/... return a boxed Java value that is `null` when the key is missing; assigning it to a non-null primitive silently unboxed it, throwing a raw `NullPointerException` instead of surfacing the absence (#318).
- `AssignabilitySupport.processAssignable` now emits a new warning, `W0015` (`platform-unboxing`), at the boxed→primitive unboxing site, mirroring the existing `W0012` null-to-non-nullable trade-off: Java-sourced values stay unchecked but now get a diagnostic. Suppressible with `--Wno W0015` / `--Wno platform-unboxing`.
- `Json::getIntOr(obj, key, default)` (and friends) remain the NPE-free way to consume a possibly-missing key; they are unaffected (already primitive, no warning).

## Test plan
- [x] Added `PlatformUnboxingWarningSpec` (models `NullToNonNullableSpec`): warns once on `Json::getInt` assigned to `Int`, silent for `getIntOr`, fails under `--warn error`.
- [x] `sbt -Duser.language=en compile` — clean (pre-existing warnings only).
- [x] `sbt -Duser.language=en test` — full suite green: 2389/2389 passed, 1 canceled (environment-gated smoke test, as expected), 0 failed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Kdzj84GE6uuk39qNKMg8)_