### PR TITLE
Route law/example compile-time check messages through the i18n bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **`law`/`example` compile-time check failures (E0064/E0065) are now bilingual.** `LawCheckPhase`
+  built these two diagnostics as hardcoded English string interpolation instead of going through
+  the `errorMessage`/`errorMessage_ja` resource bundles like every other error, so a Japanese
+  locale never got a translated message for a falsified law or a failed example. Added the message
+  keys to both bundles and switched the phase to format through `toolbox.Message`.
+
 ## [0.6.0] - 2026-07-25
 
 - **Fixed wrong `Http` method names in the stdlib docs (en/ja).** `docs/reference/stdlib.md`

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -82,4 +82,8 @@ error.semantic.recordDeriveComponentUnsupported=record component {0} has type {1
 error.semantic.recordDeriveUnknownMarker=unknown derive! marker `{0}`. Supported markers: Json, Yaml.
 error.semantic.rawTypeNotAllowed=raw type {0} is not allowed; supply type arguments (e.g. {0}[...]). Onion forbids raw generic types.
 error.semantic.missingReturn=method {0} may reach the end of its body without returning a {1}. Every path must return a value (or throw); use an explicit `return`, or the `= expr` body form.
+error.semantic.exampleFailedFalse=example `{0}` in {1} failed: evaluated to false
+error.semantic.exampleFailedThrew=example `{0}` in {1} failed: threw {2}
+error.semantic.lawFalsified=law `{0}` in {1} falsified by counterexample: ({2})
+error.semantic.lawThrew=law `{0}` in {1} threw on ({2}): {3}
 error.parsing.unexpected_eof=unexpected end of file — a closing `}` or `)` is probably missing.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -81,5 +81,9 @@ error.semantic.recordDeriveComponentUnsupported=レコード成分 {0} の型 {1
 error.semantic.recordDeriveUnknownMarker=未知の derive! マーカー `{0}` です。サポートしているマーカー: Json, Yaml。
 error.semantic.rawTypeNotAllowed=raw 型 {0} は使用できません。型引数を指定してください（例 {0}[...]）。Onion では raw なジェネリック型を禁止しています。
 error.semantic.missingReturn=メソッド {0} は値 {1} を返さずに本体の末尾に到達する可能性があります。すべてのパスで値を返す（または throw する）必要があります。明示的な `return` を書くか、`= expr` 形式の本体を使ってください。
+error.semantic.exampleFailedFalse=example `{0}`（{1}）が失敗しました: false と評価されました。
+error.semantic.exampleFailedThrew=example `{0}`（{1}）が失敗しました: {2} がスローされました。
+error.semantic.lawFalsified=law `{0}`（{1}）が反例 ({2}) によって反証されました。
+error.semantic.lawThrew=law `{0}`（{1}）が ({2}) で {3} をスローしました。
 error.parsing.unexpected_eof=予期しないファイル終端です — 閉じ括弧 `}` か `)` が足りない可能性があります。
 error.semantic.valRequiresInitializer=\u30ed\u30fc\u30ab\u30eb val {0} \u306f\u5ba3\u8a00\u6642\u306b\u521d\u671f\u5316\u3059\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002\u521d\u671f\u5316\u5f0f\u3092\u8ffd\u52a0\u3059\u308b\uff08val {0}: T = ...\uff09\u304b\u3001\u5f8c\u3067\u4ee3\u5165\u3057\u305f\u3044\u5834\u5408\u306f var \u3092\u4f7f\u3063\u3066\u304f\u3060\u3055\u3044\u3002

--- a/src/main/scala/onion/compiler/verification/LawCheckPhase.scala
+++ b/src/main/scala/onion/compiler/verification/LawCheckPhase.scala
@@ -3,6 +3,7 @@ package onion.compiler.verification
 import onion.compiler.{CompiledClass, CompileError, CompilerConfig, OnionClassLoader, SemanticError}
 import onion.compiler.exceptions.CompilationException
 import onion.compiler.pipeline.{CompilerPhase, PhaseContext}
+import onion.compiler.toolbox.Message
 
 import java.lang.reflect.{InvocationTargetException, Method, Modifier}
 import scala.collection.mutable.ArrayBuffer
@@ -66,10 +67,10 @@ final class LawCheckPhase(config: CompilerConfig)
     val label = m.getName.substring(ExamplePrefix.length)
     try {
       if (m.invoke(null) != java.lang.Boolean.TRUE)
-        errors += err(SemanticError.EXAMPLE_FAILED.errorCode, cc, s"example '$label' in ${simpleName(cc)} failed: evaluated to false")
+        errors += err(SemanticError.EXAMPLE_FAILED.errorCode, cc, Message("error.semantic.exampleFailedFalse", Array[Any](label, simpleName(cc))))
     } catch {
       case e: Throwable =>
-        errors += err(SemanticError.EXAMPLE_FAILED.errorCode, cc, s"example '$label' in ${simpleName(cc)} failed: threw ${describe(rootCause(e))}")
+        errors += err(SemanticError.EXAMPLE_FAILED.errorCode, cc, Message("error.semantic.exampleFailedThrew", Array[Any](label, simpleName(cc), describe(rootCause(e)))))
     }
   }
 
@@ -87,12 +88,12 @@ final class LawCheckPhase(config: CompilerConfig)
       val shown = if (args.isEmpty) "(no args)" else args.map(String.valueOf).mkString(", ")
       try {
         if (m.invoke(null, args*) != java.lang.Boolean.TRUE) {
-          errors += err(SemanticError.LAW_VIOLATION.errorCode, cc, s"law '$label' in ${simpleName(cc)} falsified by counterexample: ($shown)")
+          errors += err(SemanticError.LAW_VIOLATION.errorCode, cc, Message("error.semantic.lawFalsified", Array[Any](label, simpleName(cc), shown)))
           done = true
         }
       } catch {
         case e: Throwable =>
-          errors += err(SemanticError.LAW_VIOLATION.errorCode, cc, s"law '$label' in ${simpleName(cc)} threw on ($shown): ${describe(rootCause(e))}")
+          errors += err(SemanticError.LAW_VIOLATION.errorCode, cc, Message("error.semantic.lawThrew", Array[Any](label, simpleName(cc), shown, describe(rootCause(e)))))
           done = true
       }
     }

