### PR TITLE
docs(run): add BrokenLogDemo.on, the runnable "broken log" story (#355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **New: `run/BrokenLogDemo.on` — the "broken log" story, runnable (partial #355).** A
+  concrete demo exercising `onion.Shape`, `onion.Shapes::regex` and `onion.Outcome`
+  end to end: an access-log shape reads six lines, two of them malformed, and
+  `Outcome::values`/`Outcome::defects` split the four good rows from the two reported
+  defects instead of the parse either crashing on the first bad line or silently
+  dropping it. Also exercises the `sepBy`, `xmap` and `orElse` combinators. This covers
+  the `run/` sample half of #355; the EN/JA guide pages, doc examples and crash-corpus
+  entries are still open.
+
 - **Constant narrowing now reaches constructor arguments (#374).** `val b: Byte = 100` has always
   narrowed an in-range integer literal to `Byte`/`Short`/`Char`, but `new All("hi", -3, -4)` for a
   `Short`/`Byte`-typed constructor parameter reported `E0021` ("constructor applicable ... is not

--- a/run/BrokenLogDemo.on
+++ b/run/BrokenLogDemo.on
@@ -1,0 +1,91 @@
+// BrokenLogDemo — onion.Shape, onion.Outcome and the "broken log" story.
+//
+// A log file is never perfectly clean. `eachLine` reads the lines it can and reports
+// the ones it can't, together, instead of the two failure modes every ad-hoc parser
+// picks between: crash on the first bad line, or silently drop it. `Outcome::values`
+// and `Outcome::defects` split the two apart; both are worth having.
+//
+//   onion BrokenLogDemo.on
+
+record AccessLine(time: String, method: String, path: String, status: Int)
+
+// A record for a value produced by `xmap`: a distance that happens to be spelled
+// as a bare integer on the wire.
+record Meters(value: Int)
+
+// Two spellings of the same date, joined with `orElse`.
+record Stamp(year: Int, month: Int, day: Int)
+
+class BrokenLogDemo {
+public:
+  static def main(args: String[]): Int {
+    val accessShape: Shape[AccessLine] = Shapes::regex(
+      "(\\S+) (\\w+) (\\S+) (\\d+)",
+      ["time", "method", "path", "status"],
+      ["String", "String", "String", "Int"],
+      (parts: List[Object]) -> new AccessLine(
+        (parts.get(0) as String), (parts.get(1) as String), (parts.get(2) as String), (parts.get(3) as Int)),
+      (a: AccessLine) -> a.time() + " " + a.method() + " " + a.path() + " " + a.status()
+    )
+
+    // Six lines, two broken: one that is not a log line at all, one whose status
+    // is not a number. Both are still worth reporting, not just discarding.
+    val log =
+      "127.0.0.1 GET /index 200\n" +
+      "127.0.0.1 POST /login 303\n" +
+      "not a valid line at all\n" +
+      "127.0.0.1 GET /about 200\n" +
+      "127.0.0.1 GET /missing abc\n" +
+      "127.0.0.1 DELETE /item 204\n"
+
+    val origin = Origin::atLine("access.log", 1)
+    val outcomes: List[Outcome[AccessLine]] = accessShape.eachLine(log, origin)
+    val goodRows: List[AccessLine] = Outcome::values(outcomes)
+    val badLines: List[Defect] = Outcome::defects(outcomes)
+
+    IO::println("read " + goodRows.size + " of " + outcomes.size + " lines")
+    foreach row: AccessLine in goodRows {
+      IO::println("  ok:  " + row.method() + " " + row.path() + " -> " + row.status())
+    }
+    foreach d: Defect in badLines {
+      IO::println("  bad: " + d.describe())
+    }
+
+    // sepBy — a shape repeated with a literal separator, all or nothing.
+    val intShape: Shape[Int] = Shapes::regex(
+      "(-?\\d+)", ["n"], ["Int"],
+      (parts: List[Object]) -> (parts.get(0) as Int),
+      (n: Int) -> n.toString()
+    )
+    val intListShape: Shape[List[Int]] = intShape.sepBy(",")
+    val ints = intListShape.parse("1,2,3,4,5", origin)
+    IO::println("sepBy: " + intListShape.print(ints.get()) + " = " + ints.get().size + " values")
+
+    // xmap — the same boundary, carried along an isomorphism so `print` still works.
+    val metersShape: Shape[Meters] = intShape.xmap(
+      (n: Int) -> new Meters(n),
+      (m: Meters) -> m.value()
+    )
+    val distance = metersShape.parse("42", origin)
+    IO::println("xmap: " + distance.get().value() + "m, prints back as " + metersShape.print(distance.get()))
+
+    // orElse — two spellings of the same value; both sets of defects when neither reads.
+    val isoStamp: Shape[Stamp] = Shapes::regex(
+      "(\\d{4})-(\\d{2})-(\\d{2})", ["year", "month", "day"], ["Int", "Int", "Int"],
+      (parts: List[Object]) -> new Stamp((parts.get(0) as Int), (parts.get(1) as Int), (parts.get(2) as Int)),
+      (s: Stamp) -> s.year() + "-" + s.month() + "-" + s.day()
+    )
+    val usStamp: Shape[Stamp] = Shapes::regex(
+      "(\\d{2})/(\\d{2})/(\\d{4})", ["month", "day", "year"], ["Int", "Int", "Int"],
+      (parts: List[Object]) -> new Stamp((parts.get(2) as Int), (parts.get(0) as Int), (parts.get(1) as Int)),
+      (s: Stamp) -> s.month() + "/" + s.day() + "/" + s.year()
+    )
+    val stamp: Shape[Stamp] = isoStamp.orElse(usStamp)
+    val fromIso = stamp.parse("2026-07-25", origin)
+    val fromUs = stamp.parse("07/25/2026", origin)
+    val fromNeither = stamp.parse("not a date", origin)
+    IO::println("orElse: iso=" + fromIso.isOk() + " us=" + fromUs.isOk() + " neither ok=" + fromNeither.isOk() + " defects=" + fromNeither.defects().size)
+
+    return goodRows.size
+  }
+}

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -38,5 +38,9 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs RecordLaws.on") {
       assert(Shell.Success("ok") == runSample("run/RecordLaws.on"))
     }
+
+    it("runs BrokenLogDemo.on") {
+      assert(Shell.Success(4) == runSample("run/BrokenLogDemo.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `run/BrokenLogDemo.on`, an end-to-end demo of `onion.Shape`, `onion.Shapes::regex` and `onion.Outcome`: an access-log shape reads six lines (two malformed), and `Outcome::values`/`Outcome::defects` split the four good rows from the two reported defects — instead of crashing on the first bad line or silently dropping it, which is the core pitch of #355.
- Also exercises the `sepBy`, `xmap` and `orElse` combinators in the same file.
- Adds a `RunSamplesSpec` case asserting the exact return value, and a `CHANGELOG.md [Unreleased]` entry.

This covers the `run/` sample half of #355. The EN/JA guide pages, labelled doc examples, and crash-corpus entries called for by that issue are still open — left for a follow-up, per the "one session, one unit of work" policy this repo's maintenance routine follows.

## Test plan

- [x] `sbt -Duser.language=en 'runScript run/BrokenLogDemo.on'` — compiles and runs, output matches the demo's intent (4 good rows, 2 defects, sepBy/xmap/orElse all behave as documented)
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — 7/7 pass including the new case
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green: 2537 tests, 0 failed, 1 canceled


---
_Generated by [Claude Code](https://claude.ai/code/session_018GLRh3hXPvqrYskY74imyJ)_