### PR TITLE
test: make ProjectBuilderSpec locale-independent

### DIFF
--- a/src/test/scala/onion/tools/project/ProjectBuilderSpec.scala
+++ b/src/test/scala/onion/tools/project/ProjectBuilderSpec.scala
@@ -313,8 +313,10 @@ class ProjectBuilderSpec extends AnyFunSuite with Matchers:
     val (errorResult, errors) = build(errorProject)
 
     errorResult.isLeft shouldBe true
-    errors should include("src/main.on")
-    errors should include("errors are found")
+    // The `path:line:col:` prefix is structural; the message text and the closing
+    // "N errors are found." trailer are localized (error.count), so asserting on
+    // them passes in an English locale and fails only under -Duser.language=ja.
+    errors should include("src/main.on:1:10:")
     temporaryDirectories(errorProject.paths) shouldBe Vector.empty
 
   test("requires successful compiler results to contain parsed source units"):
@@ -335,7 +337,8 @@ class ProjectBuilderSpec extends AnyFunSuite with Matchers:
     val (result, diagnostics) = build(reload(project.root))
 
     result.isLeft shouldBe true
-    diagnostics should include("error")
+    // Locale-agnostic: the diagnostic's position prefix, not its localized text.
+    diagnostics should include("src/main.on:1:10:")
     outputSnapshot(project.paths) shouldBe before
     temporaryDirectories(project.paths) shouldBe Vector.empty
 


### PR DESCRIPTION
## What

Fixes the 2 `ProjectBuilderSpec` failures that appear only under `-Duser.language=ja`.

## Why

Two assertions matched localized diagnostic text: `"errors are found"` and `"error"`. The error-count trailer comes from `error.count` in `errorMessage.properties` and renders as 「N 個のエラーが発見されました。」 in a ja locale, so the spec passed in the (English) release CI but failed on a ja_JP dev machine — exactly the trap CLAUDE.md's locale-independence note warns about.

## How

Assert on the structural `src/main.on:1:10:` position prefix instead — which is what both tests' intent (diagnostics reach the injected error stream) actually needs. The neighbouring `"warning(s)"` assertion stays: that trailer is hardcoded English in `DiagnosticRenderer`, not localized.

## Tests

Full suite green under **both** locales: `-Duser.language=ja` 2590/0 and `-Duser.language=en` 2590/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)