### PR TITLE
docs(null-safety,stdlib): correct two claims the implementation contradicts (#267, #223)

### DIFF
--- a/docs/guide/null-safety.md
+++ b/docs/guide/null-safety.md
@@ -7,14 +7,20 @@ Onion provides null safety features inspired by Kotlin, helping you avoid `NullP
 By default, types in Onion cannot hold `null`. To allow `null`, use the `?` suffix:
 
 ```onion
-// Non-nullable: cannot be null
+// Non-nullable: not meant to hold null
 val name: String = "Alice"
-// val name: String = null  // Compile error!
+// val name: String = null  // W0012 warning — see "Null Literal Checking" below
 
 // Nullable: can be null
 val maybeName: String? = null  // OK
 val anotherName: String? = "Bob"  // Also OK
 ```
+
+Assigning the `null` literal to a non-nullable type is a **warning**, not an
+error, so that `null` stays usable where a Java API genuinely accepts it
+(`encodeUrl(null)`) and for `val anything: Object = null`. The trade-off, and
+how to turn it into an error for your own build, is described under
+[Null Literal Checking](#null-literal-checking-w0012).
 
 ### Type Compatibility
 
@@ -347,6 +353,28 @@ The warning covers declarations, assignments, arguments and returns.
 Promote it to an error with `--warn error`, or suppress it with
 `--Wno null-to-non-nullable`. Values coming from Java APIs are not
 checked (their nullness is unknown to the compiler).
+
+### Why a warning and not an error
+
+The value written here is statically known to be `null`, so a later
+dereference is a guaranteed `NullPointerException` — an error would seem
+strictly better. It is a warning because `null` is also a *legitimate* value in
+several places the same check covers:
+
+- Java APIs that accept and handle null (`Http::encodeUrl(null)` returns `""`).
+- `val anything: Object = null`, which is ordinary JVM code.
+- A field or local whose type is a bare type variable `T`, where `null` is the
+  only value available without an instance (see issue #283).
+
+Making it an error was tried and rejected: it broke 23 tests across 12 suites,
+essentially all of them legitimate uses like the above, rather than latent
+NPEs. If your own code has no such cases, `--warn error` gives you the strict
+behavior for your build without imposing it on Java interop.
+
+If you want the strictness only where it matters most, keep `null` out of
+non-nullable *declarations* (`val s: String = null`) — that is the shape that
+turns into a surprise NPE later — and reserve it for arguments to APIs
+documented to accept it.
 
 ## Safe Indexing (`?[]`) and Non-Null Assertion (`!!`)
 

--- a/docs/ja/guide/null-safety.md
+++ b/docs/ja/guide/null-safety.md
@@ -7,12 +7,30 @@ OnionはKotlin風のnull安全機能を持ち、`NullPointerException` をコン
 デフォルトでは型は `null` を保持できません。`?` 接尾辞で `null` を許可します。
 
 ```onion
-val name: String = "Alice"       // 非null（null を代入するとコンパイルエラー）
+val name: String = "Alice"       // 非null（null を代入すると W0012 警告）
 val maybeName: String? = null    // nullable: OK
 ```
 
 - `T` → `T?` は許可されます（widening）
 - `T?` → `T` は許可されません（明示的な処理が必要）
+
+### null リテラルの代入は警告（W0012）
+
+非null型に `null` リテラルを代入するのは**エラーではなく警告**です。静的に
+`null` と分かっている以上エラーのほうが厳しくて良さそうに見えますが、同じ検査が
+かかる場所には `null` が**正当な値**であるケースが含まれるためです。
+
+- null を受け付けて正しく処理する Java API（`Http::encodeUrl(null)` は `""` を返します）
+- `val anything: Object = null`（ごく普通の JVM コード）
+- 型変数 `T` の値。インスタンスなしに得られる値が `null` だけの場合があります（issue #283）
+
+実際にエラーへ格上げする変更を試したところ、12 スイート 23 テストが失敗し、その
+ほとんどが潜在的な NPE ではなく上記のような正当な用途でした。自分のコードにこう
+した事情が無いなら、`--warn error` でビルド単位で厳格にできます（`--Wno
+null-to-non-nullable` で抑制も可能）。
+
+厳しくするなら、まず**宣言**（`val s: String = null`）で `null` を避けるのが
+効果的です。後から NPE として表面化するのはこの形だからです。
 
 ## セーフコール演算子 `?.`
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -488,6 +488,19 @@ Stats::min(xs) / Stats::max(xs)    // 10.0 / 40.0
 Stats::variance(xs) / Stats::stddev(xs)
 ```
 
+メソッド呼び出しの形でも使えます（実際のコードではこちらが自然です）。ただし
+**メソッド形式も同じく倍精度**なので、`Int` のリストでも合計は `Double` になります。
+`Int` で受け取りたい場合は `Stats::sumInt` を使ってください。
+
+```onion
+val xs: List[Int] = [10, 20, 30, 40]
+xs.sum()             // 100.0  （Double: 汎用集計）
+Stats::sumInt(xs)    // 100    （Int）
+```
+
+`Int` を返す `sum()` のオーバーロードが無いのは型消去のためです。実行時には要素型が
+消えるので、`sum(List[Int])` と `sum(List[Double])` は同じ JVM シグネチャになります。
+
 ## Format モジュール
 
 locale 非依存の人間可読フォーマット（`onion.Format`）——桁区切り・小数・サイズ・時間。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -927,6 +927,20 @@ Stats::min(xs) / Stats::max(xs)    // 10.0 / 40.0
 Stats::variance(xs) / Stats::stddev(xs)
 ```
 
+These are also reachable as method calls, which is the form most code reaches
+for. **The method form has the same double precision**, so a list of `Int`
+sums to a `Double` — use `Stats::sumInt` when you want an `Int` back:
+
+```onion
+val xs: List[Int] = [10, 20, 30, 40]
+xs.sum()             // 100.0  (Double — the generic aggregate)
+Stats::sumInt(xs)    // 100    (Int)
+```
+
+Type erasure is the reason there is no `Int`-returning `sum()` overload: the
+element type is gone at runtime, so `sum(List[Int])` and `sum(List[Double])`
+would be the same JVM signature.
+
 ## Format Module
 
 Locale-independent human-readable formatting (`onion.Format`) — commas, decimals,


### PR DESCRIPTION
Closes #267. Closes #223.

Both issues turned out to be documentation defects rather than implementation defects — but I only established that by implementing the "obvious" fixes first and measuring what they broke.

## #267 — null literal into a non-nullable type

The guide opened with:

```onion
// val name: String = null  // Compile error!
```

…while the *same document's* "Null Literal Checking (W0012)" section correctly described it as a warning. A reader who hit the warning had no way to tell which statement was true.

**I implemented the error upgrade and measured it: 23 tests failed across 12 suites.** Essentially every failure was a legitimate use, not a latent NPE:

- `Http::encodeUrl(null)` — a Java API that accepts and handles null (explicitly tested to return `""`)
- `val anything: Object = null` — ordinary JVM code (`AutoBoxingSpec`, "boxes null to Object")
- null into a bare type-variable slot — which **#283 deliberately made warn-and-allow**, so the upgrade would have reverted a prior decision

So #132's "option B" (warn) is correct, and the *documentation* was wrong. The guide now says warning, and — more usefully — says **why**, since "statically known null, therefore guaranteed NPE" makes an error look strictly better until you see the interop cases. It also points readers at the practical middle ground: keep null out of non-nullable *declarations* (the shape that actually becomes a surprise NPE), and use `--warn error` if your build wants full strictness.

## #223 — "No list sum()"

`sum()` exists (`onion.Stats`) and has since before the issue. What the docs missed is the form users actually write: they documented `Stats::sum(xs)` but not `xs.sum()`, which is where the surprise lands — a `List[Int]` sums to `100.0`, not `100`.

Both forms are now documented, along with `Stats::sumInt` for integer precision and the erasure reason there is no `Int`-returning overload (`sum(List[Int])` and `sum(List[Double])` are the same JVM signature, so it cannot be an overload — it would need type-class dispatch, which is tracked under #224).

## Test plan

- [x] `sbt -Duser.language=en test` — **2415 tests, 0 failures** (1 expected cancellation: dist smoke, gated behind `-Donion.dist.path`). Doc code blocks are compile-checked by `DocExamplesCompileSpec`, so the new examples are verified, not just prose.
- [x] Both changes mirrored in `docs/ja`.