### PR TITLE
fix(build): run test suites serially so global output capture is reliable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,6 +173,15 @@ lazy val onionSettings = Seq(
   }
 )
 
+// The project test runner (onion.tools.project.ProjectTestRunner) has to capture
+// System.out/System.err to report a failing Onion test's output, and those
+// streams are process-global. With sbt's default parallel suite execution, any
+// other suite printing during that window lands inside the captured text, so
+// assertions on it fail at random -- one CI job on PR #335 failed this way while
+// the other passed, on a change that touched only workflow YAML. Serial suites
+// cost a few seconds and make the signal trustworthy.
+Test / parallelExecution := false
+
 run / fork := true
 run / connectInput := true
 repl / fork := true


### PR DESCRIPTION
## The failure

On **PR #335** — a change that touched only `.github/workflows/release.yml` and `RELEASING.md`, and therefore cannot affect the compiler — one CI job failed and the other passed:

```
ProjectTestIntegrationSpec:
- shows captured output and a concise assertion failure *** FAILED ***
  "..._test.on ... FAILED
  [15
  ]assertion-out
  ..." was not equal to "..._test.on ... FAILED
  []assertion-out
  ..."
```

A stray `15` had been spliced into the captured stdout.

## Why

`onion.tools.project.ProjectTestRunner` has to capture `System.out`/`System.err` to report a failing Onion test's output, and those streams are **process-global**. sbt runs ScalaTest suites in parallel by default, so whatever another suite prints during that capture window lands inside the captured text.

`ProjectTestRunner`'s own doc comment already says its tests must run sequentially for exactly this reason — but it can only serialize *itself*, not the suites running alongside it.

## Fix

`Test / parallelExecution := false`.

Cost: about 12 seconds locally (28s → 40s wall clock, 2415 tests). A red check on an unrelated change costs more than that — it burns a re-run and, worse, trains everyone to ignore red.

## Test plan

- [x] `sbt -Duser.language=en test` — **2415 tests, 0 failures**, 32s run time (1 expected cancellation: dist smoke, gated behind `-Donion.dist.path`)