### PR TITLE
docs(stdlib): fix Http method names and add missing ja section

### DIFF
--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -6,7 +6,7 @@ Onionの標準ライブラリは、一般的な機能のための組み込みモ
 
 | 領域 | モジュール |
 |------|-----------|
-| **I/O・システム** | `IO`（コンソール）, `Files`（ファイル・パス）, `System`, `Proc`（サブプロセス）, `Args`（CLI） |
+| **I/O・システム** | `IO`（コンソール）, `Files`（ファイル・パス）, `System`, `Proc`（サブプロセス）, `Args`（CLI）, `Http`（HTTPクライアント） |
 | **コレクション** | `Colls`（リスト: map/filter/fold, chunked/windowed, sumBy/maxBy）, `Iterables`, `Maps`, `Sets` |
 | **テキスト** | `Strings`（大小文字・分割・パディング・パース）, `Text`（wrap/indent/table）, `Regex` |
 | **数値** | `Math`, `Stats`（sum/average/median/stddev）, `Format`（桁区切り・bytes・duration） |
@@ -675,6 +675,55 @@ Colls::sortedBy(people) { p => p.age() }
 // map/filter/reduce/fold のパイプラインは List/Iterable/配列の拡張メソッド:
 // xs.map { x => x * 2 }.filter { x => x > 0 }
 ```
+
+## Http
+
+HTTPクライアントユーティリティ（Java 11+ の HttpClient を使用）。
+
+### GET リクエスト
+
+```
+Http::get(url): String
+Http::get(url, headers): String    // headers: ["Key1", "Value1", ...]
+```
+
+### POST リクエスト
+
+```
+Http::post(url, body): String
+Http::postJson(url, jsonBody): String    // Content-Type: application/json を設定
+Http::post(url, body, headers): String
+```
+
+### その他のメソッド
+
+```
+Http::put(url, body): String
+Http::delete(url): String
+```
+
+### URL ユーティリティ
+
+```
+Http::encodeUrl(str): String
+Http::decodeUrl(str): String
+Http::buildQuery(params): String        // params: ["key1", "val1", ...]
+Http::buildUrl(baseUrl, params): String // "?"/"&" + buildQuery(params) を付加
+```
+
+### 例
+
+```
+val response: String = Http::get("https://api.example.com/data");
+val data: Object = Json::parse(response);
+
+val postResponse: String = Http::postJson(
+  "https://api.example.com/users",
+  "{\"name\": \"Bob\"}"
+);
+```
+
+---
 
 ## DateTime
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -684,7 +684,15 @@ HTTPクライアントユーティリティ（Java 11+ の HttpClient を使用�
 
 ```
 Http::get(url): String
-Http::get(url, headers): String    // headers: ["Key1", "Value1", ...]
+Http::get(url, headers): String
+```
+
+`headers` は名前と値を交互に並べたフラットな `String[]` です。**配列である必要があり**、
+リストリテラル（`["Key1", "Value1"]`）は `List` になるためこのオーバーロードには
+一致しません。
+
+```onion
+val headers: String[] = new String[]{"Accept", "application/json"}
 ```
 
 ### POST リクエスト
@@ -692,7 +700,7 @@ Http::get(url, headers): String    // headers: ["Key1", "Value1", ...]
 ```
 Http::post(url, body): String
 Http::postJson(url, jsonBody): String    // Content-Type: application/json を設定
-Http::post(url, body, headers): String
+Http::post(url, body, headers): String   // headers は get と同じく String[]
 ```
 
 ### その他のメソッド
@@ -707,8 +715,16 @@ Http::delete(url): String
 ```
 Http::encodeUrl(str): String
 Http::decodeUrl(str): String
-Http::buildQuery(params): String        // params: ["key1", "val1", ...]
+Http::buildQuery(params): String        // params: キーと値を交互に並べる
 Http::buildUrl(baseUrl, params): String // "?"/"&" + buildQuery(params) を付加
