### PR TITLE
fix: constant narrowing now reaches constructor arguments (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Constant narrowing now reaches constructor arguments (#374).** `val b: Byte = 100` has always
+  narrowed an in-range integer literal to `Byte`/`Short`/`Char`, but `new All("hi", -3, -4)` for a
+  `Short`/`Byte`-typed constructor parameter reported `E0021` ("constructor applicable ... is not
+  found") and needed an explicit `(-3 as Short)` cast. Constructor overload resolution matched
+  arguments only via boxing-aware assignability, never consulting the same constant-narrowing
+  rule `AssignabilitySupport` already applied to plain assignment. Extracted the literal-narrowing
+  check into a shared `ConstantNarrowing` helper and applied it to `ConstructionTyping`'s
+  boxing-fallback constructor resolution, both when selecting the matching constructor and when
+  adapting the chosen literal argument's type.
+
 - **`law`/`example` compile-time check failures (E0064/E0065) are now bilingual.** `LawCheckPhase`
   built these two diagnostics as hardcoded English string interpolation instead of going through
   the `errorMessage`/`errorMessage_ja` resource bundles like every other error, so a Japanese

--- a/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
+++ b/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
@@ -39,24 +39,6 @@ private[compiler] final class AssignabilitySupport(
     }
   }
 
-  /** The compile-time int value of an integer literal or its unary negation,
-    * for constant narrowing (`100`, `-128`). */
-  private def constantIntOf(term: Term): Option[Int] = term match {
-    case iv: IntValue => Some(iv.value)
-    case u: UnaryTerm if u.kind == UnaryTerm.Kind.MINUS =>
-      u.operand match { case iv: IntValue => Some(-iv.value); case _ => None }
-    case _ => None
-  }
-
-  /** Whether an integer literal fits the range of a narrow integral target,
-    * enabling `val b: Byte = 100` style constant narrowing. */
-  private def integerLiteralFits(bt: BasicType, value: Int): Boolean = bt match {
-    case BasicType.BYTE  => value >= -128 && value <= 127
-    case BasicType.SHORT => value >= -32768 && value <= 32767
-    case BasicType.CHAR  => value >= 0 && value <= 65535
-    case _ => false
-  }
-
   def processAssignable(node: AST.Node, expected: Type, actual: Term): Term = {
     if (actual == null) return null
     // Target-type an empty collection literal ([] / [:]) to the expected
@@ -84,7 +66,7 @@ private[compiler] final class AssignabilitySupport(
     // Constant narrowing: an integer literal (or its negation) that fits the
     // target range target-types to Byte/Short/Char (like Java's `byte b = 100`).
     expected match {
-      case bt: BasicType if constantIntOf(actual).exists(v => integerLiteralFits(bt, v)) =>
+      case bt: BasicType if ConstantNarrowing.constantIntOf(actual).exists(v => ConstantNarrowing.fits(bt, v)) =>
         return new AsInstanceOf(node.location, actual, bt)
       case _ =>
     }

--- a/src/main/scala/onion/compiler/typing/ConstantNarrowing.scala
+++ b/src/main/scala/onion/compiler/typing/ConstantNarrowing.scala
@@ -1,0 +1,29 @@
+package onion.compiler.typing
+
+import onion.compiler.TypedAST.*
+
+/**
+ * Constant narrowing: an integer literal (or its negation) that fits a
+ * narrow integral target's range target-types to Byte/Short/Char, mirroring
+ * Java's `byte b = 100`. Shared between plain assignment (`AssignabilitySupport`)
+ * and constructor overload resolution (`ConstructionTyping`), which both need to
+ * recognize the same literals.
+ */
+private[typing] object ConstantNarrowing {
+
+  /** The compile-time int value of an integer literal or its unary negation. */
+  def constantIntOf(term: Term): Option[Int] = term match {
+    case iv: IntValue => Some(iv.value)
+    case u: UnaryTerm if u.kind == UnaryTerm.Kind.MINUS =>
+      u.operand match { case iv: IntValue => Some(-iv.value); case _ => None }
+    case _ => None
+  }
+
+  /** Whether an integer value fits the range of a narrow integral target. */
+  def fits(bt: BasicType, value: Int): Boolean = bt match {
+    case BasicType.BYTE  => value >= -128 && value <= 127
+    case BasicType.SHORT => value >= -32768 && value <= 32767
+    case BasicType.CHAR  => value >= 0 && value <= 65535
+    case _ => false
+  }
+}

--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -343,10 +343,21 @@ final class ConstructionTyping(
     }
   }
 
+  /** Whether `actual` can fill a parameter declared `formal`, either through
+    * ordinary boxing-aware assignability or -- for a literal like `-3` against
+    * a `Byte`/`Short`/`Char` formal -- constant narrowing (issue #374). */
+  private def formalAccepts(formal: Type, actual: Term): Boolean =
+    TypeRelations.isAssignableWithBoxing(formal, actual.`type`, bodyContext.table) ||
+      (formal match {
+        case bt: BasicType => ConstantNarrowing.constantIntOf(actual).exists(v => ConstantNarrowing.fits(bt, v))
+        case _ => false
+      })
+
   /**
    * Boxing-aware constructor fallback: substitutes class type arguments into
-   * the constructor signatures, matches with primitive boxing, and adapts
-   * the argument terms (boxing primitives) for the unique match.
+   * the constructor signatures, matches with primitive boxing or constant
+   * narrowing, and adapts the argument terms (boxing primitives, narrowing
+   * literals) for the unique match.
    */
   private def findConstructorWithBoxing(
     typeRef: ClassType,
@@ -358,14 +369,18 @@ final class ConstructionTyping(
     val candidates = typeRef.constructors.filter { c =>
       val formals = substitutedArgs(c)
       formals.length == parameters.length &&
-        formals.indices.forall(i => TypeRelations.isAssignableWithBoxing(formals(i), parameters(i).`type`, bodyContext.table))
+        formals.indices.forall(i => formalAccepts(formals(i), parameters(i)))
     }
     if (candidates.length != 1) (candidates, parameters)
     else {
       val formals = substitutedArgs(candidates(0))
       val adapted = parameters.zip(formals).map { (p, f) =>
         if (!f.isBasicType && p.isBasicType) Boxing.boxing(bodyContext.table, p)
-        else p
+        else f match {
+          case bt: BasicType if bt != p.`type` && ConstantNarrowing.constantIntOf(p).exists(v => ConstantNarrowing.fits(bt, v)) =>
+            new AsInstanceOf(p.location, p, bt)
+          case _ => p
+        }
       }
       (candidates, adapted)
     }

--- a/src/test/scala/onion/compiler/tools/ConstructorLiteralNarrowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ConstructorLiteralNarrowingSpec.scala
@@ -1,0 +1,43 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * Constant narrowing (issue #374): an integer literal (or its negation) that
+ * fits a Byte/Short/Char parameter's range should be accepted at a
+ * constructor call site, exactly as it already is for `val b: Byte = 100`.
+ */
+class ConstructorLiteralNarrowingSpec extends AbstractShellSpec {
+  describe("constant narrowing at a constructor call site") {
+    it("narrows negative literals to Short/Byte record components") {
+      assert(Shell.Success(-7) == shell.run(
+        """
+          |record All(s: String, sh: Short, by: Byte)
+          |def main(args: String[]): Int {
+          |  val a = new All("hi", -3, -4)
+          |  return (a.sh() as Int) + (a.by() as Int)
+          |}
+        """.stripMargin, "None", Array()))
+    }
+    it("narrows a positive literal to a Byte constructor parameter") {
+      assert(Shell.Success(100) == shell.run(
+        """
+          |class C {
+          |  public: val b: Byte
+          |  def this(b: Byte) { this.b = b }
+          |}
+          |def main(args: String[]): Int { return new C(100).b as Int }
+        """.stripMargin, "None", Array()))
+    }
+    it("still rejects an out-of-range literal at a constructor call site") {
+      assert(Shell.Failure(-1) == shell.run(
+        """
+          |class C {
+          |  public: val b: Byte
+          |  def this(b: Byte) { this.b = b }
+          |}
+          |def main(args: String[]): Int { return new C(200).b as Int }
+        """.stripMargin, "None", Array()))
+    }
+  }
+}


### PR DESCRIPTION
Closes #374.

## The bug

```onion
record All(s: String, sh: Short, by: Byte)

val b: Byte = 100                      // fine — constant narrowing applies
val v = new All("hi", -3, -4)          // E0021: constructor applicable for
                                        // All(String, Int, Int) is not found
val ok = new All("hi", (-3 as Short), (-4 as Byte))
```

`AssignabilitySupport.processAssignable` already narrows an in-range integer literal (or its
negation) to a `Byte`/`Short`/`Char` target for plain assignment — that's what makes
`val b: Byte = 100` work. Constructor overload resolution (`ConstructionTyping.findConstructorWithBoxing`)
never consulted that rule: it filtered candidates and adapted arguments using only
`TypeRelations.isAssignableWithBoxing`, so a literal typed `Int` never matched a `Byte`/`Short`
formal parameter.

## The fix

- Extracted the two small narrowing checks (`constantIntOf`, `integerLiteralFits`) out of
  `AssignabilitySupport` into a new shared `ConstantNarrowing` object, so the same rule can be
  reused instead of re-implemented.
- `ConstructionTyping.findConstructorWithBoxing` now accepts a candidate when a formal parameter
  is reachable either via boxing-aware assignability (as before) or via constant narrowing, and
  adapts the chosen literal argument with an `AsInstanceOf` cast to the narrow type — mirroring
  exactly what `processAssignable` already does for a `val` of that type.

Only the constructor path is touched. The issue also flags — but doesn't confirm — that ordinary
method-call overload resolution may have the same gap; that's left for a separate investigation
rather than folded into this fix.

## Verification

- TDD: added `ConstructorLiteralNarrowingSpec` first, confirmed it fails with the reported `E0021`
  against the pre-fix code (verified by temporarily reverting the fix commits and re-running), then
  confirmed it passes after the fix.
- `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — **2448 passed, 0 failed**
  (1 expected cancellation: dist smoke, gated behind `-Donion.dist.path`).
- `CHANGELOG.md` updated under `[Unreleased]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJhUNYhbvbLwPwarRy6mDi)_