### PR TITLE
docs(examples): fix garbled "Multiple inheritance" bullet in oop.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   document's line number — mirroring the existing `BrokenLogDemo.on` pattern for the
   regex-shape form.
 
+- **docs(examples): fix a garbled "Multiple inheritance" bullet in `docs/examples/oop.md`.**
+  The `extends`/`conforms` rewrite (#391) accidentally collapsed the English prose line
+  to `Multiple inheritance (: JFrame, implements ActionListener)`, leaving a bare `:`
+  where `extends` belonged and disagreeing with the `class Calculator extends JFrame
+  conforms ActionListener` sample directly above it. The Japanese translation was
+  unaffected. Fixed to `Multiple inheritance (extends JFrame, conforms ActionListener)`.
+
 ## [0.8.0] - 2026-07-25
 
 The v0.8.0 tag was moved after the fact. As first cut it promised `eachLine` on

--- a/docs/examples/oop.md
+++ b/docs/examples/oop.md
@@ -351,7 +351,7 @@ class Calculator extends JFrame conforms ActionListener {
 ```
 
 **Topics:**
-- Multiple inheritance (: JFrame, implements ActionListener)
+- Multiple inheritance (extends JFrame, conforms ActionListener)
 - Swing GUI components
 - Event handling
 - `self` reference


### PR DESCRIPTION
## Summary
- The `extends`/`conforms` rewrite (#391) collapsed the English "Topics" bullet in `docs/examples/oop.md` from "Multiple inheritance (extends JFrame, implements ActionListener)" to "Multiple inheritance (**:** JFrame, implements ActionListener)" — a stray leftover `:` where `extends` belonged, disagreeing with the `class Calculator extends JFrame conforms ActionListener` sample directly above it.
- The Japanese translation (`docs/ja/examples/oop.md`) was unaffected by the bug.
- Fixed to "Multiple inheritance (extends JFrame, conforms ActionListener)" and added a CHANGELOG entry.
- Swept the rest of `docs/` for the same pattern; no other occurrences found.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2590 tests, 0 failed, 1 canceled (pre-existing/environment-dependent), green.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01HAvuf97QNaYWg3uxua1GrJ)_