### PR TITLE
feat!: spell inheritance with words — `extends` / `conforms`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **BREAKING: inheritance is spelled with words. `:` became `extends` and `<:` became
+  `conforms`.** `class Dog : Animal <: Greeter` is now
+  `class Dog extends Animal conforms Greeter`; the same change applies to `record`,
+  `interface` and `trait` declarations. A symbol cannot be searched for, read aloud, or
+  guessed at from the outside, and `:` in particular already meant three other things
+  (type annotations, record components, `select` cases), so the one position where it
+  meant inheritance was the odd one out. `conforms` is a **soft keyword** — recognized
+  only in the supertype position — so `def conforms(..)`, a field or a local of that name
+  all still parse. Old source gets a targeted hint naming the replacement rather than a
+  bare list of expected tokens; `<:` is still lexed as a single token purely so that
+  hint can fire. The generated API-doc signatures and the VS Code grammar follow.
+
 - **`run/JsonYamlShapeDemo.on` — a standalone example for `shape name = json`/`yaml`.**
   The v0.8.0 named document-boundary shape had unit-test coverage (`FormatShapeSpec.scala`)
   but no `run/` sample demonstrating it end-to-end. Added one covering parsing, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ If modifying the parser grammar (`grammar/JJOnionParser.jj`):
 
 ```onion
 // Class definition with inheritance and interface implementation
-class MyClass : ParentClass <: Interface1, Interface2 {
+class MyClass extends ParentClass conforms Interface1, Interface2 {
   val immutableField: String      // immutable field
   var mutableField: Int           // mutable field
 public:
@@ -436,12 +436,14 @@ These are frequently confused with other languages. **Always check these:**
 
 ### Inheritance & Interfaces
 
-| Wrong (Java/Scala style) | Correct (Onion) |
-|--------------------------|-----------------|
-| `class A extends B` | `class A : B` - colon for inheritance |
-| `class A implements I` | `class A <: I` - `<:` for interface |
-| `class A extends B implements I` | `class A : B <: I` - combine both |
-| `class A implements I, J` | `class A <: I, J` - comma-separated |
+| Wrong | Correct (Onion) |
+|-------|-----------------|
+| `class A : B` (Onion before this change) | `class A extends B` - `extends` for a superclass |
+| `class A <: I` (Onion before this change) | `class A conforms I` - `conforms` for interfaces |
+| `class A implements I` (Java) | `class A conforms I` |
+| `class A extends B implements I` (Java) | `class A extends B conforms I` - combine both |
+| `class A conforms I, J` | ✓ correct - comma-separated |
+| `def conforms(..)` rejected as a keyword? | ✓ correct - `conforms` is a **soft** keyword; only the supertype position treats it specially |
 
 ### Records
 
@@ -450,11 +452,11 @@ These are frequently confused with other languages. **Always check these:**
 | `record Point { int x; int y; }` | `record Point(x: Int, y: Int)` - constructor-style |
 | `point.x` for record field | `point.x()` - record fields are methods (need parens) |
 | `point.copy(y=9)` unsupported? | ✓ correct - named partial copy, `copy()` clone, positional all work |
-| record with methods? | `record Fraction(num: Int, den: Int) { public: def plus(o: Fraction): Fraction = ...; static def of(...) ... }` - a record may carry a `{ access-section* }` body (instance/static/operator methods, private helpers); methods see the generated accessors. Also works on a generic record implementing a generic interface (`record Foo[T](v: T) <: Bar[T]`) |
+| record with methods? | `record Fraction(num: Int, den: Int) { public: def plus(o: Fraction): Fraction = ...; static def of(...) ... }` - a record may carry a `{ access-section* }` body (instance/static/operator methods, private helpers); methods see the generated accessors. Also works on a generic record implementing a generic interface (`record Foo[T](v: T) conforms Bar[T]`) |
 | `enum Planet(mass: Double) { MERCURY(3.3) }` | ✓ correct - data-carrying enums; `mass()` accessor, `values()`/`valueOf()` work |
 | ADT / sum-of-products enum? | `enum Shape { case Circle(radius: Double); case Square(side: Double); case Origin; public: def area(): Double = select this { case c is Circle: ...; case o is Origin: 0.0 } }` - `case`-keyword cases each carry their own fields; desugars to a sealed interface + one record per case, so `select` exhaustiveness (E0042) applies. Singleton case = zero-field record via `new Origin()`. A `case`-enum is a sealed hierarchy, not a `java.lang.Enum` (no `values()`/`ordinal()`); mixing shared params with `case` cases is an error |
 | generic ADT enum? | `enum Opt[T] { case Some(value: T); case Nothing }` - type parameters flow onto the generated sealed interface and each case record. A type pattern recovers the scrutinee's type argument, so matching `Some` out of an `Opt[String]` binds `Some[String]` and `s.value()` is a `String`. A *homogeneous* enum cannot take type parameters (it becomes a `java.lang.Enum`) |
-| derive a parser from a record by hand | `record R(...) from re"..."` - synthesizes `R::parse(s): R?` (anchored, null on no-match/convert-fail) and `R::parseAll(text): List`; `from` goes before `<:` |
+| derive a parser from a record by hand | `record R(...) from re"..."` - synthesizes `R::parse(s): R?` (anchored, null on no-match/convert-fail) and `R::parseAll(text): List`; `from` goes before `conforms` |
 | serialize a record by hand (JSON/YAML) | `record R(...) derive!(Json, Yaml)` - macro-derives `R::fromJson`/`toJson`/`fromYaml`/`toYaml` over a shared `toMap`/`fromMap` core; scalar components only (else E0062), unknown marker E0063; coexists with `from re"..."` |
 | test a record in a separate suite | `record R(...) law name(p: T) { boolExpr } example { boolExpr }` - the compiler runs them at build time; a false `example` is E0065, a falsified `law` is E0064 (with a counterexample); makes `parse∘format==id` machine-checked |
 

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ public:
 }
 
 sealed interface Shape {}
-record Circle(r: Int) <: Shape
-record Rect(w: Int, h: Int) <: Shape
+record Circle(r: Int) conforms Shape
+record Rect(w: Int, h: Int) conforms Shape
 select shape {                                     // exhaustiveness-checked
   case Circle(r):  println("circle " + r)
   case Rect(w, h): println(w * h)

--- a/docs/design/type-classes.md
+++ b/docs/design/type-classes.md
@@ -43,8 +43,8 @@ def sum[T: Numeric](xs: List[T]): T {
 
 - **`trait Name[T, …] { <sigs + optional default bodies> }`** — a near-clone of
   `interface_decl`, reusing `interface_method_decl` (which already parses both
-  abstract signatures and default-method bodies). Super-traits via `<:`
-  (`trait Ord[T] <: Eq[T]`), matching interface supertype syntax.
+  abstract signatures and default-method bodies). Super-traits via `conforms`
+  (`trait Ord[T] conforms Eq[T]`), matching interface supertype syntax.
 - **`instance TraitName[ConcreteType, …] { <method defs> }`** — body is a flat
   list of `method_decl` like `extension`; the head type list uses
   `type_arguments()` (so `instance Numeric[Int]`, `instance Show[List[String]]`
@@ -189,7 +189,7 @@ ground type.
 - **Stage 2 — `Eq`/`Ord`/`Show`.** Traits + instances; reframe `min`/`max`/`sort`
   on `Ord`; UFCS method-style calls for trait methods.
 - **Stage 3 — deriving.** `derive!(Eq, Ord, Show)` reusing the structural fold.
-- **Stage 4 — advanced.** Trait inheritance (`trait Ord[T] <: Eq[T]`), parametric/
+- **Stage 4 — advanced.** Trait inheritance (`trait Ord[T] conforms Eq[T]`), parametric/
   conditional instances (`instance [T: Numeric] Numeric[List[T]]`), full
   applied-type coherence keys, multi-parameter traits.
 

--- a/docs/examples/oop.md
+++ b/docs/examples/oop.md
@@ -53,7 +53,7 @@ protected:
     def speak: String = this.name + " makes a sound"
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   val breed: String
 
   public:
@@ -87,7 +87,7 @@ import {
   java.util.Arrays;
 }
 
-class Student <: Comparable[Object] {
+class Student conforms Comparable[Object] {
   val name: String
   val grade: Int
 
@@ -136,7 +136,7 @@ interface Logger {
   def count(): Int
 }
 
-class BasicLogger <: Logger {
+class BasicLogger conforms Logger {
   var n: Int
 
   public:
@@ -148,7 +148,7 @@ class BasicLogger <: Logger {
     def count(): Int = n
 }
 
-class Delegation <: Logger {
+class Delegation conforms Logger {
   forward val delegate: Logger
 
   public:
@@ -183,7 +183,7 @@ import {
   java.io.ByteArrayInputStream;
 }
 
-class ExampleBean <: Serializable {
+class ExampleBean conforms Serializable {
   var name: String
   var value: Int
 
@@ -257,7 +257,7 @@ import {
   java.awt.BorderLayout;
 }
 
-class Calculator : JFrame <: ActionListener {
+class Calculator extends JFrame conforms ActionListener {
   val text: JTextField
   var currentValue: Long
   var operator: String
@@ -351,7 +351,7 @@ class Calculator : JFrame <: ActionListener {
 ```
 
 **Topics:**
-- Multiple inheritance (extends JFrame, implements ActionListener)
+- Multiple inheritance (: JFrame, implements ActionListener)
 - Swing GUI components
 - Event handling
 - `self` reference

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -165,7 +165,7 @@ interface Logger {
   def count(): Int
 }
 
