### PR TITLE
fix(diagnostics): stop a failed declaration cascading "variable not found" (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **One broken declaration now reports one error (#333).** `val bad = xs.noSuchMethod()` reported the
+  real error *plus* "local variable bad is not found" for every later use of `bad` — misleading,
+  because `bad` is declared and only its type is unknown, and loud enough to bury the root cause in a
+  real file. A declaration whose initializer fails to type is remembered, and later references to it
+  stay silent. Binding the name at a placeholder type was tried and rejected: it traded this noise
+  for wrong-type noise on the placeholder (`Object.map() is not found`, suggesting `wait`), which is
+  worse for the common case of using the variable as a receiver. A genuinely undeclared name still
+  errors, and each distinct one is still reported.
+
 - **Generic ADT enums (#311).** `enum Opt[T] { case Some(value: T); case Nothing }` was a syntax
   error — `enum` accepted no type parameters — which kept the natural killer app for ADT enums
   (`Option[T]`, `Result[T, E]`) out of reach. Type parameters now flow onto the generated sealed

--- a/src/main/scala/onion/compiler/LocalContext.scala
+++ b/src/main/scala/onion/compiler/LocalContext.scala
@@ -264,6 +264,19 @@ class LocalContext {
     usageTracker.recordUsage(name)
   }
 
+  // Declarations whose type could not be determined (the initializer failed to
+  // type, and no explicit type was given). The name is NOT bound -- binding it
+  // at some placeholder type just trades "variable not found" noise for
+  // wrong-type noise on the placeholder. Instead the name is remembered so a
+  // later reference can stay silent: the root cause is already reported, and
+  // repeating "variable is not found" once per use is both misleading (the
+  // variable *is* declared) and drowns out the real error (issue #333).
+  private val failedDeclarations = scala.collection.mutable.HashSet[String]()
+
+  def recordFailedDeclaration(name: String): Unit = failedDeclarations += name
+
+  def isFailedDeclaration(name: String): Boolean = failedDeclarations.contains(name)
+
   /**
    * Gets all unused local variables (not parameters).
    */

--- a/src/main/scala/onion/compiler/typing/AssignmentTyping.scala
+++ b/src/main/scala/onion/compiler/typing/AssignmentTyping.scala
@@ -21,7 +21,12 @@ final class AssignmentTyping(
     var value: Term = typed(node.rhs, context, expectedType).getOrElse(null)
     if (value == null) return null
     if (bind == null) {
-      bodyContext.report(VARIABLE_NOT_FOUND, id, id.name, context.allNames.toArray)
+      // Assigning to a name whose declaration failed to type: the root cause is
+      // already reported, so stay silent rather than adding a misleading
+      // "variable is not found" (#333).
+      if (!context.isFailedDeclaration(id.name)) {
+        bodyContext.report(VARIABLE_NOT_FOUND, id, id.name, context.allNames.toArray)
+      }
       return null
     }
     if (!bind.isMutable) {

--- a/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
+++ b/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
@@ -277,10 +277,18 @@ final class BlockElementLowering(
       }
       if (node.typeRef == null) {
         val inferred = typed(node.init, context).getOrElse(null)
-        if (inferred == null) return new NOP(node.location)
+        if (inferred == null) {
+          // The initializer failed to type (already reported) and there is no
+          // declared type to fall back on, so the name cannot be bound. Remember
+          // it so later references stay silent instead of repeating a misleading
+          // "variable is not found" once per use (issue #333).
+          context.recordFailedDeclaration(node.name)
+          return new NOP(node.location)
+        }
         val inferredType = inferred.`type`
         if (inferredType == BasicType.VOID) {
           bodyContext.report(INCOMPATIBLE_TYPE, node.init, bodyContext.rootClass, inferredType)
+          context.recordFailedDeclaration(node.name)
           return new NOP(node.location)
         }
         typing.checkAndReportShadowing(node.name, node.location, context)

--- a/src/main/scala/onion/compiler/typing/SimpleExpressionTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/SimpleExpressionTypingSupport.scala
@@ -348,9 +348,14 @@ private[compiler] final class SimpleExpressionTypingSupport(
             case None =>
               // Fields that can't be reached this way (e.g. an instance field from
               // a static method) still suggest the qualified form to use.
-              fieldQualificationHint(node.name, context) match {
-                case Some(hint) => bodyContext.report(VARIABLE_NOT_FOUND, node, node.name, context.allNames.toArray, hint)
-                case None => bodyContext.report(VARIABLE_NOT_FOUND, node, node.name, context.allNames.toArray)
+              // A name whose own declaration failed to type is already accounted
+              // for by that error; saying "not found" once per use would be both
+              // wrong (it *is* declared) and louder than the root cause (#333).
+              if (!context.isFailedDeclaration(node.name)) {
+                fieldQualificationHint(node.name, context) match {
+                  case Some(hint) => bodyContext.report(VARIABLE_NOT_FOUND, node, node.name, context.allNames.toArray, hint)
+                  case None => bodyContext.report(VARIABLE_NOT_FOUND, node, node.name, context.allNames.toArray)
+                }
               }
               None
           }

--- a/src/test/scala/onion/compiler/tools/FailedDeclarationCascadeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FailedDeclarationCascadeSpec.scala
@@ -1,0 +1,78 @@
+package onion.compiler.tools
+
+import onion.compiler.{CompilerConfig, OnionCompiler, StreamInputSource}
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * One broken declaration should produce one error (issue #333).
+ *
+ * `val bad = xs.noSuchMethod()` used to report the real error plus a
+ * "local variable bad is not found" for every later use — misleading, because
+ * `bad` *is* declared (only its type is unknown), and loud enough to bury the
+ * root cause in a real file.
+ *
+ * Binding the name at a placeholder type was tried and rejected: it traded this
+ * noise for wrong-type noise on the placeholder (`Object.map() is not found` —
+ * with `did you mean: wait` from Object's own methods), which is worse for the
+ * common case of using the variable as a receiver. Suppressing the follow-on
+ * report keeps the root cause alone.
+ */
+class FailedDeclarationCascadeSpec extends AnyFunSpec {
+
+  private def errors(source: String): Seq[String] =
+    new OnionCompiler(CompilerConfig(Seq("."), null, "UTF-8", "", 20))
+      .compileDetailed(Seq(new StreamInputSource(() => new StringReader(source), "S.on")))
+      .allErrors
+      .map(_.message)
+      .toSeq
+
+  describe("a declaration whose initializer failed to type") {
+    it("reports the root cause once, not once per later use") {
+      val messages = errors(
+        """val xs = [1, 2, 3]
+          |val bad = xs.noSuchMethod()
+          |println(bad)
+          |println(bad.toString())
+          |println(bad)
+          |""".stripMargin)
+      assert(messages.length == 1, messages.mkString("; "))
+      assert(messages.head.contains("noSuchMethod"), messages.head)
+    }
+
+    it("does not claim the variable is undeclared") {
+      val messages = errors(
+        """val xs = [1, 2, 3]
+          |val bad = xs.noSuchMethod()
+          |println(bad)
+          |""".stripMargin)
+      // "bad" is declared; only its type is unknown.
+      assert(!messages.exists(_.contains("bad")), messages.mkString("; "))
+    }
+
+    it("stays silent for an assignment to the broken name too") {
+      val messages = errors(
+        """val xs = [1, 2, 3]
+          |var bad = xs.noSuchMethod()
+          |bad = 5
+          |""".stripMargin)
+      assert(messages.length == 1, messages.mkString("; "))
+    }
+
+    it("still reports a genuinely undeclared variable") {
+      val messages = errors("val a = 1\nprintln(notDeclared)\n")
+      assert(messages.exists(_.contains("notDeclared")), messages.mkString("; "))
+    }
+
+    it("still reports each distinct undeclared name") {
+      val messages = errors("println(alpha)\nprintln(beta)\n")
+      assert(messages.exists(_.contains("alpha")), messages.mkString("; "))
+      assert(messages.exists(_.contains("beta")), messages.mkString("; "))
+    }
+
+    it("leaves a well-typed declaration and its uses alone") {
+      assert(errors("val ok = [1, 2].size\nprintln(ok)\nprintln(ok + 1)\n").isEmpty)
+    }
+  }
+}


### PR DESCRIPTION
Closes #333.

## Before

```onion
val xs = [1, 2, 3]
val bad = xs.noSuchMethod()   // the only real error
println(bad)
println(bad + 1)
println(bad.toString())
```

```
cascade.on:2:13: [E0005] method applicable for List[Int].noSuchMethod() is not found.
cascade.on:3:9:  [E0002] local variable bad is not found.
cascade.on:4:9:  [E0002] local variable bad is not found.
cascade.on:5:9:  [E0002] local variable bad is not found.
```

Four errors from one cause, and the follow-on message isn't true: `bad` **is** declared — only its type is unknown. In a real file this buries the root cause.

## After

One error: the `noSuchMethod` one.

## Why not bind the name at a placeholder type

That's the obvious fix, and it's what the *declared-type* path in the same function already does (added for #257). I implemented it and measured it before choosing:

- Reading-only uses improve (4 errors → 2).
- **Receiver uses get worse**, and that's the common case:

```
[E0005] method applicable for Object.iterator() is not found.
[E0005] method applicable for Object.map() is not found.
  did you mean: wait          ← picked from Object's own methods
```

Same volume of noise, plus a wrong suggestion. So it was dropped rather than shipped.

Doing this "properly" means a type that silently absorbs downstream operations (an error/unknown type), which is a type-system change. Suppressing the follow-on report gets the user-visible benefit without one.

## Test plan

- [x] New `FailedDeclarationCascadeSpec`, 6 cases: one error not one-per-use; the message doesn't claim the variable is undeclared; assignment to the broken name is silent too; a **genuinely** undeclared variable still errors; each distinct undeclared name is still reported; a well-typed declaration and its uses are untouched.
- [x] `sbt -Duser.language=en test` — **2433 tests, 0 failures** (1 expected cancellation: dist smoke, gated behind `-Donion.dist.path`).