### PR TITLE
docs(ja): remove duplicated Generics section in spec

### DIFF
--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -93,12 +93,6 @@ val         var         when        while
 `record Pair[A, B](first: A, second: B)`。ワイルドカード `?`、`? extends T`、
 `? super T` を型引数として受け入れます。
 
-### ジェネリクス
-
-`[]` 構文の消去ベースジェネリクス: `class Box[T]`、`def first[T](xs: List[T]): T`、
-`record Pair[A, B](first: A, second: B)`。ワイルドカード `?`、`? extends T`、
-`? super T` を型引数として受け入れます。
-
 プリミティブ型も型引数として使えます。内部ではボックス化されます
 （`Int` -> `Integer`）ので、`Comparator[Int]` のような Java 汎用インターフェースを
 プリミティブなパラメータ型で実装できます。コンパイラは消去されたボックス化された
@@ -112,7 +106,7 @@ public:
   }
 }
 
-val nums: ArrayList[Int] = [5, 1, 3]
+val nums: List[Int] = [5, 1, 3]
 Collections::sort(nums, new IntComparator())
 ```
 


### PR DESCRIPTION
## Summary
- `docs/ja/reference/specification.md` had the `### ジェネリクス` heading and its opening paragraph duplicated verbatim back-to-back — a copy-paste artifact not present in the English source (`docs/reference/specification.md`).
- Also aligned the example's `ArrayList[Int]` to `List[Int]` to match the English version's code sample.
- Heading counts between `docs/reference/specification.md` and `docs/ja/reference/specification.md` now match (44/44).

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2576 succeeded, 0 failed, 1 canceled (pre-existing, environment-dependent), all green.
- Doc-only change; no source/behavior change.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UcZWXGmPfBXYiPY4ojwSuc)_