### PR TITLE
docs(design): define Onion's thesis — typed boundaries

### DIFF
--- a/docs/design/onion-v0.5-audit.md
+++ b/docs/design/onion-v0.5-audit.md
@@ -1,0 +1,435 @@
+# Onion v0.5 Audit (evidence-based)
+
+Status: **audit only.** This document records what Onion v0.5 *is*, with citations
+to the implementation. It proposes nothing; the design that follows from it lives in
+[typed-boundaries.md](typed-boundaries.md), and the schedule lives in
+[roadmap.md](roadmap.md).
+
+Every claim below names a file and line range. Where a finding is "nothing does X",
+the search that established it is given so the claim can be re-run. Line numbers are
+as of `develop` @ `e4a3033c` (2026-07-25).
+
+---
+
+## 1. What Onion already does well
+
+These are load-bearing and should survive any repositioning.
+
+**A compile-time verification phase that actually runs user code.** `law` and `example`
+clauses on records are desugared into static boolean methods
+(`Rewriting.scala:583-596`, named `onion$$law$$<name>` / `onion$$example$$<name>`) and
+executed by a real pipeline phase after bytecode generation
+(`verification/LawCheckPhase.scala:32-58`), which loads the freshly compiled classes
+through `OnionClassLoader` and invokes them reflectively. A falsified law fails the
+build with a counterexample (`LawCheckPhase.scala:89-91`). Very few languages check
+properties as part of `compile`. §4 covers what is wrong with it; the *idea* is sound
+and is the natural place to machine-check a round-trip law.
+
+**A derivation that produces both directions.** `record R(...) from re"..."` synthesizes
+`parse` (`Rewriting.scala:667-670`) and — when the pattern is invertible —
+`format` (`Rewriting.scala:704-727`). The invertibility analysis (`formatSegments`,
+`Rewriting.scala:862-900`) is genuinely conservative: it rejects escapes, non-capturing
+groups, nesting, quantified groups and bare metacharacters rather than guessing.
+
+**Derivation reuses the type checker instead of duplicating it.** `synthesizeFromMethods`
+emits an ordinary `AST.RegexPattern` with one generated binding per component
+(`Rewriting.scala:644-645`), so the regex select-pattern's existing checks apply to it
+for free: bad pattern → `E0059`, group-count ≠ component-count → `E0060`
+(`typing/SelectExpressionTyping.scala:467-479`). "Capture groups must match components"
+is enforced with no dedicated code.
+
+**An open scheme-literal mechanism.** `re"…"` / `file"…"` / `http"…"` are not special:
+the parser rewrites `prefix"raw"` into the unqualified call `prefix("raw")`
+(`grammar/JJOnionParser.jj:255-261`, dispatched at `:2755-2760`). The generic
+`SCHEME_STRING` token (`:1124-1139`) means **any** identifier prefix works, so a user
+registers a scheme just by defining a function of that name — verified by
+`src/test/scala/onion/compiler/tools/UserSchemeLiteralSpec.scala`. New boundary syntax
+does not require grammar changes.
+
+**A no-crash bar with teeth.** `MutationFuzzSpec.scala` runs a deterministic mutation
+fuzzer (seed `20260610L`, 60 mutations × 59 `run/*.on` seeds = 3,540 mutants) and treats
+both escaped `Throwable`s and `I0000` internal-error diagnostics as failures
+(`:30-38`). `CompilerCrashRegressionSpec.scala` pins a 29-file crash corpus under
+`src/test/resources/crash-corpus/`, named so the corpus reads as a history.
+
+**A single choke point for assignability.** Every "does this value fit this expected
+type" decision in the compiler funnels through `AssignabilitySupport.processAssignable`
+(`typing/AssignabilitySupport.scala:60-190`) via the forwarder
+`TypingBodyPass.processAssignable` (`typing/TypingBodyPass.scala:75-76`); argument
+positions reach it through an injected function value in
+`typing/CallArgumentTypingSupport.scala:13`. 38 references, one implementation. Any
+future subsumption rule has exactly one place to go.
+
+**`Result` and `Option` are complete and wired into `do` notation.** `Result.java:161-312`
+and `Option.java:115-237` carry `map`/`flatMap`/`fold`/`recover`/`orElse`, plus the
+`successful`/`bind` pair that `do[Result]` / `do[Option]` desugar to.
+
+---
+
+## 2. Four boundary mechanisms that share nothing
+
+Onion has four ways to turn external text into typed values. They were built
+independently and have no common vocabulary.
+
+| Mechanism | Implementation | Component types |
+|---|---|---|
+| `record R(...) from re"..."` | `Rewriting.scala:636-730` | 8 scalars |
+| `derive!(Json, Yaml)` | `Rewriting.scala:772-851` | the same 8 scalars |
+| auto-CLI from `main`'s signature | `Rewriting.scala:292-436` + `src/main/java/onion/Cli.java` | the same 8 scalars |
+| scheme literals (`file""` / `http""`) | `grammar/JJOnionParser.jj:2755-2760` → `src/main/java/onion/Resources.java` | untyped; fixed method menu |
+
+### 2.1 The same eight scalars are switched on in five places
+
+`Int, Long, Double, Float, Boolean, Short, Byte, String` — enumerated separately at:
+
+- `Rewriting.scala:401-415` — `cliKindOf`, AST type → tag string
+- `Rewriting.scala:421-436` — `convertCliValue`, tag → `onion.Cli.parseX` call
+- `Rewriting.scala:438-458` — `convertCapturedValue`, tag → `java.lang.X.parseX` call
+- `Rewriting.scala:733-742` — `jsonGetterOf`, tag → `Json.getX` name
+- `src/main/java/onion/Cli.java:101-157` — the `parseX(name, value)` runtime helpers
+
+and a sixth, type-level copy of the same set in
+`typing/TypingOutlinePass.scala:297-305` (`isFromDerivableType`, with
+`isDataDerivableType` delegating to it at `:304-305`).
+
+Adding one component type — `java.time.LocalDate`, say — means six edits in two
+languages. This is not a missing feature; it is a missing abstraction.
+
+### 2.2 The four mechanisms disagree about what a "kind" is
+
+`cliKindOf` returns a `String` tag that three other functions re-match by string
+equality. `Rewriting.scala:444-458` (`convertCapturedValue`, for `from re"…"`) and
+`Rewriting.scala:421-436` (`convertCliValue`, for auto-CLI) deliberately generate
+*different* conversion calls for the same tag: the former uses raw
+`java.lang.Integer.parseInt` so a `NumberFormatException` can be caught and turned into
+`null` (`Rewriting.scala:663-665`), the latter uses `onion.Cli.parseInt` so a failure
+prints and exits. Two conversion policies, selected by which desugaring you are in.
+
+---
+
+## 3. Five failure conventions for one concept
+
+"The external data did not match what we expected" is expressed five different ways.
+
+| Situation | Behaviour | Citation |
+|---|---|---|
+| Regex does not match | returns `null` | `Rewriting.scala:660` |
+| Numeric conversion fails | returns `null` — **indistinguishable from no-match** | `Rewriting.scala:663-665` |
+| A line in `parseAll` is malformed | **silently dropped** | `Rewriting.scala:683-688` |
+| JSON/YAML is malformed | returns `null`, discarding the parser's position | `Rewriting.scala:832-834` |
+| A CLI argument is invalid | **`System.exit(1)`** | `src/main/java/onion/Cli.java:186-189` |
+| A CSV row is ragged | does not fail; the row is accepted as-is | `src/main/java/onion/Csv.java:76-79` |
+
+### 3.1 `parseAll` drops bad lines with no trace
+
+The synthesized loop guards the accumulator with a plain null check and **no else
+branch** (`Rewriting.scala:683-688` — `AST.IfExpression(..., NotEqual(__r, null), add, null)`).
+The signature is `parseAll(text: String): List[R]`, so a caller cannot learn how many
+lines were dropped, which ones, or why. `docs/reference/specification.md:252-253`
+documents this as intended ("parses each, drops the `null`s") and
+`RecordFromRegexSpec.scala:84` locks it in.
+
+### 3.2 A missing String key silently constructs a broken record
+
+This is the sharpest instance. For a record component of type `String`, the synthesized
+`fromMap` calls `Json.getString`, which returns `null` both when the key is absent and
+when it holds a non-string (`src/main/java/onion/Json.java:139-142`). That `null` is
+passed straight to the record constructor, and the generated constructor performs **no
+validation** (`typing/TypingOutlinePass.scala:196-217` creates fields, accessors and the
+`ConstructorDefinition` with no null check).
+
+So `R::fromJson("{}")` for a record with a `String` component returns a *successfully
+constructed* record whose non-nullable field is `null` — not `null`, not an error. The
+numeric case is caught only incidentally, by the unbox NPE being trapped at
+`Rewriting.scala:802-804`. **There is no test covering the String case.**
+
+### 3.3 Boolean conversion cannot fail
+
+`convertCapturedValue` maps the `Boolean` kind to `java.lang.Boolean.parseBoolean`
+(`Rewriting.scala:453`), which never throws: `"maybe"`, `"yes"` and `"1"` all become
+`false`. `Cli.parseBoolean` (`Cli.java:155-157`) has the same shape, and is the only
+`parseX` in that file that does not validate — `--count=maybe` exits with an error while
+`--loud=maybe` is silently `false`.
+
+---
+
+## 4. `law` can silently not run
+
+The verification phase is the feature most at odds with its own promise.
+
+**A law over a non-generatable parameter type is skipped with no diagnostic.**
+`LawCheckPhase.scala:80-81`:
+
+```scala
+val perParam: Array[List[AnyRef]] = paramTypes.map(t => ArgGenerator.generateValues(t, loader).orNull)
+if (perParam.exists(_ == null)) return // a parameter type isn't generatable — skip this law (MVP)
+```
+
+`ArgGenerator` can generate the 8 scalars plus their boxed forms and `String`
+(`verification/ArgGenerator.scala:72-82`), and "flat records" — exactly one declared
+constructor, non-empty parameters, every parameter recursively generatable, depth ≤ 3
+(`ArgGenerator.scala:212-274`). Arrays, `List`, `Map`, enums, interfaces, generics and
+any multi-constructor class are not generatable. A law over one of them is
+indistinguishable from a law that passed.
+
+**Two more silent-skip paths.** A class that fails to load takes all of its laws and
+examples with it (`LawCheckPhase.scala:44` swallows `Throwable` into `null`), and record
+instantiation failures are dropped entry-by-entry (`ArgGenerator.scala:261-271` catches
+five exception types), which can cascade into a whole-law skip via the rule above.
+
+**Nothing tests any of this.** There is no `ArgGeneratorSpec` and no
+`src/test/scala/onion/compiler/verification/` directory. `LawExampleSpec.scala`'s six
+cases assert only `Shell.Success("ok")` vs `Shell.Failure`; no test asserts an error
+code, a message, or a counterexample value.
+
+**Sampling is unreported and unconfigurable.** `N = 40` is hard-coded twice
+(`LawCheckPhase.scala:26`, `ArgGenerator.scala:18`); the seed is fixed at `42L`
+(`ArgGenerator.scala:20-22`) and appears in no message. `CompilerConfig` exposes only
+`checkLaws: Boolean` (`CompilerConfig.scala:27`). There is no shrinking anywhere — the
+first failing tuple is reported verbatim and the loop stops (`LawCheckPhase.scala:83-98`).
+
+**Diagnostics lose their location.** `LawCheckPhase.scala:114-115`:
+
+```scala
+private def err(code: String, cc: CompiledClass, msg: String): CompileError =
+  CompileError(cc.className, null, msg, Some(code))
+```
+
+The class name is put in the `sourceFile` slot and the location is `null`, even though
+`AST.LawClause.location` was captured at `Rewriting.scala:586` and discarded. In
+`DiagnosticRenderer.formatError` (`diagnostics/DiagnosticRenderer.scala:64-79`) this
+yields no file, no line, no caret, no source excerpt; in the LSP it lands at line 0,
+column 0 (`tools/lsp/OnionTextDocumentService.scala:622-627`).
+
+**`E0064` / `E0065` bypass i18n.** They are declared at `SemanticError.scala:132-133`
+but have **no entries in `src/main/resources/errorMessage.properties`** and no
+`SemanticErrorReporter` registration; all four messages are hard-coded English string
+interpolations at `LawCheckPhase.scala:69,72,90,95`. They are the only codes that do this.
+
+**Law checking is always on, including in the editor.** `checkLaws` defaults to `true`
+(`CompilerConfig.scala:27`) and no CLI flag sets it (`ScriptRunner.scala:266-278` and
+`CompilerFrontend.scala:189-201` construct `CompilerConfig` without it). The language
+server uses the defaults (`tools/lsp/OnionTextDocumentService.scala:574`), so **the LSP
+executes user code on every document validation.**
+
+**The documented behaviour does not match.** `docs/reference/specification.md:321-323`
+promises "a message showing the expression that returned `false`"; the implementation
+emits only the clause's label.
+
+---
+
+## 5. No runtime notion of where a value came from
+
+- `onion.compiler.Location` (`Location.scala:18-42`) is compile-time only. Its
+  `endLine` / `endColumn` span fields exist and are **never set by production code** —
+  `grep -rn "withSpan|endLine|endColumn" src/main/scala` matches only `Location.scala`
+  itself and an unrelated `RawDoc.endLine` in `tools/doc/DocModel.scala`. The only
+  producers of a spanned `Location` are tests (`src/test/scala/onion/compiler/TestSupport.scala:25`,
+  `.../diagnostics/DiagnosticRendererSpec.scala:23`). Consequently `spanLength` is always
+  1 and every caret rendered by `DiagnosticRenderer.underlineAt` (`:129-138`) is a single `^`.
+  The LSP works around this by re-deriving an end position from the line text
+  (`OnionTextDocumentService.scala:628`).
+- At runtime, position information exists in exactly two places and both are discarded
+  by the generated code: `Json.JsonParseException.position` (a character offset,
+  `Json.java:35-46`) and `Yaml.YamlParseException.line` (`Yaml.java:35-46`), both swallowed
+  by the synthesized `fromXxx`'s `catch Exception → null` (`Rewriting.scala:832-834`).
+- `grep -rniE "provenance|sourceSpan|valueOrigin" src/main src/test` → **0 matches.**
+  There is no type, field or convention associating a runtime value with a syntactic origin.
+
+## 6. `Result` / `Option` exist but the boundary layer ignores them
+
+`Result` and `Option` are complete (§1) and are the declared `do`-notation carriers, yet
+`grep` over `src/main/java/onion/` shows their only consumer in the standard library is
+`Future.java:281,294`. `Json`, `Yaml`, `Csv`, `Regex`, `FileResource`, `HttpResource`,
+`Config`, `Cli` and every synthesized `parse` return `null`, an empty collection, or exit.
+
+`Result` also lacks `zip` / `product` / any error-accumulating combinator, so reporting
+three simultaneously-bad fields in one pass is not expressible today.
+
+---
+
+## 7. The effect surface, and why capabilities are harder than they look
+
+### 7.1 The surface itself is small and already segregated
+
+12 of 45 classes in `src/main/java/onion/` perform effects, ~110 entry points total:
+
+| Effect | Classes |
+|---|---|
+| filesystem | `Files` (352 L), `FileResource` (77 L) |
+| process | `Proc` (144 L) |
+| network | `Http` (281 L), `HttpResource` (65 L) |
+| filesystem + env | `Config` (155 L) |
+| console | `IO` (240 L), `Cli` (209 L) |
+| clock | `DateTime` (2 effectful of ~40 methods: `now` :24, `nowString` :31,:38), `Timing` |
+| randomness | `Rand` (every public method) |
+
+The remaining 33 (`Json`, `Yaml`, `Csv`, `Regex`, `Strings`, `Colls`, `Maps`, `Sets`,
+`OnionMath`, `Stats`, `Text`, `Format`, `Codec`, `Hash`, `Result`, `Option`, …) are pure.
+`Resources.java:17-35` is already shaped like a capability factory: `file(String)` →
+`FileResource`, `http(String)` → `HttpResource`, `re(String)` → `Pattern`.
+
+That is a good starting position. The two problems are below.
+
+### 7.2 Five effectful classes are ambiently imported
+
+`src/main/resources/onion/default-static-imports.txt`, loaded by
+`DefaultStaticImports.scala:15-34`, static-imports into **every** source file:
+
+```
+java.lang.System, java.lang.Runtime, java.lang.Math,
+onion.IO, onion.Strings, onion.Files, onion.Iterables, onion.Regex,
+onion.DateTime, onion.Http, onion.Resources, onion.Csv
+```
+
+So `println(...)`, `readText(...)`, `get(url)`, `now()` and `System::exit` are callable
+unqualified, from anywhere, and are **indistinguishable at the call site from pure
+calls**. Any capability story has to confront this: tracking the effect is possible, but
+making it *visible to a reader* is not, while the most common effectful call in the
+language is a bare `println`.
+
+On top of that, `TypingHeaderPass.scala:42-73` implicitly on-demand-imports
+`onion.*, java.lang.*, java.io.*, java.util.*, javax.swing.*, java.awt.event.*` into every
+unit, and only single-class imports are validated (`:67-68`).
+
+### 7.3 Java interop is completely unrestricted
+
+`ClassTable.loadOrNull` (`ClassTable.scala:57-77`) tries the classpath and falls back to
+`Class.forName` with no name filter, package allowlist, or module check. The parent-first
+list in `ExplicitClasspathClassLoader.scala:50-51` (`java.`, `javax.`, `jdk.`, `sun.`,
+`com.sun.`) is about *resolution order*, not permission.
+`grep -rniE "whitelist|blacklist|allowlist|forbidden|restricted" src/main/scala` returns
+one unrelated comment (`TypingOutlinePass.scala:40`).
+
+### 7.4 The existing annotation mechanism cannot carry effects
+
+- Storage is `MethodDefinition.annotations: Set[String]` (`TypedAST.scala:735`) — bare
+  names, no arguments, no positions.
+- **The `Method` trait itself has no `annotations` member** (`TypedAST.scala:1371-1395`
+  declares `affiliation`, `arguments`, `returnType`, `typeParameters`, `isVararg`,
+  `argumentsWithDefaults` — and nothing else). `AsmRefs.scala` and `ReflectionRefs.scala`
+  never read annotations, so **no annotation on a Java method reaches the type checker.**
+- Nothing is emitted to bytecode: `grep -rn "visitAnnotation" src/main/scala` → **0 matches.**
+- `AST.Annotation` (`AST.scala:300`) attaches only to `FunctionDeclaration` (`:268`) and
+  `MethodDeclaration` (`:302`) — not to classes, fields or parameters.
+- There are exactly two readers, both testing one string:
+  `optimization/TailCallOptimization.scala:93` and
+  `optimization/MutualRecursionOptimization.scala:133`. The latter **drops annotations
+  entirely** when it rebuilds a method (`:321`, `annotations = Set.empty`).
+
+Effect information therefore cannot ride on annotations. It needs an out-of-band table
+plus a new member on the `Method` trait.
+
+---
+
+## 8. Positioning is internally inconsistent
+
+- **README contradicts itself.** `README.md:3-4` sells "an object-oriented and statically
+  typed programming language… compiles into JVM class files", while `README.md:171-205`
+  ("Shape-First Scripting") sells scheme literals, `record … from re"…"`, `|>` and an
+  auto-derived CLI. The opening paragraph and the most distinctive section describe two
+  different languages.
+- **Type classes are invisible from the front door.**
+  `grep -nE "trait|instance|type class" README.md` → 0 matches, although
+  `docs/design/type-classes.md:1` records them as "implemented (v1)" and
+  `docs/guide/type-classes.md` exists in both languages.
+- **EN/JA feature lists have drifted.** `docs/index.md:9-21` lists 13 key features;
+  `docs/ja/index.md` lists 11. The two missing from the Japanese list are
+  **"Bidirectional Records" and "Compile-Time Specs"** — the two most distinctive claims
+  in the set.
+- **Neither guide index links `guide/type-classes.md`**, though the file exists in
+  `docs/guide/` and `docs/ja/guide/` and both are in `mkdocs.yml`.
+- **There is no central design document.** `docs/design/` contained exactly one file
+  before this one (`type-classes.md`), and `docs/index.md` does not link it. The three
+  design-ish documents that are linked (`docs/GENERICS_DESIGN.md`,
+  `docs/parser-refactoring.md`, `docs/quality-bar.md`) live outside `docs/design/`.
+- **`CHANGELOG.md` contains no positioning statement**, so there is no third source to
+  arbitrate the README's self-contradiction.
+
+---
+
+## 9. Structural debt that constrains the design space
+
+**There is no IR between the typed AST and code generation.** The pipeline
+(`pipeline/PipelineRunner.scala:15-41`) runs
+parsing → rewriting → typing → TCO → mutual-recursion → bytecode → law-check, and
+`backend/BytecodeGenerationPhase.scala:11-12` takes `Seq[TypedAST.ClassDefinition]`
+straight into ASM emission (`backend/asm/`, 2,905 lines across 13 files). `TypedAST` is
+simultaneously the type checker's output, the optimizers' mutable working representation
+(`var block` at `TypedAST.scala:731`, TCO metadata setters at `:756-765`) and the codegen
+input. **There is nowhere to put a lowered, effect-erased form.** Any new type-level
+concept must either be fully erased inside `Typing`, or be understood by the ASM backend.
+
+**`Rewriting.scala` is 1,416 lines carrying ten unrelated desugarings:** type-class
+dictionary passing (`:129`), ADT enums (`:235`), auto-CLI (`:309`), `instance` lowering
+(`:501`), `Trait[T]::` lowering (`:539`), `from re"…"` (`:636`), `derive!` (`:772`),
+`law`/`example` (`:584`,`:591`), do-notation (`:1154`), and return-type hint propagation
+(`:917`). Its header comment (`:23-77`) still documents only do-notation — stale by eight
+features. `rewriteExpression` (`:999-1152`) is a ~90-case identity traversal that must be
+extended by hand for every new AST node.
+
+**Scheme-literal desugaring is split across two phases** — the parser rewrites the token
+(`grammar/JJOnionParser.jj:255-261`) and `Rewriting` handles everything else.
+
+**The typing package is 71 files / 13,943 lines**, of which call resolution alone is
+spread over 13 files (`MethodCallTyping`, `MethodResolution`, `MethodLookupSupport`,
+`MethodTargetTypingSupport`, `MethodInvocationBuilderSupport`, `InstanceMethodCallSupport`,
+`StaticMethodCallSupport`, `UnqualifiedMethodCallSupport`, `StaticImportMethodCallSupport`,
+`CallableValueCallSupport`, and three reporting/fallback helpers). Largest single files:
+`TypingOutlinePass` 754, `BlockElementLowering` 732, `SelectExpressionTyping` 699,
+`ConstructionTyping` 658, `ClosureTyping` 615.
+
+**The one choke point is already overloaded.** `AssignabilitySupport.processAssignable`
+(`AssignabilitySupport.scala:60-190`) is the right insertion point for any new subsumption
+rule (§1), but that single ~130-line method already handles empty-collection retyping
+(`:65`), bottom types (`:67-81`), constant narrowing (`:86-90`), boxing (`:92-102`), the
+null-to-non-nullable warning (`:104-109`), primitive/null rejection (`:111-115`), platform
+unboxing (`:117-133`) and structural type-variable assignability (`:138-179`).
+
+---
+
+## 10. The bar a new language feature must clear
+
+From `docs/quality-bar.md` and the test infrastructure:
+
+- an entry in **both** `docs/guide/` and `docs/ja/guide/` (parity is a measured row)
+- a `**Xxx.on**`-labeled example under `docs/examples/` **and** `docs/ja/examples/`.
+  Only labeled blocks are compile-checked, and blocks containing `...` are skipped
+  (`src/test/scala/onion/compiler/tools/DocExamplesCompileSpec.scala:33,47`). The scan
+  covers `docs/examples` and `docs/ja/examples` only (`:36`) — **`docs/design/` is not
+  compile-checked**, which is why this document and `typed-boundaries.md` may show
+  proposed syntax.
+- usage inside a ≥100-line `run/*.on` program, which then also becomes a fuzz seed
+  (+60 mutants)
+- a `src/test/resources/crash-corpus/` entry per crash found during development
+  (29 today; the type-class work added 3)
+- dedicated `E00xx` codes with **both** EN and JA messages
+- no regression in the ~2,450-test suite, which runs serially
+  (`build.sbt:183`, `Test / parallelExecution := false`)
+
+**The quality-bar baseline is stale.** `docs/quality-bar.md:7-12` records "1193 pass / 0
+fail" and "36 / 36 compile" as of 2026-06-26; the suite is now ~2,450 tests and there are
+59 files in `run/`. Row 3's list of large programs and row 7's "~24 codes" are likewise
+behind.
+
+**An unwired asset.** `src/main/scala/onion/tools/readiness/docs/`
+(`MarkdownExampleExtractor.scala`, 347 lines, plus `DocumentationDirective.scala` and
+`DocumentationExample.scala`) implements a richer doc-example framework supporting
+`<!-- onion-example: compile | run | reject code=E0059 | fragment reason="…" -->` and
+`<!-- onion-output: stdout -->` directives. Its specs exercise it against inline strings
+only; **it is not connected to the documentation tree.** It is available as a foundation
+for stricter doc verification.
+
+---
+
+## Summary
+
+The recurring pattern is not missing features — it is **four parallel implementations of
+one idea, each choosing its own failure convention, none of which can say where anything
+came from.** The eight-scalar list is written out five times (§2.1); the same conceptual
+failure is reported five ways (§3); the compile-time verification that would catch the
+resulting bugs can silently not run (§4); and there is no runtime type that carries a
+position, so even the failures that *are* reported cannot point at their cause (§5).
+
+The design in [typed-boundaries.md](typed-boundaries.md) addresses this by naming the
+missing abstraction rather than adding a fifth mechanism.

