### PR TITLE
docs(changelog): record the Http stdlib doc fix in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Fixed wrong `Http` method names in the stdlib docs (en/ja).** `docs/reference/stdlib.md`
+  documented `Http::urlEncode`/`Http::urlDecode`, but the implemented (and tested) names are
+  `encodeUrl`/`decodeUrl` — following the doc raised a "method not found" error. Corrected both
+  names, documented the previously-missing `Http::buildUrl`, added `Http` to the "Modules at a
+  glance" summary table (English and Japanese), and added the Japanese `Http` module section that
+  was missing entirely. Also corrected the header-argument example: `headers: ["Key1", "Value1"]`
+  is a `List` in Onion, but `Http::get`/`Http::post`'s header overloads take a `String[]` only —
+  the doc now uses `new String[]{"Key1", "Value1"}`, matching what actually compiles.
+
 ## [0.5.0] - 2026-07-25
 
 - **A throw-only lambda no longer pins a type argument to `Object` (#314).**


### PR DESCRIPTION
## Summary
- PR #342 fixed wrong `Http` method names and a header-argument example in `docs/reference/stdlib.md` / `docs/ja/reference/stdlib.md`, but it merged after `[Unreleased]` had already been promoted to `[0.5.0]`, so the change left no changelog trace. Adds the missing entry.

CHANGELOG-only change, no code or docs touched.

## Test plan
- [x] `LANG=C.utf8 SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` (from PR #342, same develop base) — 2439 succeeded, 0 failed.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01PH8sTSQTtyPG8gPqGn8aop)_