### PR TITLE
fix(stdlib): HttpResource gains eachLine(shape), matching the 0.8.0 changelog promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **`http"…".eachLine(shape)` — v0.8.0 shipped only half of "the same on `http`".** The
+  0.8.0 changelog entry for shape-applied resource reads promised `eachLine` on `http"…"`
+  to match `file"…"`, but `HttpResource` only ever grew `read`; the line-oriented method
+  didn't exist, so calling it reported `E0005` ("method applicable ... is not found").
+  Added `HttpResource.eachLine(Shape[T])`, mirroring `FileResource.eachLine`: the response
+  body is split and parsed per line, keeping the lines that read and the defects for the
+  ones that didn't, each positioned by line number; a transport failure (bad URL, refused
+  connection, ...) is a single defect rather than a thrown exception, consistent with `read`.
+
 - **Constant narrowing now reaches ordinary method/function call arguments.** `val b: Byte = 100`
   and, since v0.7.0, `new R(..., -3)` against a `Short`/`Byte` component both narrow an
   in-range integer literal — but `takesShort(-3)` against a plain `def takesShort(x: Short)`

--- a/src/main/java/onion/HttpResource.java
+++ b/src/main/java/onion/HttpResource.java
@@ -1,5 +1,8 @@
 package onion;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A URL as a typed resource. Created by the {@code http"url"} literal (or
  * {@code http(url)}); the verb methods wrap {@link Http} so a fetch-and-parse
@@ -49,11 +52,31 @@ public final class HttpResource {
         try {
             body = get();
         } catch (Exception e) {
-            String m = e.getMessage();
-            return Outcome.bad(Defect.at(Origin.atLine(url, 1), "", "a successful response",
-                m == null || m.isEmpty() ? e.getClass().getSimpleName() : m));
+            return Outcome.bad(Defect.at(Origin.atLine(url, 1), "", "a successful response", describe(e)));
         }
         return shape.parse(body, Origin.atLine(url, 1));
+    }
+
+    /**
+     * One value per line of the response body, keeping both the lines that read and the
+     * reasons the rest did not -- see {@link Shape#eachLine}. Each defect is positioned on
+     * its line of the response. A transport failure is a single defect, not an exception.
+     */
+    public <T> List<Outcome<T>> eachLine(Shape<T> shape) {
+        String body;
+        try {
+            body = get();
+        } catch (Exception e) {
+            List<Outcome<T>> failed = new ArrayList<>();
+            failed.add(Outcome.bad(Defect.at(Origin.atLine(url, 1), "", "a successful response", describe(e))));
+            return failed;
+        }
+        return shape.eachLine(body, Origin.atLine(url, 1));
+    }
+
+    private static String describe(Exception e) {
+        String m = e.getMessage();
+        return m == null || m.isEmpty() ? e.getClass().getSimpleName() : m;
     }
 
     /** POST a body, returning the response body. */

--- a/src/test/scala/onion/compiler/tools/ResourceShapeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ResourceShapeSpec.scala
@@ -4,6 +4,8 @@ import onion.tools.Shell
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
+import java.net.InetSocketAddress
+import com.sun.net.httpserver.{HttpServer, HttpExchange, HttpHandler}
 
 /**
  * `file"…".read(shape)` and `http"…".read(shape)` replace a fixed method menu with an
@@ -98,6 +100,62 @@ class ResourceShapeSpec extends AbstractShellSpec {
           |}
           |""".stripMargin, "None", Array())
       assert(Shell.Success("a readable file") == r)
+    }
+  }
+
+  private def withHttpServer(body: String)(test: String => Unit): Unit = {
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/", new HttpHandler {
+      override def handle(exchange: HttpExchange): Unit = {
+        val bytes = body.getBytes(StandardCharsets.UTF_8)
+        exchange.sendResponseHeaders(200, bytes.length)
+        val os = exchange.getResponseBody
+        try os.write(bytes) finally os.close()
+      }
+    })
+    server.start()
+    try {
+      test(s"http://127.0.0.1:${server.getAddress.getPort}/")
+    } finally server.stop(0)
+  }
+
+  describe("reading an http resource through a shape") {
+    it("reads line-oriented responses, keeping the lines it could not read") {
+      withHttpServer("1,2\nbroken\n3,4\n") { url =>
+        val r = shell.run(
+          s"""
+             |record Pt(x: Int, y: Int)
+             |  shape text = re"(-?\\d+),(-?\\d+)"
+             |class Test {
+             |public:
+             |  static def main(args: String[]): String {
+             |    val each = http"$url".eachLine(Pt::text())
+             |    val bad = Outcome::defects(each)
+             |    return Outcome::values(each).size + "/" + bad.size + "/" +
+             |           (bad[0] as Defect).origin().line()
+             |  }
+             |}
+             |""".stripMargin, "None", Array())
+        assert(Shell.Success("2/1/2") == r)
+      }
+    }
+
+    it("reports a transport failure as a defect rather than throwing") {
+      val r = shell.run(
+        """
+          |record Pt(x: Int, y: Int)
+          |  shape text = re"(-?\d+),(-?\d+)"
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val each = http"not a valid url".eachLine(Pt::text())
+          |    val bad = Outcome::defects(each)
+          |    if bad.size != 1 { return "expected exactly one defect" }
+          |    return (bad[0] as Defect).expected()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("a successful response") == r)
     }
   }
 


### PR DESCRIPTION
## Summary

- v0.8.0's changelog entry for shape-applied resource reads promised `eachLine` on `http"…"` to match `file"…"`, but `HttpResource` only ever grew `read` — `eachLine` didn't exist, so calling it reported `E0005` ("method applicable ... is not found").
- Added `HttpResource.eachLine(Shape[T])`, mirroring `FileResource.eachLine`: the response body is split and parsed per line, keeping the lines that read alongside defects for the ones that didn't (each positioned by line number). A transport failure (bad URL, refused connection, ...) is a single defect rather than a thrown exception, consistent with `read`.
- Added a `CHANGELOG.md` entry under `[Unreleased]` (the gap shipped in the already-released 0.8.0, so it's not touched).

## Test plan

- [x] Added a failing-first test in `ResourceShapeSpec.scala` confirming `E0005` before the fix
- [x] Added a success-path test using a local `com.sun.net.httpserver.HttpServer` on loopback, mirroring the existing file-based `eachLine` test
- [x] Added a failure-path test (malformed URL) confirming a transport failure becomes a single `Defect` instead of throwing
- [x] `sbt -Duser.language=en 'testOnly *ResourceShapeSpec'` green
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2581 pass / 0 fail / 1 cancelled (the gated dist smoke test)


---
_Generated by [Claude Code](https://claude.ai/code/session_018G9dwNYLYBTn6dMUdjsn89)_