### PR TITLE
fix(typing): a throw-only lambda no longer pins a type argument to Object (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A throw-only lambda no longer pins a type argument to `Object` (#314).**
+  `val f = Future::async(() -> { throw ... })` inferred `Future[Object]`, so `val b: Int = f.await()`
+  was rejected and the target had to be annotated. A closure that never completes normally now keeps
+  a bottom return in its static type, so the call infers `Future[Nothing]` and its result is
+  assignable anywhere. Bottom is still not a usable JVM return type — the synthesized closure method
+  continues to return `Object` — so the widening moved to exactly that one place instead of leaking
+  into inference. Two codegen paths needed to follow: assigning a bottom-typed (erased) result to a
+  primitive now inserts the unboxing the verifier expects, and discarding such a value as a statement
+  pops the reference the call actually leaves on the stack, which a bottom type previously skipped
+  because it only ever came from `throw`/`return`/`break`/`continue`.
+
 - **One broken declaration now reports one error (#333).** `val bad = xs.noSuchMethod()` reported the
   real error *plus* "local variable bad is not found" for every later use of `bad` — misleading,
   because `bad` is declared and only its type is unknown, and loud enough to bury the root cause in a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,7 +511,7 @@ These are frequently confused with other languages. **Always check these:**
 - Generics are erasure-based (no reified type info; type arguments are invariant — no variance or wildcards); nullability of type parameters is tracked at compile time (bare `[T]` is nullable, `[T extends B]` is non-null, Java type variables are platform)
 - Diagnostics are still improving; some errors may be reported later in the pipeline than ideal
 - Tail call optimization covers direct and mutual self-recursion (not general continuation-passing style)
-- Inference is local (left-to-right, no deferred/global unification): a throw-only lambda used as a generic argument with no expected type infers the type parameter as `Object` — e.g. `val f = Future::async(() -> { throw ... })` gives `Future[Object]`. Annotate the target to fix it: `val f: Future[Int] = Future::async(() -> { throw ... })` ([#314])
+- Inference is local (left-to-right, no deferred/global unification), so a type argument is pinned by what is written to its left; annotate the target when a later expression should determine it
 
 ## Entry Points for Execution
 

--- a/src/main/scala/onion/compiler/backend/asm/ControlFlowEmitter.scala
+++ b/src/main/scala/onion/compiler/backend/asm/ControlFlowEmitter.scala
@@ -73,7 +73,16 @@ final class ControlFlowEmitter(
       case term =>
         visitTerm(term)
         term.`type` match
-          case t if t.isBottomType => ()
+          // A bottom type reaches here two ways. A wrapped statement
+          // (`throw`/`return`/`break`/`continue`) transfers control and leaves
+          // nothing on the stack. But a bottom-typed *value* -- an erased
+          // generic call whose type argument was inferred as bottom, e.g.
+          // `f.call()` on a throw-only closure -- does leave a reference, and
+          // skipping the pop there desynchronizes the stackmap (issue #314).
+          case t if t.isBottomType =>
+            term match
+              case _: StatementTerm => ()
+              case _ => gen.pop()
           case BasicType.VOID => ()
           case BasicType.LONG | BasicType.DOUBLE => gen.pop2()
           case _ => gen.pop()

--- a/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
+++ b/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
@@ -64,7 +64,21 @@ private[compiler] final class AssignabilitySupport(
     // parameter's element type instead of the default Object).
     val retyped = retypeEmptyCollectionLiteral(expected, actual)
     if (retyped ne actual) return processAssignable(node, expected, retyped)
-    if (actual.`type`.isBottomType) return actual
+    if (actual.`type`.isBottomType) {
+      // A bottom-typed value never actually materializes (the expression throws
+      // or otherwise never completes), but the bytecode path still has to
+      // verify. When it came from an erased generic call -- `f.await()` on a
+      // `Future[Nothing]` -- the JVM sees a reference on the stack, so storing
+      // it into a primitive slot needs the same unboxing any reference would
+      // (issue #314). Without this, codegen produced a frame the verifier
+      // rejected.
+      expected match {
+        case bt: BasicType if bt != BasicType.VOID && !actual.isBasicType =>
+          val boxedType = Boxing.boxedType(bodyContext.table, bt)
+          return Boxing.unboxing(bodyContext.table, new AsInstanceOf(node.location, actual, boxedType), bt)
+        case _ => return actual
+      }
+    }
     if (expected == actual.`type`) return actual
 
     // Constant narrowing: an integer literal (or its negation) that fits the

--- a/src/main/scala/onion/compiler/typing/ClosureTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ClosureTyping.scala
@@ -78,12 +78,19 @@ final class ClosureTyping(
           val inferred =
             if (useExpressionBody) inferReturnTypeFromExpressionBody(node, context, argTypes, samReturnTemplate)
             else inferReturnTypeFromReturns(node, context, argTypes, samReturnTemplate)
-          // A closure whose only produced value is `null` (NullType) or that
-          // never returns normally (BottomType, e.g. a throw-only body) infers
-          // to a bottom type, which is not a valid method return type: codegen's
-          // default value for it is absent, yielding a value-less `areturn`
-          // (VerifyError: operand stack underflow). Widen it to Object.
-          inferred.map(t => if (t.isNullType || t.isBottomType) bodyContext.rootClass else t)
+          // A closure whose only produced value is `null` widens to Object: a
+          // null-typed slot carries no information and Object is the honest
+          // static type.
+          //
+          // A closure that never returns normally (`() -> { throw ... }`) keeps
+          // its BOTTOM return here, so the closure's static type is
+          // `FunctionN[..., Nothing]` and generic inference sees that it
+          // produces nothing -- `Future::async(() -> { throw ... })` infers
+          // `Future[Nothing]`, not `Future[Object]` (issue #314). Bottom is not
+          // a usable JVM return type (its default value is absent, so codegen
+          // emits a value-less `areturn` -> VerifyError), so the *synthesized
+          // method's* return type is widened separately, at `expectedRet` below.
+          inferred.map(t => if (t.isNullType) bodyContext.rootClass else t)
         } else None
 
       val typeRef =
@@ -143,7 +150,15 @@ final class ClosureTyping(
           None
         case Some(method) =>
           val expectedArgs = substitutedArgs(method)
-          val expectedRet = substitutedReturn(method)
+          // The closure's STATIC type may carry a bottom return (a throw-only
+          // body, see above), which inference needs but the JVM cannot express
+          // as a method return type. Widen it here, and only here: this feeds
+          // the synthesized method's signature, its `return` insertion and its
+          // body's expected type, while the closure term keeps the precise type.
+          val expectedRet = substitutedReturn(method) match {
+            case t if t.isBottomType => bodyContext.rootClass
+            case t => t
+          }
 
           // Use the lambda's declared argument types as the implementation method
           // signature so primitive parameters stay primitive. The generated bridge

--- a/src/test/scala/onion/compiler/tools/ThrowOnlyClosureInferenceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ThrowOnlyClosureInferenceSpec.scala
@@ -1,0 +1,112 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A closure that never completes normally (`() -> { throw ... }`) infers a
+ * bottom return, so a generic call over it is not pinned to `Object`
+ * (issue #314): `Future::async(() -> { throw ... })` is a `Future[Nothing]`,
+ * and `await()` on it is assignable anywhere.
+ *
+ * Bottom is not a usable JVM return type, so the *synthesized closure method*
+ * still returns `Object`. These tests therefore assert on executed behavior,
+ * not just compilation: the earlier attempts at this fix each compiled and then
+ * failed the class verifier.
+ */
+class ThrowOnlyClosureInferenceSpec extends AbstractShellSpec {
+
+  it("assigns the awaited result of a throw-only async to a primitive") {
+    // Future[Object] would reject this at compile time (E0000).
+    val r = shell.run(
+      """import { onion.Future; }
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val f = Future::async(() -> { throw new RuntimeException("boom") })
+        |    var caught: Int = 0
+        |    try { val b: Int = f.await() } catch e: Exception { caught = 7 }
+        |    return caught
+        |  }
+        |}
+        |""".stripMargin, "None", Array())
+    assert(Shell.Success(7) == r)
+  }
+
+  it("still compiles and runs a bare throw-only closure invoked for effect") {
+    // The value is discarded, so the emitted code must pop what the erased call
+    // actually leaves on the stack.
+    val r = shell.run(
+      """class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val f = () -> { throw new RuntimeException("boom") }
+        |    var caught: Int = 0
+        |    try { f.call() } catch e: Exception { caught = 1 }
+        |    return caught
+        |  }
+        |}
+        |""".stripMargin, "None", Array())
+    assert(Shell.Success(1) == r)
+  }
+
+  it("assigns a throw-only closure result to a reference target") {
+    val r = shell.run(
+      """class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val f = () -> { throw new RuntimeException("boom") }
+        |    var caught: Int = 0
+        |    try { val s: String = f.call() } catch e: Exception { caught = 2 }
+        |    return caught
+        |  }
+        |}
+        |""".stripMargin, "None", Array())
+    assert(Shell.Success(2) == r)
+  }
+
+  it("still honors an explicit target type over the inferred bottom") {
+    val r = shell.run(
+      """import { onion.Future; }
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val f: Future[Int] = Future::async(() -> { throw new RuntimeException("boom") })
+        |    var caught: Int = 0
+        |    try { val b: Int = f.await() } catch e: Exception { caught = 3 }
+        |    return caught
+        |  }
+        |}
+        |""".stripMargin, "None", Array())
+    assert(Shell.Success(3) == r)
+  }
+
+  it("leaves a value-returning closure inferring its real type") {
+    val r = shell.run(
+      """import { onion.Future; }
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val f = Future::async(() -> { return 40 })
+        |    return f.await() + 2
+        |  }
+        |}
+        |""".stripMargin, "None", Array())
+    assert(Shell.Success(42) == r)
+  }
+
+  it("leaves a null-returning closure widening to Object") {
+    // Only the never-returns case keeps bottom; a null-producing body still
+    // widens, since Object is its honest static type.
+    val r = shell.run(
+      """class Test {
+        |public:
+        |  static def main(args: String[]): String {
+        |    val f = () -> { return null }
+        |    val v = f.call()
+        |    return "" + v
+        |  }
+        |}
+        |""".stripMargin, "None", Array())
+    assert(Shell.Success("null") == r)
+  }
+}


### PR DESCRIPTION
Closes #314.

```onion
val f = Future::async(() -> { throw new RuntimeException("boom") })
val b: Int = f.await()   // was E0000: Int expected, Object used
```

## Cause

One widening was doing two jobs.

A closure that never completes normally infers a **bottom** return, and bottom is not a usable JVM return type — its default value is absent, so codegen emits a value-less `areturn` (VerifyError). `ClosureTyping` therefore widened it to `Object` *before* building the closure's static type — which also handed that `Object` to generic inference as if it were information about the program. It isn't; it's a codegen necessity.

## Fix

Split the two. The **static type** keeps the bottom return, so inference sees that the closure produces nothing and infers `Future[Nothing]`. The widening moves to `expectedRet`, which is exactly what feeds the synthesized method's signature, its inserted `return`, and its body's expected type. A null-returning closure still widens to `Object`, since `Object` is its honest static type.

## Two codegen paths this exposed

Letting a bottom type reach a *value* position surfaced two places that had only ever seen bottom from `throw`/`return`/`break`/`continue`:

- **Assigning** a bottom-typed result to a primitive emitted no conversion, but the erased call really does leave a reference on the stack → `Type 'V' (current frame, stack[1]) is not assignable to integer`. It now unboxes like any other reference.
- **Discarding** one as a statement skipped the pop entirely → `Inconsistent stackmap frames at branch target 35`. A wrapped statement still pops nothing; a bottom-typed *value* pops.

Both compiled cleanly and failed only at class-verification time, which is why the new spec asserts on **executed** behavior rather than "it compiles".

## Test plan

- [x] New `ThrowOnlyClosureInferenceSpec`, 6 cases: awaited throw-only async assigned to a primitive; a bare throw-only closure invoked for effect (the discard path); assignment to a reference target; an explicit target type still wins; a value-returning closure still infers its real type; a null-returning closure still widens to `Object`.
- [x] `sbt -Duser.language=en test` — **2439 tests, 0 failures** (1 expected cancellation: dist smoke, gated behind `-Donion.dist.path`). This includes the two regression tests added when the widening was introduced (`CodegenCorrectnessSpec` "throw-only lambda ... compiles and throws when invoked" and the crash-reproducer `018-throw-only-lambda-inferred-return.on`), both still green.
- [x] `CLAUDE.md` known-limitation entry for #314 removed; CHANGELOG updated.