### PR TITLE
chore(release): finalize the CHANGELOG heading for 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-25
+
 - **A throw-only lambda no longer pins a type argument to `Object` (#314).**
   `val f = Future::async(() -> { throw ... })` inferred `Future[Object]`, so `val b: Int = f.await()`
   was rejected and the target had to be annotated. A closure that never completes normally now keeps


### PR DESCRIPTION
v0.5.0 is released: tag `8edb10b2`, published with `onion-0.5.0.jar`, `onion-dist-0.5.0.zip` and `checksums.txt`.

https://github.com/onion-lang/onion/releases/tag/v0.5.0

This turns the accumulated `[Unreleased]` entries into the `## [0.5.0] - 2026-07-25` section (date taken from the release's own `publishedAt`).

**Ordering is deliberate.** The heading is finalized *after* the release exists, not before. Committing it first is exactly what turned each failed release attempt into a revert and produced the release/revert loop that left the project unable to ship between v0.4.5 (2026-07-08) and today — see #334 and the warning added to `RELEASING.md`.

## Verification of the release itself

- Downloaded `onion-0.5.0.jar` from the release, checksum verified against the published `checksums.txt`, `--version` reports `0.5.0`, and a script runs.
- Unpacked `onion-dist-0.5.0.zip` and ran the full project-CLI journey from it: `onion new hello` → `run` (prints `Hello, hello!`) → `test` (`1 tests, 1 passed, 0 failed`) → `clean` (removes `target`). `tomlj-1.1.1.jar` is present in `lib/`.

## Test plan

- [x] `sbt -Duser.language=en test` — 2439 tests, 0 failures (1 expected cancellation: dist smoke, gated behind `-Donion.dist.path`)