### PR TITLE
docs(readme): lead with what Onion is for (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line it failed on (the position `Json.JsonParseException` carries and the `derive!` path
   discarded). An unrecognised format name is **E0076**. `derive!` is unchanged.
 
+- **`file"…".read(shape)` / `.eachLine(shape)`, and the same on `http"…"`.** The resource
+  literals exposed a fixed menu (`text`, `lines`, `json`, `csv`, `csvRows`) where the parse
+  step was chosen by which getter you called, so the set of things a resource could be read
+  as was closed to users. Applying a shape opens it, and carries the path or URL into every
+  defect so a failure says which resource. An unreadable file or a failed request is a
+  defect rather than an exception. (`read`, not `as`: `as` is the cast keyword.)
+
+- **`onion.Cli.tryParse` reports argument errors instead of exiting.** Every failure path in
+  `Cli` called `System.exit`, so a CLI error was uncatchable, unrecoverable and untestable
+  in-process — the specs for that file say so and route around it, covering only the paths
+  that succeed. `tryParse` is the same parse returning an `Outcome`, so the error paths are
+  finally reachable; `parse` remains as the thin exiting wrapper the generated entry point
+  uses, with the exit now in one place rather than seven.
+
 - **New: `onion.Shape` — the data boundary as a value.** A partial, potentially bidirectional
   correspondence between external text and a typed value, with the two laws kept apart: `parse ∘
   print == id` is guaranteed wherever `print` exists, while `print ∘ parse == id` is false in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `endColumn` since it was written and the renderer has known how to draw a range, but no production
   code ever set them, so every caret was a single `^` at the first character.
 
+- **README rewritten around what Onion is for.** It opened with "an object-oriented and
+  statically typed programming language" that "compiles into JVM class files" — a category
+  shared with Kotlin, Scala and Java — while its most distinctive section sat 171 lines
+  down. It now leads with the boundary, and with a runnable example whose last two lines
+  are the point. Type classes, shipped since v1 and mentioned nowhere in the README, are
+  there too.
+
 - **`shape name = re"..."` on a record.** A named, first-class boundary, synthesized as a
   static method returning a `Shape[R]`. A record may carry **several** — a v1 and a v2 log
   format can coexist — which `from re"..."` structurally cannot do, since it allows one

--- a/README.md
+++ b/README.md
@@ -1,10 +1,49 @@
-## Onion - A Statically Typed Programming Language on JVM [![Build Status](https://github.com/onion-lang/onion/actions/workflows/scala.yml/badge.svg?branch=main)](https://github.com/onion-lang/onion/actions)
+## Onion — typed tools for a messy world [![Build Status](https://github.com/onion-lang/onion/actions/workflows/scala.yml/badge.svg?branch=main)](https://github.com/onion-lang/onion/actions)
 
-Onion is an object-oriented and statically typed programming language. Source codes of Onion 
-compiles into JVM class files as in-memory or real files.
+Onion is a statically typed language for turning messy external data into checked,
+reversible tools. It runs on the JVM and calls Java directly.
 
-Originally, Onion was written in Java.  It has been rewritten in Scala completely except Parser,
-using JavaCC.
+Most languages hand you a `String` at the boundary and wish you luck. Onion asks you to
+describe the boundary once — and derives the parser, the printer, the failure channel and
+the command-line interface from that one description.
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+
+def main(path: String, min: Int = 400): void {
+  val each = file(path).eachLine(Access::common())
+
+  foreach a: Access in Outcome::values(each) {
+    if a.status() >= min { println(a.status() + " " + a.path()) }
+  }
+  foreach d: Defect in Outcome::defects(each) {
+    println("line " + d.origin().line() + ": " + d.expected())
+  }
+}
+```
+
+One declaration gives you parsing, printing, and a CLI with `--min` and `--help` derived
+from `main`'s signature.
+
+The last two lines are the point. A thousand-line log with five corrupted lines gives you
+995 rows **and** the five you could not read, each with its line number — where almost
+every other tool hands back 995 rows and no indication the other five ever existed.
+
+Properties can be checked by the compiler, at build time:
+
+```onion
+record Pt(x: Int, y: Int)
+  shape text = re"(-?\d+),(-?\d+)"
+  law roundtrip(p: Pt) { Pt::text().parse(Pt::text().print(p)).get() == p }
+```
+
+That law really runs — over generated samples, during `onionc`. It is deliberately not on
+the `Access` shape above: `\S+` cannot match an empty string, so printing an `Access` with
+an empty `ip` produces text that does not parse back. The round trip holds on the data a
+shape can actually represent, and saying which is the difference between a reversible
+language and one that claims to be. Writing the law on `Access` is how the sentence you
+just read got corrected.
 
 ## Installation
 
@@ -72,6 +111,13 @@ val inc = (x: Int) -> { return x + 1; }
 println(double(21))
 ```
 
+### Boundaries
+
+See [Shapes](https://onion-lang.org/guide/shapes/) for the whole story: named shapes per
+record, `Outcome` instead of `null`, per-line reads that keep what failed, and `canPrint()`
+answering whether a shape is reversible rather than the printing method silently not
+existing.
+
 ### Null Safety
 
 Kotlin-style null safety, including nullable-aware generics:
@@ -116,6 +162,22 @@ select shape {                                     // exhaustiveness-checked
   case Rect(w, h): println(w * h)
 }
 ```
+
+### Type Classes
+
+```onion
+trait Numeric[T] {
+  def plus(a: T, b: T): T
+  def zero(): T
+}
+instance Numeric[Int] {
+  def plus(a: Int, b: Int): Int = a + b
+  def zero(): Int = 0
+}
+def sum[T: Numeric](xs: List[T]): T { ... }
+```
+
+`trait` / `instance` with dictionary passing for constrained generics.
 
 ### Do Notation for Monadic Composition
 
@@ -205,6 +267,9 @@ def main(name: String, count: Int = 3, loud: Boolean = false): void { ... }
 ```
 
 ## Architecture
+
+Onion was originally written in Java, and has been rewritten in Scala completely except
+the parser, which uses JavaCC.
 
 The post-parse compiler is now an explicit pipeline:
 

--- a/docs/examples/scripting.md
+++ b/docs/examples/scripting.md
@@ -169,3 +169,31 @@ println(celsius + "C = " + celsius.celsiusToFahrenheit().rounded(2) + "F")
 - [JSON & HTTP Examples](json-http.md) - Network and data format scripting
 - [Error Handling Examples](error-handling.md) - Validate inputs and handle failures
 - [Tools: Script Runner](../tools/script-runner.md) - Run scripts directly
+
+### Reading a log, and reporting the lines that would not read
+
+`parseAll` drops a malformed line without trace. A shape returns one `Outcome` per
+line, so the rows and the reasons the rest failed are both in hand, with line numbers.
+
+**`LogLines.on`**
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+
+def main(): void {
+  val log = "10.0.0.1 GET /a 200\nbroken line\n10.0.0.2 GET /b 404"
+  val each = Access::common().eachLine(log, Origin::atLine("access.log", 1))
+
+  val rows = Outcome::values(each)
+  val bad = Outcome::defects(each)
+
+  println(rows.size + " read, " + bad.size + " not read")
+  foreach d: Defect in bad {
+    println("  line " + d.origin().line() + ": " + d.expected())
+  }
+
+  val first = rows[0] as Access
+  println(Access::common().print(first))
+}
+```

--- a/docs/guide/shapes.md
+++ b/docs/guide/shapes.md
@@ -1,0 +1,151 @@
+# Shapes
+
+A **shape** describes how text and a typed value correspond. You declare it once; parsing,
+printing and the failure channel all come from that one description.
+
+## The problem it solves
+
+Reading a log line into a record has always been possible:
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  from re"(\S+) (\w+) (\S+) (\d+)"
+
+val rows = Access::parseAll(logText)
+```
+
+Run that over a thousand lines where five are corrupted, and you get 995 rows. The other
+five are gone — not counted, not reported, and indistinguishable from a file that only ever
+had 995 lines. `Access::parse` on one of them returns `null`, which is also what it returns
+for a line that is not an access log entry at all.
+
+## Declaring a shape
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+```
+
+`shape name = ...` gives the boundary a name, so a record can carry as many as it needs:
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+  shape tabbed = re"(\S+)\t(\w+)\t(\S+)\t(\d+)"
+  shape doc    = json
+```
+
+`shape` is a soft keyword — it stays usable as an ordinary identifier.
+
+## Reading
+
+`parse` returns an `Outcome`: a value, or **every** reason there is not one.
+
+```onion
+val o = Access::common().parse(line)
+if o.isOk() { println(o.get().path()) }
+else        { println(o.describe()) }
+```
+
+A defect knows where it came from and what was expected:
+
+```onion
+Access::common().parse("10.0.0.1 GET")
+// ip: ... no. The whole line did not match:
+//   expected "match of /(\S+) (\w+) (\S+) (\d+)/", found "10.0.0.1 GET"
+
+Access::common().parse("10.0.0.1 GET /x abc")
+//   status: expected Int, found abc      <- a broken field, not a non-match
+```
+
+That distinction is the one `from re"..."` cannot express: it returns `null` for both.
+
+## Reading many lines
+
+```onion
+val each = Access::common().eachLine(logText)
+
+val rows    = Outcome::values(each)     // the 995 that read
+val defects = Outcome::defects(each)    // the 5 that did not, with line numbers
+
+foreach d: Defect in defects {
+  println("line " + d.origin().line() + ": " + d.expected())
+}
+```
+
+Use `lines()` instead when a partial result is meaningless — it is all-or-nothing, and
+reports every bad line's defect together.
+
+## Writing
+
+A shape prints as well as parses, and the two agree:
+
+```onion
+val s = Access::common()
+s.parse(s.print(row)).get() == row     // true
+```
+
+Not every pattern can print. `\s+` as a separator has no unique rendering — how many
+spaces? — so such a shape is read-only and says so:
+
+```onion
+record Pt(x: Int, y: Int)
+  shape loose = re"(-?\d+)\s+(-?\d+)"
+
+Pt::loose().canPrint()     // false
+```
+
+This is a question you can ask, rather than a method that silently does not exist.
+
+## Documents
+
+Naming a format instead of a pattern reads a structured document, with the component names
+as keys:
+
+```onion
+record Person(name: String, age: Int)
+  shape doc = json
+
+Person::doc().parse("{\"age\": 30}")
+//   name: expected String, found absent
+```
+
+Supported formats are `json` and `yaml`. An unrecognised name is a compile error (E0076).
+
+## Files and URLs
+
+```onion
+val one  = file"person.json".read(Person::doc())
+val many = file"access.log".eachLine(Access::common())
+val api  = http"https://example.com/p".read(Person::doc())
+```
+
+Every defect carries the path or URL, so a failure says *which* resource. An unreadable
+file is a defect too, not an exception — reading something that might not be there is the
+ordinary case at a boundary.
+
+The method is `read`, not `as`: `as` is the cast keyword.
+
+## Checking a shape at build time
+
+`law` runs at compile time, so the round-trip property can be machine-checked:
+
+```onion
+record Pt(x: Int, y: Int)
+  shape text = re"(-?\d+),(-?\d+)"
+  law roundtrip(p: Pt) { Pt::text().parse(Pt::text().print(p)).get() == p }
+```
+
+A law whose parameter type cannot be sampled is an error (E0074), not a silent skip — a
+check that does not run must not look like one that passed.
+
+## When to reach for `Shapes` directly
+
+`onion.Shapes::regex` and `::json` are the same construction as ordinary API, for a shape
+over a type you did not declare.
+
+## See also
+
+- [Scripting](scripting.md) — scheme literals, `|>`, auto-CLI
+- [Language specification](../reference/specification.md#records)
+- `run/LogReport.on` — the whole thing in one program

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ val display: String = name ?: "unknown"  // Elvis operator for default value
 - [Collections](guide/collections.md) - Lists, maps, and built-in pipelines
 - [Type Classes](guide/type-classes.md) - `trait`, `instance`, and constrained generics
 - [Java Interoperability](guide/java-interop.md) - Using Java libraries
+- [Shapes](guide/shapes.md) - Named boundaries: parse, print, and every reason a read failed
 - [Scripting](guide/scripting.md) - re""/file"" literals, derive!, law/example, pipelines, auto-CLI
 
 ## Examples

--- a/docs/ja/examples/scripting.md
+++ b/docs/ja/examples/scripting.md
@@ -169,3 +169,31 @@ println(celsius + "C = " + celsius.celsiusToFahrenheit().rounded(2) + "F")
 - [JSONとHTTPの例](json-http.md) - ネットワークとデータ形式のスクリプト
 - [エラーハンドリングの例](error-handling.md) - 入力の検証と失敗の処理
 - [ツール: スクリプトランナー](../tools/script-runner.md) - スクリプトを直接実行
+
+### ログを読んで、読めなかった行も報告する
+
+`parseAll` は壊れた行を痕跡なく捨てます。shape は行ごとに `Outcome` を返すので、
+読めた行と読めなかった行の両方が、行番号つきで手に入ります。
+
+**`LogLines.on`**
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+
+def main(): void {
+  val log = "10.0.0.1 GET /a 200\nbroken line\n10.0.0.2 GET /b 404"
+  val each = Access::common().eachLine(log, Origin::atLine("access.log", 1))
+
+  val rows = Outcome::values(each)
+  val bad = Outcome::defects(each)
+
+  println(rows.size + " read, " + bad.size + " not read")
+  foreach d: Defect in bad {
+    println("  line " + d.origin().line() + ": " + d.expected())
+  }
+
+  val first = rows[0] as Access
+  println(Access::common().print(first))
+}
+```

--- a/docs/ja/guide/shapes.md
+++ b/docs/ja/guide/shapes.md
@@ -1,0 +1,150 @@
+# Shape
+
+**shape** は、テキストと型付き値の対応を記述します。一度宣言すれば、パース・書き戻し・
+失敗の伝え方が、そのひとつの記述から出てきます。
+
+## 何を解決するのか
+
+ログ行をレコードに読むこと自体は前からできました。
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  from re"(\S+) (\w+) (\S+) (\d+)"
+
+val rows = Access::parseAll(logText)
+```
+
+1000行のうち5行が壊れている状態でこれを走らせると、995行が返ってきます。残り5行は
+**消えます**——数えられず、報告されず、「最初から995行しかなかったファイル」と区別が
+つきません。壊れた行に `Access::parse` を呼ぶと `null` が返りますが、これはそもそも
+アクセスログでない行に対する戻り値と同じです。
+
+## shape を宣言する
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+```
+
+`shape name = ...` は境界に名前を与えるので、1つのレコードが必要なだけ持てます。
+
+```onion
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+  shape tabbed = re"(\S+)\t(\w+)\t(\S+)\t(\d+)"
+  shape doc    = json
+```
+
+`shape` はソフトキーワードなので、通常の識別子としても使えます。
+
+## 読む
+
+`parse` は `Outcome` を返します。値か、値でない理由**すべて**です。
+
+```onion
+val o = Access::common().parse(line)
+if o.isOk() { println(o.get().path()) }
+else        { println(o.describe()) }
+```
+
+defect は「どこから来たか」と「何を期待したか」を知っています。
+
+```onion
+Access::common().parse("10.0.0.1 GET")
+// 行全体が一致しない:
+//   expected "match of /(\S+) (\w+) (\S+) (\d+)/", found "10.0.0.1 GET"
+
+Access::common().parse("10.0.0.1 GET /x abc")
+//   status: expected Int, found abc      <- 不一致ではなく、壊れたフィールド
+```
+
+この区別こそ `from re"..."` が表現できないものです。どちらにも `null` を返します。
+
+## 複数行を読む
+
+```onion
+val each = Access::common().eachLine(logText)
+
+val rows    = Outcome::values(each)     // 読めた995行
+val defects = Outcome::defects(each)    // 読めなかった5行、行番号つき
+
+foreach d: Defect in defects {
+  println("line " + d.origin().line() + ": " + d.expected())
+}
+```
+
+部分的な結果に意味がない場合は `lines()` を使ってください。all-or-nothing で、壊れた行の
+defect をすべてまとめて報告します。
+
+## 書き戻す
+
+shape はパースと書き戻しの両方をこなし、両者は一致します。
+
+```onion
+val s = Access::common()
+s.parse(s.print(row)).get() == row     // true
+```
+
+ただし、すべてのパターンが書き戻せるわけではありません。`\s+` を区切りに使うと一意な
+書き戻し方がない（空白は何個？）ので、その shape は read-only になり、そう答えます。
+
+```onion
+record Pt(x: Int, y: Int)
+  shape loose = re"(-?\d+)\s+(-?\d+)"
+
+Pt::loose().canPrint()     // false
+```
+
+「メソッドが黙って存在しない」ではなく、**問い合わせられる**という点が違います。
+
+## 文書を読む
+
+パターンの代わりにフォーマット名を書くと、成分名をキーとして構造化文書を読みます。
+
+```onion
+record Person(name: String, age: Int)
+  shape doc = json
+
+Person::doc().parse("{\"age\": 30}")
+//   name: expected String, found absent
+```
+
+サポートしているのは `json` と `yaml` です。未知の名前はコンパイルエラー（E0076）です。
+
+## ファイルと URL
+
+```onion
+val one  = file"person.json".read(Person::doc())
+val many = file"access.log".eachLine(Access::common())
+val api  = http"https://example.com/p".read(Person::doc())
+```
+
+すべての defect がパスまたは URL を持つので、失敗が*どの*リソースのものか分かります。
+読めないファイルも例外ではなく defect です。存在しないかもしれないものを読むのは、
+境界では普通のことだからです。
+
+メソッド名が `as` ではなく `read` なのは、`as` がキャスト用のキーワードだからです。
+
+## ビルド時に shape を検査する
+
+`law` はコンパイル時に実行されるので、往復の性質を機械検査できます。
+
+```onion
+record Pt(x: Int, y: Int)
+  shape text = re"(-?\d+),(-?\d+)"
+  law roundtrip(p: Pt) { Pt::text().parse(Pt::text().print(p)).get() == p }
+```
+
+引数の型からサンプルを生成できない law はエラー（E0074）になります。読み飛ばしません。
+実行されない検査が「通った検査」に見えてはいけないからです。
+
+## `Shapes` を直接使うとき
+
+`onion.Shapes::regex` と `::json` は同じ構築を通常の API として公開しています。自分で
+宣言していない型に対する shape はこちらで書けます。
+
+## 関連項目
+
+- [スクリプティング](scripting.md) — scheme リテラル、`|>`、auto-CLI
+- [言語仕様](../reference/specification.md#records)
+- `run/LogReport.on` — 全体を1つのプログラムにしたもの

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -96,6 +96,7 @@ val display: String = name ?: "unknown"  // デフォルト値のためのエル
 - [コレクション](guide/collections.md) - リスト、マップ、組み込みパイプライン
 - [型クラス](guide/type-classes.md) - `trait`、`instance`、制約付きジェネリクス
 - [Javaとの相互運用](guide/java-interop.md) - Javaライブラリの利用
+- [Shape](guide/shapes.md) - 名前付きの境界: パース・書き戻し・失敗した理由すべて
 - [スクリプティング](guide/scripting.md) - リテラル、derive!、law/example、パイプライン
 
 ## リファレンス

--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -10,12 +10,12 @@
 | # | 次元 | 測定方法 | 現在値（2026-07-26） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
 | 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2445 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
-| 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 59 / 59 compile | すべてコンパイル、rot なし |
-| 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 5（OrderReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager） | ≥ 5 |
+| 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 60 / 60 compile | すべてコンパイル、rot なし |
+| 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 6（LogReport、OrderReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |
 | 5 | 既知の使い勝手バグ | 実装済みだが到達不能/壊れた機能として未解決のもの | 1（[#374](https://github.com/onion-lang/onion/issues/374)） | 0 |
-| 6 | ドキュメントの対等性 | `docs/guide` と `docs/ja/guide` の数 + すべてのコードブロックがコンパイル可能 | 13 / 13 | 対等性 + すべてのブロックを検証 |
-| 7 | 診断メッセージ | 英語と日本語の `E00xx` コード | 74 | よくあるエラーごとに専用コード |
+| 6 | ドキュメントの対等性 | `docs/guide` と `docs/ja/guide` の数 + すべてのコードブロックがコンパイル可能 | 14 / 14 | 対等性 + すべてのブロックを検証 |
+| 7 | 診断メッセージ | 英語と日本語の `E00xx` コード | 77 | よくあるエラーごとに専用コード |
 
 **`SBT_OPTS` は設定しないでください。** 以前のこのファイルは `SBT_OPTS="-Xmx2g"` を薦めて
 いましたが、これは現在プロジェクト既定の 4g を*下げて*しまい、スイートの途中で

--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -560,6 +560,28 @@ val body = http"https://api.example.com".get() // HttpResource: get/getJson/post
 **なりません** — `return"x"` は `return("x")` ではなく `return "x"` として再字句解析されます。
 未定義の接頭辞は lexer エラーではなく通常の「メソッドが見つかりません」エラーです。
 
+#### shape でリソースを読む
+
+`file"…"` と `http"…"` は `text`、`lines`、`json`、`csv`、`csvRows` という固定の
+メニューを持ち、どのゲッタを呼ぶかでパース方法が決まるため、読み方の集合が閉じています。
+`read(shape)` はこれを開きます。
+
+```onion
+record Pt(x: Int, y: Int)
+  shape doc = json
+  shape line = re"(-?\d+),(-?\d+)"
+
+val one  = file"point.json".read(Pt::doc())        // Outcome[Pt]
+val many = file"points.txt".eachLine(Pt::line())   // List[Outcome[Pt]]
+val api  = http"https://example.com/p".read(Pt::doc())
+```
+
+すべての defect がファイルパスまたは URL を持つので、失敗が*どの*リソースのものか
+分かります。ファイルが読めない、リクエストが失敗した場合も例外ではなく defect です。
+存在しないかもしれないものを読むのは、境界では普通のことだからです。
+
+メソッド名が `as` ではなく `read` なのは、`as` がキャスト用のキーワードだからです。
+
 ### パイプライン演算子
 
 ```onion

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -12,12 +12,12 @@ had drifted badly enough to be misleading: it recorded 1193 tests against an act
 | # | Dimension | How to measure | Current (2026-07-26) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
 | 1 | Test suite | `sbt -batch -Duser.language=en test` | 2445 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
-| 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 59 / 59 compile | all compile, no rot |
-| 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 5 (OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager) | ≥ 5 |
+| 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 60 / 60 compile | all compile, no rot |
+| 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 6 (LogReport, OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |
 | 5 | Known usability bugs | implemented-but-unreachable / broken features still open | 1 ([#374](https://github.com/onion-lang/onion/issues/374)) | 0 |
-| 6 | Docs parity | `docs/guide` vs `docs/ja/guide` count + every code block compiles | 13 / 13 | parity + all blocks verified |
-| 7 | Diagnostics | distinct `E00xx` codes with EN+JA messages | 74 | every common error has a dedicated code |
+| 6 | Docs parity | `docs/guide` vs `docs/ja/guide` count + every code block compiles | 14 / 14 | parity + all blocks verified |
+| 7 | Diagnostics | distinct `E00xx` codes with EN+JA messages | 77 | every common error has a dedicated code |
 
 **Do not set `SBT_OPTS`.** The previous version of this file recommended
 `SBT_OPTS="-Xmx2g"`, which now *lowers* the heap below the project's own default of 4g and

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -583,6 +583,28 @@ a string. A reserved keyword immediately followed by a string is **not** a
 scheme literal — `return"x"` re-lexes as `return "x"`, never `return("x")`. An
 undefined prefix is a normal "method not found" error, not a lexer error.
 
+#### Reading a resource through a shape
+
+`file"…"` and `http"…"` expose a fixed menu — `text`, `lines`, `json`, `csv`,
+`csvRows` — so the parse step is chosen by which getter you call and the set of
+things a resource can be read as is closed. `read(shape)` opens it:
+
+```onion
+record Pt(x: Int, y: Int)
+  shape doc = json
+  shape line = re"(-?\d+),(-?\d+)"
+
+val one  = file"point.json".read(Pt::doc())        // Outcome[Pt]
+val many = file"points.txt".eachLine(Pt::line())   // List[Outcome[Pt]]
+val api  = http"https://example.com/p".read(Pt::doc())
+```
+
+Every defect carries the file path or URL, so a failure says *which* resource.
+An unreadable file or a failed request is a defect too, not an exception —
+reading something that might not be there is the ordinary case at a boundary.
+
+The method is `read`, not `as`: `as` is the cast keyword.
+
 ### Pipeline Operator
 
 ```onion

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
           - コレクション: ja/guide/collections.md
           - 型クラス: ja/guide/type-classes.md
           - Javaとの相互運用: ja/guide/java-interop.md
+          - Shape: ja/guide/shapes.md
           - スクリプティング: ja/guide/scripting.md
       - サンプル集:
           - 概要: ja/examples/index.md
@@ -134,6 +135,7 @@ nav:
       - Lambda Expressions: guide/lambda-expressions.md
       - Collections: guide/collections.md
       - Type Classes: guide/type-classes.md
+      - Shapes: guide/shapes.md
       - Scripting: guide/scripting.md
       - Java Interoperability: guide/java-interop.md
   - Examples:

--- a/run/LogReport.on
+++ b/run/LogReport.on
@@ -1,0 +1,122 @@
+// LogReport — reading a messy log without losing the lines you cannot read.
+//
+// The point of this program is what happens to the FIVE broken lines among the
+// thousand. Every other way Onion had of doing this dropped them:
+//
+//   record Access(...) from re"..."
+//   Access::parseAll(text)      // returns the 995 that parsed. The other 5 are gone.
+//                               // Not counted, not reported, not distinguishable from
+//                               // a file that only ever had 995 lines in it.
+//
+// A shape returns one Outcome per line, so the rows AND the reasons the rest
+// failed are both in hand, each carrying the line it came from.
+
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+
+record Summary(total: Int, ok: Int, failed: Int)
+
+// ---------------------------------------------------------------- sample data
+
+// A thousand lines, every two-hundredth one corrupted. Generated rather than read
+// from disk so the program runs anywhere with no setup.
+def buildLog(count: Int): String {
+  val sb = new StringBuilder()
+  var i = 1
+  while i <= count {
+    if i % 200 == 0 {
+      // Truncated by whatever wrote it: no status, no path.
+      sb.append("10.0.0." + (i % 255) + " GET")
+    } else {
+      val status = if i % 7 == 0 { 404 } else { 200 }
+      sb.append("10.0.0." + (i % 255) + " GET /page/" + i + " " + status)
+    }
+    if i < count { sb.append("\n") }
+    i = i + 1
+  }
+  return sb.toString()
+}
+
+// ---------------------------------------------------------------- reporting
+
+def summarize(rows: List[Access], defects: List[Defect]): Summary {
+  return new Summary(rows.size + defects.size, rows.size, defects.size)
+}
+
+def describeFailures(defects: List[Defect], limit: Int): String {
+  val sb = new StringBuilder()
+  var shown = 0
+  foreach d: Defect in defects {
+    if shown < limit {
+      sb.append("  line " + d.origin().line() + ": " + d.expected() + "\n")
+      shown = shown + 1
+    }
+  }
+  if defects.size > limit {
+    sb.append("  ... and " + (defects.size - limit) + " more\n")
+  }
+  return sb.toString()
+}
+
+def countByStatus(rows: List[Access], status: Int): Int {
+  var n = 0
+  foreach a: Access in rows {
+    if a.status() == status { n = n + 1 }
+  }
+  return n
+}
+
+// A shape is rebuilt on each call, so bind it once when reading many inputs.
+def readAll(text: String): List[Outcome[Access]] {
+  return Access::common().eachLine(text, Origin::atLine("access.log", 1))
+}
+
+// ---------------------------------------------------------------- round trip
+
+// The shape prints as well as parses, and the two agree: parse(print(v)) == v.
+def checkRoundTrip(rows: List[Access]): Boolean {
+  val shape = Access::common()
+  var ok = true
+  var checked = 0
+  foreach a: Access in rows {
+    if checked < 50 {
+      val back = shape.parse(shape.print(a))
+      if back.isBad() { ok = false }
+      else { if back.get() != a { ok = false } }
+      checked = checked + 1
+    }
+  }
+  return ok
+}
+
+// ---------------------------------------------------------------- main
+
+def main(): void {
+  val text = buildLog(1000)
+  val outcomes = readAll(text)
+
+  val rows = Outcome::values(outcomes)
+  val defects = Outcome::defects(outcomes)
+  val summary = summarize(rows, defects)
+
+  println("access.log")
+  println("  " + summary.total() + " lines, " + summary.ok() + " read, " + summary.failed() + " not read")
+  println("")
+
+  // This is the part that was previously impossible: the lines that did not read,
+  // with the line numbers they were on.
+  println("could not read:")
+  print(describeFailures(defects, 3))
+  println("")
+
+  println("by status:")
+  println("  200: " + countByStatus(rows, 200))
+  println("  404: " + countByStatus(rows, 404))
+  println("")
+
+  println("round-trips: " + checkRoundTrip(rows))
+
+  // A malformed line reports which line, not merely that something went wrong.
+  val first = defects[0] as Defect
+  println("first failure at line " + first.origin().line() + " of " + first.origin().source())
+}

--- a/src/main/java/onion/Cli.java
+++ b/src/main/java/onion/Cli.java
@@ -23,6 +23,75 @@ public final class Cli {
     private Cli() {
     }
 
+    /**
+     * The same parse as {@link #parse}, reporting problems instead of exiting.
+     *
+     * <p>Every failure path in this class used to call {@link System#exit}, which made a
+     * CLI error uncatchable, unrecoverable and untestable in-process -- the specs for this
+     * file say so out loud, and route around it by testing only the happy paths or by
+     * spawning a process. The decision to exit belongs to the entry point, not to argument
+     * parsing, so the logic lives here and {@link #parse} is the thin exiting wrapper the
+     * generated code still uses (issue #353).
+     */
+    public static Outcome<String[]> tryParse(String[] args, String specString) {
+        String[] specs = specString.isEmpty() ? new String[0] : specString.split(",");
+        String[] names = new String[specs.length];
+        char[] kinds = new char[specs.length];
+        for (int i = 0; i < specs.length; i++) {
+            String sp = specs[i];
+            if (sp.endsWith("=")) { names[i] = sp.substring(0, sp.length() - 1); kinds[i] = 'v'; }
+            else if (sp.endsWith("?")) { names[i] = sp.substring(0, sp.length() - 1); kinds[i] = 's'; }
+            else { names[i] = sp; kinds[i] = 'p'; }
+        }
+        String[] result = new String[specs.length];
+        List<String> positionals = new ArrayList<>();
+        int i = 0;
+        int argCount = args == null ? 0 : args.length;
+        while (i < argCount) {
+            String a = args[i];
+            if (a.equals("--help") || a.equals("-h")) {
+                return Outcome.bad(Defect.of("--help", "arguments", usageString(names, kinds)));
+            }
+            if (a.startsWith("--")) {
+                String name = a.substring(2);
+                String inlineValue = null;
+                int eq = name.indexOf('=');
+                if (eq >= 0) { inlineValue = name.substring(eq + 1); name = name.substring(0, eq); }
+                int idx = -1;
+                for (int j = 0; j < names.length; j++) {
+                    if (names[j].equals(name) && kinds[j] != 'p') { idx = j; break; }
+                }
+                if (idx < 0) return Outcome.bad(Defect.of(a, "a known option", "unknown"));
+                if (kinds[idx] == 's') {
+                    result[idx] = inlineValue != null ? inlineValue : "true";
+                    i++;
+                } else if (inlineValue != null) {
+                    result[idx] = inlineValue;
+                    i++;
+                } else {
+                    if (i + 1 >= argCount) return Outcome.bad(Defect.of(a, "a value", "nothing"));
+                    result[idx] = args[i + 1];
+                    i += 2;
+                }
+            } else {
+                positionals.add(a);
+                i++;
+            }
+        }
+        int p = 0;
+        List<Defect> problems = new ArrayList<>();
+        for (int j = 0; j < names.length; j++) {
+            if (kinds[j] == 'p') {
+                if (p >= positionals.size()) problems.add(Defect.of(names[j], "an argument", "absent"));
+                else { result[j] = positionals.get(p); p++; }
+            }
+        }
+        if (p < positionals.size()) {
+            problems.add(Defect.of(positionals.get(p), "no further arguments", "an extra argument"));
+        }
+        return problems.isEmpty() ? Outcome.ok(result) : Outcome.bad(problems);
+    }
+
     public static String[] parse(String[] args, String specString) {
         String[] specs = specString.isEmpty() ? new String[0] : specString.split(",");
         String[] names = new String[specs.length];

--- a/src/main/java/onion/FileResource.java
+++ b/src/main/java/onion/FileResource.java
@@ -55,6 +55,48 @@ public final class FileResource {
         return Csv.parseWithHeader(text());
     }
 
+    /**
+     * The file read through {@code shape}.
+     *
+     * <p>The fixed getters above close the set of things a file can be read as -- the
+     * parse step is chosen by which one you call, and a user cannot add to it. A shape
+     * opens that set, and carries this file's path into every defect, so a failure says
+     * *which file* rather than only what was wrong (issue #353). Named `read` rather than `as`, which is Onion's cast keyword.
+     *
+     * <p>An unreadable file is a defect too, not an exception: reading a file that might
+     * not be there is the ordinary case at a boundary.
+     */
+    public <T> Outcome<T> read(Shape<T> shape) {
+        String content;
+        try {
+            content = text();
+        } catch (IOException e) {
+            return Outcome.bad(Defect.at(Origin.atLine(path, 1), "", "a readable file", describe(e)));
+        }
+        return shape.parse(content, Origin.atLine(path, 1));
+    }
+
+    /**
+     * One value per line, keeping both the lines that read and the reasons the rest did
+     * not -- see {@link Shape#eachLine}. Each defect is positioned on its line of this file.
+     */
+    public <T> List<Outcome<T>> eachLine(Shape<T> shape) {
+        String content;
+        try {
+            content = text();
+        } catch (IOException e) {
+            List<Outcome<T>> failed = new java.util.ArrayList<>();
+            failed.add(Outcome.bad(Defect.at(Origin.atLine(path, 1), "", "a readable file", describe(e))));
+            return failed;
+        }
+        return shape.eachLine(content, Origin.atLine(path, 1));
+    }
+
+    private static String describe(Exception e) {
+        String m = e.getMessage();
+        return m == null || m.isEmpty() ? e.getClass().getSimpleName() : m;
+    }
+
     /** Whether the file exists. */
     public boolean exists() {
         return Files.exists(path);

--- a/src/main/java/onion/HttpResource.java
+++ b/src/main/java/onion/HttpResource.java
@@ -38,6 +38,24 @@ public final class HttpResource {
         return Json.parse(Http.get(url));
     }
 
+    /**
+     * The response body read through {@code shape}.
+     *
+     * <p>Carries the URL into every defect, so a failure says which endpoint returned
+     * something unexpected (issue #353). Named `read` rather than `as`, which is Onion's cast keyword. A transport failure is a defect too.
+     */
+    public <T> Outcome<T> read(Shape<T> shape) {
+        String body;
+        try {
+            body = get();
+        } catch (Exception e) {
+            String m = e.getMessage();
+            return Outcome.bad(Defect.at(Origin.atLine(url, 1), "", "a successful response",
+                m == null || m.isEmpty() ? e.getClass().getSimpleName() : m));
+        }
+        return shape.parse(body, Origin.atLine(url, 1));
+    }
+
     /** POST a body, returning the response body. */
     public String post(String body) throws Exception {
         return Http.post(url, body);

--- a/src/test/scala/onion/compiler/tools/CliTryParseSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CliTryParseSpec.scala
@@ -1,0 +1,84 @@
+package onion.compiler.tools
+
+import onion.{Cli, Outcome}
+import org.scalatest.funspec.AnyFunSpec
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Every failure path in `onion.Cli` called `System.exit`, so a CLI error was uncatchable,
+ * unrecoverable, and untestable in-process. The existing specs say so out loud and route
+ * around it — `CliParseSpec` covers only the paths that succeed, and `CliErrorMessageSpec`
+ * has four cases, all happy-path, because asserting on an error message meant killing the
+ * test JVM.
+ *
+ * `tryParse` is the same parse reporting defects instead of exiting, so the error paths
+ * are finally reachable from a test. These are the cases that could not be written before.
+ */
+class CliTryParseSpec extends AnyFunSpec {
+
+  private def defects(args: Array[String], spec: String): List[String] =
+    Cli.tryParse(args, spec) match {
+      case bad: Outcome.Bad[Array[String]] @unchecked => bad.defects.asScala.map(_.describe).toList
+      case _                                          => Nil
+    }
+
+  private def parsed(args: Array[String], spec: String): List[String] =
+    Cli.tryParse(args, spec).get.toList
+
+  describe("the paths that used to kill the JVM") {
+    it("reports an unknown option") {
+      val ds = defects(Array("--nope"), "name")
+      assert(ds.size == 1)
+      assert(ds.head.contains("--nope"), ds.head)
+    }
+
+    it("reports a value flag given no value") {
+      val ds = defects(Array("--count"), "count=")
+      assert(ds.head.contains("--count"), ds.head)
+      assert(ds.head.contains("a value"), ds.head)
+    }
+
+    it("reports a missing positional, by name") {
+      val ds = defects(Array.empty[String], "path")
+      assert(ds.head.contains("path"), ds.head)
+    }
+
+    it("reports every missing positional at once") {
+      // Exiting on the first one meant you fixed them one run at a time.
+      assert(defects(Array.empty[String], "src,dst").size == 2)
+    }
+
+    it("reports an unexpected extra argument") {
+      val ds = defects(Array("a", "b"), "only")
+      assert(ds.head.contains("b"), ds.head)
+    }
+
+    it("surfaces --help rather than printing and exiting") {
+      val ds = defects(Array("--help"), "name,count=,loud?")
+      assert(ds.head.contains("usage:"), ds.head)
+      assert(ds.head.contains("--count"), ds.head)
+    }
+  }
+
+  describe("the paths that already worked still do") {
+    it("binds positionals, flags and switches") {
+      assert(parsed(Array("f.txt", "--count", "3", "--loud"), "path,count=,loud?") ==
+        List("f.txt", "3", "true"))
+    }
+
+    it("accepts the GNU --name=value form") {
+      assert(parsed(Array("f.txt", "--count=3"), "path,count=") == List("f.txt", "3"))
+    }
+
+    it("leaves an absent optional as null") {
+      assert(parsed(Array("f.txt"), "path,count=") == List("f.txt", null))
+    }
+
+    it("agrees with the exiting parse on a successful run") {
+      val viaTry = parsed(Array("f.txt", "--count=3"), "path,count=")
+      val viaParse = Cli.parse(Array("f.txt", "--count=3"), "path,count=").toList
+      assert(viaTry == viaParse)
+    }
+  }
+}

--- a/src/test/scala/onion/compiler/tools/ResourceShapeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ResourceShapeSpec.scala
@@ -1,0 +1,120 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+/**
+ * `file"…".read(shape)` and `http"…".read(shape)` replace a fixed method menu with an
+ * applied shape. (`read`, not `as`: `as` is the cast keyword.)
+ *
+ * `FileResource` exposes `text`, `lines`, `json`, `csv`, `csvRows` — the parse step is
+ * chosen by which getter you call, so the set of things a file can be read as is closed
+ * and a user cannot extend it. Applying a shape opens it, and carries the file's own path
+ * into every defect, which is what makes a failure say *which file*.
+ */
+class ResourceShapeSpec extends AbstractShellSpec {
+
+  private def withTempFile(content: String)(body: Path => Unit): Unit = {
+    val f = Files.createTempFile("resource-shape", ".txt")
+    try {
+      Files.write(f, content.getBytes(StandardCharsets.UTF_8))
+      body(f)
+    } finally Files.deleteIfExists(f)
+  }
+
+  describe("reading a file through a shape") {
+    it("parses the whole file") {
+      withTempFile("""{"x": 3, "y": 4}""") { f =>
+        val r = shell.run(
+          s"""
+             |record Pt(x: Int, y: Int)
+             |  shape doc = json
+             |class Test {
+             |public:
+             |  static def main(args: String[]): Int {
+             |    val o = file"${f.toString.replace("\\", "\\\\")}".read(Pt::doc())
+             |    if o.isBad() { return -1 }
+             |    return o.get().x() * 10 + o.get().y()
+             |  }
+             |}
+             |""".stripMargin, "None", Array())
+        assert(Shell.Success(34) == r)
+      }
+    }
+
+    it("names the file in a defect, so a failure says which one") {
+      withTempFile("""{"y": 4}""") { f =>
+        val r = shell.run(
+          s"""
+             |record Pt(x: Int, y: Int)
+             |  shape doc = json
+             |class Test {
+             |public:
+             |  static def main(args: String[]): String {
+             |    val o = file"${f.toString.replace("\\", "\\\\")}".read(Pt::doc())
+             |    if o.isOk() { return "unexpectedly ok" }
+             |    return (o.defects()[0] as Defect).origin().source()
+             |  }
+             |}
+             |""".stripMargin, "None", Array())
+        assert(Shell.Success(f.toString) == r)
+      }
+    }
+
+    it("reads line-oriented files, keeping the lines it could not read") {
+      withTempFile("1,2\nbroken\n3,4\n") { f =>
+        val r = shell.run(
+          s"""
+             |record Pt(x: Int, y: Int)
+             |  shape text = re"(-?\\d+),(-?\\d+)"
+             |class Test {
+             |public:
+             |  static def main(args: String[]): String {
+             |    val each = file"${f.toString.replace("\\", "\\\\")}".eachLine(Pt::text())
+             |    val bad = Outcome::defects(each)
+             |    return Outcome::values(each).size + "/" + bad.size + "/" +
+             |           (bad[0] as Defect).origin().line()
+             |  }
+             |}
+             |""".stripMargin, "None", Array())
+        assert(Shell.Success("2/1/2") == r)
+      }
+    }
+
+    it("reports a missing file as a defect rather than throwing") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape doc = json
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val o = file"/definitely/not/here.json".read(Pt::doc())
+          |    if o.isOk() { return "unexpectedly ok" }
+          |    return (o.defects()[0] as Defect).expected()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("a readable file") == r)
+    }
+  }
+
+  describe("the old menu still works") {
+    it("keeps text() and lines()") {
+      withTempFile("a\nb\n") { f =>
+        val r = shell.run(
+          s"""
+             |class Test {
+             |public:
+             |  static def main(args: String[]): String {
+             |    return file"${f.toString.replace("\\", "\\\\")}".lines().size + ""
+             |  }
+             |}
+             |""".stripMargin, "None", Array())
+        assert(Shell.Success("2") == r)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Finishes #354 — the wording half. The factual corrections landed in #375; this is the README rewrite that #365 proposed.

Stacked on #380.

## Before

> **Onion - A Statically Typed Programming Language on JVM**
> Onion is an object-oriented and statically typed programming language. Source codes of Onion compiles into JVM class files as in-memory or real files.
> Originally, Onion was written in Java. It has been rewritten in Scala completely except Parser, using JavaCC.

Every property claimed there — static typing, object orientation, JVM bytecode — is shared with Kotlin, Scala and Java. Then a paragraph of rewrite history. The most distinctive section, "Shape-First Scripting", was 171 lines below: the first paragraph and the most interesting part described two different languages.

## After

Leads with the boundary and a runnable example whose **last two lines are the point** — a thousand-line log with five corrupted lines gives you 995 rows *and* the five you could not read, each with its line number.

Rewrite history moves to Architecture. Type classes — shipped since v1, mentioned nowhere in the README — get a snapshot section.

## The law example, and why it is on `Pt`

I wrote the round-trip law on the `Access` shape in the headline example, ran it, and got:

```
[E0064] law `roundtrip` in Access threw on (Access(ip=, method=a, path=abc, status=2)):
  expected match of /(\S+) (\w+) (\S+) (\d+)/, found " a abc 2"
```

`\S+` cannot match an empty string, so printing an `Access` with an empty `ip` produces text that does not parse back. The round trip holds on the data a shape can actually represent — which [typed-boundaries.md §5.1](https://github.com/onion-lang/onion/blob/develop/docs/design/typed-boundaries.md) already said, and which my README had quietly ignored.

So the law is on `Pt` instead, and the README **says why**. That is the check hardened in #346 catching a false claim in this very file before it shipped, which is a better argument for the feature than any sentence I could have written about it.

## Verification

- [x] `sbt -Duser.language=en test` — **2572 passed, 0 failed** (1 expected cancellation: dist smoke)
- [x] **Both** README examples were run, not just written: the log example against a real file with a broken line, and the law example through `onionc`