--- a/docs/design/readme-rewrite-proposal.md
+++ b/docs/design/readme-rewrite-proposal.md
@@ -1,0 +1,126 @@
+# README rewrite — proposal
+
+Status: **proposal.** Nothing in `README.md` has been changed. This is the concrete
+version of [#354](https://github.com/onion-lang/onion/issues/354), split out so the
+wording can be argued about before it lands.
+
+## The problem, precisely
+
+`README.md` currently sells two different languages.
+
+**Lines 1–4** — the first thing anyone reads:
+
+> Onion - A Statically Typed Programming Language on JVM
+> Onion is an object-oriented and statically typed programming language. Source codes of
+> Onion compiles into JVM class files as in-memory or real files.
+
+Every property claimed there — static typing, object orientation, JVM bytecode — is
+shared with Kotlin, Scala, Java, Groovy and Ceylon. It is a *category*, not a reason to
+use Onion. Lines 5–7 then spend the next paragraph on rewrite history (Java → Scala,
+JavaCC), which is interesting to a contributor and irrelevant to a reader deciding
+whether to care.
+
+**Lines 171–205** — "Shape-First Scripting", buried as the sixth subsection of "Language
+Snapshot":
+
+> Onion collapses the boilerplate layers a script usually needs.
+
+*That* is the actual thesis, and it is 171 lines down.
+
+Three further inconsistencies, from [audit §8](onion-v0.5-audit.md):
+
+- `grep -nE "trait|instance|type class" README.md` → **0 matches**, although type classes
+  are implemented and shipped (`docs/design/type-classes.md:1`, "implemented (v1)") and
+  documented in `docs/guide/type-classes.md` in both languages. A headline feature is
+  absent from the front door.
+- `docs/index.md` lists 13 key features; `docs/ja/index.md` lists 11. The two missing from
+  Japanese are **"Bidirectional Records"** and **"Compile-Time Specs"** — the two most
+  distinctive items in the list.
+- `CHANGELOG.md` contains no positioning statement, so there is no third source to
+  arbitrate the README's self-contradiction.
+
+## Proposed opening
+
+Replacing lines 1–7:
+
+```markdown
+## Onion — typed tools for a messy world
+
+Onion is a statically typed language for turning messy external data and operations
+into checked, reversible tools. It runs on the JVM and calls Java directly.
+
+Most languages hand you a `String` at the boundary and wish you luck. Onion asks you
+to describe the boundary once — and derives the parser, the printer, the failure
+channel and the command-line interface from that one description.
+
+```onion
+record Access(time: String, method: String, path: String, status: Int)
+  from re"(\S+) (\w+) (\S+) (\d+)"
+  law roundtrip(a: Access) { Access::parse(Access::format(a)) == a }
+
+def main(path: String, min: Int = 400): void {
+  file(path).lines()
+    .map { line => Access::parse(line) }
+    .filter { a => a != null && a.status() >= min }
+    |> println
+}
+```
+
+One declaration gives you `parse`, `format`, a `law` the **compiler checks at build
+time**, and a CLI with `--min` and `--help` derived from `main`'s signature.
+```
+
+Notes on the sample: it is deliberately written in **current** v0.5 syntax, not the
+proposed `shape` syntax, so the README stays true while v0.6 is in progress. When
+[#350](https://github.com/onion-lang/onion/issues/350) lands, this block changes with it.
+
+The rewrite history (current lines 5–7) moves to `## Architecture` (line 207), where it
+belongs.
+
+## Proposed structure
+
+Current order buries the differentiators under the generic features:
+
+```
+Language Snapshot
+  Null Safety            ← Kotlin has this
+  Records, Enums, …      ← Java/Scala have this
+  Do Notation            ← Scala/Haskell have this
+  Trailing Lambda        ← Kotlin has this
+  Async with Future      ← everyone has this
+  Shape-First Scripting  ← ONLY Onion has this
+```
+
+Proposed: lead with what is unique, then the table stakes.
+
+```
+Language Snapshot
+  Boundaries           bidirectional records, scheme literals, |>, auto-CLI
+  Checked at Build     law / example, exhaustiveness, null safety
+  Types                records, enums, generics, type classes   ← currently missing entirely
+  Everyday             do notation, trailing lambdas, Future
+```
+
+A reader who stops after the first section should already know what Onion is for.
+
+## Companion changes
+
+Same issue, since they are the same inconsistency:
+
+- add the two missing bullets to `docs/ja/index.md` so EN/JA parity is real (13 vs 11);
+- link `guide/type-classes.md` from both guide indexes — the file exists in
+  `docs/guide/` and `docs/ja/guide/` and is in `mkdocs.yml`, but neither index links it;
+- link `docs/design/` from `docs/index.md`, which today links three design-ish documents
+  that live *outside* that directory (`GENERICS_DESIGN.md`, `parser-refactoring.md`,
+  `quality-bar.md`) and does not link `docs/design/type-classes.md` at all;
+- refresh the `docs/quality-bar.md` baseline: it records "1193 pass / 0 fail" and
+  "36 / 36 compile" as of 2026-06-26, against an actual ~2,450 tests and 59 files in `run/`.
+
+## What is deliberately not proposed
+
+**Deleting "statically typed" or "JVM".** They are true, they are what a reader filters
+on, and they belong in the second sentence. The objection is to leading with them.
+
+**Rewriting the README around v0.6 syntax now.** The README must describe the language
+that exists. The positioning changes now because it is wrong now; the code samples change
+when the code does.

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -1,0 +1,168 @@
+# Roadmap — v0.6 to v0.8
+
+Status: **index.** The roadmap itself lives on GitHub, because a roadmap in a file goes
+stale the moment work starts. This page exists so a reader who is not looking at the
+issue tracker can see the shape of the plan and follow it to the detail.
+
+- Why: [onion-v0.5-audit.md](onion-v0.5-audit.md) — what v0.5 is, with citations
+- What: [typed-boundaries.md](typed-boundaries.md) — the design thesis
+- When: the milestones below
+
+| Milestone | Theme | Issues |
+|---|---|---|
+| [v0.6](https://github.com/onion-lang/onion/milestone/17) | One boundary, one failure | 10 |
+| [v0.7](https://github.com/onion-lang/onion/milestone/18) | Contracts and capabilities | 6 |
+| [v0.8](https://github.com/onion-lang/onion/milestone/19) | Reversible | 3 |
+
+Each issue carries the same fields: user value, differentiation, dependencies, affected
+modules, complexity, migration risk, test strategy, docs impact, demo.
+
+---
+
+## v0.6 — One boundary, one failure
+
+The boring foundation. Onion has four boundary mechanisms that share nothing and five
+ways to report the same failure (audit §2, §3); this milestone replaces them with one
+declarative data boundary and one failure channel that knows where things came from.
+
+Verification is fixed **first**, deliberately. The headline claim is that
+`parse ∘ print == id` is machine-checked at build time — but today a law whose parameter
+type has no generator is skipped with no diagnostic and no test coverage
+(`LawCheckPhase.scala:80-81`). A verification that can silently not run produces unearned
+confidence, so it is a prerequisite rather than a cleanup.
+
+| # | Item |
+|---|---|
+| [#346](https://github.com/onion-lang/onion/issues/346) | law/example verification must never silently skip |
+| [#347](https://github.com/onion-lang/onion/issues/347) | `Origin` — a runtime type for where a value came from |
+| [#348](https://github.com/onion-lang/onion/issues/348) | `Outcome[T]` and `Defect` — one failure channel, with accumulation |
+| [#349](https://github.com/onion-lang/onion/issues/349) | one scalar conversion registry (collapse five duplicated switches) |
+| [#350](https://github.com/onion-lang/onion/issues/350) | `Shape[T]` and named `shape` declarations |
+| [#351](https://github.com/onion-lang/onion/issues/351) | Shape combinators — `lines`, `sepBy`, `xmap`, `zip`, `orElse` |
+| [#352](https://github.com/onion-lang/onion/issues/352) | json/yaml/csv shapes, retiring `derive!` |
+| [#353](https://github.com/onion-lang/onion/issues/353) | resource literals take a shape; `Cli` stops calling `System.exit` |
+| [#354](https://github.com/onion-lang/onion/issues/354) | fix the positioning — README, EN/JA parity, quality-bar baseline |
+| [#355](https://github.com/onion-lang/onion/issues/355) | broken-log demo, guides, examples, crash corpus |
+
+Rough order: #346 → #347 → #348 → #349 → #350 → #351 → {#352, #353} → {#354, #355}.
+
+**Demo:** 1,000 access-log lines, 5 malformed. You get 995 typed values *and* 5 defects
+with line numbers. Today `parseAll` returns 995 values and no trace the other 5 existed.
+
+## v0.7 — Contracts and capabilities
+
+The differentiator. `Shape` types the data crossing the boundary; capabilities type the
+effects crossing it. One `tool` declaration derives its CLI, a machine-readable contract,
+a statically checked capability set, and a `--plan` dry run.
+
+| # | Item |
+|---|---|
+| [#356](https://github.com/onion-lang/onion/issues/356) | effect table and `Method`-level effect access |
+| [#357](https://github.com/onion-lang/onion/issues/357) | `tool` declaration, effect inference, capability checking |
+| [#358](https://github.com/onion-lang/onion/issues/358) | machine-readable contract, and derive the CLI from it |
+| [#359](https://github.com/onion-lang/onion/issues/359) | `--plan`, a dry run derived from the effect set |
+| [#360](https://github.com/onion-lang/onion/issues/360) | narrow the default static import set |
+| [#361](https://github.com/onion-lang/onion/issues/361) | agent-callable tool demo |
+
+#360 is independent of the rest and is the highest-blast-radius change in the roadmap;
+it is kept separate for that reason.
+
+**Demo:** an agent reads a tool's contract, runs `--plan` to see it would write two files
+and contact one host, and only then executes. Today the CLI "contract" is a
+comma-separated string with the types erased, and there is no dry run at all.
+
+## v0.8 — Reversible
+
+The moonshot, scheduled last because `Origin` (#347) makes it affordable and attempting
+it first would mean building the entire foundation plus the hardest feature at once.
+
+| # | Item |
+|---|---|
+| [#362](https://github.com/onion-lang/onion/issues/362) | lossless shapes and residue |
+| [#363](https://github.com/onion-lang/onion/issues/363) | lens — edit parsed data and write it back intact |
+| [#364](https://github.com/onion-lang/onion/issues/364) | open `Shape` to user-written instances |
+
+**Demo:** read a commented config, change one field, write it back — comments and
+formatting intact, `diff` shows one line.
+
+---
+
+## Breaking changes
+
+Onion has one user today, so v0.6 and v0.7 break compatibility where the alternative is
+carrying a bad design forward. The full list with rationale is in
+[typed-boundaries.md §8](typed-boundaries.md). The largest are: `parse` returning
+`Outcome` instead of `T?`, `derive!` and `from re"…"` being replaced by named `shape`
+declarations, `Cli` no longer calling `System.exit`, and (v0.7) the default static import
+set narrowing.
+
+---
+
+## Feasibility: the first slice
+
+Before committing to the milestones above, two structural risks were checked against the
+implementation. Both came back clear.
+
+### Risk 1 — is `processAssignable` a bottleneck? **It is not on the path.**
+
+`AssignabilitySupport.processAssignable` (`typing/AssignabilitySupport.scala:60-190`) is
+the single choke point every "does this value fit this type" decision passes through — 38
+references, one implementation. It looked like the natural home for any new subsumption
+rule, but it is already a ~130-line method carrying seven orthogonal concerns
+(empty-collection retyping, bottom types, constant narrowing, boxing, the
+null-to-non-nullable warning, primitive/null rejection, platform unboxing, structural
+type-variable assignability), so adding an eighth would be the riskiest edit in the plan.
+
+It turns out not to be needed:
+
+- **`Shape[T]` needs nothing there.** A shape is an ordinary generic class. "A lossless
+  shape is usable where an L1 shape is expected" is plain subtyping, already handled.
+- **Effects need nothing there either.** Effects are declared and checked *only* at `tool`
+  boundaries ([typed-boundaries.md §6.5](typed-boundaries.md)), which is a whole-program
+  question about a call graph, not a pairwise type-compatibility question. It belongs in
+  its own pass.
+
+That pass has direct precedent. `CompilerPhase` is a four-line trait
+(`pipeline/CompilerPhase.scala`) and `CompilationPhases` already holds **two** phases of
+exactly the shape an effect check needs — `CompilerPhase[Seq[TypedAST.ClassDefinition],
+Seq[TypedAST.ClassDefinition]]` (`pipeline/PipelineRunner.scala:19-20`, the TCO and
+mutual-recursion passes). Adding a third is a local change.
+
+One caveat: `PipelineRunnerSpec.scala:22-31` pins the phase-name sequence, so a new phase
+means updating that spec deliberately rather than by accident. That is a feature.
+
+### Risk 2 — does the slice need compiler changes at all? **Barely.**
+
+`Origin`, `Defect` and `Outcome[T]` are ordinary classes in `src/main/java/onion/`. The
+`zip`/`bind` law split is a library concern. A first `Shape[T]` with `parse`/`print` is
+likewise a library type. **The compiler is not involved until the `shape` declaration form
+and `E0074`**, which means the risky, high-blast-radius work (grammar, `Rewriting.scala`'s
+already-overloaded 1,416 lines, `TypingOutlinePass`) can be deferred until the runtime
+design has been validated against real programs.
+
+That is the opposite of the usual order and it is the right one here: the semantics are
+the uncertain part, not the syntax.
+
+### Recommended starting order
+
+1. **#346 first, and alone.** It is the only item that changes behaviour people already
+   depend on, it is self-contained, and everything downstream leans on laws actually
+   running. It also has the sharpest first failing test.
+2. **#347 → #348 as pure library work**, verified by ordinary specs.
+3. **#349 (the scalar registry) as the first compiler edit**, because it is a
+   consolidation of code that already exists — five switches becoming one — rather than a
+   new concept. It is the cheapest way to find out how much `Rewriting.scala` resists.
+4. **#350 only then.**
+
+### The first failing test
+
+For #346, in a file that does not exist yet
+(`src/test/scala/onion/compiler/verification/ArgGeneratorSpec.scala` — note there is no
+`verification` test directory at all today):
+
+> A record carrying `law l(xs: List) { true }` compiles today and reports nothing,
+> because `LawCheckPhase.scala:80-81` returns silently when a parameter type has no
+> generator. The test asserts the compilation fails with **`E0078`**.
+
+It fails today for the right reason — the compile succeeds — and it pins the single
+behaviour that makes the rest of the roadmap honest.

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -136,7 +136,7 @@ means updating that spec deliberately rather than by accident. That is a feature
 `Origin`, `Defect` and `Outcome[T]` are ordinary classes in `src/main/java/onion/`. The
 `zip`/`bind` law split is a library concern. A first `Shape[T]` with `parse`/`print` is
 likewise a library type. **The compiler is not involved until the `shape` declaration form
-and `E0074`**, which means the risky, high-blast-radius work (grammar, `Rewriting.scala`'s
+and the non-invertible-`print` diagnostic**, which means the risky, high-blast-radius work (grammar, `Rewriting.scala`'s
 already-overloaded 1,416 lines, `TypingOutlinePass`) can be deferred until the runtime
 design has been validated against real programs.
 
@@ -162,7 +162,7 @@ For #346, in a file that does not exist yet
 
 > A record carrying `law l(xs: List) { true }` compiles today and reports nothing,
 > because `LawCheckPhase.scala:80-81` returns silently when a parameter type has no
-> generator. The test asserts the compilation fails with **`E0078`**.
+> generator. The test asserts the compilation fails with **`E0074`**.
 
 It fails today for the right reason — the compile succeeds — and it pins the single
 behaviour that makes the rest of the roadmap honest.

--- a/docs/design/typed-boundaries.md
+++ b/docs/design/typed-boundaries.md
@@ -1,0 +1,553 @@
+# Typed Boundaries — Onion's design thesis
+
+Status: **proposed.** Nothing here is implemented. This document defines what Onion is
+*for* from v0.6 onward and the small semantic core it derives from. The evidence it
+argues from is in [onion-v0.5-audit.md](onion-v0.5-audit.md); the schedule is in
+[roadmap.md](roadmap.md).
+
+Code blocks show **proposed** syntax. `docs/design/` is deliberately outside the scope of
+`DocExamplesCompileSpec` (`src/test/scala/onion/compiler/tools/DocExamplesCompileSpec.scala:36`),
+so nothing here is compile-checked.
+
+---
+
+## 1. Positioning
+
+> **Onion — typed tools for a messy world.**
+> A statically typed language for turning messy external data and operations into
+> checked, reversible tools.
+
+Today Onion introduces itself as "an object-oriented and statically typed programming
+language" that "compiles into JVM class files" (`README.md:3-4`). Every word of that is
+shared with Kotlin, Scala and Java. It is a category, not a reason.
+
+The reason is at the **boundary**: the place where untrusted text becomes a typed value,
+and where a program reaches out and changes the world. That is where real programs
+actually fail, and it is the one place mainstream languages still hand you a `String` and
+wish you luck. Onion's claim is:
+
+- **Describe the boundary once, declaratively.** Both directions, the failure channel and
+  the tooling are *derived*, not hand-written.
+- **A failure at the boundary is a value that knows where it came from.** Not `null`, not
+  a silently dropped line, not `System.exit(1)`.
+- **The effects a tool may perform are part of its type**, so a contract can be published
+  and a dry run can be trusted.
+
+Onion v0.5 already has four half-built boundary mechanisms (audit §2). This design does
+not add a fifth. It names the abstraction they were all approximating and rebuilds them
+on it.
+
+### Design constraints this document holds itself to
+
+1. No feature grab-bag — four new concepts, and every existing mechanism is re-derived
+   from them or deleted.
+2. Not a small version of an existing language — the weirdness must be somewhere no
+   mainstream language goes.
+3. Failure visibility over convenience — where the two conflict, visibility wins, even at
+   the cost of ergonomics.
+4. Derive from a small semantic core — concepts must compose, not accumulate.
+5. Weirdness must be semantic, not syntactic — cute syntax is not a moat.
+
+---
+
+## 2. The core, in four concepts
+
+Two of these are *boring* — they are what any language doing this seriously would need,
+and they are where most of the v0.6 work goes. Two are the *moat*.
+
+| | Concept | Role |
+|---|---|---|
+| Core 1 | `Origin` | where a runtime value came from |
+| Core 2 | `Outcome[T]` / `Defect` | the one failure channel |
+| **Core 3** | **`Shape[T]`** | **the data boundary — the boring foundation** |
+| **Core 4** | **`tool` / `Capability` / `Plan`** | **the operation boundary — the moat** |
+
+---
+
+## 3. Core 1 — `Origin`
+
+```onion
+record Origin(source: String, line: Int, column: Int, span: Int)
+```
+
+The runtime counterpart to the compiler's `onion.compiler.Location`. Onion has nothing
+like it today: `grep -rniE "provenance|sourceSpan|valueOrigin" src/main src/test` returns
+zero matches (audit §5), the two exceptions that *do* carry a position
+(`Json.JsonParseException.position`, `Yaml.YamlParseException.line`) have it discarded by
+the generated code, and even the compile-time `Location`'s span fields are never set in
+production, so every diagnostic caret is a single `^`.
+
+`Origin` is listed first because everything else degrades to hand-waving without it. A
+`Defect` with no `Origin` is just a string; a Lens (§9) has nothing to attach to.
+
+`source` is deliberately a free-form string, not a `File` — it names a file path, a URL,
+`"<stdin>"` or `"<literal>"` depending on where the text entered the program.
+
+**Companion change (compile-time).** `Location`'s dead `endLine`/`endColumn` span
+(`Location.scala:21-22`) gets populated by the parser so `spanLength` stops always
+returning 1 and `DiagnosticRenderer.underlineAt` (`:129-138`) can underline a real range.
+A language selling diagnostics quality cannot ship one-character carets.
+
+---
+
+## 4. Core 2 — `Outcome[T]` and `Defect`
+
+```onion
+record Defect(origin: Origin?, path: String, expected: String, actual: String)
+
+enum Outcome[T] {
+  case Ok(value: T)
+  case Bad(defects: List[Defect])
+}
+```
+
+`path` locates the failure *inside* the value (`"status"`, `"items[3].price"`);
+`origin` locates it in the *text*. Both are needed: one answers "which field", the other
+"which byte".
+
+### 4.1 Why not `Result[T, List[Defect]]`
+
+Because the two have different composition laws, and the difference is the point.
+
+`Result` is monadic: `bind` short-circuits, so the first bad field hides the rest.
+`Outcome` additionally offers an **accumulating** product:
+
+```
+Ok(f)      zip  Ok(x)       =  Ok((f, x))
+Bad(d₁)    zip  Ok(_)       =  Bad(d₁)
+Ok(_)      zip  Bad(d₂)     =  Bad(d₂)
+Bad(d₁)    zip  Bad(d₂)     =  Bad(d₁ ++ d₂)          ← the reason this type exists
+```
+
+This is the standard Validation-vs-Either split, and it is exactly what a boundary needs:
+a record with three malformed fields should report three defects in one pass, not one
+defect three times. `Result` has no `zip` or accumulating combinator at all today
+(audit §6), so this cannot be expressed by reusing it.
+
+`Outcome` still gets `successful`/`bind` so `do[Outcome]` works with the existing
+machinery — `bind` short-circuits (it must; the second computation may depend on the
+first), `zip` accumulates. Both are available; the derivation in §5 uses `zip`.
+
+### 4.2 What this replaces
+
+Audit §3 lists five conventions for one concept. All five collapse:
+
+| Today | v0.6 |
+|---|---|
+| `null` on regex no-match (`Rewriting.scala:660`) | `Bad([Defect(origin, "", "<pattern>", line)])` |
+| `null` on conversion failure, indistinguishable (`:663-665`) | `Bad` with `expected: "Int"`, `actual: "abc"` — **distinguishable** |
+| silently dropped `parseAll` lines (`:683-688`) | every drop is a `Defect` with its line's `Origin` |
+| `null` from `fromJson`, position discarded (`:832-834`) | the parser's position becomes an `Origin` |
+| `System.exit(1)` from `Cli` (`Cli.java:186-189`) | `Outcome`, returned to the caller |
+
+And two silent-corruption holes close:
+
+- **A missing String key** currently constructs a record with a `null` non-nullable field
+  and calls it success (audit §3.2). It becomes `Bad(path: "name", expected: "String",
+  actual: "absent")`.
+- **`"maybe"` currently parses as `false`** via `Boolean.parseBoolean`
+  (`Rewriting.scala:453`, audit §3.3). Boolean conversion becomes strict; anything outside
+  the shape's accepted spellings is a `Defect`.
+
+Both are breaking changes and both are the point: constraint 3 says visibility beats
+convenience.
+
+---
+
+## 5. Core 3 — `Shape[T]`, the data boundary
+
+A `Shape[T]` is a first-class value describing a **partial, potentially bidirectional**
+correspondence between external text and a typed value.
+
+```
+Shape[T] = {
+  parse : (Text, Origin) -> Outcome[T]
+  print : T -> Text                       // present only when derivable
+}
+```
+
+### 5.1 Semi-formal laws
+
+Write `dom(S) = { t | S.parse(t, _) is Ok }`.
+
+**(L1) Round-trip — print then parse.** For every shape that has `print`:
+
+```
+∀ v : T.   S.parse(S.print(v), _)  ==  Ok(v)
+```
+
+This is the law worth having, and it is the one a shape must guarantee.
+
+**(L2) Normalization — parse then print.** *Not* guaranteed, and deliberately so:
+
+```
+∀ t ∈ dom(S).  S.print(S.parse(t, _).value)  ==  t        -- FALSE in general
+```
+
+`"007"` parses to `7` and prints as `"7"`. `{ "a":1 }` and `{"a": 1}` parse alike. A shape
+satisfying L2 as well is called **lossless**, and losslessness is rare, valuable, and the
+foundation of §9's Lens. Most shapes are L1-only.
+
+Keeping L1 and L2 distinct is the substance behind "reversible". Today's synthesized
+`format` conflates them: the comment at `Rewriting.scala:697-703` claims
+`parse(format(x)) == x` "for data that doesn't collide with the literals" — an L1 claim
+with an unchecked side condition, and nothing verifies it (audit §1, §3).
+
+**(L3) Failure carries position.** `S.parse(t, o)` returning `Bad(ds)` implies every
+`d ∈ ds` has `d.origin` derived from `o` — a defect always points somewhere.
+
+### 5.2 Shapes are named values, not record attachments
+
+```onion
+record Access(time: String, method: String, path: String, status: Int)
+
+shape AccessLine : Access = re"(\S+) (\w+) (\S+) (\d+)"
+shape AccessJson : Access = json
+shape AccessCsv  : Access = csv
+```
+
+Today a record may have **one** `from re"..."` and a fixed marker set
+`derive!(Json, Yaml)`, which bolts nine statics onto the record (`parse`, `parseAll`,
+`format`, `toMap`, `fromMap`, `toJson`, `fromJson`, `toYaml`, `fromYaml`). That does not
+scale past two formats, and the names collide the moment you want two regex shapes for
+the same type — a v1 log line and a v2 log line, say.
+
+Making shapes named values fixes all of it and buys composition:
+
+```onion
+val r: Outcome[Access] = AccessLine.parse(line)
+val s: String          = AccessLine.print(rec)
+
+// many shapes for one type; pick at the call site
+val rows: Outcome[List[Access]] = file"access.log".as(AccessLine.lines)
+val body: Outcome[Access]       = http"…/latest".as(AccessJson)
+```
+
+### 5.3 Combinators
+
+Shapes compose, which is what makes them an abstraction rather than a fourth macro:
+
+| Combinator | Type | Meaning |
+|---|---|---|
+| `S.lines` | `Shape[T] -> Shape[List[T]]` | one `T` per line; **every failed line is a `Defect`**, none dropped |
+| `S.sepBy(sep)` | `Shape[T] -> Shape[List[T]]` | repetition |
+| `S.xmap(f, g)` | `Shape[T] -> (T->U, U->T) -> Shape[U]` | isomorphism; preserves L1 |
+| `S.zip(R)` | `Shape[A] -> Shape[B] -> Shape[(A,B)]` | accumulating product (§4.1) |
+| `S.orElse(R)` | `Shape[T] -> Shape[T] -> Shape[T]` | first success; on total failure, defects from both |
+
+`xmap` takes a *pair* of functions rather than a single `map` precisely because a shape is
+bidirectional: a one-way `map` would silently destroy `print`. That asymmetry is the type
+telling the truth.
+
+`S.lines` is where audit §3.1 dies. Its result is `Outcome[List[T]]`, and a run over 1,000
+lines with 5 malformed ones yields the 995 values *and* 5 defects with line numbers —
+today's `parseAll` returns 995 values and no evidence the other 5 existed.
+
+### 5.4 One conversion registry
+
+The eight-scalar switch that exists five times over (audit §2.1) becomes one registry
+mapping a component type to a `Shape` for that scalar. Adding `java.time.LocalDate` means
+one entry, not six edits across two languages.
+
+The registry is also the natural place to make Boolean strict (§4.2) and to give each
+scalar an *L1-checked* print, since a scalar shape is exactly a tiny bidirectional pair.
+
+### 5.5 Typing rules
+
+Shape formation from a regex, for a record `τ` with components `c₁:τ₁ … cₙ:τₙ`:
+
+```
+  Γ ⊢ τ record with components c₁:τ₁ … cₙ:τₙ
+  ∀i. τᵢ ∈ ScalarRegistry
+  p compiles;  groups(p) = n
+─────────────────────────────────────────────── (S-Regex)
+  Γ ⊢ shape S : τ = re"p"    ⇒    S : Shape[τ]
+```
+
+Failing premises map onto the existing codes, which is deliberate — `E0059` (bad pattern)
+and `E0060` (group/component mismatch) already exist and already fire for
+`from re"..."` because the desugaring routes through the regex select-pattern
+(`typing/SelectExpressionTyping.scala:467-479`, audit §1). `E0061`'s role (unsupported
+component type) is taken over by "no entry in the registry".
+
+Print derivability is a *judgement about the shape*, not a silent fork:
+
+```
+  segments(p) = literal/slot decomposition
+  every slot is flat, top-level and unquantified
+──────────────────────────────────────────────── (S-Print)
+  Γ ⊢ S has print,  and L1 holds for S
+```
+
+When the premise fails, `S` is parse-only and `S.print` is a **compile error naming the
+construct that made it non-invertible** — `E0074` below. Today `formatSegments`
+(`Rewriting.scala:862-900`) just returns `None` and no `format` appears, so the user gets
+"method not found" for a method they were never told would be missing.
+
+---
+
+## 6. Core 4 — `tool`, capabilities, and plans (the moat)
+
+`Shape` types the **data** crossing the boundary. `Capability` types the **effects**
+crossing it. Same principle, other axis — which is why this is a completion of the thesis
+rather than a second feature.
+
+```onion
+tool ingest(src: File, dst: File, dry: Boolean = false)
+  requires { read(src), write(dst) }
+{
+  val rows = file(src).as(AccessLine.lines)
+  ...
+}
+```
+
+One declaration derives four things:
+
+1. **The CLI** — flags, positionals, usage, `--help`, shell completion.
+2. **A machine-readable contract** — emitted as a resource and printed by `--contract`.
+3. **A capability set** — checked statically against the body.
+4. **A plan** — `--plan` reports what the run *would* do, without doing it.
+
+### 6.1 Why this is a moat
+
+Python + argparse, Go's `flag`, Rust's clap and every `#[derive(Parser)]` in between
+derive a CLI from a signature. **None of them derive a trustworthy dry run**, because
+none of them know what the body does. Effect systems (Koka, Eff, Unison's abilities) know
+what the body does but are whole-language type systems with a correspondingly steep price,
+and they do not emit tool contracts.
+
+Onion's bet is the narrow intersection: **effects tracked only at the tool boundary,
+which is exactly enough to publish a contract and derive a plan.** In an era where the
+caller of a script is increasingly an agent rather than a person, "here is a machine-
+readable contract, and here is a dry run you can trust" is a concrete, checkable value
+proposition. It is semantic weirdness — effects in the type — not syntactic.
+
+### 6.2 Effects and the effect table
+
+```
+ε ::= read(p) | write(p) | net(h) | exec(c) | env | clock | rand | console | unknown
+```
+
+Audit §7.1 is the good news: only 12 of 45 stdlib classes are effectful, ~110 entry
+points, already lexically segregated, and `Resources.java:17-35` is already shaped like a
+capability factory.
+
+Audit §7.4 is the bad news: **effects cannot ride on annotations.** The `Method` trait has
+no `annotations` member (`TypedAST.scala:1371-1395`), `AsmRefs`/`ReflectionRefs` never
+read annotations so nothing on a Java method reaches the type checker, nothing is emitted
+to bytecode (`visitAnnotation` → 0 matches), and `MutualRecursionOptimization.scala:321`
+drops the field it does have. So:
+
+- effects live in an **out-of-band effect table**, keyed by class + method signature,
+  shipped as a resource — the same shape as `default-static-imports.txt`;
+- the `Method` trait gains a way to report its effects, defaulting to `unknown` for
+  anything the table does not name.
+
+### 6.3 The unknown-effect decision
+
+A Java method not in the table has unknown effects. The two obvious policies are both wrong:
+
+- *unknown = forbidden* kills interop instantly — Onion's whole stdlib story is Java
+  interop, and no table will ever cover the JDK plus every jar on the classpath;
+- *unknown = harmless* makes the guarantee a lie, which is worse than having no guarantee.
+
+**The proposal is: `unknown` is a real effect that propagates.** It costs nothing inside
+ordinary code, but it must be explicitly admitted at a tool boundary:
+
+```onion
+tool scrape(url: String) requires { net(url), unknown } { ... }
+```
+
+`--plan` then honestly reports `unknown` for the parts it cannot characterize, instead of
+claiming a clean bill of health. The user can shrink the surface by adding table entries.
+This keeps constraint 3 (visibility over convenience) without making interop unusable.
+
+### 6.4 Ambient effects — the hardest problem
+
+`println`, `readText`, `get` and `System::exit` are callable unqualified from anywhere,
+because `onion.IO`, `onion.Files`, `onion.Http`, `onion.DateTime`, `onion.Resources` and
+`java.lang.System` are default static imports (audit §7.2).
+
+Tracking their effects still works — resolution knows which method it picked. What breaks
+is *legibility*: a reader cannot see that a line is effectful, so `requires` clauses will
+look arbitrary. Narrowing the default static import set is the fix, and it is a large
+breaking change in its own right, orthogonal to everything else here. It is therefore
+scheduled as **its own roadmap item**, not folded into the capability work.
+
+`console` is the pragmatic escape valve: it is the one effect that is likely to be
+implicitly permitted, because a `println` in a tool is not what anyone is trying to guard
+against.
+
+### 6.5 Typing rules
+
+Effects ride alongside the type as `τ ! ε`:
+
+```
+  m ∈ EffectTable,  EffectTable(m) = ε_m
+────────────────────────────────────────────── (E-Call)
+  Γ ⊢ m(ē) : τ ! ε_m ∪ effects(ē)
+
+  m ∉ EffectTable
+────────────────────────────────────────────── (E-Unknown)
+  Γ ⊢ m(ē) : τ ! {unknown} ∪ effects(ē)
+
+  Γ, x̄:τ̄ ⊢ body : τ ! ε        ε ⊆ δ
+────────────────────────────────────────────── (T-Tool)
+  Γ ⊢ tool f(x̄:τ̄) requires δ { body }   ok
+```
+
+`ε ⊄ δ` is `E0076`, and the message names both the missing capability *and* the call site
+that introduced it — the diagnostic is useless otherwise.
+
+Effects propagate through ordinary functions by inference (no annotation burden), and are
+**only declared and checked at `tool` boundaries**. There is no effect polymorphism, no
+effect variables in ordinary signatures, no handlers. That restraint is what keeps this
+from being a small version of Koka (constraint 2).
+
+### 6.6 Erasure — a hard feasibility constraint
+
+Audit §9: there is **no IR between the typed AST and codegen**. `TypedAST` is the type
+checker's output, the optimizers' mutable working representation and the ASM backend's
+input all at once, so there is nowhere to put a lowered, effect-annotated form.
+
+Therefore **effects must be completely erased inside `Typing`**. A `tool` lowers to:
+
+- an ordinary static method with the declared parameters,
+- a synthesized contract constant (the machine-readable descriptor),
+- a synthesized entry point that parses argv via the parameters' shapes and dispatches.
+
+The ASM backend learns nothing new. This is not an optimization — it is the condition
+under which the feature is buildable at all without first introducing an IR.
+
+---
+
+## 7. Error model
+
+New codes continue from the current maximum, `E0073` (`SemanticError.scala:141`):
+
+| Code | Meaning |
+|---|---|
+| `E0074` | `print` used on a shape that is not invertible — message names the construct responsible |
+| `E0075` | no scalar-registry entry for a component type (replaces `E0061`/`E0062`'s role) |
+| `E0076` | a tool's body performs an effect its `requires` clause does not admit |
+| `E0077` | a `requires` clause admits a capability the body cannot perform (dead capability) |
+| `E0078` | a law's parameter type has no generator — **an error, not a silent skip** |
+
+Every one gets an entry in **both** `errorMessage.properties` and
+`errorMessage_ja.properties`. That is worth stating because `E0064`/`E0065` are today the
+only codes that bypass the i18n table entirely, with English hard-coded at
+`LawCheckPhase.scala:69,72,90,95` (audit §4).
+
+`E0078` deserves emphasis. Onion's headline claim is that `parse ∘ print == id` is
+machine-checked at build time. Today a law whose parameter type has no generator is
+skipped with `return` and no diagnostic (`LawCheckPhase.scala:80-81`), and there is no
+test covering it. **A verification that can silently not run is worse than no
+verification**, because it produces unearned confidence. Turning that skip into an error
+is a prerequisite for the whole Shape story, not a nicety — which is why it lands in v0.6
+*before* `Shape` (see roadmap).
+
+---
+
+## 8. Compatibility — the breaking changes
+
+Onion has one user, so these are affordable. Listing them explicitly is the point.
+
+| # | Change | Rationale |
+|---|---|---|
+| 1 | `R::parse` returns `Outcome[R]`, not `R?` | no-match and conversion-failure become distinguishable (audit §3) |
+| 2 | `parseAll` → `S.lines`, returning `Outcome[List[R]]` | dropped lines become visible defects (audit §3.1) |
+| 3 | `fromJson` returns `Outcome[R]`; a missing `String` key is a defect | closes the silent-corruption hole (audit §3.2) |
+| 4 | Boolean conversion is strict | `"maybe"` is a defect, not `false` (audit §3.3) |
+| 5 | `onion.Cli` no longer calls `System.exit` | makes CLI failures catchable and testable (audit §3) |
+| 6 | `record … from re"…"` / `derive!(…)` replaced by named `shape` declarations | one type may have many shapes; removes nine bolted-on statics (§5.2) |
+| 7 | `FileResource`/`HttpResource`'s fixed method menu replaced by `.as(shape)` | a fixed menu cannot be extended by a user (audit §2) |
+| 8 | law checking is off by default in the LSP; `--check-laws` controls it elsewhere | the language server currently executes user code on every validation (audit §4) |
+| 9 | *(v0.7)* the default static import set narrows | ambient effects are unreadable (§6.4) |
+
+Changes 1–5 are mechanical at the call site. Change 6 is a rewrite of every shape
+declaration. Change 9 is the largest and is scheduled separately.
+
+---
+
+## 9. Reversibility (v0.8, sketched)
+
+A **lossless** shape satisfies L2 as well as L1 (§5.1): parsing and reprinting is the
+identity on the text, comments and whitespace included. That makes a *lens* possible —
+read a config, change one field, write it back, and the diff is one line:
+
+```onion
+val cfg = file"app.conf".as(ConfShape)     // lossless
+val out = ConfShape.print(cfg.value.with(port = 9090))
+```
+
+This is worth flagging as **the payoff that motivates `Origin`**. Provenance is not
+decoration: it is what lets the printer put untouched text back exactly where it was.
+
+Deliberately scheduled last. Attempted first, it would require building `Origin`,
+`Outcome` and `Shape` anyway, plus a residue representation — with none of the earlier
+pieces available to test against.
+
+---
+
+## 10. Rejected alternatives
+
+**Lossless Lens as the v0.6 headline.** This was the original nomination for the moat.
+Rejected as the *first* move: there is no runtime provenance type to attach a lens to
+(audit §5 — zero matches for `provenance`/`sourceSpan`/`valueOrigin`), so it would mean
+building the entire foundation *and* the hardest feature simultaneously, with nothing to
+validate the foundation against. It becomes cheap once `Origin` exists, so it is v0.8 (§9).
+
+**A general effect system (algebraic effects, handlers, effect polymorphism).** Rejected
+under constraint 2: it makes Onion a small version of Koka, costs a whole-language type
+system change, and is not what produces the value. The value is the *contract at the
+boundary*; effects on every function are the expensive part with the worst
+ergonomics-to-payoff ratio. Effects are declared and checked **only at `tool` boundaries**.
+
+**Carrying effects into codegen.** Rejected on feasibility: there is no IR between
+`TypedAST` and ASM emission (audit §9), so this would mean teaching a 2,905-line backend
+about a new type-level concept, or building an IR first. Effects erase inside `Typing` (§6.6).
+
+**Keeping `from re"…"` syntax and swapping only the internals.** Rejected because
+breaking changes are affordable here and the syntax should name the concept. The
+attachment form also structurally caps a type at one regex shape and a fixed marker list
+(§5.2) — the limitation is in the syntax, not the implementation.
+
+**`Shape` as an open type class over arbitrary user types.** Deferred, not rejected
+outright. Onion has type classes (`docs/design/type-classes.md`), so `Shape[T]` as a
+class with user-written instances is tempting. But the first version needs a *closed*,
+derivable set with an explicit escape hatch, so that "the compiler knows whether `print`
+exists and why" (§5.5) stays decidable. Opening it is a natural v0.8+ step once the
+closed core has proven its laws.
+
+**Refinement or dependent types for validation.** Rejected under constraint 1 and cost:
+`status: Int where 100 <= status < 600` is attractive, but it is a second, much larger type
+system serving a narrow slice of the boundary story, and `Shape` + `Outcome` already
+express the same constraint as a parse-time defect with a position — which is strictly
+more useful at a boundary, because it can say *where* in the input the bad value was.
+
+**Making `Outcome` an alias for `Result[T, List[Defect]]`.** Rejected: the accumulating
+`zip` (§4.1) has different laws from `Result`'s short-circuiting `bind`, and conflating
+them is how "report all three bad fields" quietly becomes "report the first bad field".
+
+**Fixing the four mechanisms in place instead of unifying them.** Rejected as the
+non-solution it is: it would mean five copies of the scalar table instead of five, five
+failure conventions instead of five, and no answer to "what *is* Onion for".
+
+---
+
+## 11. What this buys, concretely
+
+Three demos, one per milestone, each impossible or silently wrong today.
+
+**Repair a broken log (v0.6).** 1,000 access-log lines, 5 malformed. `AccessLine.lines`
+returns 995 typed values *and* 5 defects with line numbers and reasons. Today `parseAll`
+returns 995 values and no trace of the other 5 (audit §3.1).
+
+**A tool an agent can call (v0.7).** One `tool` declaration yields a CLI, `--help`, a
+machine-readable contract and `--plan`. An agent reads the contract, runs `--plan` to see
+that it would write two files and hit one host, and only then executes. Today the CLI
+"contract" is a comma-separated string with the types erased
+(`Rewriting.scala:371-376` → `Cli.java:26-42`) and there is no dry run at all.
+
+**Edit a config without destroying it (v0.8).** Read a commented config, change one
+field, write it back with comments and formatting intact.

--- a/docs/design/typed-boundaries.md
+++ b/docs/design/typed-boundaries.md
@@ -430,6 +430,7 @@ numbers below are therefore indicative of order, not commitments.
 | Code | Meaning | Status |
 |---|---|---|
 | `E0074` | a law's parameter type has no generator — **an error, not a silent skip** | **shipped** ([#346](https://github.com/onion-lang/onion/issues/346)) |
+| `E0075` | a class declaring laws could not be loaded, so none of its checks ran | **shipped** ([#346](https://github.com/onion-lang/onion/issues/346)) |
 | next | `print` used on a shape that is not invertible — message names the construct responsible | v0.6 |
 | next | no scalar-registry entry for a component type (replaces `E0061`/`E0062`'s role) | v0.6 |
 | next | a tool's body performs an effect its `requires` clause does not admit | v0.7 |

--- a/docs/design/typed-boundaries.md
+++ b/docs/design/typed-boundaries.md
@@ -280,7 +280,7 @@ Print derivability is a *judgement about the shape*, not a silent fork:
 ```
 
 When the premise fails, `S` is parse-only and `S.print` is a **compile error naming the
-construct that made it non-invertible** — `E0074` below. Today `formatSegments`
+construct that made it non-invertible** — see the error model below. Today `formatSegments`
 (`Rewriting.scala:862-900`) just returns `None` and no `format` appears, so the user gets
 "method not found" for a method they were never told would be missing.
 
@@ -396,7 +396,7 @@ Effects ride alongside the type as `τ ! ε`:
   Γ ⊢ tool f(x̄:τ̄) requires δ { body }   ok
 ```
 
-`ε ⊄ δ` is `E0076`, and the message names both the missing capability *and* the call site
+An effect the `requires` clause does not admit is an error, and the message names both the missing capability *and* the call site
 that introduced it — the diagnostic is useless otherwise.
 
 Effects propagate through ordinary functions by inference (no annotation burden), and are
@@ -423,28 +423,29 @@ under which the feature is buildable at all without first introducing an IR.
 
 ## 7. Error model
 
-New codes continue from the current maximum, `E0073` (`SemanticError.scala:141`):
+Codes are allocated **sequentially as features land**, not reserved in advance — a
+reserved block leaves permanent gaps whenever a planned feature changes shape. The
+numbers below are therefore indicative of order, not commitments.
 
-| Code | Meaning |
-|---|---|
-| `E0074` | `print` used on a shape that is not invertible — message names the construct responsible |
-| `E0075` | no scalar-registry entry for a component type (replaces `E0061`/`E0062`'s role) |
-| `E0076` | a tool's body performs an effect its `requires` clause does not admit |
-| `E0077` | a `requires` clause admits a capability the body cannot perform (dead capability) |
-| `E0078` | a law's parameter type has no generator — **an error, not a silent skip** |
+| Code | Meaning | Status |
+|---|---|---|
+| `E0074` | a law's parameter type has no generator — **an error, not a silent skip** | **shipped** ([#346](https://github.com/onion-lang/onion/issues/346)) |
+| next | `print` used on a shape that is not invertible — message names the construct responsible | v0.6 |
+| next | no scalar-registry entry for a component type (replaces `E0061`/`E0062`'s role) | v0.6 |
+| next | a tool's body performs an effect its `requires` clause does not admit | v0.7 |
+| next | a `requires` clause admits a capability the body cannot perform (dead capability) | v0.7 |
 
 Every one gets an entry in **both** `errorMessage.properties` and
 `errorMessage_ja.properties`. That is worth stating because `E0064`/`E0065` are today the
 only codes that bypass the i18n table entirely, with English hard-coded at
 `LawCheckPhase.scala:69,72,90,95` (audit §4).
 
-`E0078` deserves emphasis. Onion's headline claim is that `parse ∘ print == id` is
-machine-checked at build time. Today a law whose parameter type has no generator is
-skipped with `return` and no diagnostic (`LawCheckPhase.scala:80-81`), and there is no
-test covering it. **A verification that can silently not run is worse than no
+`E0074` deserves emphasis, and is the reason it shipped first. Onion's headline claim is
+that `parse ∘ print == id` is machine-checked at build time. Before #346 a law whose
+parameter type had no generator was skipped with a bare `return` and no diagnostic, with
+no test covering it. **A verification that can silently not run is worse than no
 verification**, because it produces unearned confidence. Turning that skip into an error
-is a prerequisite for the whole Shape story, not a nicety — which is why it lands in v0.6
-*before* `Shape` (see roadmap).
+is a prerequisite for the whole Shape story, not a nicety.
 
 ---
 

--- a/docs/design/typed-boundaries.md
+++ b/docs/design/typed-boundaries.md
@@ -229,19 +229,30 @@ Shapes compose, which is what makes them an abstraction rather than a fourth mac
 
 | Combinator | Type | Meaning |
 |---|---|---|
-| `S.lines` | `Shape[T] -> Shape[List[T]]` | one `T` per line; **every failed line is a `Defect`**, none dropped |
-| `S.sepBy(sep)` | `Shape[T] -> Shape[List[T]]` | repetition |
+| `S.eachLine` | `Shape[T] -> (Text, Origin) -> List[Outcome[T]]` | one outcome per line, each positioned on its line |
+| `S.lines` | `Shape[T] -> Shape[List[T]]` | all-or-nothing; **every failed line is a `Defect`**, none dropped |
+| `S.sepBy(sep)` | `Shape[T] -> Shape[List[T]]` | repetition with a **literal** separator |
 | `S.xmap(f, g)` | `Shape[T] -> (T->U, U->T) -> Shape[U]` | isomorphism; preserves L1 |
-| `S.zip(R)` | `Shape[A] -> Shape[B] -> Shape[(A,B)]` | accumulating product (§4.1) |
 | `S.orElse(R)` | `Shape[T] -> Shape[T] -> Shape[T]` | first success; on total failure, defects from both |
+
+`eachLine` and `lines` answer different questions, and an earlier draft of this document
+conflated them by claiming `lines` returns "995 values *and* 5 defects". It cannot: an
+`Outcome` is a value **or** defects. A log file is exactly the case where a partial result
+is worth having, so `eachLine` returns one outcome per line and `Outcome.values` /
+`Outcome.defects` (§4) recover both; `lines` is for when a partial result is meaningless.
+
+`sepBy` takes a literal separator rather than a pattern because a regex separator has no
+unique rendering — the shape would silently become read-only. A general `zip` over two
+*text* shapes is deliberately absent: a product needs a rule for where one component's
+text ends and the next begins, and without a delimiter there is none. `sepBy` is that rule.
 
 `xmap` takes a *pair* of functions rather than a single `map` precisely because a shape is
 bidirectional: a one-way `map` would silently destroy `print`. That asymmetry is the type
 telling the truth.
 
-`S.lines` is where audit §3.1 dies. Its result is `Outcome[List[T]]`, and a run over 1,000
-lines with 5 malformed ones yields the 995 values *and* 5 defects with line numbers —
-today's `parseAll` returns 995 values and no evidence the other 5 existed.
+`eachLine` is where audit §3.1 dies. A run over 1,000 lines with 5 malformed ones yields
+the 995 values *and* 5 defects carrying their line numbers — today's `parseAll` returns
+995 values and no evidence the other 5 existed.
 
 ### 5.4 One conversion registry
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,11 @@ nav:
       - Building from Source: contributing/building.md
       - Releasing: RELEASING.md
   - Design Notes:
+      - "Typed Boundaries (thesis)": design/typed-boundaries.md
+      - v0.5 Audit: design/onion-v0.5-audit.md
+      - "Roadmap: v0.6-v0.8": design/roadmap.md
+      - README Rewrite Proposal: design/readme-rewrite-proposal.md
+      - Type Classes: design/type-classes.md
       - Generics Design: GENERICS_DESIGN.md
       - Parser Refactoring: parser-refactoring.md
       - Quality Bar: quality-bar.md


### PR DESCRIPTION
Design-only PR. No code changes, no behaviour changes.

## Why

Onion v0.5 compiles and runs but cannot say what it is for. `README.md:3-4` sells "an object-oriented and statically typed programming language" that "compiles into JVM class files" — a category shared with Kotlin, Scala and Java — while `README.md:171-205` ("Shape-First Scripting") sells something else. Neither is a reason to choose Onion.

## What is here

| Document | Contents |
|---|---|
| [`onion-v0.5-audit.md`](https://github.com/onion-lang/onion/blob/docs/typed-boundaries/docs/design/onion-v0.5-audit.md) | What v0.5 is, every claim cited to a file and line |
| [`typed-boundaries.md`](https://github.com/onion-lang/onion/blob/docs/typed-boundaries/docs/design/typed-boundaries.md) | The thesis: positioning, four core concepts, semi-formal laws, typing rules, error model, breaking changes, rejected alternatives |
| [`roadmap.md`](https://github.com/onion-lang/onion/blob/docs/typed-boundaries/docs/design/roadmap.md) | Index into the GitHub milestones + the feasibility assessment |
| [`readme-rewrite-proposal.md`](https://github.com/onion-lang/onion/blob/docs/typed-boundaries/docs/design/readme-rewrite-proposal.md) | Concrete wording for #354, split out so it can be argued about separately |

## What the audit found

Four mechanisms turn external text into typed values (`from re"..."`, `derive!`, auto-CLI, scheme literals) and share nothing:

- the same **eight scalar types are switched on in five places** across two languages (`Rewriting.scala:401-415`, `:421-436`, `:438-458`, `:733-742`, `Cli.java:101-157`), plus a sixth type-level copy — adding `LocalDate` is six edits
- the same conceptual failure is reported **five different ways**: `null`, a second indistinguishable `null`, a silently dropped line, a `null` that discards the parser's position, and `System.exit(1)`

Two findings are sharp enough to call out:

- **A missing String key silently constructs a broken record.** `Json.getString` returns `null` for both "absent" and "not a string" (`Json.java:139-142`), the record constructor performs no validation (`TypingOutlinePass.scala:196-217`), so `R::fromJson("{}")` returns a *successfully constructed* record with a `null` non-nullable field. **No test covers this.**
- **`law` can silently not run.** A law whose parameter type has no generator is skipped with a bare `return` and no diagnostic (`LawCheckPhase.scala:80-81`); there is no `ArgGeneratorSpec` and no `verification` test directory. The headline claim that `parse ∘ format == id` is machine-checked cannot currently be relied on.

## The design, in one paragraph

Name the abstraction those four mechanisms were approximating instead of adding a fifth. `Origin` gives runtime values a position — there is none today (`provenance`/`sourceSpan`/`valueOrigin` have **zero matches** repo-wide, and even the compile-time `Location`'s span fields are never set in production, so every caret is a single `^`). `Outcome`/`Defect` gives one accumulating failure channel. `Shape[T]` is the declarative data boundary. Those three are the boring foundation.

The differentiator is the other axis: **`Shape` types the data crossing a boundary, capabilities type the effects crossing it.** One `tool` declaration derives its CLI, a machine-readable contract, a statically checked capability set, and a `--plan` dry run. argparse, Go's `flag` and clap all derive a CLI from a signature; none knows what the body does, so none can offer a dry run you can trust. Effect systems know, but are whole-language type systems emitting no contracts.

## Two deviations worth your attention

1. **Lossless lenses were the original nomination for the differentiator; they are scheduled last (v0.8).** With no runtime provenance type to attach them to, doing them first means building the entire foundation *and* the hardest feature simultaneously, with nothing to validate the foundation against.
2. **`law` hardening is scheduled before `Shape`,** not after. If the law that proves the round-trip can silently not run, the central claim is hollow.

## Feasibility (checked against the implementation, not assumed)

- **`processAssignable` is not on the path.** The 130-line choke point carrying seven concerns looked like the natural home for new subsumption rules. It is not needed: `Shape[T]` is an ordinary generic class, and effect checking is a whole-program question belonging in its own pass — for which `CompilerPhase[Seq[ClassDefinition], Seq[ClassDefinition]]` already has two instances (`PipelineRunner.scala:19-20`).
- **The first slice is almost entirely runtime-library work.** `Origin`, `Outcome` and a first `Shape` are ordinary classes; the compiler is not involved until the `shape` declaration form. The semantics can be validated before touching `Rewriting.scala`'s overloaded 1,416 lines.
- **The first failing test is identified**: a record carrying `law l(xs: List) { true }` compiles silently today; it should be `E0078`.

## Roadmap

On GitHub so it cannot go stale — [v0.6](https://github.com/onion-lang/onion/milestone/17) (10), [v0.7](https://github.com/onion-lang/onion/milestone/18) (6), [v0.8](https://github.com/onion-lang/onion/milestone/19) (3), #346–#364. Each issue carries user value, differentiation, dependencies, affected modules, complexity, migration risk, test strategy, docs impact and demo. `roadmap.md` is an index only.

## Verification

- [x] Every `file:line` citation in the audit re-checked by hand against `develop` @ `e4a3033c` — the subagent-reported ASM line count was wrong (2,918/14 files → **2,905/13**) and is corrected
- [x] `DocExamplesCompileSpec` — 13 tests, 0 failures, all still from `docs/examples`, confirming `docs/design/` is outside its scan (`:36`) and may show proposed syntax
- [x] `mkdocs build --strict` passes; design notes are now in the nav — **they were previously unreachable from anywhere**, `type-classes.md` included
- [x] No code changes, so no full-suite run: `git diff --stat develop...HEAD` touches only `docs/design/` and `mkdocs.yml`

## What this PR deliberately does not do

Change `README.md`. The rewrite is proposed as a separate document so the wording can be settled before it ships (#354).
