### PR TITLE
feat(lang): `shape name = re"..."` — a named boundary on a record (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `endColumn` since it was written and the renderer has known how to draw a range, but no production
   code ever set them, so every caret was a single `^` at the first character.
 
+- **`shape name = re"..."` on a record.** A named, first-class boundary, synthesized as a
+  static method returning a `Shape[R]`. A record may carry **several** — a v1 and a v2 log
+  format can coexist — which `from re"..."` structurally cannot do, since it allows one
+  pattern and bolts fixed-name statics on. The regex checks are the same ones `from` gets
+  (**E0059** malformed, **E0060** group/component mismatch). What it adds: `parse` returns
+  an `Outcome`, so a non-match and a broken field are distinguishable (`from` returns
+  `null` for both) and every defect carries a position; every bad field is reported at
+  once; `eachLine` keeps the lines it could not read instead of dropping them; and
+  `canPrint()` answers whether the pattern is invertible rather than the printing method
+  silently not existing. `from re"..."` is unchanged and still works.
+
 - **New: `onion.Shape` — the data boundary as a value.** A partial, potentially bidirectional
   correspondence between external text and a typed value, with the two laws kept apart: `parse ∘
   print == id` is guaranteed wherever `print` exists, while `print ∘ parse == id` is false in

--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -255,6 +255,41 @@ record Access(time: String, method: String, path: String, status: Int)
 両方ともコンパイル時にチェックされます（グループ/数の不一致は **E0060**、
 不正な正規表現は **E0059**）。サポートされていないコンポーネント型は **E0061** です。
 
+#### `shape` — レコードに名前付きの境界を与える
+
+`shape name = re"..."` 句は、`Shape[R]` を返す静的メソッドを合成します。テキストと
+レコードの、双方向になりうる第一級の対応です。`shape` はこの位置でのみ認識される
+ソフトキーワードなので、通常の識別子としても使えます。
+
+```onion
+record Access(time: String, method: String, path: String, status: Int)
+  shape v1 = re"(\S+) (\w+) (\S+) (\d+)"
+  shape v2 = re"(\S+)\t(\w+)\t(\S+)\t(\d+)"
+
+val rows = Access::v1().eachLine(logText)
+```
+
+1つのレコードが**複数の** shape を持てます。`from re"..."` は1パターンと固定名の
+静的メソッドしか許さないため構造的にできなかったことです。成分型、グループ数検査
+（**E0060**）、正規表現の妥当性検査（**E0059**）は `from` と同じです。
+
+`from` にはない点:
+
+- **失敗が位置を持つ値になる。** `parse` は `Outcome[R]` を返すので、不一致と
+  壊れたフィールドを区別できます（前者は文書全体に属するので `path` が空）。
+  `from` の `parse` はどちらも `null` です。
+- **壊れたフィールドを一度に全部報告する。** `"abc,def"` を `Int` 2つとして読むと
+  defect は2件です。1件目だけではありません。
+- **行が黙って消えない。** `eachLine` は行ごとに `Outcome` を返し、
+  `Outcome::values` と `Outcome::defects` で読めた行と失敗した行（行番号つき）の
+  両方が取れます。`parseAll` は痕跡なく捨てます。
+- **書き戻せるかを正直に答える。** パターンに一意な書き戻し方が無い場合
+  （`\s+` 区切りなど）`canPrint()` が `false` になります。メソッドが単に存在しない、
+  という形にはしません。
+
+shape は呼び出しごとに再構築されるので、多くの入力を読むときは `val` に束ねてください。
+自分で宣言していない型に対する shape は、同じ構築を `onion.Shapes::regex` で書けます。
+
 #### `derive!` — record serde 導出
 
 record のコンポーネントリストの後（または `from re"..."` 節の後、`<:` スーパータイプの前）に

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -259,6 +259,46 @@ valid — both are checked at compile time (group/count mismatch is **E0060**,
 a malformed regex is **E0059**), and an unsupported component type is
 **E0061**.
 
+#### `shape` — a named boundary for a record
+
+A `shape name = re"..."` clause synthesizes a static method returning a
+`Shape[R]` — a first-class, potentially bidirectional correspondence between
+text and the record. `shape` is a soft keyword, recognized only in this
+position, so it stays usable as an ordinary identifier.
+
+```onion
+record Access(time: String, method: String, path: String, status: Int)
+  shape v1 = re"(\S+) (\w+) (\S+) (\d+)"
+  shape v2 = re"(\S+)\t(\w+)\t(\S+)\t(\d+)"
+
+val rows = Access::v1().eachLine(logText)
+```
+
+A record may carry **several** shapes — the thing `from re"..."` structurally
+cannot do, since it allows one pattern and fixed-name statics. The component
+types, the group-count check (**E0060**) and the regex validity check
+(**E0059**) are the same as for `from`.
+
+What a shape gives that `from` does not:
+
+- **Failure is a value with a position.** `parse` returns
+  `Outcome[R]`, so a non-match and a broken field are distinguishable — the
+  first carries an empty `path` because it belongs to the whole text — and
+  every defect knows where it came from. `from`'s `parse` returns `null` for
+  both.
+- **Every bad field at once.** Reading `"abc,def"` as two `Int`s reports two
+  defects, not the first.
+- **No silently dropped lines.** `eachLine` returns one `Outcome` per line;
+  `Outcome::values` and `Outcome::defects` recover the rows *and* the lines
+  that failed, with their line numbers. `parseAll` drops them without trace.
+- **An honest answer about printing.** `canPrint()` is `false` when the
+  pattern has no unique rendering (a `\s+` separator, say), instead of the
+  printing method simply not existing.
+
+The shape is rebuilt on each call, so bind it to a `val` when reading many
+inputs. `onion.Shapes::regex` is the same construction as ordinary API, for a
+shape over a type you did not declare.
+
 #### `derive!` — record serde derivation
 
 Adding `derive!(Format, ...)` after a record's component list (or after a

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -1499,7 +1499,9 @@ AST.RecordDeclaration record_decl(int mset) : {
   ArrayBuffer<String> deriveBuf = new ArrayBuffer<String>();
   ArrayBuffer<AST.LawClause> lawBuf = new ArrayBuffer<AST.LawClause>();
   ArrayBuffer<AST.ExampleClause> exBuf = new ArrayBuffer<AST.ExampleClause>();
+  ArrayBuffer<AST.ShapeClause> shapeBuf = new ArrayBuffer<AST.ShapeClause>();
   ArrayBuffer<AST.AccessSection> sections = new ArrayBuffer<AST.AccessSection>();
+  Token st, srt;
 }{
   t1="record" t2=id() [tparams=type_params()] "(" args=args() ")"
   // Optional `from re"..."` clause (shape-first records). `from` is a soft keyword
@@ -1528,6 +1530,13 @@ AST.RecordDeclaration record_decl(int mset) : {
     LOOKAHEAD({getToken(1).image.equals("example") && (getToken(2).kind == LBRACE || getToken(2).kind == ID)})
       et=<ID> { enm = null; } [ LOOKAHEAD({getToken(1).kind == ID}) enm=<ID> ] eb=block()
       { append(exBuf, AST.exampleClause(p(et), enm == null ? null : c(enm), eb)); }
+  |
+    // `shape name = re"..."` — a named boundary for this record. Like `law` and
+    // `example`, `shape` is a soft keyword recognized only here, so it stays usable as
+    // an ordinary identifier. A record may carry several.
+    LOOKAHEAD({getToken(1).image.equals("shape") && getToken(2).kind == ID})
+      <ID> st=<ID> "=" srt=<RE_STRING>
+      { append(shapeBuf, new AST.ShapeClause(p(st), c(st), srt.image.substring(3, srt.image.length() - 1))); }
   )*
   [ "<:"
     superType = type() {append(superTypes, superType);}
@@ -1541,7 +1550,7 @@ AST.RecordDeclaration record_decl(int mset) : {
   [";"] {
     return AST.recordDeclaration(
       p(t1), mset, c(t2), tparams, args, toList(superTypes), fromRaw, toList(deriveBuf),
-      toList(lawBuf), toList(exBuf), toList(sections)
+      toList(lawBuf), toList(exBuf), toList(sections), toList(shapeBuf)
     );
   }
 }

--- a/src/main/scala/onion/compiler/AST.scala
+++ b/src/main/scala/onion/compiler/AST.scala
@@ -37,9 +37,9 @@ object AST {
     typeParameters: List[TypeParameter], args: List[Argument],
     superInterfaces: List[TypeNode], fromRaw: String, derives: List[String],
     laws: List[LawClause], examples: List[ExampleClause],
-    sections: List[AccessSection]
+    sections: List[AccessSection], shapes: List[ShapeClause]
   ): RecordDeclaration =
-    RecordDeclaration(location, modifiers, name, typeParameters, args, superInterfaces, Option(fromRaw), derives, laws, examples, Nil, sections)
+    RecordDeclaration(location, modifiers, name, typeParameters, args, superInterfaces, Option(fromRaw), derives, laws, examples, Nil, sections, shapes)
 
   /** Java-callable factory for an `example` clause; `name` may be null (unnamed example). */
   def exampleClause(location: Location, name: String, body: BlockExpression): ExampleClause =
@@ -318,7 +318,15 @@ object AST {
    *                           synthesize the static `parse`/`parseAll` methods (None when absent).
    * @param synthesizedMethods Methods derived from `fromPattern` (filled in during Rewriting).
    */
-  case class RecordDeclaration(location: Location, modifiers: Int, name: String, typeParameters: List[TypeParameter], args: List[Argument], superInterfaces: List[TypeNode] = Nil, fromPattern: Option[String] = None, derives: List[String] = Nil, laws: List[LawClause] = Nil, examples: List[ExampleClause] = Nil, synthesizedMethods: List[MethodDeclaration] = Nil, sections: List[AccessSection] = Nil) extends TypeDeclaration
+  case class RecordDeclaration(location: Location, modifiers: Int, name: String, typeParameters: List[TypeParameter], args: List[Argument], superInterfaces: List[TypeNode] = Nil, fromPattern: Option[String] = None, derives: List[String] = Nil, laws: List[LawClause] = Nil, examples: List[ExampleClause] = Nil, synthesizedMethods: List[MethodDeclaration] = Nil, sections: List[AccessSection] = Nil, shapes: List[ShapeClause] = Nil) extends TypeDeclaration
+  /**
+   * A `shape name = re"..."` clause on a record — a named, first-class boundary.
+   *
+   * Unlike `from re"..."`, which allows one pattern per record and bolts fixed-name
+   * statics onto it, a record may carry as many shape clauses as it needs: a v1 and a v2
+   * log format can coexist, each reached by its own name.
+   */
+  case class ShapeClause(location: Location, name: String, pattern: String) extends Node
   /** A `law name(p: T) { boolean-expr }` clause on a record — a compile-time property check. */
   case class LawClause(location: Location, name: String, params: List[Argument], body: BlockExpression) extends Node
   /** An `example { boolean-expr }` clause on a record — a compile-time concrete check. */

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -282,7 +282,7 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
       val fields = c.caseFields.getOrElse(Nil)
       AST.recordDeclaration(
         loc, AST.M_PUBLIC, c.name, typeParams, fields, List(enumTypeNode),
-        null, Nil, Nil, Nil, Nil
+        null, Nil, Nil, Nil, Nil, Nil
       )
     }
 
@@ -546,11 +546,108 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
     // law/example clauses (B3): each becomes a boolean static method the compiler runs at
     // build time (LawCheckPhase). No `derivable` guard — a componentless record can still
     // carry laws/examples (the law's own params drive generation).
+    val shapeMethods = declaration.shapes.flatMap(sc => synthesizeShapeMethod(declaration, sc))
     val lawMethods = declaration.laws.map(synthesizeLawMethod)
     val exampleMethods = declaration.examples.zipWithIndex.map { case (ex, i) => synthesizeExampleMethod(ex, i) }
-    val all = fromMethods ++ dataMethods ++ jsonMethods ++ yamlMethods ++ lawMethods ++ exampleMethods
+    val all = fromMethods ++ dataMethods ++ jsonMethods ++ yamlMethods ++ shapeMethods ++ lawMethods ++ exampleMethods
     if (all.isEmpty) declaration
+    // `shapes` is deliberately kept: typing validates each pattern (E0059) and its
+    // capture-group count against the components (E0060), which the `from` synthesis gets
+    // for free by routing through a regex select pattern and this one does not.
     else declaration.copy(synthesizedMethods = all, laws = Nil, examples = Nil)
+  }
+
+  /**
+   * `shape name = re"..."` -> `static def name(): Shape[R]`, returning a Shapes.regex
+   * built from the record's own components.
+   *
+   * Unlike the `from re"..."` synthesis this replaces, the result is an ordinary value
+   * rather than a fixed set of statics, so a record can carry several shapes and the
+   * failure it reports is an `Outcome` carrying positioned defects instead of a bare
+   * `null` that cannot distinguish a non-match from a broken field (issue #350).
+   *
+   * The printer is supplied only when the pattern is invertible -- the same
+   * `formatSegments` analysis `format` already used. A read-only shape says so through
+   * `canPrint()`, rather than the method silently not existing.
+   *
+   * A method rather than a field: it needs no static-initializer ordering, at the cost of
+   * rebuilding the shape per call. Bind it to a val when reading many inputs.
+   */
+  private def synthesizeShapeMethod(declaration: AST.RecordDeclaration, clause: AST.ShapeClause): Option[AST.MethodDeclaration] = {
+    if (declaration.args.isEmpty) return None
+    val loc = clause.location
+    val recordName = declaration.name
+    val recordType = AST.TypeNode(loc, AST.ReferenceType(recordName, false), false)
+    val shapeType = AST.TypeNode(loc, AST.ParameterizedType(
+      AST.ReferenceType("onion.Shape", true), List(AST.ReferenceType(recordName, false))), false)
+
+    def strList(values: List[String]): AST.Expression =
+      AST.ListLiteral(loc, values.map(v => AST.StringLiteral(loc, v)))
+
+    // Every component must be a known scalar; typing reports the ones that are not, the
+    // same way it does for `from` (E0061).
+    val kinds = declaration.args.map(a => ScalarConversions.ofAst(a.typeRef).map(_.tag))
+    if (kinds.exists(_.isEmpty)) return None
+    val tags = kinds.map(_.get)
+
+    // build: { __p => new R(__p[0] as K0, __p[1] as K1, ...) }
+    val partsName = "__p"
+    val ctorArgs = declaration.args.zipWithIndex.map { case (arg, i) =>
+      val element = AST.Indexing(loc, AST.Id(loc, partsName), AST.IntegerLiteral(loc, i))
+      AST.Cast(loc, element, boxedTypeNodeFor(loc, tags(i)))
+    }
+    val buildBody = AST.BlockExpression(loc, List(AST.ReturnExpression(loc, AST.NewObject(loc, recordType, ctorArgs))))
+    val buildLambda = AST.ClosureExpression(loc,
+      AST.TypeNode(loc, AST.ReferenceType("onion.Function1", true), true), "call",
+      List(AST.Argument(loc, partsName,
+        AST.TypeNode(loc, AST.ParameterizedType(AST.ReferenceType("java.util.List", true),
+          List(AST.ReferenceType("java.lang.Object", true))), false))),
+      null, buildBody)
+
+    // printer: { __v => "" + lit + __v.c0() + lit + ... }, only when invertible.
+    val printerExpr: AST.Expression = formatSegments(clause.pattern) match {
+      case Some(segs) if segs.count(_.isEmpty) == declaration.args.length =>
+        var slot = 0
+        val parts: List[AST.Expression] = segs.map {
+          case Some(literal) => AST.StringLiteral(loc, literal)
+          case None =>
+            val comp = declaration.args(slot); slot += 1
+            AST.MethodCall(loc, AST.Id(loc, "__v"), comp.name, Nil)
+        }
+        val chain = (AST.StringLiteral(loc, "") :: parts).reduceLeft((a, b) => AST.Addition(loc, a, b))
+        val body = AST.BlockExpression(loc, List(AST.ReturnExpression(loc, chain)))
+        AST.ClosureExpression(loc,
+          AST.TypeNode(loc, AST.ReferenceType("onion.Function1", true), true), "call",
+          List(AST.Argument(loc, "__v", recordType)), null, body)
+      case _ => AST.NullLiteral(loc)
+    }
+
+    val call = AST.StaticMethodCall(loc,
+      AST.TypeNode(loc, AST.ReferenceType("onion.Shapes", true), false), "regex",
+      List(
+        AST.StringLiteral(loc, clause.pattern),
+        strList(declaration.args.map(_.name)),
+        strList(tags),
+        buildLambda,
+        printerExpr
+      ))
+    Some(AST.MethodDeclaration(loc, AST.M_PUBLIC | AST.M_STATIC, clause.name, Nil, shapeType,
+      AST.BlockExpression(loc, List(AST.ReturnExpression(loc, call)))))
+  }
+
+  /** The boxed type a component of `tag` arrives as inside the erased parts list. */
+  private def boxedTypeNodeFor(loc: Location, tag: String): AST.TypeNode = {
+    val name = tag match {
+      case "Int"     => "java.lang.Integer"
+      case "Long"    => "java.lang.Long"
+      case "Double"  => "java.lang.Double"
+      case "Float"   => "java.lang.Float"
+      case "Boolean" => "java.lang.Boolean"
+      case "Short"   => "java.lang.Short"
+      case "Byte"    => "java.lang.Byte"
+      case _         => "java.lang.String"
+    }
+    AST.TypeNode(loc, AST.ReferenceType(name, true), false)
   }
 
   /** `law name(p: T) { expr }` -> `static def onion$$law$$name(p: T): boolean { return expr }`. */

--- a/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
@@ -259,13 +259,14 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
       // whose zero bindings would also dodge the E0060 group-count check.
       val hasFrom = node.fromPattern.isDefined
       val hasData = node.derives.exists(m => m == "Json" || m == "Yaml")
+      val hasShapes = node.shapes.nonEmpty
       // law/example methods (B3) register unconditionally — independent of from/derive and of
       // args.nonEmpty (a componentless record can still carry laws/examples; the law's own
       // params drive the check). from/data methods stay gated on the component-type check.
       val (checkMethods, derivedMethods) = node.synthesizedMethods.partition(m =>
         m.name.startsWith("onion$$law$$") || m.name.startsWith("onion$$example$$"))
       checkMethods.foreach(processMethodDeclaration)
-      if ((hasFrom || hasData) && node.args.nonEmpty) {
+      if ((hasFrom || hasData || hasShapes) && node.args.nonEmpty) {
         val unsupportedFrom =
           if (hasFrom) node.args.zip(argTypes).filterNot { case (_, argType) => isFromDerivableType(argType) }
           else Nil
@@ -280,7 +281,19 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
           report(SemanticError.RECORD_DERIVE_COMPONENT_UNSUPPORTED, arg, arg.name, argType.displayName,
             ScalarConversions.supportedNames)
         }
-        if (unsupportedFrom.isEmpty && unsupportedData.isEmpty)
+        // A shape reads its components out of captured text, so it needs the same
+        // component types `from` does.
+        val unsupportedShape =
+          if (hasShapes) node.args.zip(argTypes).filterNot { case (_, argType) => isFromDerivableType(argType) }
+          else Nil
+        if (hasShapes && unsupportedFrom.isEmpty) unsupportedShape.foreach { case (arg, argType) =>
+          report(SemanticError.RECORD_FROM_COMPONENT_UNSUPPORTED, arg, arg.name, argType.displayName,
+            ScalarConversions.supportedNames)
+        }
+        // The `from` synthesis inherits E0059/E0060 by lowering to a regex select pattern;
+        // a shape lowers to a Shapes.regex call, so the same two checks are made here.
+        val badShapes = if (hasShapes) node.shapes.filterNot(sc => checkShapePattern(sc, node.args.length)) else Nil
+        if (unsupportedFrom.isEmpty && unsupportedData.isEmpty && unsupportedShape.isEmpty && badShapes.isEmpty)
           derivedMethods.foreach(processMethodDeclaration)
       }
       // Unknown derive! markers — Json and Yaml are supported at present.
@@ -297,6 +310,25 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
 
   /** Component types a `from re"..."` clause can produce from a captured String. */
   private def isFromDerivableType(tp: Type): Boolean = ScalarConversions.isDerivable(tp)
+
+  /**
+   * A shape's pattern must compile (E0059) and expose exactly one capture group per
+   * component (E0060) -- the same two checks the `from` clause gets by lowering through a
+   * regex select pattern. Returns false when it reported a problem.
+   */
+  private def checkShapePattern(clause: AST.ShapeClause, componentCount: Int): Boolean =
+    try {
+      val compiled = java.util.regex.Pattern.compile(clause.pattern)
+      val groups = compiled.matcher("").groupCount()
+      if (groups != componentCount) {
+        report(SemanticError.REGEX_GROUP_MISMATCH, clause, groups.toString, componentCount.toString)
+        false
+      } else true
+    } catch {
+      case e: java.util.regex.PatternSyntaxException =>
+        report(SemanticError.REGEX_PATTERN_INVALID, clause, e.getDescription + " (at index " + e.getIndex + ")")
+        false
+    }
 
   /** Component types `derive!` (Json/Yaml) can serialize — the same scalar set as `from`. */
   private def isDataDerivableType(tp: Type): Boolean = isFromDerivableType(tp)

--- a/src/test/scala/onion/compiler/tools/ShapeDeclarationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ShapeDeclarationSpec.scala
@@ -1,0 +1,193 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `shape name = re"..."` on a record: a named, first-class `Shape` for that record.
+ *
+ * `from re"..."` allows exactly one pattern per record and bolts fixed-name statics onto
+ * it (`parse`, `parseAll`, `format`), so a type cannot have a v1 and a v2 log format at
+ * once, and the failure it reports is a bare `null` that cannot distinguish "this line is
+ * not a record" from "this line has a broken field".
+ *
+ * A shape clause names its shape, so a record may carry as many as it needs, and the
+ * result is an ordinary `Shape` value with the whole `Outcome` vocabulary behind it.
+ */
+class ShapeDeclarationSpec extends AbstractShellSpec {
+
+  describe("a record with a shape clause") {
+    it("parses through the named shape") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape text = re"(-?\d+),(-?\d+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val s = Pt::text()
+          |    val o = s.parse("3,4")
+          |    if o.isBad() { return -1 }
+          |    return o.get().x() * 10 + o.get().y()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success(34) == r)
+    }
+
+    it("prints back, and satisfies parse(print(v)) == Ok(v)") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape text = re"(-?\d+),(-?\d+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val s = Pt::text()
+          |    val printed = s.print(new Pt(-7, 9))
+          |    val back = s.parse(printed)
+          |    return printed + "|" + back.get().x() + "," + back.get().y()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("-7,9|-7,9") == r)
+    }
+
+    it("carries more than one shape for the same record") {
+      // The thing `from re"..."` structurally cannot do.
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape v1 = re"(-?\d+),(-?\d+)"
+          |  shape v2 = re"x=(-?\d+) y=(-?\d+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val a = Pt::v1().parse("1,2")
+          |    val b = Pt::v2().parse("x=3 y=4")
+          |    return "" + a.get().x() + a.get().y() + b.get().x() + b.get().y()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("1234") == r)
+    }
+  }
+
+  describe("failure is a defect, not a null") {
+    it("distinguishes a non-match from a broken field") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape text = re"(\w+),(\w+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val s = Pt::text()
+          |    val noMatch = s.parse("nope")
+          |    val badField = s.parse("abc,4")
+          |    return noMatch.defects().size + "/" + badField.defects().size + "/" +
+          |           (badField.defects()[0] as Defect).path()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("1/1/x") == r)
+    }
+
+    it("reports every broken field at once") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape text = re"(\w+),(\w+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return Pt::text().parse("abc,def").defects().size
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success(2) == r)
+    }
+
+    it("keeps the good lines and the bad ones, with line numbers") {
+      // What parseAll cannot do: it drops the bad lines without trace.
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape text = re"(-?\d+),(-?\d+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val each = Pt::text().eachLine("1,2\nbroken\n3,4")
+          |    val bad = Outcome::defects(each)
+          |    return Outcome::values(each).size + "/" + bad.size + "/" +
+          |           (bad[0] as Defect).origin().line()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("2/1/2") == r)
+    }
+  }
+
+  describe("compile-time checks are the same ones `from` gets") {
+    it("rejects a capture-group / component-count mismatch") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape bad = re"(-?\d+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(r.isInstanceOf[Shell.Failure], s"expected a compile failure, got $r")
+    }
+
+    it("rejects a malformed regex literal") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape bad = re"([unclosed"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(r.isInstanceOf[Shell.Failure], s"expected a compile failure, got $r")
+    }
+  }
+
+  describe("a non-invertible pattern") {
+    it("still parses, and says it cannot print rather than lacking the method") {
+      // `\s+` has no unique rendering. `from re"..."` silently omits `format` here, so a
+      // caller meets "method not found"; a shape answers the question directly.
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape loose = re"(-?\d+)\s+(-?\d+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val s = Pt::loose()
+          |    return s.parse("5   6").get().x() + "/" + s.canPrint()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("5/false") == r)
+    }
+  }
+
+  describe("`shape` stays an ordinary identifier") {
+    it("does not become a reserved word") {
+      val r = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val shape = "circle"
+          |    return shape
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("circle") == r)
+    }
+  }
+}


