### PR TITLE
docs(stdlib): document the Config module (en/ja)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Documented the `Config` stdlib module (en/ja).** `onion.Config` (`loadJson`/`parseJson`,
+  dot-notation `get`/`getString`/`getInt`/`getLong`/`getDouble`/`getBoolean` with array
+  indexing and defaults, `getEnv`/`getWithEnvOverride`, `hasPath`) has been fully implemented
+  and tested since its introduction but was missing from `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md` entirely, including the "Modules at a glance" summary table.
+  Added a `Config Module` section to both, with the same worked examples the module's own
+  tests cover.
 - **A duplicate top-level function definition reported the wrong diagnostic (E0012 fix).**
   Two top-level `def foo(...)` functions with the same name and parameter types reported
   "duplicated global variable definition foo." (`error.semantic.duplicatedGlobalVariable`,

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -10,7 +10,7 @@ Onionの標準ライブラリは、一般的な機能のための組み込みモ
 | **コレクション** | `Colls`（リスト: map/filter/fold, chunked/windowed, sumBy/maxBy）, `Iterables`, `Maps`, `Sets` |
 | **テキスト** | `Strings`（大小文字・分割・パディング・パース）, `Text`（wrap/indent/table）, `Regex` |
 | **数値** | `Math`, `Stats`（sum/average/median/stddev）, `Format`（桁区切り・bytes・duration） |
-| **データ形式** | `Json`, `Yaml`, `Csv` |
+| **データ形式** | `Json`, `Yaml`, `Csv`, `Config`（ドット記法での設定値アクセス） |
 | **エンコード** | `Codec`（base64/hex/url）, `Hash`（md5/sha256/…） |
 | **関数型** | `Option`, `Result`, `Future` |
 | **日時・乱数** | `DateTime`, `Rand`（choice/shuffle/sample/uuid） |
@@ -367,6 +367,42 @@ val text = Yaml::stringify(obj)               // "name: ko\nage: 3\n"
 ```
 
 scalar の型推論は Json と一致します（`3`→Long、`3.5`→Double、`true`→Boolean、`null`→null）。自分が出力した範囲を読み戻せる round-trip サブセットで、`record ... derive!(Yaml)` の土台になっています。
+
+## Config モジュール
+
+パース済み JSON に対するドット記法アクセスと設定読み込み（`onion.Config`）。内部では `Json::parse` をそのまま使うので、object / array / scalar の形は Json と同じです。YAML や `.env` 形式には対応せず、あくまで JSON とドット区切りパス、環境変数によるオーバーライドを提供します。
+
+```onion
+val config = Config::loadJson("config.json")          // ファイルを読んでパース
+val config2 = Config::parseJson("{\"port\": 8080}")   // JSON 文字列を直接パース
+
+Config::get(config, "database.host")                   // 生の値、見つからなければ null
+Config::getString(config, "database.host", "localhost")
+Config::getInt(config, "database.port", 5432)
+Config::getLong(config, "database.maxConnections", 10L)
+Config::getDouble(config, "database.timeout", 30.0)
+Config::getBoolean(config, "database.ssl", false)
+```
+
+パスはドット区切りで、object と array の両方をたどれます。数字のセグメントは array のインデックスとして扱われます:
+
+```onion
+val config = Config::parseJson("{\"users\": [{\"name\": \"Alice\"}, {\"name\": \"Bob\"}]}")
+Config::getString(config, "users.0.name", "unknown")   // "Alice"
+```
+
+キーが見つからない場合・array の添字が範囲外の場合・値を要求された型へ変換できない場合は、例外を投げず指定したデフォルト値にフォールバックします。数値系のゲッターは JSON の数値だけでなく数値文字列も受け付けます。`hasPath` はデフォルト値なしで存在確認だけ行います:
+
+```onion
+Config::hasPath(config, "database.host")   // true / false
+```
+
+環境変数へのアクセスも用意されています。`getEnv` はそのまま環境変数を読み、`getWithEnvOverride` は設定パスを読みつつ、対応する環境変数がセットされていればそちらを優先します（デプロイ時に設定ファイルの値を上書きするのに便利です）:
+
+```onion
+Config::getEnv("PORT", "3000")
+Config::getWithEnvOverride(config, "database.host", "DB_HOST", "localhost")
+```
 
 ## Strings モジュール
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -10,7 +10,7 @@ Onion's standard library consists of built-in modules and interfaces for common 
 | **Collections** | `Colls` (lists: map/filter/fold, chunked/windowed, sumBy/maxBy), `Iterables`, `Maps`, `Sets` |
 | **Text** | `Strings` (case, split, pad, parse), `Text` (wrap/indent/table), `Regex` |
 | **Numbers** | `Math`, `Stats` (sum/average/median/stddev), `Format` (grouping, bytes, durations) |
-| **Data formats** | `Json`, `Yaml`, `Csv` |
+| **Data formats** | `Json`, `Yaml`, `Csv`, `Config` (dot-notation config access) |
 | **Encoding** | `Codec` (base64/hex/url), `Hash` (md5/sha256/…) |
 | **Functional** | `Option`, `Result`, `Future` |
 | **Date & random** | `DateTime`, `Rand` (choice/shuffle/sample/uuid) |
@@ -828,6 +828,50 @@ record User(name: String, age: Int) derive!(Json, Yaml)
 val u = new User("ko", 3)
 val viaJson = User::fromJson(User::toJson(u))   // == u
 val viaYaml = User::fromYaml(User::toYaml(u))  // == u
+```
+
+## Config Module
+
+Configuration loading and dot-notation access over parsed JSON (`onion.Config`). Builds on
+`Json::parse`, so the same object/array/scalar shape applies; nothing here is YAML- or
+`.env`-aware — it's JSON plus dotted-path lookups and environment-variable overrides.
+
+```onion
+val config = Config::loadJson("config.json")          // reads + parses a JSON file
+val config2 = Config::parseJson("{\"port\": 8080}")   // parses a JSON string directly
+
+Config::get(config, "database.host")                   // raw value, or null if not found
+Config::getString(config, "database.host", "localhost")
+Config::getInt(config, "database.port", 5432)
+Config::getLong(config, "database.maxConnections", 10L)
+Config::getDouble(config, "database.timeout", 30.0)
+Config::getBoolean(config, "database.ssl", false)
+```
+
+Paths are dot-separated and walk both objects and arrays — a numeric segment indexes into
+an array:
+
+```onion
+val config = Config::parseJson("{\"users\": [{\"name\": \"Alice\"}, {\"name\": \"Bob\"}]}")
+Config::getString(config, "users.0.name", "unknown")   // "Alice"
+```
+
+A missing key, an out-of-range array index, or a value that can't convert to the requested
+type all fall back to the supplied default instead of throwing; the numeric getters accept
+the stored value as either a JSON number or a numeric string. `hasPath` checks presence
+without needing a default:
+
+```onion
+Config::hasPath(config, "database.host")   // true / false
+```
+
+Environment variables round out configuration — `getEnv` reads one directly, and
+`getWithEnvOverride` reads a config path but lets an environment variable take precedence
+when set, which is useful for overriding a checked-in config value at deploy time:
+
+```onion
+Config::getEnv("PORT", "3000")
+Config::getWithEnvOverride(config, "database.host", "DB_HOST", "localhost")
 ```
 
 ## Csv Module


### PR DESCRIPTION
## Summary
- `onion.Config` (`loadJson`/`parseJson`, dot-notation `get`/`getString`/`getInt`/`getLong`/`getDouble`/`getBoolean` with array indexing and defaults, `getEnv`/`getWithEnvOverride`, `hasPath`) is fully implemented and covered by 12 passing tests in `ConfigSpec.scala`, but was entirely undocumented — zero mentions in `docs/reference/stdlib.md` or `docs/ja/reference/stdlib.md`.
- Adds a `Config Module` section to both docs (mirroring the style of the neighboring Json/Yaml sections) and lists `Config` in the "Modules at a glance" / "モジュール一覧" summary table.
- Doc-only change; no source or behavior changes.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2398 succeeded, 0 failed, 1 canceled (pre-existing, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vthn17CTKU3gnjfkDgkwMW)_