### PR TITLE
fix(typing): constant narrowing reaches method/function call arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Constant narrowing now reaches ordinary method/function call arguments.** `val b: Byte = 100`
+  and, since v0.7.0, `new R(..., -3)` against a `Short`/`Byte` component both narrow an
+  in-range integer literal — but `takesShort(-3)` against a plain `def takesShort(x: Short)`
+  still reported `E0005` ("method applicable ... is not found") and needed an explicit
+  `(-3 as Short)` cast. Method overload resolution (`MethodResolutionSupport.applicable`)
+  checked only boxing-aware assignability, never the `ConstantNarrowing` helper that
+  constructor resolution and plain assignment already use. Added the same fallback check
+  there, so a literal that fits a narrow integral parameter's range is accepted at any call
+  site, not just constructors. `docs/quality-bar.md` row 5 ("known usability bugs") is
+  updated to reflect that #374's underlying gap is now fully closed.
+
 ## [0.8.0] - 2026-07-25
 
 - **README rewritten around what Onion is for.** It opened with "an object-oriented and

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -15,7 +15,7 @@ had drifted badly enough to be misleading: it recorded 1193 tests against an act
 | 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 60 / 60 compile | all compile, no rot |
 | 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 6 (LogReport, OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |
-| 5 | Known usability bugs | implemented-but-unreachable / broken features still open | 1 ([#374](https://github.com/onion-lang/onion/issues/374)) | 0 |
+| 5 | Known usability bugs | implemented-but-unreachable / broken features still open | 0 | 0 |
 | 6 | Docs parity | `docs/guide` vs `docs/ja/guide` count + every code block compiles | 14 / 14 | parity + all blocks verified |
 | 7 | Diagnostics | distinct `E00xx` codes with EN+JA messages | 77 | every common error has a dedicated code |
 
@@ -56,13 +56,16 @@ A feature counts as covered once it runs inside at least one large sample
 
 ## Row 5 — currently open usability bugs (tracked)
 
-1. **Constant narrowing does not reach constructor arguments.** `val b: Byte = 100`
-   narrows, but `new R(..., -3)` against a `Short` component is `E0021`
-   ("constructor applicable for R(..., Int) is not found") and needs `(-3 as Short)`.
-   Found while writing `ScalarConversionSpec`; it will be hit again by anything that
-   builds a record out of parsed components. ([#374](https://github.com/onion-lang/onion/issues/374))
+None open.
 
 Previously tracked and resolved:
 
 1. **Primitive-type extensions** — fixed. `extension Int { def double(): Int = self * 2 }` and `(5).double()` now work. Extension methods on primitive receivers are registered under the boxed class name and the call target is unboxed before invoking the backing static method.
 2. **Top-level function called from a class method** — fixed. Top-level `val`/`var` and functions are emitted as static members of the synthetic top-level class, and bare identifiers / unqualified calls in class methods fall back to these static members.
+3. **Constant narrowing does not reach constructor arguments.** `val b: Byte = 100`
+   narrows, but `new R(..., -3)` against a `Short` component was `E0021`
+   ("constructor applicable for R(..., Int) is not found") and needed `(-3 as Short)`.
+   Fixed for constructors ([#374](https://github.com/onion-lang/onion/issues/374)); the same
+   gap in ordinary method/function overload resolution (`takesShort(-3)` against a
+   `Short` parameter, reported as `E0005`) was found and fixed alongside it — both now
+   share the `ConstantNarrowing` helper.

--- a/src/main/scala/onion/compiler/typing/ConstantNarrowing.scala
+++ b/src/main/scala/onion/compiler/typing/ConstantNarrowing.scala
@@ -5,9 +5,10 @@ import onion.compiler.TypedAST.*
 /**
  * Constant narrowing: an integer literal (or its negation) that fits a
  * narrow integral target's range target-types to Byte/Short/Char, mirroring
- * Java's `byte b = 100`. Shared between plain assignment (`AssignabilitySupport`)
- * and constructor overload resolution (`ConstructionTyping`), which both need to
- * recognize the same literals.
+ * Java's `byte b = 100`. Shared between plain assignment (`AssignabilitySupport`),
+ * constructor overload resolution (`ConstructionTyping`), and method overload
+ * resolution (`MethodResolutionSupport`), which all need to recognize the same
+ * literals.
  */
 private[typing] object ConstantNarrowing {
 

--- a/src/main/scala/onion/compiler/typing/MethodResolutionSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodResolutionSupport.scala
@@ -41,7 +41,11 @@ private[compiler] final class MethodResolutionSupport(
         structuralMatch(argsWithTypeParams(idx), params(idx).`type`, methodTypeParams)
       else
         isAssignableWithBoxing(expected(idx), params(idx).`type`) ||
-          TypeRules.emptyCollectionLiteralAccepts(expected(idx), params(idx))
+          TypeRules.emptyCollectionLiteralAccepts(expected(idx), params(idx)) ||
+          (expected(idx) match {
+            case bt: BasicType => ConstantNarrowing.constantIntOf(params(idx)).exists(v => ConstantNarrowing.fits(bt, v))
+            case _ => false
+          })
 
     if method.isVararg && expected.nonEmpty then
       val fixedArgCount = expected.length - 1

--- a/src/test/scala/onion/compiler/tools/MethodLiteralNarrowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MethodLiteralNarrowingSpec.scala
@@ -1,0 +1,39 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * Constant narrowing at a method call site: an integer literal (or its
+ * negation) that fits a Byte/Short/Char parameter's range should be accepted
+ * exactly as it already is for a constructor call site (issue #374) and for
+ * plain assignment (`val b: Byte = 100`).
+ */
+class MethodLiteralNarrowingSpec extends AbstractShellSpec {
+  describe("constant narrowing at a method call site") {
+    it("narrows negative literals to Short/Byte top-level function parameters") {
+      assert(Shell.Success(-7) == shell.run(
+        """
+          |def takesShort(x: Short): Int { return x as Int }
+          |def takesByte(x: Byte): Int { return x as Int }
+          |def main(args: String[]): Int { return takesShort(-3) + takesByte(-4) }
+        """.stripMargin, "None", Array()))
+    }
+    it("narrows a positive literal to a Byte instance method parameter") {
+      assert(Shell.Success(100) == shell.run(
+        """
+          |class C {
+          |public:
+          |  def takesByte(b: Byte): Int { return b as Int }
+          |}
+          |def main(args: String[]): Int { return new C().takesByte(100) }
+        """.stripMargin, "None", Array()))
+    }
+    it("still rejects an out-of-range literal at a method call site") {
+      assert(Shell.Failure(-1) == shell.run(
+        """
+          |def takesByte(b: Byte): Int { return b as Int }
+          |def main(args: String[]): Int { return takesByte(200) }
+        """.stripMargin, "None", Array()))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Constant narrowing (#374) fixed `val` bindings and constructor arguments, but a literal like `takesShort(-3)` against a plain `def takesShort(x: Short)` still reported `E0005` ("method applicable ... is not found"), needing an explicit `(-3 as Short)` cast.
- `MethodResolutionSupport.applicable` (the shared overload-resolution filter for instance/static/unqualified method calls) checked only boxing-aware assignability, never the `ConstantNarrowing` helper that constructor resolution and plain assignment already use. Added the same fallback there, so both paths share one helper (comment in `ConstantNarrowing.scala` updated accordingly).
- Corrected `docs/quality-bar.md` row 5 ("known usability bugs"), which still listed #374 as open even though it shipped in v0.7.0; folded it into the "previously resolved" list with a note about this follow-up fix.
- Added `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] New spec `MethodLiteralNarrowingSpec` (mirrors `ConstructorLiteralNarrowingSpec`): negative literal narrows to a top-level function's `Short`/`Byte` params, positive literal narrows to an instance method's `Byte` param, out-of-range literal still rejected.
- [x] Confirmed red before the fix (`E0005` on both narrowing cases), green after.
- [x] Full suite: `sbt -Duser.language=en test` — 2579 passed, 0 failed, 1 cancelled (gated dist smoke test).

---
_Generated by [Claude Code](https://claude.ai/code/session_016Fucyvk4VKco2fKxroaY7y)_