--- a/src/test/scala/onion/compiler/LawCheckMessageI18nSpec.scala
+++ b/src/test/scala/onion/compiler/LawCheckMessageI18nSpec.scala
@@ -1,0 +1,46 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.util.{Locale, MissingResourceException, ResourceBundle}
+
+/**
+ * `law`/`example` compile-time check failures (E0064/E0065) are built directly in
+ * LawCheckPhase rather than through SemanticErrorReporter, and used to hard-code English
+ * text instead of going through the bilingual `errorMessage` bundle like every other
+ * diagnostic. Both locale bundles must carry the keys LawCheckPhase resolves.
+ */
+class LawCheckMessageI18nSpec extends AnyFunSpec with Diagrams {
+  private val keys = Seq(
+    "error.semantic.exampleFailedFalse",
+    "error.semantic.exampleFailedThrew",
+    "error.semantic.lawFalsified",
+    "error.semantic.lawThrew"
+  )
+
+  private def assertResolvable(locale: Locale): Unit = {
+    val bundle = ResourceBundle.getBundle("errorMessage", locale)
+    for (key <- keys) {
+      try bundle.getString(key)
+      catch {
+        case _: MissingResourceException => fail(s"missing key '$key' for locale $locale")
+      }
+    }
+  }
+
+  it("resolves every LawCheckPhase message key in the English bundle") {
+    assertResolvable(Locale.ENGLISH)
+  }
+
+  it("resolves every LawCheckPhase message key in the Japanese bundle") {
+    assertResolvable(Locale.JAPANESE)
+  }
+
+  it("formats placeholders via onion.compiler.toolbox.Message") {
+    val falsified = onion.compiler.toolbox.Message("error.semantic.lawFalsified", Array[Any]("roundtrip", "Pt", "3, 4"))
+    assert(falsified.contains("roundtrip"))
+    assert(falsified.contains("Pt"))
+    assert(falsified.contains("3, 4"))
+  }
+}


### PR DESCRIPTION
## Why

`LawCheckPhase` (compile-time `law`/`example` clause checking, E0064/E0065) builds its `CompileError` messages with hardcoded English string interpolation instead of going through the `errorMessage`/`errorMessage_ja` resource bundles that every other diagnostic in the compiler uses. As a result, a Japanese-locale build (`errorMessage_ja.properties`) never got a translated message for a falsified law or a failed example — these two codes silently bypassed i18n.

## What

- Added `error.semantic.exampleFailedFalse`, `error.semantic.exampleFailedThrew`, `error.semantic.lawFalsified`, and `error.semantic.lawThrew` message keys to both `errorMessage.properties` and `errorMessage_ja.properties`.
- Switched `LawCheckPhase` to format its four failure messages via `onion.compiler.toolbox.Message` instead of raw `s"..."` interpolation.
- Added `LawCheckMessageI18nSpec`, which asserts both locale bundles resolve all four keys and that `Message` formatting substitutes placeholders correctly (this caught a real bug during development: `Message`'s overloaded `apply` silently picks the single-arg `Any` overload instead of the `Array[Any]` one when passed an `Array[String]` literal, since Scala arrays are invariant — fixed by widening to `Array[Any]` explicitly at each call site).
- Added a matching `[Unreleased]` entry to `CHANGELOG.md`.

No user-visible behavior change beyond the message text now being locale-aware; error codes, compile success/failure, and existing `LawExampleSpec`/`RecordDuplicateLawExampleSpec` assertions (which check codes/`Shell.Failure`, not message text, per this repo's testing convention) are unaffected.

## Test plan

- [x] Added `LawCheckMessageI18nSpec` — confirmed red before the fix (missing bundle keys), green after
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.LawCheckMessageI18nSpec onion.compiler.tools.LawExampleSpec onion.compiler.tools.RecordDuplicateLawExampleSpec'` — all pass
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2445 passed, 0 failed, 1 canceled


---
_Generated by [Claude Code](https://claude.ai/code/session_017fGDvCsBCxdfM6SBnL5nE4)_