### PR TITLE
examples: add run/JsonYamlShapeDemo.on — shape name = json/yaml dogfood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **`run/JsonYamlShapeDemo.on` — a standalone example for `shape name = json`/`yaml`.**
+  The v0.8.0 named document-boundary shape had unit-test coverage (`FormatShapeSpec.scala`)
+  but no `run/` sample demonstrating it end-to-end. Added one covering parsing, the
+  round-trip law, a missing key, several bad fields reported at once, and a malformed
+  document's line number — mirroring the existing `BrokenLogDemo.on` pattern for the
+  regex-shape form.
+
 ## [0.8.0] - 2026-07-25
 
 The v0.8.0 tag was moved after the fact. As first cut it promised `eachLine` on

--- a/run/JsonYamlShapeDemo.on
+++ b/run/JsonYamlShapeDemo.on
@@ -1,0 +1,56 @@
+// JsonYamlShapeDemo — `shape name = json` / `yaml`, the named boundary over a structured
+// document.
+//
+// `record R(...) shape doc = json` (or `= yaml`) gives a record a named parse/print pair
+// over that document format, the same way `shape name = re"..."` names one over a line of
+// text. Unlike `derive!(Json, Yaml)`, a missing or wrongly-typed key is reported as a
+// Defect rather than silently building a record with a null non-nullable field, and a
+// record can carry a shape per format at once.
+//
+//   onion JsonYamlShapeDemo.on
+
+record Person(name: String, age: Int)
+  shape doc = json
+
+record Config(host: String, port: Int)
+  shape doc = yaml
+
+class JsonYamlShapeDemo {
+public:
+  static def main(args: String[]): Int {
+    // A clean document reads straight into the record.
+    val ok = Person::doc().parse("{\"name\": \"Ada\", \"age\": 36}")
+    IO::println("ok:      " + ok.isOk() + " -> " + ok.get().name() + ", " + ok.get().age())
+
+    // parse(print(v)) == Ok(v) — the round-trip law every printing shape guarantees.
+    val original = new Person("Grace", 85)
+    val roundTripped = Person::doc().parse(Person::doc().print(original)).get()
+    IO::println("roundtrip ok: " + (roundTripped == original))
+
+    // A missing key is a Defect, not a record with a null field.
+    val missing = Person::doc().parse("{\"age\": 30}")
+    IO::println("missing: " + missing.isOk())
+    foreach d: Defect in missing.defects() {
+      IO::println("  " + d.describe())
+    }
+
+    // Every bad field is reported at once, not just the first.
+    val bothBad = Person::doc().parse("{\"name\": 7, \"age\": \"old\"}")
+    IO::println("both bad defect count: " + bothBad.defects().size)
+
+    // Malformed JSON carries the line it failed on.
+    val broken = Person::doc().parse("{\n  \"name\": \"Ada\",\n  oops\n}")
+    if broken.isBad() {
+      val first = broken.defects()[0] as Defect
+      IO::println("malformed at line: " + first.origin().line())
+    }
+
+    // A second record with a yaml shape, round-tripped the same way.
+    val cfg = new Config("example.com", 8080)
+    val cfgText = Config::doc().print(cfg)
+    val cfgBack = Config::doc().parse(cfgText).get()
+    IO::println("yaml roundtrip ok: " + (cfgBack == cfg))
+
+    return 0
+  }
+}


### PR DESCRIPTION
## Summary
- The v0.8.0 `shape name = json`/`yaml` named document boundary (see `docs/guide/shapes.md`, `FormatShapeSpec.scala`) had unit-test coverage but no standalone `run/` sample demonstrating it end-to-end.
- Adds `run/JsonYamlShapeDemo.on`, mirroring the existing `BrokenLogDemo.on` pattern for the regex-shape form: a clean parse, the round-trip law (`parse(print(v)) == Ok(v)`), a missing key reported as a `Defect` instead of a null field, multiple bad fields reported at once, a malformed document's failing line number, and a second record using the `yaml` format.
- Notes the addition in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2584 tests, 0 failed, 1 cancelled (expected: the distribution smoke test), all passed.
- [x] Manually ran `sbt -Duser.language=en 'runScript run/JsonYamlShapeDemo.on'` and confirmed the output matches the demonstrated behavior (round-trip, missing-key defect, multi-field defects, malformed-document line number).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmzjspJXw8mTuwDo3p4Bhq)_