-class BasicLogger <: Logger {
+class BasicLogger conforms Logger {
   var n: Int
 
   public:
@@ -178,7 +178,7 @@ class BasicLogger <: Logger {
 }
 
 // `forward` auto-implements the Logger interface by delegating to `delegate`.
-class PrefixLogger <: Logger {
+class PrefixLogger conforms Logger {
   forward val delegate: Logger
 
   public:
@@ -189,9 +189,9 @@ class PrefixLogger <: Logger {
 ```
 
 Syntax:
-- `class Child : Parent` - extends a class
-- `class Impl <: Interface` - implements an interface
-- `class Multi : Parent <: Interface` - both
+- `class Child extends Parent` - extends a class
+- `class Impl conforms Interface` - implements an interface
+- `class Multi extends Parent conforms Interface` - both
 - `forward val m: Interface` - auto-implement `Interface` by delegating to `m`
 
 ## Java Interoperability

--- a/docs/guide/basic-syntax.md
+++ b/docs/guide/basic-syntax.md
@@ -364,7 +364,7 @@ closing `}` on the same line:
 ```onion
 interface Shape { def area(): Double }
 
-class Circle : Object <: Shape {
+class Circle extends Object conforms Shape {
   val r: Double
 public:
   def this(r: Double) { this.r = r }

--- a/docs/guide/classes-and-objects.md
+++ b/docs/guide/classes-and-objects.md
@@ -49,7 +49,7 @@ public:
 class Conf(val host: String = "localhost", var port: Int = 8080)
 
 class Animal(val name: String)
-class Dog(name: String, val breed: String) : Animal(name)   // body-less is fine
+class Dog(name: String, val breed: String) extends Animal(name)   // body-less is fine
 
 val p = new Point(3, 4)        // p.x, p.y readable; p.x = 9 is an error (val)
 val c = new Conf(port = 9090)  // host defaults to "localhost"
@@ -267,7 +267,7 @@ import {
   java.awt.event.ActionListener;
 }
 
-class ButtonHandler <: ActionListener {
+class ButtonHandler conforms ActionListener {
   public:
     def actionPerformed(event :ActionEvent) {
       val button: JButton = event.getSource() as JButton

--- a/docs/guide/control-flow.md
+++ b/docs/guide/control-flow.md
@@ -253,8 +253,8 @@ Records destructure positionally (`_` ignores a component), and `when`
 adds a guard to any pattern:
 
 ```onion
-record Circle(r: Int) <: Shape
-record Rect(w: Int, h: Int) <: Shape
+record Circle(r: Int) conforms Shape
+record Rect(w: Int, h: Int) conforms Shape
 
 select shape {
   case Circle(r) when r > 10: println("big circle")
@@ -268,8 +268,8 @@ place and used at the narrowed type:
 
 ```onion
 sealed interface E {}
-record Num(v: Int) <: E
-record Add(l: E, r: E) <: E
+record Num(v: Int) conforms E
+record Add(l: E, r: E) conforms E
 record Wrap(x: Object)
 
 select e {

--- a/docs/guide/inheritance.md
+++ b/docs/guide/inheritance.md
@@ -6,7 +6,7 @@ Onion supports both class inheritance and interface implementation, allowing you
 
 ### Basic Inheritance
 
-Use `:` to extend a parent class:
+Use `extends` to extend a parent class:
 
 ```onion
 class Animal {
@@ -21,7 +21,7 @@ protected:
     def speak: String = "Some sound"
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   public:
     def this(n: String): (n) { }
 
@@ -46,7 +46,7 @@ class Vehicle {
     }
 }
 
-class Car : Vehicle {
+class Car extends Vehicle {
   val model: String
 
   public:
@@ -68,7 +68,7 @@ class Shape {
     def describe: String = "A shape"
 }
 
-class Circle : Shape {
+class Circle extends Shape {
   val radius: Double
 
   public:
@@ -86,12 +86,12 @@ class Circle : Shape {
 
 ### Single Interface
 
-Use `<:` to implement an interface:
+Use `conforms` to implement an interface:
 
 ```onion
 import { java.lang.Comparable; }
 
-class Person <: Comparable[Object] {
+class Person conforms Comparable[Object] {
   val name: String
   val age: Int
 
@@ -121,7 +121,7 @@ interface Greeter {
   def shout(): String = "HEY " + this.name()
 }
 
-class K <: Greeter {
+class K conforms Greeter {
 public:
   def this {}
   def name(): String { return "kota" }
@@ -140,7 +140,7 @@ import {
   java.lang.Comparable;
 }
 
-class Student <: Serializable, Comparable[Object] {
+class Student conforms Serializable, Comparable[Object] {
   val id: Int
   val name: String
 
@@ -159,7 +159,7 @@ class Student <: Serializable, Comparable[Object] {
 
 ## Combining Inheritance and Interfaces
 
-Use both `:` (extend class) and `<:` (implement interface):
+Use both `extends` (extend a class) and `conforms` (implement an interface):
 
 ```onion
 import {
@@ -168,7 +168,7 @@ import {
   java.awt.event.ActionEvent;
 }
 
-class Calculator : JFrame <: ActionListener {
+class Calculator extends JFrame conforms ActionListener {
   var result: Long
 
   public:
@@ -186,7 +186,7 @@ class Calculator : JFrame <: ActionListener {
 
 Syntax:
 ```onion
-class Child : ParentClass <: Interface1, Interface2 {
+class Child extends ParentClass conforms Interface1, Interface2 {
   // ...
 }
 ```
@@ -203,7 +203,7 @@ interface Logger {
   def count(): Int
 }
 
-class BasicLogger <: Logger {
+class BasicLogger conforms Logger {
   var n: Int
 
   public:
@@ -215,7 +215,7 @@ class BasicLogger <: Logger {
     def count(): Int = n
 }
 
-class PrefixLogger <: Logger {
+class PrefixLogger conforms Logger {
   forward val delegate: Logger
 
   public:
@@ -248,7 +248,7 @@ import {
   java.util.ArrayList;
 }
 
-class MyList <: List[String] {
+class MyList conforms List[String] {
   forward val backing: List[String]
 
   public:
@@ -278,14 +278,14 @@ interface Container[T] {
   def count(): Int
 }
 
-class IntBox <: Container[Int] {
+class IntBox conforms Container[Int] {
   public:
     def this {}
     def first(): Int { return 42 }
     def count(): Int { return 3 }
 }
 
-class Wrapper <: Container[Int] {
+class Wrapper conforms Container[Int] {
   forward val inner: Container[Int]
 
   public:
@@ -311,12 +311,12 @@ class Animal {
     def speak: String = "Generic sound"
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   public:
     def speak: String = "Woof!"
 }
 
-class Cat : Animal {
+class Cat extends Animal {
   public:
     def speak: String = "Meow!"
 }
@@ -366,7 +366,7 @@ abstract class Shape {
     abstract def area(): Double;
 }
 
-class Circle : Shape {
+class Circle extends Shape {
   val radius: Double
 
   public:
@@ -391,10 +391,10 @@ interface Logger {
 }
 
 // Instead of inheriting from a concrete BasicLogger...
-// class PrefixLogger : BasicLogger { ... }
+// class PrefixLogger extends BasicLogger { ... }
 
 // ...prefer delegating to the Logger interface.
-class PrefixLogger <: Logger {
+class PrefixLogger conforms Logger {
   forward val delegate: Logger
 
   public:
@@ -437,7 +437,7 @@ class Parent {
     }
 }
 
-class Child : Parent {
+class Child extends Parent {
   public:
     def process(value :Int) :Int {
       // Maintain parent's behavior

--- a/docs/guide/java-interop.md
+++ b/docs/guide/java-interop.md
@@ -244,7 +244,7 @@ import {
   javax.swing.JButton;
 }
 
-class MyButtonHandler <: ActionListener {
+class MyButtonHandler conforms ActionListener {
   public:
     def actionPerformed(event :ActionEvent) {
       println("Button clicked!")
@@ -263,7 +263,7 @@ button.addActionListener(handler)
 ```onion
 import { java.lang.Runnable; }
 
-class MyTask <: Runnable {
+class MyTask conforms Runnable {
   val name: String
 
   public:
@@ -286,7 +286,7 @@ thread.start()
 ```onion
 import { java.lang.Comparable; }
 
-class Person <: Comparable[Object] {
+class Person conforms Comparable[Object] {
   val name: String
   val age: Int
 
@@ -314,7 +314,7 @@ import {
   java.awt.FlowLayout;
 }
 
-class MyWindow : JFrame {
+class MyWindow extends JFrame {
   public:
     def this {
       setTitle("My Window")
@@ -407,7 +407,7 @@ import {
   java.awt.event.ActionEvent;
 }
 
-class CalculatorApp : JFrame <: ActionListener {
+class CalculatorApp extends JFrame conforms ActionListener {
   val textField: JTextField
   var currentValue: Double
 

--- a/docs/guide/lambda-expressions.md
+++ b/docs/guide/lambda-expressions.md
@@ -312,7 +312,7 @@ import {
   java.util.Comparator;
 }
 
-class LambdaComparator <: Comparator[Object] {
+class LambdaComparator conforms Comparator[Object] {
   val compareFunc: (Object, Object) -> Int
 
   public:
@@ -355,7 +355,7 @@ import {
   java.awt.event.ActionEvent;
 }
 
-class LambdaActionListener <: ActionListener {
+class LambdaActionListener conforms ActionListener {
   val handler: (ActionEvent) -> Int
 
   public:

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -74,7 +74,7 @@ class Animal {
     }
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   public:
     def this(n: String): (n) {
     }

--- a/docs/guide/variables-and-types.md
+++ b/docs/guide/variables-and-types.md
@@ -295,7 +295,7 @@ identical parameterization is compatible:
 
 ```onion
 class Animal { public: def this {} }
-class Dog : Animal { public: def this {} }
+class Dog extends Animal { public: def this {} }
 
 class Box[T] {
   val v: T

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Describe a boundary once — a log format, a JSON document, a command line — a
 println("Hello, World!")
 
 // Class definition with inheritance
-class Calculator : JFrame <: ActionListener {
+class Calculator extends JFrame conforms ActionListener {
   var result: Long
 
   public:

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -211,7 +211,7 @@ Onionコンパイラは、古典的なコンパイラアーキテクチャに従
 
 ```onion
 // 継承とインターフェース実装を伴うクラス定義
-class MyClass : ParentClass <: Interface1, Interface2 {
+class MyClass extends ParentClass conforms Interface1, Interface2 {
   val immutableField: String      // 不変フィールド
   var mutableField: Int           // 可変フィールド
 public:
@@ -380,12 +380,14 @@ try {
 
 ### 継承とインターフェース
 
-| 誤り（Java/Scala風） | 正しい（Onion） |
-|---------------------|----------------|
-| `class A extends B` | `class A : B` - 継承はコロン |
-| `class A implements I` | `class A <: I` - インターフェースは`<:` |
-| `class A extends B implements I` | `class A : B <: I` - 両方を組み合わせ |
-| `class A implements I, J` | `class A <: I, J` - カンマ区切り |
+| 誤り | 正しい（Onion） |
+|------|----------------|
+| `class A : B`（この変更以前のOnion） | `class A extends B` - 親クラスは `extends` |
+| `class A <: I`（この変更以前のOnion） | `class A conforms I` - インターフェースは `conforms` |
+| `class A implements I`（Java） | `class A conforms I` |
+| `class A extends B implements I`（Java） | `class A extends B conforms I` - 両方を組み合わせ |
+| `class A conforms I, J` | ✓ 正しい - カンマ区切り |
+| `def conforms(..)` はキーワードだから書けない？ | ✓ 書ける - `conforms` は**ソフトキーワード**で、スーパータイプ位置でのみ特別扱いされる |
 
 ### レコード
 

--- a/docs/ja/examples/oop.md
+++ b/docs/ja/examples/oop.md
@@ -53,7 +53,7 @@ protected:
     def speak: String = this.name + " makes a sound"
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   val breed: String
 
   public:
@@ -87,7 +87,7 @@ import {
   java.util.Arrays;
 }
 
-class Student <: Comparable[Object] {
+class Student conforms Comparable[Object] {
   val name: String
   val grade: Int
 
@@ -136,7 +136,7 @@ interface Logger {
   def count(): Int
 }
 
-class BasicLogger <: Logger {
+class BasicLogger conforms Logger {
   var n: Int
 
   public:
@@ -148,7 +148,7 @@ class BasicLogger <: Logger {
     def count(): Int = n
 }
 
-class Delegation <: Logger {
+class Delegation conforms Logger {
   forward val delegate: Logger
 
   public:
@@ -183,7 +183,7 @@ import {
   java.io.ByteArrayInputStream;
 }
 
-class ExampleBean <: Serializable {
+class ExampleBean conforms Serializable {
   var name: String
   var value: Int
 
@@ -257,7 +257,7 @@ import {
   java.awt.BorderLayout;
 }
 
-class Calculator : JFrame <: ActionListener {
+class Calculator extends JFrame conforms ActionListener {
   val text: JTextField
   var currentValue: Long
   var operator: String

--- a/docs/ja/getting-started/quick-start.md
+++ b/docs/ja/getting-started/quick-start.md
@@ -165,7 +165,7 @@ interface Logger {
   def count(): Int
 }
 
-class BasicLogger <: Logger {
+class BasicLogger conforms Logger {
   var n: Int
 
   public:
@@ -178,7 +178,7 @@ class BasicLogger <: Logger {
 }
 
 // `forward` は Logger インターフェースを `delegate` への委譲で自動実装します。
-class PrefixLogger <: Logger {
+class PrefixLogger conforms Logger {
   forward val delegate: Logger
 
   public:
@@ -189,9 +189,9 @@ class PrefixLogger <: Logger {
 ```
 
 構文：
-- `class Child : Parent` - クラスを継承
-- `class Impl <: Interface` - インターフェースを実装
-- `class Multi : Parent <: Interface` - 両方
+- `class Child extends Parent` - クラスを継承
+- `class Impl conforms Interface` - インターフェースを実装
+- `class Multi extends Parent conforms Interface` - 両方
 - `forward val m: Interface` - `Interface` を `m` への委譲で自動実装
 
 ## Java相互運用

--- a/docs/ja/guide/basic-syntax.md
+++ b/docs/ja/guide/basic-syntax.md
@@ -239,7 +239,7 @@ class Person {
 ```onion
 interface Shape { def area(): Double }
 
-class Circle : Object <: Shape {
+class Circle extends Object conforms Shape {
   val r: Double
 public:
   def this(r: Double) { this.r = r }

--- a/docs/ja/guide/classes-and-objects.md
+++ b/docs/ja/guide/classes-and-objects.md
@@ -41,7 +41,7 @@ public:
 class Conf(val host: String = "localhost", var port: Int = 8080)
 
 class Animal(val name: String)
-class Dog(name: String, val breed: String) : Animal(name)
+class Dog(name: String, val breed: String) extends Animal(name)
 
 val p = new Point(3, 4)        // p.x、p.y が使える
 val c = new Conf(port = 9090)  // host はデフォルト値 "localhost"

--- a/docs/ja/guide/control-flow.md
+++ b/docs/ja/guide/control-flow.md
@@ -45,8 +45,8 @@ else: handleOther()
 
 ```onion
 sealed interface E {}
-record Num(v: Int) <: E
-record Add(l: E, r: E) <: E
+record Num(v: Int) conforms E
+record Add(l: E, r: E) conforms E
 record Wrap(x: Object)
 
 select e {

--- a/docs/ja/guide/inheritance.md
+++ b/docs/ja/guide/inheritance.md
@@ -4,7 +4,7 @@ Onionはクラスの継承とインターフェースの実装をサポートし
 
 ## クラスの継承
 
-`:` で親クラスを継承します：
+`extends` で親クラスを継承します：
 
 ```onion
 class Animal {
@@ -18,7 +18,7 @@ class Animal {
     def speak: String = "Some sound"
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   public:
     def this(n: String): (n) { }   // 親コンストラクタの呼び出し
 
@@ -41,7 +41,7 @@ class Vehicle {
     }
 }
 
-class Car : Vehicle {
+class Car extends Vehicle {
   val model: String
 
   public:
@@ -53,12 +53,12 @@ class Car : Vehicle {
 
 ## インターフェースの実装
 
-`<:` でインターフェースを実装します。複数のインターフェースはカンマ区切りで列挙します：
+`conforms` でインターフェースを実装します。複数のインターフェースはカンマ区切りで列挙します：
 
 ```onion
 import { java.lang.Comparable; }
 
-class Person <: Comparable[Object] {
+class Person conforms Comparable[Object] {
   val name: String
   val age: Int
 
@@ -85,7 +85,7 @@ interface Greeter {
   def greet(): String { return "Hello, " + this.name() }
 }
 
-class K <: Greeter {
+class K conforms Greeter {
 public:
   def this {}
   def name(): String { return "kota" }
@@ -96,11 +96,11 @@ println(new K().greet())   // Hello, kota（overrideなしで使える）
 
 ## 継承とインターフェースの組み合わせ
 
-`:` と `<:` を組み合わせて使えます：
+`extends` と `conforms` を組み合わせて使えます：
 
 ```onion
 // 構文
-class Child : ParentClass <: Interface1, Interface2 {
+class Child extends ParentClass conforms Interface1, Interface2 {
   // ...
 }
 ```
@@ -115,7 +115,7 @@ interface Logger {
   def count(): Int
 }
 
-class BasicLogger <: Logger {
+class BasicLogger conforms Logger {
   var n: Int
 
   public:
@@ -127,7 +127,7 @@ class BasicLogger <: Logger {
     def count(): Int = n
 }
 
-class PrefixLogger <: Logger {
+class PrefixLogger conforms Logger {
   forward val delegate: Logger
 
   public:
@@ -156,7 +156,7 @@ import {
   java.util.ArrayList;
 }
 
-class MyList <: List[String] {
+class MyList conforms List[String] {
   forward val backing: List[String]
 
   public:
@@ -186,14 +186,14 @@ interface Container[T] {
   def count(): Int
 }
 
-class IntBox <: Container[Int] {
+class IntBox conforms Container[Int] {
   public:
     def this {}
     def first(): Int { return 42 }
     def count(): Int { return 3 }
 }
 
-class Wrapper <: Container[Int] {
+class Wrapper conforms Container[Int] {
   forward val inner: Container[Int]
 
   public:
@@ -217,12 +217,12 @@ class Animal {
     def speak: String = "Generic sound"
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   public:
     def speak: String = "Woof!"
 }
 
-class Cat : Animal {
+class Cat extends Animal {
   public:
     def speak: String = "Meow!"
 }
@@ -250,7 +250,7 @@ abstract class Shape {
     abstract def area(): Double;
 }
 
-class Circle : Shape {
+class Circle extends Shape {
   val radius: Double
 
   public:

--- a/docs/ja/guide/java-interop.md
+++ b/docs/ja/guide/java-interop.md
@@ -109,12 +109,12 @@ xs.add(abs(-5))
 
 ## Javaインターフェースの実装
 
-`<:` でJavaインターフェースを実装します：
+`conforms` でJavaインターフェースを実装します：
 
 ```onion
 import { java.lang.Runnable; }
 
-class MyTask <: Runnable {
+class MyTask conforms Runnable {
   val name: String
 
   public:
@@ -143,7 +143,7 @@ import {
   java.awt.FlowLayout;
 }
 
-class MyWindow : JFrame {
+class MyWindow extends JFrame {
   public:
     def this {
       setTitle("My Window")

--- a/docs/ja/guide/overview.md
+++ b/docs/ja/guide/overview.md
@@ -69,7 +69,7 @@ class Animal {
     def speak: String = "Some sound"
 }
 
-class Dog : Animal {
+class Dog extends Animal {
   public:
     def this(n: String): (n) { }
 

--- a/docs/ja/guide/variables-and-types.md
+++ b/docs/ja/guide/variables-and-types.md
@@ -88,7 +88,7 @@ val x: Int = list.get(0)
 
 ```onion
 class Animal { public: def this {} }
-class Dog : Animal { public: def this {} }
+class Dog extends Animal { public: def this {} }
 
 class Box[T] {
   val v: T

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -30,7 +30,7 @@
 println("Hello, World!")
 
 // 継承を伴うクラス定義
-class Calculator : JFrame <: ActionListener {
+class Calculator extends JFrame conforms ActionListener {
   var result: Long
 
   public:

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -170,8 +170,8 @@ sealed 型に対する `select` がすべてのケースを網羅していませ
 
 ```onion
 sealed interface Shape {}
-record Circle(r: Int) <: Shape
-record Rect(w: Int, h: Int) <: Shape
+record Circle(r: Int) conforms Shape
+record Rect(w: Int, h: Int) conforms Shape
 
 select shape {
   case Circle(r): println("circle")

--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -99,7 +99,7 @@ val         var         when        while
 契約とプリミティブ実装の間のブリッジを生成します。
 
 ```onion
-class IntComparator <: Comparator[Int] {
+class IntComparator conforms Comparator[Int] {
 public:
   def compare(a: Int, b: Int): Int {
     return a - b
@@ -158,7 +158,7 @@ def generic[T](x: T): T { ... }                     // メソッド型パラメ�
 ### クラス
 
 ```onion
-class Name [TypeParams] [(primary params)] [: Super[(args)]] [<: I1, I2] {
+class Name [TypeParams] [(primary params)] [extends Super[(args)]] [conforms I1, I2] {
   sections
 }
 ```
@@ -170,7 +170,7 @@ class Name [TypeParams] [(primary params)] [: Super[(args)]] [<: I1, I2] {
 
 ```onion
 class Point(val x: Int, val y: Int)
-class Dog(name: String, val breed: String) : Animal(name)
+class Dog(name: String, val breed: String) extends Animal(name)
 ```
 
 **クラシックなコンストラクタ**も利用可能です。
@@ -201,7 +201,7 @@ interface Greeter {
 
 ```onion
 record Point(x: Int, y: Int)
-record Pair[A, B](first: A, second: B) <: SomeInterface
+record Pair[A, B](first: A, second: B) conforms SomeInterface
 ```
 
 コンポーネントは private final フィールドになり、public アクセサ *メソッド* が
@@ -225,7 +225,7 @@ public:
 
 #### パターン付き records (`from re"..."`)
 
-record は、コンポーネントリストの直後（`<:` スーパータイプの前）に正規表現リテラルを
+record は、コンポーネントリストの直後（`conforms` スーパータイプの前）に正規表現リテラルを
 付けることで、その形状から型付きパーサーを導出できます。`from` はソフトキーワードで、
 直後に正規表現リテラルが続く場合にのみ認識されるため、通常の識別子としても使えます。
 
@@ -301,7 +301,7 @@ shape は呼び出しごとに再構築されるので、多くの入力を読�
 
 #### `derive!` — record serde 導出
 
-record のコンポーネントリストの後（または `from re"..."` 節の後、`<:` スーパータイプの前）に
+record のコンポーネントリストの後（または `from re"..."` 節の後、`conforms` スーパータイプの前）に
 `derive!(Format, ...)` を追加すると、コンパイラは record の形状からシリアライズメソッドを
 合成します。`!` 接尾辞は、型クラス制約ではなくマクロスタイルの展開を示します。
 
@@ -309,7 +309,7 @@ record のコンポーネントリストの後（または `from re"..."` 節の
 record User(name: String, age: Int) derive!(Json)
 record Config(host: String, port: Int, debug: Boolean) derive!(Json, Yaml)
 record Point(x: Int, y: Int) from re"(-?\d+),(-?\d+)" derive!(Json, Yaml)
-  <: Printable
+  conforms Printable
 ```
 
 サポートされるマーカーは **`Json`** と **`Yaml`** です。認識できないマーカーは **E0063** です。
@@ -438,7 +438,7 @@ type Names = List[String]
 ### 委譲
 
 ```onion
-class MyClass <: Interface {
+class MyClass conforms Interface {
   forward val member: Interface
   ...
 }

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -170,8 +170,8 @@ A `select` on a sealed type does not cover all cases.
 
 ```onion
 sealed interface Shape {}
-record Circle(r: Int) <: Shape
-record Rect(w: Int, h: Int) <: Shape
+record Circle(r: Int) conforms Shape
+record Rect(w: Int, h: Int) conforms Shape
 
 select shape {
   case Circle(r): println("circle")

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -104,7 +104,7 @@ Primitive types can be used as type arguments. They are boxed internally
 necessary bridges between the erased boxed contract and the primitive implementation.
 
 ```onion
-class IntComparator <: Comparator[Int] {
+class IntComparator conforms Comparator[Int] {
 public:
   def compare(a: Int, b: Int): Int {
     return a - b
@@ -164,7 +164,7 @@ support named arguments and defaults.
 ### Classes
 
 ```onion
-class Name [TypeParams] [(primary params)] [: Super[(args)]] [<: I1, I2] {
+class Name [TypeParams] [(primary params)] [extends Super[(args)]] [conforms I1, I2] {
   sections
 }
 ```
@@ -176,7 +176,7 @@ optional.
 
 ```onion
 class Point(val x: Int, val y: Int)
-class Dog(name: String, val breed: String) : Animal(name)
+class Dog(name: String, val breed: String) extends Animal(name)
 ```
 
 **Classic constructors** remain available:
@@ -208,7 +208,7 @@ exhaustiveness checking in `select`.
 
 ```onion
 record Point(x: Int, y: Int)
-record Pair[A, B](first: A, second: B) <: SomeInterface
+record Pair[A, B](first: A, second: B) conforms SomeInterface
 ```
 
 Components become private final fields with public accessor *methods*
@@ -233,7 +233,7 @@ public:
 #### Pattern-attached records (`from re"..."`)
 
 A record can derive a typed parser from its shape by attaching a regex
-literal right after the component list (before any `<:` supertypes). `from`
+literal right after the component list (before any `conforms` supertypes). `from`
 is a soft keyword, recognized only when immediately followed by a regex
 literal, so it stays usable as an ordinary identifier:
 
@@ -318,7 +318,7 @@ shape over a type you did not declare.
 #### `derive!` — record serde derivation
 
 Adding `derive!(Format, ...)` after a record's component list (or after a
-`from re"..."` clause, before any `<:` supertypes) instructs the compiler to
+`from re"..."` clause, before any `conforms` supertypes) instructs the compiler to
 synthesize serialization methods from the record's shape. The `!` suffix
 signals macro-style expansion rather than a type-class constraint.
 
@@ -326,7 +326,7 @@ signals macro-style expansion rather than a type-class constraint.
 record User(name: String, age: Int) derive!(Json)
 record Config(host: String, port: Int, debug: Boolean) derive!(Json, Yaml)
 record Point(x: Int, y: Int) from re"(-?\d+),(-?\d+)" derive!(Json, Yaml)
-  <: Printable
+  conforms Printable
 ```
 
 Supported markers are **`Json`** and **`Yaml`**; an unrecognized marker is
@@ -462,7 +462,7 @@ type Names = List[String]
 ### Delegation
 
 ```onion
-class MyClass <: Interface {
+class MyClass conforms Interface {
   forward val member: Interface
   ...
 }

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -1000,6 +1000,10 @@ TOKEN : {
 | <DOTDOT:         ".."           >
 | <ARROW2:         "=>"           >
 | <LARROW:         "<-"           >
+// No longer part of any production: `class A <: I` became `class A conforms I`, and
+// `class A : B` became `class A extends B`. The token is kept so that old source still
+// lexes as one `<:` and reports `Encountered "<:"` rather than splitting into `<` and `:`
+// and pointing somewhere unhelpful.
 | <SUBTYPE:        "<:"           >
 | <NOT:            "!"            >
 | <AMP:            "&"            >
@@ -1440,13 +1444,15 @@ AST.ClassDeclaration class_decl(int mset) : {
     [ {kind = 0;} [ (pk="val" {kind = 1;} | pk="var" {kind = 2;}) ] pa=argument() {primaryParams.add(pa); primaryKinds.add(kind);}
       ("," {kind = 0;} [ (pk="val" {kind = 1;} | pk="var" {kind = 2;}) ] pa=argument() {primaryParams.add(pa); primaryKinds.add(kind);})*
     ] ")" ]
-  [":" ty1=type() [LOOKAHEAD(2) "(" superArgs=terms() ")"]]
-  ["<:" ty2=type() {append(ty2s, ty2);} ("," ty2=type() {append(ty2s, ty2);})*]
+  [<K_EXTENDS> ty1=type() [LOOKAHEAD(2) "(" superArgs=terms() ")"]]
+  // `conforms` is a soft keyword: recognized only in this supertype position, so it
+  // stays usable as an ordinary identifier (a `def conforms(..)` still parses).
+  [ LOOKAHEAD({getToken(1).image.equals("conforms")}) <ID> ty2=type() {append(ty2s, ty2);} ("," ty2=type() {append(ty2s, ty2);})*]
   ( "{"
     [sec1=default_section()] { sec3 = option(sec1); }
     (sec2=access_section() {append(sec2s, sec2);})*
     "}" [";"]
-  | ";"   // body-less: class Dog(name: String, val breed: String) : Animal(name);
+  | ";"   // body-less: class Dog(name: String, val breed: String) extends Animal(name);
   | LOOKAHEAD({getToken(1).kind != LBRACE}) {}
   ) {
     if (sec3 == null) { sec3 = option(sec1); }
@@ -1542,7 +1548,7 @@ AST.RecordDeclaration record_decl(int mset) : {
           { append(shapeBuf, AST.formatShapeClause(p(st), c(st), c(srt))); }
       )
   )*
-  [ "<:"
+  [ LOOKAHEAD({getToken(1).image.equals("conforms")}) <ID>
     superType = type() {append(superTypes, superType);}
     ("," superType = type() {append(superTypes, superType);})*
   ]
@@ -1568,7 +1574,7 @@ AST.InterfaceDeclaration interface_decl(int mset) : {
   List<AST.TypeParameter> tparams = scala.collection.immutable.List$.MODULE$.<AST.TypeParameter>empty();
 }{
   start = "interface" name = id() [tparams=type_params()]
-  [ "<:"
+  [ LOOKAHEAD({getToken(1).image.equals("conforms")}) <ID>
     superType = type() {append(superTypes, superType);}
     ("," superType = type() {append(superTypes, superType);})*
   ]
@@ -1599,7 +1605,7 @@ AST.InterfaceDeclaration trait_decl(int mset) : {
   List<AST.TypeParameter> tparams = scala.collection.immutable.List$.MODULE$.<AST.TypeParameter>empty();
 }{
   start = "trait" name = id() [tparams=type_params()]
-  [ "<:"
+  [ LOOKAHEAD({getToken(1).image.equals("conforms")}) <ID>
     superType = type() {append(superTypes, superType);}
     ("," superType = type() {append(superTypes, superType);})*
   ] "{"

--- a/grammar/JJOnionParserRefactored.jj
+++ b/grammar/JJOnionParserRefactored.jj
@@ -323,7 +323,7 @@ TOKEN : {
 | <GT:             ">"            >
 | <ARROW:          "->"           >
 | <ARROW2:         "=>"           >
-| <SUBTYPE:        "<:"           >
+| <K_CONFORMS:     "conforms"      >
 | <NOT:            "!"            >
 | <AMP:            "&"            >
 | <AND:            "&&"           >
@@ -475,7 +475,7 @@ AST.ClassDeclaration class_decl(int mset) : {
   ArrayBuffer<AST.AccessSection> sec2s = new ArrayBuffer<AST.AccessSection>();
 }{
   t1="class" t2=<ID> [":" ty1=class_type()]
-  ["<:" ty2=class_type() {append(ty2s, ty2);} ("," ty2=class_type() {append(ty2s, ty2);})*] "{"
+  [<K_CONFORMS> ty2=class_type() {append(ty2s, ty2);} ("," ty2=class_type() {append(ty2s, ty2);})*] "{"
     [sec1=default_section()] { sec3 = option(sec1); }
     (sec2=access_section() {append(sec2s, sec2);})*
   "}" {

--- a/run/Bean.on
+++ b/run/Bean.on
@@ -3,7 +3,7 @@ import {
   java.beans.*;
 }
 
-class ExampleBean <: Serializable {
+class ExampleBean conforms Serializable {
   var name: String;
   var value: Int;
 

--- a/run/Calculator.on
+++ b/run/Calculator.on
@@ -5,7 +5,7 @@ import {
 	java.lang.Long as JLong;
 }
 
-class Calculator : JFrame <: ActionListener {
+class Calculator extends JFrame conforms ActionListener {
 	val text: JTextField
 	var left: Long
 	var right: Long

--- a/run/ExprEval.on
+++ b/run/ExprEval.on
@@ -6,7 +6,7 @@ interface Expr {
   def show(): String
 }
 
-class Num <: Expr {
+class Num conforms Expr {
   val value: Int
 public:
   def this(v: Int) { this.value = v }
@@ -14,7 +14,7 @@ public:
   def show(): String { return "" + value }
 }
 
-class Add <: Expr {
+class Add conforms Expr {
   val left: Expr
   val right: Expr
 public:
@@ -23,7 +23,7 @@ public:
   def show(): String { return "(" + left.show() + " + " + right.show() + ")" }
 }
 
-class Sub <: Expr {
+class Sub conforms Expr {
   val left: Expr
   val right: Expr
 public:
@@ -32,7 +32,7 @@ public:
   def show(): String { return "(" + left.show() + " - " + right.show() + ")" }
 }
 
-class Mul <: Expr {
+class Mul conforms Expr {
   val left: Expr
   val right: Expr
 public:
@@ -41,7 +41,7 @@ public:
   def show(): String { return "(" + left.show() + " * " + right.show() + ")" }
 }
 
-class Neg <: Expr {
+class Neg conforms Expr {
   val arg: Expr
 public:
   def this(a: Expr) { this.arg = a }
@@ -67,7 +67,7 @@ val shownDesc = exprs
   .map { ex => (ex as Expr).show() }
 IO::println("byValueDesc: " + shownDesc.toString())
 
-class Div <: Expr {
+class Div conforms Expr {
   val left: Expr
   val right: Expr
 public:

--- a/run/ShapeProcessor.on
+++ b/run/ShapeProcessor.on
@@ -27,7 +27,7 @@ public:
   }
 }
 
-class CircleShape : Shape {
+class CircleShape extends Shape {
 public:
   val data: Circle
 
@@ -42,7 +42,7 @@ public:
   }
 }
 
-class RectangleShape : Shape {
+class RectangleShape extends Shape {
 public:
   val data: Rectangle
 
@@ -57,7 +57,7 @@ public:
   }
 }
 
-class PointShape : Shape {
+class PointShape extends Shape {
 public:
   val data: Point
 

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -90,3 +90,5 @@ error.parsing.unexpected_eof=unexpected end of file — a closing `}` or `)` is 
 error.semantic.lawParameterNotGeneratable=law `{0}` in {1} cannot run: there is no sample generator for parameter type {2}. Generatable types are String, Int, Long, Double, Float, Boolean, Short, Byte, and records whose components are all generatable. Change the parameter type or remove the law -- a law that cannot run must not look like one that passed.
 error.semantic.lawClassNotLoadable={0} declares law/example clauses but its class could not be loaded, so none of them ran.
 error.semantic.shapeFormatUnknown=unknown shape format `{0}`. Supported formats: {1}. For an inline pattern write `shape name = re"..."`.
+error.parsing.hint.old_extends=Hint: a superclass is named with `extends`, not `:` — write `class A extends B`.
+error.parsing.hint.old_conforms=Hint: interfaces are named with `conforms`, not `<:` — write `class A conforms I` (and `class A extends B conforms I`).

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -90,3 +90,5 @@ error.semantic.valRequiresInitializer=\u30ed\u30fc\u30ab\u30eb val {0} \u306f\u5
 error.semantic.lawParameterNotGeneratable=law `{0}`（{1}）は実行できません。引数の型 {2} に対応するサンプル生成器がありません。生成できる型は String, Int, Long, Double, Float, Boolean, Short, Byte と、全成分が生成可能なレコードです。引数の型を変えるか law を削除してください。実行されない law が「通った law」と同じに見えてはいけません。
 error.semantic.lawClassNotLoadable={0} は law/example 句を持ちますが、クラスをロードできなかったため、いずれも実行されませんでした。
 error.semantic.shapeFormatUnknown=未知の shape フォーマット `{0}` です。サポートしているフォーマット: {1}。インラインのパターンを書く場合は `shape name = re"..."` としてください。
+error.parsing.hint.old_extends=ヒント: 親クラスは `:` ではなく `extends` で指定します — `class A extends B` と書いてください。
+error.parsing.hint.old_conforms=ヒント: インターフェースは `<:` ではなく `conforms` で指定します — `class A conforms I`（親クラスと併用する場合は `class A extends B conforms I`）と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -177,6 +177,12 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * Add friendly hints for common syntax mistakes.
    */
   private def commonSyntaxHint(found: String, expected: String): String = found match {
+    // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
+    // `<:` no longer appears in any production, so meeting one can only be old source.
+    case "<:" =>
+      Message("error.parsing.hint.old_conforms")
+    case ":" if expected.contains("extends") =>
+      Message("error.parsing.hint.old_extends")
     case "in" =>
       "Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`."
     case "else" =>

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -224,11 +224,11 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
    * we generate:
    *   - `sealed interface Shape { <the enum body-section methods, verbatim, as
    *     default methods> }`
-   *   - `record Circle(radius: Double) <: Shape`  (one per product case)
-   *   - `record Square(side: Double) <: Shape`
-   *   - `record Origin() <: Shape`               (zero-field record per singleton)
+   *   - `record Circle(radius: Double) conforms Shape`  (one per product case)
+   *   - `record Square(side: Double) conforms Shape`
+   *   - `record Origin() conforms Shape`               (zero-field record per singleton)
    *
-   * A `sealed interface` + `record X <: Shape` + a `select` over `case x is X:`
+   * A `sealed interface` + `record X conforms Shape` + a `select` over `case x is X:`
    * gives exhaustiveness (E0042) for free. A singleton case is constructed as
    * `new Origin()` (first-cut form; see the singleton note below).
    */

--- a/src/main/scala/onion/compiler/typing/TypingDuplicationPass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingDuplicationPass.scala
@@ -175,7 +175,7 @@ final class TypingDuplicationPass(private val typing: Typing, private val unitCo
       DuplicationChecks.checkErasureSignatureCollisions(typing, clazz, node.location)
     }
 
-  // A record can declare `<: Interface`, but its only methods are the synthesized
+  // A record can declare `conforms Interface`, but its only methods are the synthesized
   // accessors; an interface method with no matching accessor was previously
   // unchecked, so the record compiled and threw AbstractMethodError at runtime.
   //

--- a/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
@@ -158,7 +158,7 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
 
     // Process super interfaces if any — with the record's type parameters in
     // scope, so a generic supertype like `Bar[T]` resolves (T is the record's
-    // own type parameter). Without this scope, `record Foo[T](v: T) <: Bar[T]`
+    // own type parameter). Without this scope, `record Foo[T](v: T) conforms Bar[T]`
     // failed with E0003 while the equivalent generic class (which resolves its
     // supertypes inside its type-parameter scope) worked.
     val interfaces = Buffer[ClassType]()
@@ -169,7 +169,7 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
           interfaces += superType
           // Register this record as a subtype of sealed interfaces. A generic
           // record implements a *parameterization* of the interface
-          // (`record Some[T](..) <: Opt[T]`), which is an AppliedClassType, so
+          // (`record Some[T](..) conforms Opt[T]`), which is an AppliedClassType, so
           // the raw class has to be unwrapped or the subtype goes unregistered
           // and exhaustiveness silently passes any select over it (#311).
           sealedOwnerOf(superType).foreach(_.addSealedSubtype(definition_))

--- a/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
+++ b/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
@@ -206,7 +206,7 @@ final class TypingTypeSupport(private val typing: Typing) {
                     // Object is the top type, so any reference-type argument satisfies
                     // an unbounded (Object) parameter. Short-circuit here: isAssignable
                     // walks the argument's supertype chain, which is not yet established
-                    // for a self/forward reference like `class Ver <: Comparable[Ver]`
+                    // for a self/forward reference like `class Ver conforms Comparable[Ver]`
                     // during the outline pass, and would wrongly reject it.
                     val satisfiesObjectBound = (upper eq typing.rootClass) && !checkedArg.isBasicType
                     if (!satisfiesObjectBound && !TypeRules.isAssignable(upper, checkedArg)) {

--- a/src/main/scala/onion/tools/doc/SignatureRenderer.scala
+++ b/src/main/scala/onion/tools/doc/SignatureRenderer.scala
@@ -86,10 +86,10 @@ object SignatureRenderer {
   def renderClass(c: AST.ClassDeclaration): String = {
     val tp = renderTypeParams(c.typeParameters)
     val sup =
-      if (c.superClass == null) "" else s" : ${renderType(c.superClass)}"
+      if (c.superClass == null) "" else s" extends ${renderType(c.superClass)}"
     val ifaces =
       if (c.superInterfaces.isEmpty) ""
-      else s" <: ${c.superInterfaces.map(renderType).mkString(", ")}"
+      else s" conforms ${c.superInterfaces.map(renderType).mkString(", ")}"
     s"class ${c.name}$tp$sup$ifaces"
   }
 
@@ -97,7 +97,7 @@ object SignatureRenderer {
     val tp = renderTypeParams(i.typeParameters)
     val ifaces =
       if (i.superInterfaces.isEmpty) ""
-      else s" <: ${i.superInterfaces.map(renderType).mkString(", ")}"
+      else s" conforms ${i.superInterfaces.map(renderType).mkString(", ")}"
     s"interface ${i.name}$tp$ifaces"
   }
 
@@ -106,7 +106,7 @@ object SignatureRenderer {
     val args = r.args.map(renderArg).mkString(", ")
     val ifaces =
       if (r.superInterfaces.isEmpty) ""
-      else s" <: ${r.superInterfaces.map(renderType).mkString(", ")}"
+      else s" conforms ${r.superInterfaces.map(renderType).mkString(", ")}"
     s"record ${r.name}$tp($args)$ifaces"
   }
 

--- a/src/test/resources/crash-corpus/013-super-arg-class-type.on
+++ b/src/test/resources/crash-corpus/013-super-arg-class-type.on
@@ -27,7 +27,7 @@ public:
   }
 }
 
-class CircleShape : Shape {
+class CircleShape extends Shape {
 public:
   val data: Circle
 
@@ -42,7 +42,7 @@ public:
   }
 }
 
-class RectangleShape : Shape {
+class RectangleShape extends Shape {
 public:
   val data: Rectangle
 
@@ -57,7 +57,7 @@ public:
   }
 }
 
-class PointShape : Shape {
+class PointShape extends Shape {
 public:
   val data: Point
 

--- a/src/test/scala/onion/compiler/tools/AbstractClassSpec.scala
+++ b/src/test/scala/onion/compiler/tools/AbstractClassSpec.scala
@@ -11,7 +11,7 @@ class AbstractClassSpec extends AbstractShellSpec {
           |public:
           |  abstract def speak(): String;
           |}
-          |class Dog : Animal {
+          |class Dog extends Animal {
           |public:
           |  def speak(): String { return "Woof!"; }
           |}
@@ -36,7 +36,7 @@ class AbstractClassSpec extends AbstractShellSpec {
           |public:
           |  abstract def area(): Int;
           |}
-          |class Square : Shape {
+          |class Square extends Shape {
           |  var side: Int;
           |public:
           |  def this(s: Int) { this.side = s; }
@@ -63,11 +63,11 @@ class AbstractClassSpec extends AbstractShellSpec {
           |public:
           |  abstract def getValue(): Int;
           |}
-          |abstract class Middle : Base {
+          |abstract class Middle extends Base {
           |public:
           |  def getDoubleValue(): Int { return getValue() * 2; }
           |}
-          |class Concrete : Middle {
+          |class Concrete extends Middle {
           |public:
           |  def getValue(): Int { return 10; }
           |}

--- a/src/test/scala/onion/compiler/tools/AbstractMethodBodySpec.scala
+++ b/src/test/scala/onion/compiler/tools/AbstractMethodBodySpec.scala
@@ -15,7 +15,7 @@ class AbstractMethodBodySpec extends AbstractShellSpec {
         | public:
         |   abstract def foo(): Int { return 99 }
         | }
-        | class I : B { public: override def foo(): Int = 1 }
+        | class I extends B { public: override def foo(): Int = 1 }
         | static def main(args: String[]): Int { return new I().foo() }
       """.stripMargin, "None", Array())
     assert(Shell.Failure(-1) == result)
@@ -28,7 +28,7 @@ class AbstractMethodBodySpec extends AbstractShellSpec {
         | public:
         |   abstract def foo(): Int
         | }
-        | class I : B { public: override def foo(): Int = 7 }
+        | class I extends B { public: override def foo(): Int = 7 }
         | static def main(args: String[]): Int { return new I().foo() }
       """.stripMargin, "None", Array())
     assert(Shell.Success(7) == result)
@@ -40,7 +40,7 @@ class AbstractMethodBodySpec extends AbstractShellSpec {
         | interface Greeter {
         |   def greet(): String { return "hi" }
         | }
-        | class G <: Greeter { }
+        | class G conforms Greeter { }
         | static def main(args: String[]): String { return (new G() as Greeter).greet() }
       """.stripMargin, "None", Array())
     assert(Shell.Success("hi") == result)

--- a/src/test/scala/onion/compiler/tools/AbstractMethodMemberOrderSpec.scala
+++ b/src/test/scala/onion/compiler/tools/AbstractMethodMemberOrderSpec.scala
@@ -17,7 +17,7 @@ class AbstractMethodMemberOrderSpec extends AbstractShellSpec {
         |  abstract def area(): Double
         |  abstract def perimeter(): Double
         |}
-        |class Square : Shape {
+        |class Square extends Shape {
         |public:
         |  def this {}
         |  def area(): Double = 4.0

--- a/src/test/scala/onion/compiler/tools/ArrayBranchLubSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ArrayBranchLubSpec.scala
@@ -19,12 +19,12 @@ class ArrayBranchLubSpec extends AbstractShellSpec {
           |   def this {}
           |   def sound(): String = "..."
           | }
-          | class Dog : Animal {
+          | class Dog extends Animal {
           | public:
           |   def this {}
           |   override def sound(): String = "woof"
           | }
-          | class Cat : Animal {
+          | class Cat extends Animal {
           | public:
           |   def this {}
           |   override def sound(): String = "meow"
@@ -49,8 +49,8 @@ class ArrayBranchLubSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           | class Animal { public: def this {} }
-          | class Dog : Animal { public: def this {} }
-          | class Cat : Animal { public: def this {} }
+          | class Dog extends Animal { public: def this {} }
+          | class Cat extends Animal { public: def this {} }
           | static def main(args: String[]): Int {
           |   val n = 1
           |   val xs = select n {
@@ -71,12 +71,12 @@ class ArrayBranchLubSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           | interface Shape { def area(): Int }
-          | class Sq <: Shape {
+          | class Sq conforms Shape {
           | public:
           |   def this {}
           |   def area(): Int = 4
           | }
-          | class Ci <: Shape {
+          | class Ci conforms Shape {
           | public:
           |   def this {}
           |   def area(): Int = 3

--- a/src/test/scala/onion/compiler/tools/BareInterfaceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/BareInterfaceSpec.scala
@@ -4,24 +4,24 @@ import onion.tools.Shell
 
 /**
  * An interface may omit its body, like a class can (`class Empty` already worked).
- * `interface Marker`, `interface Marker;`, and `interface Marker <: Simple` all
+ * `interface Marker`, `interface Marker;`, and `interface Marker conforms Simple` all
  * parse now (a bare marker interface used to be a syntax error).
  */
 class BareInterfaceSpec extends AbstractShellSpec {
   it("parses a bare marker interface") {
     assert(Shell.Success("ok") == shell.run(
-      "interface Marker\nclass C <: Marker { public: def this{} }\ndef main(args: String[]): String { return \"ok\" }", "None", Array()))
+      "interface Marker\nclass C conforms Marker { public: def this{} }\ndef main(args: String[]): String { return \"ok\" }", "None", Array()))
   }
   it("parses a bare sealed interface with record subtypes") {
     assert(Shell.Success(9) == shell.run(
-      "sealed interface Shape\nrecord Circle(r: Int) <: Shape\nrecord Square(s: Int) <: Shape\ndef area(sh: Shape): Int { return select sh { case Circle(r): r * r\n case Square(s): s * s } }\ndef main(args: String[]): Int { return area(new Circle(3)) }", "None", Array()))
+      "sealed interface Shape\nrecord Circle(r: Int) conforms Shape\nrecord Square(s: Int) conforms Shape\ndef area(sh: Shape): Int { return select sh { case Circle(r): r * r\n case Square(s): s * s } }\ndef main(args: String[]): Int { return area(new Circle(3)) }", "None", Array()))
   }
   it("parses a bare interface terminated with a semicolon") {
     assert(Shell.Success("ok") == shell.run(
-      "interface Marker;\nclass C <: Marker { public: def this{} }\ndef main(args: String[]): String { return \"ok\" }", "None", Array()))
+      "interface Marker;\nclass C conforms Marker { public: def this{} }\ndef main(args: String[]): String { return \"ok\" }", "None", Array()))
   }
   it("still parses an interface with a body") {
     assert(Shell.Success("hi") == shell.run(
-      "interface Greet { def hi(): String }\nclass C <: Greet { public: def this{}\n def hi(): String = \"hi\" }\ndef main(args: String[]): String { return new C().hi() }", "None", Array()))
+      "interface Greet { def hi(): String }\nclass C conforms Greet { public: def this{}\n def hi(): String = \"hi\" }\ndef main(args: String[]): String { return new C().hi() }", "None", Array()))
   }
 }

--- a/src/test/scala/onion/compiler/tools/BeanSpec.scala
+++ b/src/test/scala/onion/compiler/tools/BeanSpec.scala
@@ -7,7 +7,7 @@ class BeanSpec extends AbstractShellSpec {
     it("compiles") {
       val resultBean = shell.run(
         """
-          | class Bean <: Serializable {
+          | class Bean conforms Serializable {
           |   var value: Int
           | public:
           |   def this {

--- a/src/test/scala/onion/compiler/tools/BranchEmptyLiteralTargetTypeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/BranchEmptyLiteralTargetTypeSpec.scala
@@ -88,7 +88,7 @@ class BranchEmptyLiteralTargetTypeSpec extends AbstractShellSpec {
 
     it("exhaustive sealed select still type-checks") {
       assert(Shell.Success(13) == shell.run(
-        "sealed interface Shape\nrecord Circle(r: Int) <: Shape\nrecord Square(s: Int) <: Shape\n" +
+        "sealed interface Shape\nrecord Circle(r: Int) conforms Shape\nrecord Square(s: Int) conforms Shape\n" +
           "def area(sh: Shape): Int = select sh {\n" +
           "  case c is Circle: c.r() * c.r()\n" +
           "  case s is Square: s.s() * s.s()\n}\n" +
@@ -97,7 +97,7 @@ class BranchEmptyLiteralTargetTypeSpec extends AbstractShellSpec {
 
     it("non-exhaustive sealed select is still rejected (E0042)") {
       assert(Shell.Failure(-1) == shell.run(
-        "sealed interface Shape\nrecord Circle(r: Int) <: Shape\nrecord Square(s: Int) <: Shape\n" +
+        "sealed interface Shape\nrecord Circle(r: Int) conforms Shape\nrecord Square(s: Int) conforms Shape\n" +
           "def area(sh: Shape): Int = select sh {\n  case c is Circle: c.r()\n}\n" +
           "def main(args: String[]): Int { return area(new Circle(2)) }", "None", Array()))
     }

--- a/src/test/scala/onion/compiler/tools/BranchLubCommonAncestorSpec.scala
+++ b/src/test/scala/onion/compiler/tools/BranchLubCommonAncestorSpec.scala
@@ -18,12 +18,12 @@ class BranchLubCommonAncestorSpec extends AbstractShellSpec {
           |   def this {}
           |   def sound(): String = "..."
           | }
-          | class Dog : Animal {
+          | class Dog extends Animal {
           | public:
           |   def this {}
           |   override def sound(): String = "woof"
           | }
-          | class Cat : Animal {
+          | class Cat extends Animal {
           | public:
           |   def this {}
           |   override def sound(): String = "meow"
@@ -45,12 +45,12 @@ class BranchLubCommonAncestorSpec extends AbstractShellSpec {
           | interface Speaker {
           |   def speak(): String
           | }
-          | class A <: Speaker {
+          | class A conforms Speaker {
           | public:
           |   def this {}
           |   def speak(): String = "A"
           | }
-          | class B <: Speaker {
+          | class B conforms Speaker {
           | public:
           |   def this {}
           |   def speak(): String = "B"
@@ -74,7 +74,7 @@ class BranchLubCommonAncestorSpec extends AbstractShellSpec {
           |   def this {}
           |   def sound(): String = "animal"
           | }
-          | class Dog : Animal {
+          | class Dog extends Animal {
           | public:
           |   def this {}
           |   override def sound(): String = "woof"
@@ -98,12 +98,12 @@ class BranchLubCommonAncestorSpec extends AbstractShellSpec {
           |   def this {}
           |   def sound(): String = "..."
           | }
-          | class Dog : Animal {
+          | class Dog extends Animal {
           | public:
           |   def this {}
           |   override def sound(): String = "woof"
           | }
-          | class Cat : Animal {
+          | class Cat extends Animal {
           | public:
           |   def this {}
           |   override def sound(): String = "meow"
@@ -130,13 +130,13 @@ class BranchLubCommonAncestorSpec extends AbstractShellSpec {
         """
           | interface I1 { def m1(): String }
           | interface I2 { def m2(): String }
-          | class P <: I1, I2 {
+          | class P conforms I1, I2 {
           | public:
           |   def this {}
           |   def m1(): String = "p1"
           |   def m2(): String = "p2"
           | }
-          | class Q <: I1, I2 {
+          | class Q conforms I1, I2 {
           | public:
           |   def this {}
           |   def m1(): String = "q1"

--- a/src/test/scala/onion/compiler/tools/CastValidationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CastValidationSpec.scala
@@ -85,7 +85,7 @@ class CastValidationSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |class Animal { }
-          |class Dog : Animal {
+          |class Dog extends Animal {
           |public:
           |  def bark(): Int = 1
           |}

--- a/src/test/scala/onion/compiler/tools/CompilationFailureSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CompilationFailureSpec.scala
@@ -78,7 +78,7 @@ class CompilationFailureSpec extends AbstractShellSpec {
           |public:
           |  final def calculate(): Int { return 42; }
           |}
-          |class Derived : Base {
+          |class Derived extends Base {
           |public:
           |  def calculate(): Int { return 100; }
           |}
@@ -121,7 +121,7 @@ class CompilationFailureSpec extends AbstractShellSpec {
           |public:
           |  abstract def speak(): String;
           |}
-          |class Dog : Animal {
+          |class Dog extends Animal {
           |public:
           |  // Missing speak() implementation
           |}

--- a/src/test/scala/onion/compiler/tools/ConstructorSelfDelegationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ConstructorSelfDelegationSpec.scala
@@ -80,7 +80,7 @@ class ConstructorSelfDelegationSpec extends AbstractShellSpec {
           |   def this(x: Int) { self.x = x }
           |   def getX(): Int { return x }
           | }
-          | class Sub : Base {
+          | class Sub extends Base {
           |   val y: Int
           | public:
           |   def this(x: Int, y: Int) : (x) { self.y = y }
@@ -123,7 +123,7 @@ class ConstructorSelfDelegationSpec extends AbstractShellSpec {
           |   def this(name: String) { self.name = name }
           |   def getName(): String { return name }
           | }
-          | class Dog : Animal {
+          | class Dog extends Animal {
           | public:
           |   def this() : ("Rex") { }
           |   static def main(args: String[]): String { return new Dog().getName() }

--- a/src/test/scala/onion/compiler/tools/DestructuringPatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DestructuringPatternSpec.scala
@@ -50,8 +50,8 @@ class DestructuringPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Result {}
-          |record Success(value: String) <: Result;
-          |record Error(message: String) <: Result;
+          |record Success(value: String) conforms Result;
+          |record Error(message: String) conforms Result;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -73,8 +73,8 @@ class DestructuringPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Result {}
-          |record Success(value: String) <: Result;
-          |record Error(message: String) <: Result;
+          |record Success(value: String) conforms Result;
+          |record Error(message: String) conforms Result;
           |class Test {
           |public:
           |  static def main(args: String[]): String {

--- a/src/test/scala/onion/compiler/tools/FBoundedSelfTypeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FBoundedSelfTypeSpec.scala
@@ -14,7 +14,7 @@ import onion.tools.Shell
  */
 class FBoundedSelfTypeSpec extends AbstractShellSpec {
   describe("F-bounded self types (CRTP)") {
-    it("compiles and runs a bounded self-inheriting class: class Sub : Base[Sub]") {
+    it("compiles and runs a bounded self-inheriting class: class Sub extends Base[Sub]") {
       val result = shell.run(
         """
           | class Base[T extends Base[T]] {
@@ -22,7 +22,7 @@ class FBoundedSelfTypeSpec extends AbstractShellSpec {
           |   def this { }
           |   def who(): String { return "Base" }
           | }
-          | class Sub : Base[Sub] {
+          | class Sub extends Base[Sub] {
           | public:
           |   def this { }
           | }
@@ -46,7 +46,7 @@ class FBoundedSelfTypeSpec extends AbstractShellSpec {
           | interface Cmp[T extends Cmp[T]] {
           |   def to(o: T): Int
           | }
-          | class Item <: Cmp[Item] {
+          | class Item conforms Cmp[Item] {
           | public:
           |   def this { }
           |   def to(o: Item): Int = 0
@@ -66,14 +66,14 @@ class FBoundedSelfTypeSpec extends AbstractShellSpec {
       assert(Shell.Success("0") == result)
     }
 
-    it("rejects a bound-violating type argument: class Bad : Base[String]") {
+    it("rejects a bound-violating type argument: class Bad extends Base[String]") {
       val result = shell.run(
         """
           | class Base[T extends Base[T]] {
           | public:
           |   def this { }
           | }
-          | class Bad : Base[String] {
+          | class Bad extends Base[String] {
           | public:
           |   def this { }
           | }

--- a/src/test/scala/onion/compiler/tools/ForwardGenericInterfaceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ForwardGenericInterfaceSpec.scala
@@ -18,10 +18,10 @@ class ForwardGenericInterfaceSpec extends AbstractShellSpec {
           |interface A[T] {
           |  def f(x: T): String
           |}
-          |interface B[T] <: A[T] {
+          |interface B[T] conforms A[T] {
           |  def f(x: T): String
           |}
-          |class Real <: B[String] {
+          |class Real conforms B[String] {
           |public:
           |  def this {}
           |  def f(x: String): String { return "f:" + x }
@@ -39,12 +39,12 @@ class ForwardGenericInterfaceSpec extends AbstractShellSpec {
           |interface Box[T] {
           |  def get(): T
           |}
-          |class RealBox <: Box[String] {
+          |class RealBox conforms Box[String] {
           |public:
           |  def this {}
           |  def get(): String { return "hello" }
           |}
-          |class Fwd <: Box[String] {
+          |class Fwd conforms Box[String] {
           |  forward val b: Box[String]
           |public:
           |  def this(x: Box[String]) { b = x }
@@ -61,14 +61,14 @@ class ForwardGenericInterfaceSpec extends AbstractShellSpec {
           |  def get(): T
           |  def put(x: T): void
           |}
-          |class IntBox <: Container[Int] {
+          |class IntBox conforms Container[Int] {
           |  var v: Int
           |public:
           |  def this { v = 0 }
           |  def get(): Int { return v }
           |  def put(x: Int): void { v = x }
           |}
-          |class Fwd <: Container[Int] {
+          |class Fwd conforms Container[Int] {
           |  forward val c: Container[Int]
           |public:
           |  def this(x: Container[Int]) { c = x }
@@ -85,7 +85,7 @@ class ForwardGenericInterfaceSpec extends AbstractShellSpec {
     it("java.util.List[String] (the issue example), usable as List[String]") {
       val r = shell.run(
         """
-          |class MyList <: List[String] {
+          |class MyList conforms List[String] {
           |  forward val backing: List[String]
           |public:
           |  def this(xs: List[String]) { backing = xs }
@@ -104,7 +104,7 @@ class ForwardGenericInterfaceSpec extends AbstractShellSpec {
     it("java.util.Map[String, Int]") {
       val r = shell.run(
         """
-          |class MyMap <: Map[String, Int] {
+          |class MyMap conforms Map[String, Int] {
           |  forward val backing: Map[String, Int]
           |public:
           |  def this(m: Map[String, Int]) { backing = m }
@@ -123,12 +123,12 @@ class ForwardGenericInterfaceSpec extends AbstractShellSpec {
           |interface Greeter {
           |  def greet(): String
           |}
-          |class Polite <: Greeter {
+          |class Polite conforms Greeter {
           |public:
           |  def this {}
           |  def greet(): String { return "Hi" }
           |}
-          |class D <: Greeter {
+          |class D conforms Greeter {
           |  forward val g: Greeter
           |public:
           |  def this(x: Greeter) { g = x }

--- a/src/test/scala/onion/compiler/tools/GenericAdtEnumSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericAdtEnumSpec.scala
@@ -58,8 +58,8 @@ class GenericAdtEnumSpec extends AbstractShellSpec {
   it("recovers the type argument for a hand-written generic sealed hierarchy too") {
     assert(Shell.Success("hi") == shell.run(
       """sealed interface Box[T] {}
-        |record Full[T](value: T) <: Box[T]
-        |record Empty[T]() <: Box[T]
+        |record Full[T](value: T) conforms Box[T]
+        |record Empty[T]() conforms Box[T]
         |def get(b: Box[String]): String = select b {
         |  case f is Full: f.value()
         |  case e is Empty: "none"

--- a/src/test/scala/onion/compiler/tools/GenericInheritanceSelfCallSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericInheritanceSelfCallSpec.scala
@@ -5,7 +5,7 @@ import onion.tools.Shell
 /**
  * Issue #271: a class extending a generic parent with a concrete type argument
  * must specialize the parent's type parameter when an inherited method is called
- * unqualified (via self). `class StrBox : Box[String]` calling inherited
+ * unqualified (via self). `class StrBox extends Box[String]` calling inherited
  * `Box.get(): T` must see `String`, not the raw `T`.
  */
 class GenericInheritanceSelfCallSpec extends AbstractShellSpec {
@@ -19,7 +19,7 @@ class GenericInheritanceSelfCallSpec extends AbstractShellSpec {
           |   def this(v: T) { value = v }
           |   def get(): T { return value }
           | }
-          | class StrBox(v: String) : Box[String](v) {
+          | class StrBox(v: String) extends Box[String](v) {
           | public:
           |   def upper(): String {
           |     val g: String = get()
@@ -48,7 +48,7 @@ class GenericInheritanceSelfCallSpec extends AbstractShellSpec {
           |   def this(v: T) { value = v }
           |   def get(): T { return value }
           | }
-          | class IntBox(v: Integer) : Box[Integer](v) {
+          | class IntBox(v: Integer) extends Box[Integer](v) {
           | public:
           |   def plusOne(): Int {
           |     val g: Int = get()
@@ -77,11 +77,11 @@ class GenericInheritanceSelfCallSpec extends AbstractShellSpec {
           |   def this(v: T) { value = v }
           |   def get(): T { return value }
           | }
-          | class Mid[U](v: U) : Box[U](v) {
+          | class Mid[U](v: U) extends Box[U](v) {
           | public:
           |   def mid(): U { return get() }
           | }
-          | class StrBox2(v: String) : Mid[String](v) {
+          | class StrBox2(v: String) extends Mid[String](v) {
           | public:
           |   def upper(): String {
           |     val g: String = get()

--- a/src/test/scala/onion/compiler/tools/GenericInvarianceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericInvarianceSpec.scala
@@ -11,8 +11,8 @@ class GenericInvarianceSpec extends AbstractShellSpec {
   private val decls =
     """
       |class Animal { public: def this {} }
-      |class Dog : Animal { public: def this {} }
-      |class Cat : Animal { public: def this {} }
+      |class Dog extends Animal { public: def this {} }
+      |class Cat extends Animal { public: def this {} }
       |class Box[T] {
       |  var value: T
       |public:

--- a/src/test/scala/onion/compiler/tools/GenericRecordInterfaceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericRecordInterfaceSpec.scala
@@ -4,7 +4,7 @@ import onion.tools.Shell
 
 /**
  * A generic record may implement a generic interface parameterized by the
- * record's own type variable (`record Foo[T](v: T) <: Bar[T]`). The record's
+ * record's own type variable (`record Foo[T](v: T) conforms Bar[T]`). The record's
  * type parameters must be in scope while its supertypes are resolved — a
  * generic class already worked, but a generic record used to fail with E0003
  * ("type Bar[T] not found") because its supertype clause was resolved outside
@@ -19,7 +19,7 @@ class GenericRecordInterfaceSpec extends AbstractShellSpec {
           | interface Bar[T] {
           |   def get(): T
           | }
-          | record Foo[T](v: T) <: Bar[T] {
+          | record Foo[T](v: T) conforms Bar[T] {
           | public:
           |   def get(): T = v()
           | }
@@ -38,7 +38,7 @@ class GenericRecordInterfaceSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           | interface Named { def label(): String }
-          | record Foo[T](v: T) <: Named {
+          | record Foo[T](v: T) conforms Named {
           | public:
           |   def label(): String = "foo"
           | }

--- a/src/test/scala/onion/compiler/tools/GenericSubtypeAssignabilitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericSubtypeAssignabilitySpec.scala
@@ -21,7 +21,7 @@ class GenericSubtypeAssignabilitySpec extends AbstractShellSpec {
   }
   it("assigns a user generic subtype to its generic interface with a type variable") {
     assert(Shell.Success(2) == shell.run(
-      "interface Container[T] { def item(): T }\nclass BoxC[T] <: Container[T] { val v: T\npublic: def this(x: T) { this.v = x }\n def item(): T = v }\ndef wrap[T](x: T): Container[T] = new BoxC[T](x)\ndef main(args: String[]): Int = wrap(\"hi\").item().length()", "None", Array()))
+      "interface Container[T] { def item(): T }\nclass BoxC[T] conforms Container[T] { val v: T\npublic: def this(x: T) { this.v = x }\n def item(): T = v }\ndef wrap[T](x: T): Container[T] = new BoxC[T](x)\ndef main(args: String[]): Int = wrap(\"hi\").item().length()", "None", Array()))
   }
   it("still enforces invariant generics (List[String] is not List[Integer])") {
     assert(Shell.Failure(-1) == shell.run(

--- a/src/test/scala/onion/compiler/tools/GenericSuperConstructorPrimitiveSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericSuperConstructorPrimitiveSpec.scala
@@ -19,7 +19,7 @@ class GenericSuperConstructorPrimitiveSpec extends AbstractShellSpec {
   it("resolves the super constructor for a primitive type argument (Int)") {
     assert(Shell.Success(42) == shell.run(
       box +
-      "class IntBox(v: Int) : Box[Int](v) {\n" +
+      "class IntBox(v: Int) extends Box[Int](v) {\n" +
       "public: def unwrap(): Int { return (get() as Int) } }\n" +
       "class Main { public: static def main(args: String[]): Int { return new IntBox(42).unwrap() } }",
       "None", Array()))
@@ -28,7 +28,7 @@ class GenericSuperConstructorPrimitiveSpec extends AbstractShellSpec {
   it("resolves the super constructor for a primitive Double type argument") {
     assert(Shell.Success(3) == shell.run(
       box +
-      "class DBox(v: Double) : Box[Double](v) {\n" +
+      "class DBox(v: Double) extends Box[Double](v) {\n" +
       "public: def unwrap(): Int { return ((get() as Double) as Int) } }\n" +
       "class Main { public: static def main(args: String[]): Int { return new DBox(3.5).unwrap() } }",
       "None", Array()))
@@ -37,7 +37,7 @@ class GenericSuperConstructorPrimitiveSpec extends AbstractShellSpec {
   it("still resolves the super constructor for a reference type argument") {
     assert(Shell.Success("HI") == shell.run(
       box +
-      "class SBox(v: String) : Box[String](v) {\n" +
+      "class SBox(v: String) extends Box[String](v) {\n" +
       "public: def unwrap(): String { return (get() as String) } }\n" +
       "class Main { public: static def main(args: String[]): String { return new SBox(\"hi\").unwrap().toUpperCase() } }",
       "None", Array()))
@@ -48,7 +48,7 @@ class GenericSuperConstructorPrimitiveSpec extends AbstractShellSpec {
       "class Pair[A, B] { val a: A\n val b: B\n" +
       "public: def this(x: A, y: B) { a = x\n b = y }\n" +
       " def first(): A { return a } }\n" +
-      "class IntStr(x: Int, y: String) : Pair[Int, String](x, y) {\n" +
+      "class IntStr(x: Int, y: String) extends Pair[Int, String](x, y) {\n" +
       "public: def fst(): Int { return (first() as Int) } }\n" +
       "class Main { public: static def main(args: String[]): Int { return new IntStr(5, \"z\").fst() } }",
       "None", Array()))
@@ -57,7 +57,7 @@ class GenericSuperConstructorPrimitiveSpec extends AbstractShellSpec {
   it("rejects a super-init argument incompatible with the primitive type argument") {
     assert(Shell.Failure(-1) == shell.run(
       box +
-      "class BadBox(v: Boolean) : Box[Int](v) {\n" +
+      "class BadBox(v: Boolean) extends Box[Int](v) {\n" +
       "public: def u(): Int { return (get() as Int) } }\n" +
       "class Main { public: static def main(args: String[]): void { } }",
       "None", Array()))

--- a/src/test/scala/onion/compiler/tools/GenericsBridgeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericsBridgeSpec.scala
@@ -14,7 +14,7 @@ class GenericsBridgeSpec extends AbstractShellSpec {
           |  }
           |}
           |
-          |class Sub : Base[String] {
+          |class Sub extends Base[String] {
           |public:
           |  def get(x: String): String {
           |    return x + "!"
@@ -41,7 +41,7 @@ class GenericsBridgeSpec extends AbstractShellSpec {
           |  def get(): T { return this.item }
           |}
           |
-          |class StringBox : Box[String] {
+          |class StringBox extends Box[String] {
           |public:
           |  def this(s: String) : (s) {}
           |  def shout(): String { return this.get().toUpperCase() }

--- a/src/test/scala/onion/compiler/tools/GenericsInterfaceBridgeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericsInterfaceBridgeSpec.scala
@@ -11,7 +11,7 @@ class GenericsInterfaceBridgeSpec extends AbstractShellSpec {
           |  def get(x: T): T
           |}
           |
-          |class Impl <: I[String] {
+          |class Impl conforms I[String] {
           |public:
           |  def get(x: String): String {
           |    return x + "!"

--- a/src/test/scala/onion/compiler/tools/GenericsTypingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericsTypingSpec.scala
@@ -264,7 +264,7 @@ class GenericsTypingSpec extends AbstractShellSpec {
           |  def pick(x: T): String
           |}
           |
-          |class PickerImpl <: Picker[String] {
+          |class PickerImpl conforms Picker[String] {
           |public:
           |  def pick(x: String): String {
           |    return "ok"
@@ -291,7 +291,7 @@ class GenericsTypingSpec extends AbstractShellSpec {
             |  def get(): T { return null }
             |}
             |
-            |class Sub : Base[String] {
+            |class Sub extends Base[String] {
             |public:
             |  def get(): Object { return new Object }
             |  static def main(args: String[]): Int { return 0 }
@@ -310,7 +310,7 @@ class GenericsTypingSpec extends AbstractShellSpec {
             |  def id(x: T): T
             |}
             |
-            |class BadImpl <: Id[String] {
+            |class BadImpl conforms Id[String] {
             |public:
             |  def id(x: String): Object { return x }
             |  static def main(args: String[]): Int { return 0 }
@@ -328,7 +328,7 @@ class GenericsTypingSpec extends AbstractShellSpec {
           |  def id(x: T): T
           |}
           |
-          |class OkImpl <: Id2[String] {
+          |class OkImpl conforms Id2[String] {
           |public:
           |  def id(x: String): String {
           |    return x

--- a/src/test/scala/onion/compiler/tools/GuardPatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GuardPatternSpec.scala
@@ -50,9 +50,9 @@ class GuardPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Number {}
-          |record Positive(value: Int) <: Number;
-          |record Negative(value: Int) <: Number;
-          |record Zero() <: Number;
+          |record Positive(value: Int) conforms Number;
+          |record Negative(value: Int) conforms Number;
+          |record Zero() conforms Number;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -76,9 +76,9 @@ class GuardPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Number {}
-          |record Positive(value: Int) <: Number;
-          |record Negative(value: Int) <: Number;
-          |record Zero() <: Number;
+          |record Positive(value: Int) conforms Number;
+          |record Negative(value: Int) conforms Number;
+          |record Zero() conforms Number;
           |class Test {
           |public:
           |  static def main(args: String[]): String {

--- a/src/test/scala/onion/compiler/tools/IfExpressionTargetTypeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IfExpressionTargetTypeSpec.scala
@@ -10,7 +10,7 @@ import onion.tools.Shell
  */
 class IfExpressionTargetTypeSpec extends AbstractShellSpec {
   private val decls =
-    "sealed interface Event\nrecord Click(x: Int) <: Event\nrecord Key(c: Int) <: Event\n"
+    "sealed interface Event\nrecord Click(x: Int) conforms Event\nrecord Key(c: Int) conforms Event\n"
 
   it("adopts the expected supertype for mixed-subtype branches") {
     assert(Shell.Success("click1") == shell.run(

--- a/src/test/scala/onion/compiler/tools/InheritanceKeywordSpec.scala
+++ b/src/test/scala/onion/compiler/tools/InheritanceKeywordSpec.scala
@@ -1,0 +1,186 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * Inheritance is spelled with words, not symbols: `extends` for a superclass and
+ * `conforms` for interfaces, where `:` and `<:` used to be.
+ *
+ * A symbol is unsearchable — you cannot grep for `<:`, ask about it out loud, or guess
+ * what it means from the outside. `conforms` is a soft keyword so that trading the
+ * symbol for a word does not also take the word away as an identifier.
+ */
+class InheritanceKeywordSpec extends AbstractShellSpec {
+
+  describe("extends") {
+    it("names a superclass") {
+      val r = shell.run(
+        """
+          |class Animal {
+          |public:
+          |  def this {}
+          |  def sound(): String = "..."
+          |}
+          |class Dog extends Animal {
+          |public:
+          |  def this {}
+          |  override def sound(): String = "woof"
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return new Dog().sound() }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("woof") == r)
+    }
+
+    it("carries superclass constructor arguments") {
+      val r = shell.run(
+        """
+          |class Animal(val kind: String)
+          |class Dog(kind: String, val breed: String) extends Animal(kind)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val d = new Dog("dog", "shiba")
+          |    return d.kind + "/" + d.breed
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("dog/shiba") == r)
+    }
+  }
+
+  describe("conforms") {
+    it("names the interfaces a class implements") {
+      val r = shell.run(
+        """
+          |interface Greeter { def greet(): String }
+          |interface Named { def name(): String }
+          |class Person(val who: String) conforms Greeter, Named {
+          |public:
+          |  def greet(): String = "hi"
+          |  def name(): String = who
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val p = new Person("ko")
+          |    return p.greet() + "/" + p.name()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("hi/ko") == r)
+    }
+
+    it("combines with extends") {
+      val r = shell.run(
+        """
+          |interface Greeter { def greet(): String }
+          |class Animal(val kind: String)
+          |class Dog(kind: String) extends Animal(kind) conforms Greeter {
+          |public:
+          |  def greet(): String = "woof " + kind
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return new Dog("dog").greet() }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("woof dog") == r)
+    }
+
+    it("works on a record and on an interface") {
+      val r = shell.run(
+        """
+          |interface Shown { def show(): String }
+          |interface Loud conforms Shown { def yell(): String }
+          |record Pt(x: Int, y: Int) conforms Loud {
+          |public:
+          |  def show(): String = x() + "," + y()
+          |  def yell(): String = show().toUpperCase()
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val p: Shown = new Pt(1, 2)
+          |    return p.show()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("1,2") == r)
+    }
+  }
+
+  describe("`conforms` stays an ordinary identifier") {
+    it("is usable as a method name, a local and a field") {
+      val r = shell.run(
+        """
+          |class Test {
+          |  var conforms: Int
+          |public:
+          |  def this { conforms = 1 }
+          |  def conforms(n: Int): Int = n + conforms
+          |  static def main(args: String[]): Int {
+          |    val conforms = new Test()
+          |    return conforms.conforms(41)
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success(42) == r)
+    }
+  }
+
+  describe("the old symbolic spellings") {
+    it("rejects `:` for a superclass") {
+      val r = shell.run(
+        """
+          |class Animal { public: def this {} }
+          |class Dog : Animal { public: def this {} }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(r.isInstanceOf[Shell.Failure], s"expected a parse failure, got $r")
+    }
+
+    it("still lists `extends` among the expected tokens for a stray `:`") {
+      // The migration hint itself is localized, so assert on the token the parser
+      // offers rather than on message text.
+      val out = captureErr {
+        shell.run(
+          """
+            |class Animal { public: def this {} }
+            |class Dog : Animal { public: def this {} }
+            |""".stripMargin, "None", Array())
+      }
+      assert(out.contains("extends"), out)
+    }
+
+    it("rejects `<:` for interfaces") {
+      val r = shell.run(
+        """
+          |interface Greeter { def greet(): String }
+          |class Person <: Greeter {
+          |public:
+          |  def this {}
+          |  def greet(): String = "hi"
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(r.isInstanceOf[Shell.Failure], s"expected a parse failure, got $r")
+    }
+  }
+
+  private def captureErr(body: => Any): String = {
+    val buf = new java.io.ByteArrayOutputStream()
+    val out = new java.io.PrintStream(buf, true, "UTF-8")
+    Console.withErr(out) { Console.withOut(out) { body } }
+    out.flush()
+    new String(buf.toByteArray, "UTF-8")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/IntegrationPatternsSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IntegrationPatternsSpec.scala
@@ -10,7 +10,7 @@ import onion.tools.Shell
 class IntegrationPatternsSpec extends AbstractShellSpec {
   it("evaluates a recursive sealed-record expression tree") {
     val src =
-      "sealed interface Expr\nrecord Num(v: Int) <: Expr\nrecord Add(l: Expr, r: Expr) <: Expr\nrecord Mul(l: Expr, r: Expr) <: Expr\n" +
+      "sealed interface Expr\nrecord Num(v: Int) conforms Expr\nrecord Add(l: Expr, r: Expr) conforms Expr\nrecord Mul(l: Expr, r: Expr) conforms Expr\n" +
       "def eval(e: Expr): Int { return select e { case Num(v): v\n case Add(l, r): eval(l) + eval(r)\n case Mul(l, r): eval(l) * eval(r) } }\n" +
       "def main(args: String[]): Int { val e: Expr = new Add(new Num(3), new Mul(new Num(4), new Num(5)))\n return eval(e) }"
     assert(Shell.Success(23) == shell.run(src, "None", Array()))

--- a/src/test/scala/onion/compiler/tools/InterfaceDefaultMethodSpec.scala
+++ b/src/test/scala/onion/compiler/tools/InterfaceDefaultMethodSpec.scala
@@ -17,7 +17,7 @@ class InterfaceDefaultMethodSpec extends AbstractShellSpec {
           |  def name(): String
           |  def greet(): String { return "Hello, " + this.name() }
           |}
-          |class K <: Greeter {
+          |class K conforms Greeter {
           |public:
           |  def this {}
           |  def name(): String { return "kota" }
@@ -42,7 +42,7 @@ class InterfaceDefaultMethodSpec extends AbstractShellSpec {
           |  def name(): String
           |  def shout(): String = "HEY " + this.name()
           |}
-          |class K <: Greeter {
+          |class K conforms Greeter {
           |public:
           |  def this {}
           |  def name(): String { return "kota" }
@@ -67,7 +67,7 @@ class InterfaceDefaultMethodSpec extends AbstractShellSpec {
           |  def name(): String
           |  def greet(): String { return "Hello, " + this.name() }
           |}
-          |class Loud <: Greeter {
+          |class Loud conforms Greeter {
           |public:
           |  def this {}
           |  def name(): String { return "loud" }
@@ -94,7 +94,7 @@ class InterfaceDefaultMethodSpec extends AbstractShellSpec {
           |  def base(): Int
           |  def doubled(): Int { return this.base() * 2 }
           |}
-          |class Impl <: WithDefault {
+          |class Impl conforms WithDefault {
           |public:
           |  def this {}
           |  def base(): Int { return 21 }

--- a/src/test/scala/onion/compiler/tools/JavaGenericsInteropSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaGenericsInteropSpec.scala
@@ -570,7 +570,7 @@ class JavaGenericsInteropSpec extends AbstractShellSpec {
     it("supports Comparator[Int] implemented with primitive Int parameters") {
       val result = shell.run(
         """
-          |class IntComparator <: Comparator[Int] {
+          |class IntComparator conforms Comparator[Int] {
           |public:
           |  def compare(a: Int, b: Int): Int {
           |    return a - b
@@ -598,7 +598,7 @@ class JavaGenericsInteropSpec extends AbstractShellSpec {
     it("supports Comparator[Double] implemented with primitive Double parameters") {
       val result = shell.run(
         """
-          |class DoubleComparator <: Comparator[Double] {
+          |class DoubleComparator conforms Comparator[Double] {
           |public:
           |  def compare(a: Double, b: Double): Int {
           |    if a < b { return -1 }

--- a/src/test/scala/onion/compiler/tools/MapLiteralTargetTypeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapLiteralTargetTypeSpec.scala
@@ -10,7 +10,7 @@ import onion.tools.Shell
  */
 class MapLiteralTargetTypeSpec extends AbstractShellSpec {
   private val shapes =
-    "sealed interface Shape\nrecord Circle(r: Int) <: Shape\nrecord Square(s: Int) <: Shape\n"
+    "sealed interface Shape\nrecord Circle(r: Int) conforms Shape\nrecord Square(s: Int) conforms Shape\n"
 
   it("target-types mixed-subtype values to the expected value supertype") {
     assert(Shell.Success(2) == shell.run(

--- a/src/test/scala/onion/compiler/tools/MixedSubtypeListLiteralSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MixedSubtypeListLiteralSpec.scala
@@ -10,7 +10,7 @@ import onion.tools.Shell
  */
 class MixedSubtypeListLiteralSpec extends AbstractShellSpec {
   private val decls =
-    "sealed interface Event\nrecord Click(x: Int, y: Int) <: Event\nrecord Key(code: Int) <: Event\n"
+    "sealed interface Event\nrecord Click(x: Int, y: Int) conforms Event\nrecord Key(code: Int) conforms Event\n"
 
   it("builds a List[Event] from mixed record subtypes") {
     assert(Shell.Success(3) == shell.run(

--- a/src/test/scala/onion/compiler/tools/NestedPatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NestedPatternSpec.scala
@@ -8,8 +8,8 @@ class NestedPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Tree {}
-          |record Leaf(value: Int) <: Tree;
-          |record Node(left: Tree, right: Tree) <: Tree;
+          |record Leaf(value: Int) conforms Tree;
+          |record Node(left: Tree, right: Tree) conforms Tree;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -31,8 +31,8 @@ class NestedPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Tree {}
-          |record Leaf(value: Int) <: Tree;
-          |record Node(left: Tree, right: Tree) <: Tree;
+          |record Leaf(value: Int) conforms Tree;
+          |record Node(left: Tree, right: Tree) conforms Tree;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -54,8 +54,8 @@ class NestedPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Tree {}
-          |record Leaf(value: Int) <: Tree;
-          |record Node(left: Tree, right: Tree) <: Tree;
+          |record Leaf(value: Int) conforms Tree;
+          |record Node(left: Tree, right: Tree) conforms Tree;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -194,8 +194,8 @@ class NestedPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Data {}
-          |record Value(n: Int) <: Data;
-          |record Pair(a: Data, b: Data) <: Data;
+          |record Value(n: Int) conforms Data;
+          |record Pair(a: Data, b: Data) conforms Data;
           |record Container(data: Data);
           |class Test {
           |public:

--- a/src/test/scala/onion/compiler/tools/NestedTypePatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NestedTypePatternSpec.scala
@@ -15,8 +15,8 @@ import onion.tools.Shell
 class NestedTypePatternSpec extends AbstractShellSpec {
   private val exprAdt =
     """sealed interface E {}
-      |record Num(v: Int) <: E
-      |record Add(l: E, r: E) <: E
+      |record Num(v: Int) conforms E
+      |record Add(l: E, r: E) conforms E
       |""".stripMargin
 
   it("matches a nested type pattern and binds it at the narrowed type") {

--- a/src/test/scala/onion/compiler/tools/OneLineMemberTerminatorSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OneLineMemberTerminatorSpec.scala
@@ -14,7 +14,7 @@ class OneLineMemberTerminatorSpec extends AbstractShellSpec {
   }
   it("allows a forward field on the closing-brace line") {
     assert(Shell.Success("hi") == shell.run(
-      "interface Greet { def hi(): String }\nclass Impl <: Greet { public: def this{}\n def hi(): String = \"hi\" }\nclass C <: Greet { public: def this{}\n forward val g: Greet = new Impl() }\ndef main(args: String[]): String { return new C().hi() }", "None", Array()))
+      "interface Greet { def hi(): String }\nclass Impl conforms Greet { public: def this{}\n def hi(): String = \"hi\" }\nclass C conforms Greet { public: def this{}\n forward val g: Greet = new Impl() }\ndef main(args: String[]): String { return new C().hi() }", "None", Array()))
   }
   it("still parses multi-line fields") {
     assert(Shell.Success(3) == shell.run(

--- a/src/test/scala/onion/compiler/tools/OneLineMethodDeclSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OneLineMethodDeclSpec.scala
@@ -13,16 +13,16 @@ class OneLineMethodDeclSpec extends AbstractShellSpec {
 
   describe("one-line method declarations") {
     it("one-line interface with an abstract method") {
-      ok("interface A { def f(): Int }\nclass C <: A { public: def this {} def f(): Int { return 5 } }\ndef main(args: String[]): Int { return new C().f() }", 5)
+      ok("interface A { def f(): Int }\nclass C conforms A { public: def this {} def f(): Int { return 5 } }\ndef main(args: String[]): Int { return new C().f() }", 5)
     }
     it("one-line interface with a = expr default method") {
-      ok("interface A { def f(): Int = 6 }\nclass C <: A { public: def this {} }\ndef main(args: String[]): Int { return new C().f() }", 6)
+      ok("interface A { def f(): Int = 6 }\nclass C conforms A { public: def this {} }\ndef main(args: String[]): Int { return new C().f() }", 6)
     }
     it("still parses the = expr method form (regression)") {
       ok("class C { public: def this {} def f(): Int = 42 }\ndef main(args: String[]): Int { return new C().f() }", 42)
     }
     it("still parses interface default methods with block bodies (regression)") {
-      ok("interface A {\n  def f(): Int { return 9 }\n}\nclass C <: A { public: def this {} }\ndef main(args: String[]): Int { return new C().f() }", 9)
+      ok("interface A {\n  def f(): Int { return 9 }\n}\nclass C conforms A { public: def this {} }\ndef main(args: String[]): Int { return new C().f() }", 9)
     }
   }
 }

--- a/src/test/scala/onion/compiler/tools/OverrideCheckSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OverrideCheckSpec.scala
@@ -11,7 +11,7 @@ class OverrideCheckSpec extends AbstractShellSpec {
           |public:
           |  def foo(): Int { return 1 }
           |}
-          |class Derived : Base {
+          |class Derived extends Base {
           |public:
           |  override def bar(): Int { return 2 }
           |}
@@ -33,7 +33,7 @@ class OverrideCheckSpec extends AbstractShellSpec {
           |public:
           |  def foo(x: Int): Int { return x }
           |}
-          |class Derived : Base {
+          |class Derived extends Base {
           |public:
           |  override def foo(): Int { return 0 }
           |}
@@ -55,7 +55,7 @@ class OverrideCheckSpec extends AbstractShellSpec {
           |public:
           |  def foo(): Int { return 1 }
           |}
-          |class Derived : Base {
+          |class Derived extends Base {
           |public:
           |  override def foo(): Int { return 2 }
           |}
@@ -76,7 +76,7 @@ class OverrideCheckSpec extends AbstractShellSpec {
           |interface Greeter {
           |  def greet(): String
           |}
-          |class Hello <: Greeter {
+          |class Hello conforms Greeter {
           |public:
           |  override def greet(): String { return "hi" }
           |}
@@ -97,7 +97,7 @@ class OverrideCheckSpec extends AbstractShellSpec {
           |interface Box[T] {
           |  def get(): T
           |}
-          |class IntBox <: Box[Int] {
+          |class IntBox conforms Box[Int] {
           |public:
           |  override def get(): Int { return 42 }
           |}

--- a/src/test/scala/onion/compiler/tools/PrimaryConstructorSpec.scala
+++ b/src/test/scala/onion/compiler/tools/PrimaryConstructorSpec.scala
@@ -62,7 +62,7 @@ class PrimaryConstructorSpec extends AbstractShellSpec {
           |public:
           |  def who(): String { return this.name }
           |}
-          |class Dog(name: String, val breed: String) : Animal(name)
+          |class Dog(name: String, val breed: String) extends Animal(name)
           |class Test {
           |public:
           |  static def main(args: String[]): String {

--- a/src/test/scala/onion/compiler/tools/RecordMethodsSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RecordMethodsSpec.scala
@@ -87,7 +87,7 @@ class RecordMethodsSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |interface Named { def label(): String }
-          |record Person(name: String, age: Int) <: Named {
+          |record Person(name: String, age: Int) conforms Named {
           |public:
           |  def label(): String = name() + "(" + age() + ")"
           |  def older(): Person = self.copy(age = age() + 1)

--- a/src/test/scala/onion/compiler/tools/SealedExhaustivenessSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SealedExhaustivenessSpec.scala
@@ -13,8 +13,8 @@ class SealedExhaustivenessSpec extends AbstractShellSpec {
       val r = shell.run(
         """
           |sealed class Expr {}
-          |class Num : Expr { public: def this { } }
-          |class Add : Expr { public: def this { } }
+          |class Num extends Expr { public: def this { } }
+          |class Add extends Expr { public: def this { } }
           |def kind(e: Expr): String { return select e { case n is Num: "num" } }
           |""".stripMargin, "None", Array())
       assert(Shell.Failure(-1) == r)
@@ -23,8 +23,8 @@ class SealedExhaustivenessSpec extends AbstractShellSpec {
       val r = shell.run(
         """
           |sealed class Expr {}
-          |class Num : Expr { public: def this { } }
-          |class Add : Expr { public: def this { } }
+          |class Num extends Expr { public: def this { } }
+          |class Add extends Expr { public: def this { } }
           |def kind(e: Expr): String {
           |  return select e {
           |    case n is Num: "num"
@@ -39,8 +39,8 @@ class SealedExhaustivenessSpec extends AbstractShellSpec {
       val r = shell.run(
         """
           |sealed interface Shape {}
-          |class Circle <: Shape { public: def this { } }
-          |class Square <: Shape { public: def this { } }
+          |class Circle conforms Shape { public: def this { } }
+          |class Square conforms Shape { public: def this { } }
           |def name(s: Shape): String { return select s { case c is Circle: "circle" } }
           |""".stripMargin, "None", Array())
       assert(Shell.Failure(-1) == r)

--- a/src/test/scala/onion/compiler/tools/SealedInterfaceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SealedInterfaceSpec.scala
@@ -8,8 +8,8 @@ class SealedInterfaceSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Result {}
-          |record Success(value: String) <: Result;
-          |record Error(code: Int) <: Result;
+          |record Success(value: String) conforms Result;
+          |record Error(code: Int) conforms Result;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -29,8 +29,8 @@ class SealedInterfaceSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Shape {}
-          |record Circle(radius: Int) <: Shape;
-          |record Rectangle(width: Int, height: Int) <: Shape;
+          |record Circle(radius: Int) conforms Shape;
+          |record Rectangle(width: Int, height: Int) conforms Shape;
           |class Test {
           |public:
           |  static def process(s: Shape): String {
@@ -56,7 +56,7 @@ class SealedInterfaceSpec extends AbstractShellSpec {
         """
           |sealed interface Message {}
           |sealed interface Notification {}
-          |record Alert(text: String) <: Message, Notification;
+          |record Alert(text: String) conforms Message, Notification;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -77,7 +77,7 @@ class SealedInterfaceSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Result {}
-          |record Success(value: String) <: Result;
+          |record Success(value: String) conforms Result;
           |class Test {
           |public:
           |  static def main(args: String[]): String {

--- a/src/test/scala/onion/compiler/tools/SelectPatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SelectPatternSpec.scala
@@ -8,8 +8,8 @@ class SelectPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Animal {}
-          |record Dog(name: String) <: Animal
-          |record Cat(name: String) <: Animal
+          |record Dog(name: String) conforms Animal
+          |record Cat(name: String) conforms Animal
           |
           |class Test {
           |public:
@@ -34,9 +34,9 @@ class SelectPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Shape {}
-          |record Circle(radius: Int) <: Shape
-          |record Square(side: Int) <: Shape
-          |record Triangle(base: Int, height: Int) <: Shape
+          |record Circle(radius: Int) conforms Shape
+          |record Square(side: Int) conforms Shape
+          |record Triangle(base: Int, height: Int) conforms Shape
           |
           |class Test {
           |public:
@@ -87,8 +87,8 @@ class SelectPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Result {}
-          |record Success(value: Int) <: Result
-          |record Error(message: String) <: Result
+          |record Success(value: Int) conforms Result
+          |record Error(message: String) conforms Result
           |
           |class Test {
           |public:
@@ -139,8 +139,8 @@ class SelectPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Box {}
-          |record IntBox(value: Int) <: Box
-          |record StringBox(value: String) <: Box
+          |record IntBox(value: Int) conforms Box
+          |record StringBox(value: String) conforms Box
           |
           |class Test {
           |public:
@@ -194,8 +194,8 @@ class SelectPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Value {}
-          |record IntVal(n: Int) <: Value
-          |record StrVal(s: String) <: Value
+          |record IntVal(n: Int) conforms Value
+          |record StrVal(s: String) conforms Value
           |
           |class Test {
           |public:

--- a/src/test/scala/onion/compiler/tools/SelectStatementMixedBranchSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SelectStatementMixedBranchSpec.scala
@@ -134,8 +134,8 @@ class SelectStatementMixedBranchSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Shape {}
-          |record Circle(r: Int) <: Shape
-          |record Square(s: Int) <: Shape
+          |record Circle(r: Int) conforms Shape
+          |record Square(s: Int) conforms Shape
           |class Test {
           |public:
           |  static def area(sh: Shape): void {

--- a/src/test/scala/onion/compiler/tools/SelfReferentialInterfaceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SelfReferentialInterfaceSpec.scala
@@ -4,25 +4,25 @@ import onion.tools.Shell
 
 /**
  * A class may implement a generic interface with itself as the type argument
- * (`class Ver <: Comparable[Ver]`), the standard natural-ordering pattern. It used
+ * (`class Ver conforms Comparable[Ver]`), the standard natural-ordering pattern. It used
  * to fail with E0000 because the type-argument bound check walked the class's not-yet
  * established supertype chain and wrongly rejected it against the Object bound.
  */
 class SelfReferentialInterfaceSpec extends AbstractShellSpec {
   it("implements Comparable with itself as the type argument") {
     assert(Shell.Success(-2) == shell.run(
-      "class Ver <: Comparable[Ver] { public: val n: Int\n def this(n: Int) { this.n = n }\n def compareTo(o: Ver): Int = n - o.n }\ndef main(args: String[]): Int { return new Ver(3).compareTo(new Ver(5)) }", "None", Array()))
+      "class Ver conforms Comparable[Ver] { public: val n: Int\n def this(n: Int) { this.n = n }\n def compareTo(o: Ver): Int = n - o.n }\ndef main(args: String[]): Int { return new Ver(3).compareTo(new Ver(5)) }", "None", Array()))
   }
   it("sorts a self-Comparable class through Collections.sort") {
     assert(Shell.Success("[v1, v2, v3]") == shell.run(
-      "class Ver <: java.lang.Comparable[Ver] { public: val n: Int\n def this(n: Int) { this.n = n }\n def compareTo(o: Ver): Int = n - o.n\n def toString(): String = \"v\" + n }\ndef main(args: String[]): String { val xs = new java.util.ArrayList[Ver]()\n xs.add(new Ver(3))\n xs.add(new Ver(1))\n xs.add(new Ver(2))\n java.util.Collections::sort(xs)\n return \"\" + xs }", "None", Array()))
+      "class Ver conforms java.lang.Comparable[Ver] { public: val n: Int\n def this(n: Int) { this.n = n }\n def compareTo(o: Ver): Int = n - o.n\n def toString(): String = \"v\" + n }\ndef main(args: String[]): String { val xs = new java.util.ArrayList[Ver]()\n xs.add(new Ver(3))\n xs.add(new Ver(1))\n xs.add(new Ver(2))\n java.util.Collections::sort(xs)\n return \"\" + xs }", "None", Array()))
   }
   it("implements a user-defined self-referential generic interface") {
     assert(Shell.Success("ok") == shell.run(
-      "interface Holder[T] { def value(): T }\nclass Node <: Holder[Node] { public: def this{}\n def value(): Node = self }\ndef main(args: String[]): String { return if new Node().value() != null { \"ok\" } else { \"no\" } }", "None", Array()))
+      "interface Holder[T] { def value(): T }\nclass Node conforms Holder[Node] { public: def this{}\n def value(): Node = self }\ndef main(args: String[]): String { return if new Node().value() != null { \"ok\" } else { \"no\" } }", "None", Array()))
   }
   it("still requires abstract methods of the implemented interface") {
     assert(Shell.Failure(-1) == shell.run(
-      "class C <: java.util.List[String] { public: def this{} }\ndef main(args: String[]): void { }", "None", Array()))
+      "class C conforms java.util.List[String] { public: def this{} }\ndef main(args: String[]): void { }", "None", Array()))
   }
 }

--- a/src/test/scala/onion/compiler/tools/SiblingInterfaceCastSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SiblingInterfaceCastSpec.scala
@@ -17,7 +17,7 @@ class SiblingInterfaceCastSpec extends AbstractShellSpec {
         """
           |interface Named { def name(): String }
           |interface Aged { def age(): Int }
-          |class Person <: Named, Aged {
+          |class Person conforms Named, Aged {
           |  var name_: String
           |  var age_: Int
           |public:

--- a/src/test/scala/onion/compiler/tools/SoundnessProbeFixesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SoundnessProbeFixesSpec.scala
@@ -18,11 +18,11 @@ class SoundnessProbeFixesSpec extends AbstractShellSpec {
   describe("record implementing an interface") {
     it("is rejected when an abstract method is unimplemented") {
       assert(Shell.Failure(-1) == shell.run(
-        "interface Describable { def describe(): String }\nrecord Point(x: Int, y: Int) <: Describable\ndef main(args: String[]): void { }", "None", Array()))
+        "interface Describable { def describe(): String }\nrecord Point(x: Int, y: Int) conforms Describable\ndef main(args: String[]): void { }", "None", Array()))
     }
     it("compiles when an accessor satisfies the interface method") {
       assert(Shell.Success("Alice") == shell.run(
-        "interface Named { def name(): String }\nrecord Person(name: String) <: Named\ndef main(args: String[]): String { val n: Named = new Person(\"Alice\")\n return n.name() }", "None", Array()))
+        "interface Named { def name(): String }\nrecord Person(name: String) conforms Named\ndef main(args: String[]): String { val n: Named = new Person(\"Alice\")\n return n.name() }", "None", Array()))
     }
   }
 }

--- a/src/test/scala/onion/compiler/tools/SupertypeValidationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SupertypeValidationSpec.scala
@@ -10,7 +10,7 @@ class SupertypeValidationSpec extends AbstractShellSpec {
       val result = silenceErr {
         shell.run(
           """
-            |class Bad : int {
+            |class Bad extends int {
             |public:
             |  static def main(args: String[]): Int { return 0 }
             |}
@@ -26,7 +26,7 @@ class SupertypeValidationSpec extends AbstractShellSpec {
       val result = silenceErr {
         shell.run(
           """
-            |class Bad <: int {
+            |class Bad conforms int {
             |public:
             |  static def main(args: String[]): Int { return 0 }
             |}
@@ -42,7 +42,7 @@ class SupertypeValidationSpec extends AbstractShellSpec {
       val result = silenceErr {
         shell.run(
           """
-            |interface I <: int {
+            |interface I conforms int {
             |  def f(): int
             |}
             |

--- a/src/test/scala/onion/compiler/tools/ThrowsClauseSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ThrowsClauseSpec.scala
@@ -48,7 +48,7 @@ class ThrowsClauseSpec extends AbstractShellSpec {
           |interface Processor {
           |  def process(): String throws Exception
           |}
-          |class SimpleProcessor <: Processor {
+          |class SimpleProcessor conforms Processor {
           |public:
           |  def process(): String throws Exception {
           |    return "processed";

--- a/src/test/scala/onion/compiler/tools/TraitParsingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TraitParsingSpec.scala
@@ -16,7 +16,7 @@ class TraitParsingSpec extends AbstractShellSpec {
           |  def zero(): T
           |  def plus(a: T, b: T): T
           |}
-          |class IntNum <: Numeric[Integer] {
+          |class IntNum conforms Numeric[Integer] {
           |public:
           |  def this {}
           |  def zero(): Integer = 0
@@ -36,7 +36,7 @@ class TraitParsingSpec extends AbstractShellSpec {
           |  def name(): String
           |  def greet(): String { return "Hi " + name() }
           |}
-          |class P <: Greeter { public: def this {}
+          |class P conforms Greeter { public: def this {}
           |  def name(): String { return "Ann" } }
           |def main(args: String[]): String { return new P().greet() }
           |""".stripMargin, "None", Array())

--- a/src/test/scala/onion/compiler/tools/TryElvisEmptyLiteralTargetTypeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryElvisEmptyLiteralTargetTypeSpec.scala
@@ -86,7 +86,7 @@ class TryElvisEmptyLiteralTargetTypeSpec extends AbstractShellSpec {
 
     it("try-with-resources still works (e)") {
       assert(Shell.Success(42) == shell.run(
-        "class R <: java.lang.AutoCloseable {\n" +
+        "class R conforms java.lang.AutoCloseable {\n" +
           "public:\n" +
           "  def this { }\n" +
           "  def close(): void { }\n" +

--- a/src/test/scala/onion/compiler/tools/TryWithResourcesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryWithResourcesSpec.scala
@@ -8,7 +8,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |import { java.lang.AutoCloseable; }
-          |class SimpleResource <: AutoCloseable {
+          |class SimpleResource conforms AutoCloseable {
           |  var result: StringBuilder;
           |public:
           |  def this(r: StringBuilder) {
@@ -39,7 +39,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |import { java.lang.AutoCloseable; }
-          |class MyCloseable <: AutoCloseable {
+          |class MyCloseable conforms AutoCloseable {
           |  var log: StringBuilder;
           |public:
           |  def this(l: StringBuilder) {
@@ -71,7 +71,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |import { java.lang.AutoCloseable; }
-          |class MyCloseable <: AutoCloseable {
+          |class MyCloseable conforms AutoCloseable {
           |  var log: StringBuilder;
           |public:
           |  def this(l: StringBuilder) {
@@ -105,7 +105,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |import { java.lang.AutoCloseable; }
-          |class MyCloseable <: AutoCloseable {
+          |class MyCloseable conforms AutoCloseable {
           |  var log: StringBuilder;
           |public:
           |  def this(l: StringBuilder) {
@@ -138,7 +138,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |import { java.lang.AutoCloseable; }
-          |class MyCloseable <: AutoCloseable {
+          |class MyCloseable conforms AutoCloseable {
           |  var log: StringBuilder;
           |public:
           |  def this(l: StringBuilder) {
@@ -173,7 +173,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |import { java.lang.AutoCloseable; }
-          |class MyResource <: AutoCloseable {
+          |class MyResource conforms AutoCloseable {
           |  var name: String;
           |public:
           |  def this(n: String) {
@@ -204,7 +204,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |import { java.lang.AutoCloseable; }
-          |class Resource1 <: AutoCloseable {
+          |class Resource1 conforms AutoCloseable {
           |  var log: StringBuilder;
           |public:
           |  def this(l: StringBuilder) {
@@ -214,7 +214,7 @@ class TryWithResourcesSpec extends AbstractShellSpec {
           |    this.log.append("1,");
           |  }
           |}
-          |class Resource2 <: AutoCloseable {
+          |class Resource2 conforms AutoCloseable {
           |  var log: StringBuilder;
           |public:
           |  def this(l: StringBuilder) {

--- a/src/test/scala/onion/compiler/tools/TypePatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TypePatternSpec.scala
@@ -8,8 +8,8 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Result {}
-          |record Success(value: String) <: Result;
-          |record Error(message: String) <: Result;
+          |record Success(value: String) conforms Result;
+          |record Error(message: String) conforms Result;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -32,8 +32,8 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Tree {}
-          |record Leaf(value: Int) <: Tree;
-          |record Node(left: Tree, right: Tree) <: Tree;
+          |record Leaf(value: Int) conforms Tree;
+          |record Node(left: Tree, right: Tree) conforms Tree;
           |class Test {
           |public:
           |  static def sum(t: Tree): Int {
@@ -59,9 +59,9 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Shape {}
-          |record Circle(radius: Int) <: Shape;
-          |record Square(side: Int) <: Shape;
-          |record Triangle(base: Int, height: Int) <: Shape;
+          |record Circle(radius: Int) conforms Shape;
+          |record Square(side: Int) conforms Shape;
+          |record Triangle(base: Int, height: Int) conforms Shape;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -84,8 +84,8 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Option {}
-          |record Some(value: String) <: Option;
-          |record None() <: Option;
+          |record Some(value: String) conforms Option;
+          |record None() conforms Option;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -107,9 +107,9 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Status {}
-          |record Active() <: Status;
-          |record Inactive() <: Status;
-          |record Pending() <: Status;
+          |record Active() conforms Status;
+          |record Inactive() conforms Status;
+          |record Pending() conforms Status;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -131,8 +131,8 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Status {}
-          |record Active() <: Status;
-          |record Inactive() <: Status;
+          |record Active() conforms Status;
+          |record Inactive() conforms Status;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -155,8 +155,8 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Option {}
-          |record Some(value: Int) <: Option;
-          |record None() <: Option;
+          |record Some(value: Int) conforms Option;
+          |record None() conforms Option;
           |class Test {
           |public:
           |  static def main(args: String[]): String {
@@ -179,8 +179,8 @@ class TypePatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Tree {}
-          |record Leaf(value: Int) <: Tree;
-          |record Node(left: Tree, right: Tree) <: Tree;
+          |record Leaf(value: Int) conforms Tree;
+          |record Node(left: Tree, right: Tree) conforms Tree;
           |class Test {
           |public:
           |  static def main(args: String[]): String {

--- a/src/test/scala/onion/compiler/tools/WildcardPatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/WildcardPatternSpec.scala
@@ -69,8 +69,8 @@ class WildcardPatternSpec extends AbstractShellSpec {
       val result = shell.run(
         """
           |sealed interface Result {}
-          |record Success(value: String) <: Result;
-          |record Error(message: String) <: Result;
+          |record Success(value: String) conforms Result;
+          |record Error(message: String) conforms Result;
           |class Test {
           |public:
           |  static def main(args: String[]): String {

--- a/vscode-onion/README.md
+++ b/vscode-onion/README.md
@@ -6,7 +6,7 @@ Language support for the [Onion programming language](https://github.com/kmizu/o
 
 - **Syntax Highlighting** — Full TextMate-based highlighting for Onion source
   files (`.on`): keywords, types, strings with `#{}` interpolation, numbers,
-  operators (including `as`, `?.`, `?:`, `!!`, `<:`, ranges), `select`/`case
+  operators (including `as`, `?.`, `?:`, `!!`, ranges), `select`/`case
   is`/`when`, `do`/`ret` notation, records, enums, and more.
 - **Editor Configuration** — Comment toggling, bracket matching, auto-closing
   pairs, and indentation rules.

--- a/vscode-onion/syntaxes/onion.tmLanguage.json
+++ b/vscode-onion/syntaxes/onion.tmLanguage.json
@@ -121,7 +121,7 @@
         },
         {
           "name": "keyword.other.onion",
-          "match": "\\b(extends|forward)\\b"
+          "match": "\\b(extends|conforms|forward)\\b"
         }
       ]
     },
@@ -179,10 +179,6 @@
     },
     "operators": {
       "patterns": [
-        {
-          "name": "keyword.operator.interface.onion",
-          "match": "<:"
-        },
         {
           "name": "keyword.operator.safe-access.onion",
           "match": "\\?\\.|\\?\\[|\\?:|!!"


### PR DESCRIPTION
## What

Replaces the symbolic inheritance spellings, docs included:

| before | after |
|---|---|
| `class Dog : Animal` | `class Dog extends Animal` |
| `class A <: I, J` | `class A conforms I, J` |
| `class Dog : Animal <: Greeter` | `class Dog extends Animal conforms Greeter` |

Applies equally to `record` / `interface` / `trait` supertype lists.

## Why

Symbols hurt searchability and readability: you cannot grep for `<:` meaningfully, and `:` already carried three other meanings (type annotations, record components, `select` cases) — the inheritance position was the odd one out.

## How

- **Grammar** — `extends` reuses the existing `K_EXTENDS` token. `conforms` is a **soft keyword** (image-based `LOOKAHEAD`, same device as `from`/`shape`), so `def conforms(..)`, fields and locals named `conforms` still parse.
- **Migration diagnostics** — `<:` stays lexed as a single token purely so old source gets a targeted hint: `Hint: interfaces are named with `conforms`, not `<:` …`. A stray `:` in the supertype position hints at `extends`. Both messages are EN+JA (`error.parsing.hint.old_extends` / `old_conforms`).
- **Tooling** — `SignatureRenderer` (generated API docs) and the VS Code tmLanguage follow; `<:` dropped from highlighted operators.
- **Corpus** — `run/`, crash-corpus, 43 test suites, docs EN+JA, `CLAUDE.md`/`CLAUDE_ja.md` migrated. CHANGELOG history untouched; new `[Unreleased]` entry added.

## Tests

- New `InheritanceKeywordSpec` (9 cases): both keywords, combined use, record/interface positions, `conforms` as method/field/local, old spellings rejected, `extends` listed among expected tokens.
- `sbt -Duser.language=en test`: **2590 passed, 0 failed**.
- ja locale: the 2 `ProjectBuilderSpec` failures reproduce on `origin/develop` unchanged — pre-existing, unrelated.
- All `run/*.on` samples executed OK after migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)