### PR TITLE
feat(patterns): let a type pattern nest inside a destructuring pattern (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A type pattern nests inside a destructuring pattern (#299).** `case Add(l, n is Num)` was a
+  syntax error, even though a type pattern worked at the top level of a `case` and record patterns
+  already nested — so `is` was the one pattern form that could not nest. It now can, and the nested
+  binding is usable at the *narrowed* type (`n.v()` resolves because `n` is a `Num`, not the declared
+  `E`). This also covers the case that had no clean workaround: narrowing a component whose declared
+  type is not a record (`case Wrap(s is String)`), which a nested constructor pattern cannot express.
+
 - **A not-found member now points at the member that exists.** Three everyday mistakes produced
   errors the compiler already had the answer to. `xs.length` on a `List` reported "field
   List[Int].length is not found" with no suggestion at all, because only *fields* were considered as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,7 @@ These are frequently confused with other languages. **Always check these:**
 | `else if condition { }` | ✓ correct - `else if` chains are supported (also as expressions) |
 | `switch value { case 1: }` | `select value { case 1: }` - use `select` not `switch` |
 | `case s: String:` (Java/Scala pattern) | `case s is String:` - type patterns use `is`; sealed exhaustiveness (E0042) applies |
+| `case Add(l, n is Num):` nested type pattern? | ✓ correct - type patterns nest inside destructuring, and the binding is usable at the narrowed type; also works for a non-record component (`case Wrap(s is String)`) |
 | `case Circle(r):` unsupported? | ✓ correct - record destructuring patterns work, also `case x when guard:` |
 | `for (int i = 0; ...)` | `for var i: Int = 0; ...` - no parentheses |
 | `for i in 0..10` (other langs) | `foreach i: Int in 0..10` - ranges: `a..b` inclusive, `a..<b` exclusive |

--- a/docs/guide/control-flow.md
+++ b/docs/guide/control-flow.md
@@ -266,6 +266,29 @@ select shape {
 }
 ```
 
+Patterns nest, including type patterns, so a component can be narrowed in
+place and used at the narrowed type:
+
+```onion
+sealed interface E {}
+record Num(v: Int) <: E
+record Add(l: E, r: E) <: E
+record Wrap(x: Object)
+
+select e {
+  case Add(l, n is Num): println("added " + n.v())  // n is a Num here
+  case Add(l, r):        println("added something else")
+  case n is Num:         println("just " + n.v())
+}
+
+// Works for a component whose declared type is not a record, which a
+// nested constructor pattern cannot express:
+select w {
+  case Wrap(s is String): println(s.toUpperCase())
+  case Wrap(o):           println("not a string")
+}
+```
+
 When the matched value's type is a `sealed` interface, the compiler
 checks exhaustiveness (E0042) and lists any uncovered subtypes — an
 `else` branch is unnecessary once every case is handled.

--- a/docs/ja/guide/control-flow.md
+++ b/docs/ja/guide/control-flow.md
@@ -40,6 +40,29 @@ else: handleOther()
 }
 ```
 
+パターンは入れ子にできます。型パターンも同様で、成分をその場で絞り込んで
+絞り込んだ型のまま使えます。
+
+```onion
+sealed interface E {}
+record Num(v: Int) <: E
+record Add(l: E, r: E) <: E
+record Wrap(x: Object)
+
+select e {
+  case Add(l, n is Num): println("added " + n.v())  // ここでの n は Num
+  case Add(l, r):        println("added something else")
+  case n is Num:         println("just " + n.v())
+}
+
+// 成分の宣言型がレコードでない場合にも使えます
+// （入れ子のコンストラクタパターンでは表現できないケース）
+select w {
+  case Wrap(s is String): println(s.toUpperCase())
+  case Wrap(o):           println("not a string")
+}
+```
+
 sealed な階層に対しては網羅性が検査されます（漏れは E0042）。
 
 ## break / continue

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -2129,14 +2129,19 @@ AST.Pattern simple_pattern() :{
 | e=term() { return new AST.ExpressionPattern(e); }
 }
 
-// Patterns allowed inside destructuring: binding name, wildcard, or nested destructuring
+// Patterns allowed inside destructuring: binding name, wildcard, a nested
+// destructuring, or a nested type pattern (`Add(l, n is Num)`). The type-pattern
+// alternative mirrors simple_pattern()'s, so `is` nests the same way a
+// constructor pattern already does.
 AST.Pattern destructuring_field_pattern() :{
-  Token t; List<AST.Pattern> bindings;
+  Token t; List<AST.Pattern> bindings; AST.TypeNode ty;
 }{
   LOOKAHEAD({getToken(1).kind == ID && getToken(1).image.equals("_")})
   t=<ID> { return new AST.WildcardPattern(p(t)); }
 | LOOKAHEAD(2, id() "(")
   t=id() "(" bindings=destructuring_bindings() ")" { return new AST.DestructuringPattern(p(t), c(t), bindings); }
+| LOOKAHEAD(2, id() "is")
+  t=id() "is" ty=type() { return new AST.TypePattern(p(t), c(t), ty); }
 | t=<ID> { return new AST.BindingPattern(p(t), c(t)); }
 }
 

--- a/src/main/scala/onion/compiler/typing/DestructuringPatternProcessor.scala
+++ b/src/main/scala/onion/compiler/typing/DestructuringPatternProcessor.scala
@@ -103,6 +103,36 @@ private[typing] class DestructuringPatternProcessor(private val typing: Typing) 
           processNestedFieldPattern(nestedFieldPat, nestedField.`type`, nestedPath, bindingEntries, nestedConditions, nested)
         }
 
+      case tp @ AST.TypePattern(_, bindingName, typeRef) =>
+        // A nested type pattern: `Add(l, n is Num)`. Like the nested
+        // destructuring case it contributes an instanceof condition on the
+        // field, but binds the field itself at the narrowed type instead of
+        // decomposing it further -- so it also works for a component whose type
+        // is not a record (`Wrap(s is String)`), which a nested constructor
+        // pattern cannot express (issue #299).
+        val mappedType = typing.mapFrom(typeRef).getOrElse(break(None))
+        if (!mappedType.isObjectType) {
+          typing.report(INCOMPATIBLE_TYPE, tp, typing.rootClass, mappedType)
+          break(None)
+        }
+        def buildAccessor(base: Term, path: List[AccessStep]): Term = path match {
+          case Nil => base
+          case AccessStep(castType, getter) :: rest =>
+            val cast = new AsInstanceOf(base, castType)
+            if (getter == null) buildAccessor(cast, rest)
+            else buildAccessor(new Call(cast, getter, Array.empty), rest)
+        }
+        nestedConditions +=
+          new InstanceOf(buildAccessor(new RefLocal(bind), currentPath), mappedType.asInstanceOf[ObjectType])
+        // The field is declared at its component type, so the binding's access
+        // path needs a final cast-only step down to the narrowed type. Without
+        // it the loaded value keeps the wider static type while the binding
+        // claims the narrower one, and codegen emits an unverifiable frame.
+        bindingEntries += BindingEntry(
+          bindingName,
+          mappedType,
+          currentPath :+ AccessStep(mappedType.asInstanceOf[ClassType], null))
+
       case other =>
         // Other patterns not supported in destructuring position
         typing.report(NOT_A_RECORD_TYPE, parentNode, s"unsupported pattern type in destructuring: ${other.getClass.getSimpleName}")

--- a/src/test/scala/onion/compiler/tools/NestedTypePatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NestedTypePatternSpec.scala
@@ -1,0 +1,95 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A type pattern nests inside a destructuring pattern (issue #299):
+ * `case Add(l, n is Num)`. Type patterns already worked at the top level of a
+ * `case`, and record patterns already nested, so `is` not nesting was an
+ * asymmetry with no workaround for a non-record component.
+ *
+ * The nested binding must be usable at the *narrowed* type — the component is
+ * declared at the wider type, so the binding's access path needs a cast; without
+ * it the class verifier rejects the method.
+ */
+class NestedTypePatternSpec extends AbstractShellSpec {
+  private val exprAdt =
+    """sealed interface E {}
+      |record Num(v: Int) <: E
+      |record Add(l: E, r: E) <: E
+      |""".stripMargin
+
+  it("matches a nested type pattern and binds it at the narrowed type") {
+    // n.v() only resolves if n is bound as Num, not as the declared E.
+    assert(Shell.Success("add-num:2") == shell.run(
+      exprAdt +
+        """def f(e: E): String = select e {
+          |  case Add(l, n is Num): "add-num:" + n.v()
+          |  case Add(l, r): "add-other"
+          |  case n is Num: "num"
+          |}
+          |def main(args: String[]): String { return f(new Add(new Num(1), new Num(2))) }
+          |""".stripMargin, "None", Array()))
+  }
+
+  it("falls through when the nested type does not match") {
+    assert(Shell.Success("add-other") == shell.run(
+      exprAdt +
+        """def f(e: E): String = select e {
+          |  case Add(l, n is Num): "add-num"
+          |  case Add(l, r): "add-other"
+          |  case n is Num: "num"
+          |}
+          |def main(args: String[]): String {
+          |  return f(new Add(new Num(1), new Add(new Num(2), new Num(3))))
+          |}
+          |""".stripMargin, "None", Array()))
+  }
+
+  it("narrows a component whose declared type is not a record") {
+    // No nested *constructor* pattern can express this, so it is the case the
+    // workaround (`case Wrap(x) when x is String`) existed for.
+    assert(Shell.Success("str:HI") == shell.run(
+      """record Wrap(x: Object)
+        |def g(w: Wrap): String = select w {
+        |  case Wrap(s is String): "str:" + s.toUpperCase()
+        |  case Wrap(o): "other"
+        |}
+        |def main(args: String[]): String { return g(new Wrap("hi")) }
+        |""".stripMargin, "None", Array()))
+  }
+
+  it("takes the later case when the non-record component has another type") {
+    assert(Shell.Success("other") == shell.run(
+      """record Wrap(x: Object)
+        |def g(w: Wrap): String = select w {
+        |  case Wrap(s is String): "str"
+        |  case Wrap(o): "other"
+        |}
+        |def main(args: String[]): String { return g(new Wrap(42)) }
+        |""".stripMargin, "None", Array()))
+  }
+
+  it("still supports the plain and nested-record forms alongside it") {
+    assert(Shell.Success("num:7") == shell.run(
+      exprAdt +
+        """def f(e: E): String = select e {
+          |  case Add(Num(a), Num(b)): "both:" + (a + b)
+          |  case n is Num: "num:" + n.v()
+          |  else: "other"
+          |}
+          |def main(args: String[]): String { return f(new Num(7)) }
+          |""".stripMargin, "None", Array()))
+  }
+
+  it("rejects a nested type pattern naming a non-object type") {
+    assert(Shell.Failure(-1) == shell.run(
+      """record Wrap(x: Object)
+        |def g(w: Wrap): String = select w {
+        |  case Wrap(s is NoSuchType): "str"
+        |  else: "other"
+        |}
+        |def main(args: String[]): String { return g(new Wrap("hi")) }
+        |""".stripMargin, "None", Array()))
+  }
+}


### PR DESCRIPTION
Closes #299.

## The asymmetry

A type pattern worked at the top level of a `case`, and record patterns already nested to any depth — but `is` was the one pattern form that could not nest:

```onion
case n is Num:              // OK
case Add(Num(v)):           // OK — nested record pattern
case Add(l, n is Num):      // syntax error: Encountered "is", but expecting ")", ","
case Wrap(s is String):     // syntax error
```

## Change

**Grammar** — `destructuring_field_pattern` gains the same type-pattern alternative `simple_pattern` already has.

**Typing** — `DestructuringPatternProcessor` rejected anything but a wildcard, binding, or nested constructor in a field position. A nested type pattern now contributes an instanceof condition on the field (like the nested-constructor case) but binds the field itself at the narrowed type instead of decomposing further. That difference is what makes it work for `Wrap(s is String)` — a component whose declared type is **not** a record, which a nested constructor pattern cannot express and which the `bind + when` workaround existed for.

## The bug this surfaced

The first version compiled cleanly and then failed the class verifier at runtime:

```
Type 'E' (current frame, stack[1]) is not assignable to 'Num'
```

The binding claimed the narrowed type while the access path still loaded the field at its wider declared type. The fix appends a cast-only `AccessStep` to the binding's path. Worth noting because it was invisible to compilation — only running the program caught it, which is why the spec asserts on *executed output* (`n.v()`, `s.toUpperCase()`) rather than just "compiles".

## Test plan

- [x] New `NestedTypePatternSpec`, 6 cases: nested match binds at the narrowed type (`n.v()` only resolves if `n` is a `Num`); non-matching nested type falls through to the later case; non-record component narrowing (`Wrap(s is String)`) and its negative case; plain and nested-record forms still work alongside it; an unknown type in a nested pattern is still rejected.
- [x] `sbt -Duser.language=en test` — **2421 tests, 0 failures** (1 expected cancellation: dist smoke, gated behind `-Donion.dist.path`).
- [x] Docs updated: `docs/guide/control-flow.md` + `docs/ja` mirror (examples are compile-checked by `DocExamplesCompileSpec`), `CLAUDE.md` pattern table, CHANGELOG.