+```
+
+上のヘッダー引数とは異なり、`buildQuery` と `buildUrl` は `String[]` と `List` の
+**どちらも**受け付けるので、リストリテラルも使えます。
+
+```onion
+Http::buildQuery(new String[]{"q", "hello world"})
+Http::buildQuery(["q", "hello world"])
 ```
 
 ### 例

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -6,7 +6,7 @@ Onion's standard library consists of built-in modules and interfaces for common 
 
 | Area | Modules |
 |------|---------|
-| **I/O & system** | `IO` (console), `Files` (files + paths), `System`, `Proc` (subprocesses), `Args` (CLI) |
+| **I/O & system** | `IO` (console), `Files` (files + paths), `System`, `Proc` (subprocesses), `Args` (CLI), `Http` (HTTP client) |
 | **Collections** | `Colls` (lists: map/filter/fold, chunked/windowed, sumBy/maxBy), `Iterables`, `Maps`, `Sets` |
 | **Text** | `Strings` (case, split, pad, parse), `Text` (wrap/indent/table), `Regex` |
 | **Numbers** | `Math`, `Stats` (sum/average/median/stddev), `Format` (grouping, bytes, durations) |
@@ -1036,9 +1036,10 @@ Http::delete(url): String
 ### URL Utilities
 
 ```
-Http::urlEncode(str): String
-Http::urlDecode(str): String
-Http::buildQuery(params): String    // params: ["key1", "val1", ...]
+Http::encodeUrl(str): String
+Http::decodeUrl(str): String
+Http::buildQuery(params): String        // params: ["key1", "val1", ...]
+Http::buildUrl(baseUrl, params): String // appends "?"/"&" + buildQuery(params)
 ```
 
 ### Example

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1015,7 +1015,15 @@ HTTP client utilities (uses Java 11+ HttpClient).
 
 ```
 Http::get(url): String
-Http::get(url, headers): String    // headers: ["Key1", "Value1", ...]
+Http::get(url, headers): String
+```
+
+`headers` is a flat `String[]` of alternating names and values. It must be an
+array, not a list literal — `["Key1", "Value1"]` builds a `List` and does not
+match this overload:
+
+```onion
+val headers: String[] = new String[]{"Accept", "application/json"}
 ```
 
 ### POST Requests
@@ -1023,7 +1031,7 @@ Http::get(url, headers): String    // headers: ["Key1", "Value1", ...]
 ```
 Http::post(url, body): String
 Http::postJson(url, jsonBody): String    // Sets Content-Type: application/json
-Http::post(url, body, headers): String
+Http::post(url, body, headers): String   // headers: String[], as for get
 ```
 
 ### Other Methods
@@ -1038,8 +1046,16 @@ Http::delete(url): String
 ```
 Http::encodeUrl(str): String
 Http::decodeUrl(str): String
-Http::buildQuery(params): String        // params: ["key1", "val1", ...]
+Http::buildQuery(params): String        // params: alternating keys and values
 Http::buildUrl(baseUrl, params): String // appends "?"/"&" + buildQuery(params)
+```
+
+Unlike the header parameters above, `buildQuery` and `buildUrl` accept **either**
+a `String[]` or a `List`, so a list literal works here:
+
+```onion
+Http::buildQuery(new String[]{"q", "hello world"})
+Http::buildQuery(["q", "hello world"])
 ```
 
 ### Example


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md` documented `Http::urlEncode`/`Http::urlDecode`, but the implemented (and tested) method names are `encodeUrl`/`decodeUrl` (`src/main/java/onion/Http.java`, `src/test/scala/onion/compiler/tools/HttpSpec.scala`). Any user following the doc would hit a "method not found" error. Corrected both names and added the previously-undocumented `Http::buildUrl`.
- Added `Http` to both the English and Japanese "Modules at a glance" summary tables — it was missing from both.
- `docs/ja/reference/stdlib.md` was missing the entire `Http` module section (same gap as the nine modules fixed in `051409cc`). Added a translated section using the corrected method names.

Docs-only change, no code touched.

## Test plan
- [x] `LANG=C.utf8 SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2433 succeeded, 0 failed, 1 canceled, 0 ignored. All tests passed.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01PH8sTSQTtyPG8gPqGn8aop)_