### PR DESCRIPTION
Closes #350 (part 2 — the compiler half; part 1 was #372/#373).

## The problem `from re"..."` has

It allows **one** pattern per record and bolts fixed-name statics onto it (`parse`, `parseAll`, `format`), so a type cannot carry a v1 and a v2 log format at once. And it reports a bare `null` for both a non-match and a broken field (`Rewriting.scala:660` vs `:663-665`), so a caller cannot tell *"this line is not a record"* from *"this line is a record with a bad status"*.

## What a shape clause gives

```onion
record Access(time: String, method: String, path: String, status: Int)
  shape v1 = re"(\S+) (\w+) (\S+) (\d+)"
  shape v2 = re"(\S+)\t(\w+)\t(\S+)\t(\d+)"
```

| | `from re"..."` | `shape name = re"..."` |
|---|---|---|
| per record | one | as many as needed |
| failure | `null` | `Outcome` with positioned defects |
| non-match vs bad field | indistinguishable | distinguishable (empty `path` vs the component's) |
| several bad fields | first only | all at once |
| bad lines in a multi-line read | **dropped** | kept, with line numbers |
| non-invertible pattern | `format` silently absent | `canPrint()` says so |

`from re"..."` is **untouched** and still works.

## Two decisions worth reviewing

**This narrows the design.** [typed-boundaries.md §5.2](https://github.com/onion-lang/onion/blob/develop/docs/design/typed-boundaries.md) called for shapes as standalone top-level values, arguing that attachment "structurally caps a type at one regex shape". A clause removes that cap while keeping the record's components in scope, so the desugaring needs no cross-unit lookup — a much smaller and safer change that still delivers what the design was after. A shape over a type you did not declare is `Shapes::regex`, which is public API. Worth revisiting once there is a reason to.

**E0059/E0060 are checked explicitly.** The `from` synthesis inherits them for free by lowering through a regex select pattern; this lowers to a `Shapes.regex` call instead, so the clauses deliberately survive rewriting and `TypingOutlinePass` runs the same two checks on them. Without that, a bad pattern would have compiled and failed at runtime.

## Verification

- [x] `sbt -Duser.language=en test` — **2543 passed, 0 failed** (1 expected cancellation: dist smoke)
- [x] The spec covers both directions of every claim in the table above, including that `shape` stays usable as an ordinary identifier
- [x] `parse(print(v)) == Ok(v)` asserted for the shape the clause produces, not just for hand-built ones
- [x] `docs/reference/specification.md` + JA mirror; `DocExamplesCompileSpec` 13/13

## Note

The synthesized method rebuilds the shape on each call — no static-initializer ordering to get wrong, at the cost of an allocation. Documented in the spec: bind it to a `val` when reading many inputs. A cached static field would be the obvious follow-up if it matters.
