### PR TITLE
chore(session): add SessionStart hook to fix sbt/locale in web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Ensures `sbt` (required by CLAUDE.md's build/test commands) is usable in a
+# freshly cloned container:
+#
+#  1. Origin carries remote-tracking branches whose names contain byte
+#     sequences that are not valid in this container's ASCII (POSIX/C)
+#     locale (e.g. `codex/bcel...asm...` with mojibake Japanese text). sbt's
+#     scalafix plugin scans all refs at project-load time via jgit, and
+#     `File.toPath()` throws `InvalidPathException` on those names, which
+#     hangs `sbt` at a "Project loading failed: (r)etry..." prompt -- so
+#     *every* sbt invocation fails before compiling or testing anything.
+#     Switching to the `C.utf8` locale makes those byte sequences valid
+#     path characters again, so the ref scan succeeds.
+#  2. `sbt` itself is not preinstalled in this container. Download the
+#     launcher matching project/build.properties if it's missing.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+if locale -a 2>/dev/null | grep -qi '^C\.utf8$'; then
+  echo 'export LC_ALL=C.utf8' >> "$CLAUDE_ENV_FILE"
+  echo 'export LANG=C.utf8' >> "$CLAUDE_ENV_FILE"
+elif locale -a 2>/dev/null | grep -qi '^C\.UTF-8$'; then
+  echo 'export LC_ALL=C.UTF-8' >> "$CLAUDE_ENV_FILE"
+  echo 'export LANG=C.UTF-8' >> "$CLAUDE_ENV_FILE"
+fi
+
+SBT_HOME="$HOME/.local/sbt-launcher"
+
+if ! command -v sbt >/dev/null 2>&1 && [ ! -x "$SBT_HOME/bin/sbt" ]; then
+  SBT_VERSION="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$CLAUDE_PROJECT_DIR/project/build.properties" | head -1)"
+  mkdir -p "$SBT_HOME"
+  curl -fsSL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
+    | tar xz -C "$SBT_HOME" --strip-components=1
+fi
+
+if [ -x "$SBT_HOME/bin/sbt" ] && ! command -v sbt >/dev/null 2>&1; then
+  echo "export PATH=\"$SBT_HOME/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+# Warm the build (dependency resolution + compile) so later `sbt compile`/
+# `sbt test` invocations in the session don't pay the cold-cache cost.
+cd "$CLAUDE_PROJECT_DIR"
+PATH="$SBT_HOME/bin:$PATH" LC_ALL=C.utf8 LANG=C.utf8 SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt compile

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(git checkout:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(mkdir -p /home/user/onion/.claude/hooks)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary

Every Claude Code on the web session for this repo currently fails to run `sbt` at all:

- `origin` carries remote-tracking branches whose names contain byte sequences that are invalid under this container's POSIX/C locale (mojibake `codex/bcel...asm...` branch names). sbt's scalafix plugin scans **all** refs via jgit at project-load time, and `File.toPath()` throws `InvalidPathException` on those names, hanging sbt at a `Project loading failed: (r)etry...` prompt before it compiles or tests anything.
- `sbt` is also not preinstalled in a fresh container.

Confirmed by reproducing it in this session: `sbt compile`/`sbt test` failed with the above `InvalidPathException` until the local remote-tracking refs were pruned and the locale switched to `C.utf8` — after which a full `sbt -Duser.language=en test` ran clean (2442 passed, 0 failed, 1 opt-in smoke test skipped as designed).

- `.claude/hooks/session-start.sh` — switches the session to the `C.utf8` locale (fixing the ref-scan crash) and installs the sbt launcher pinned by `project/build.properties` if it's not already on `PATH`, then warms the build with `sbt compile`.
- `.claude/settings.json` — registers the hook for `SessionStart`.

No compiler/runtime code changed; this only affects how future Claude Code web sessions bootstrap themselves, so no `CHANGELOG.md` entry.

## Test plan

- [x] `sbt compile` succeeds after the locale fix (previously hung on `InvalidPathException`)
- [x] `sbt -Duser.language=en test`: 2442 succeeded, 0 failed, 1 canceled (opt-in dist smoke test, by design)
- [x] Hook validated standalone (`CLAUDE_CODE_REMOTE=true`, stripped `PATH`, throwaway `HOME`): installs sbt, writes `LC_ALL`/`LANG`/`PATH` to `$CLAUDE_ENV_FILE`, `sbt compile` succeeds
- [x] Re-ran the hook a second time to confirm it's idempotent (skips the download, still succeeds)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKPb8JDavQUXH3CCQbS9GA)_