### PR TITLE
docs(grammar): sync docs/grammar.txt with the extends/conforms rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **docs(grammar): sync `docs/grammar.txt` with the `extends`/`conforms` rewrite.**
+  The `extends`/`conforms` change (below) updated the parser, the hint messages, the
+  API-doc generator and the VS Code grammar, but missed the informal EBNF sketch in
+  `docs/grammar.txt`: `class_decl` and `interface_decl` still showed the old `[':' type]`
+  and `['<:' type (',' type)*]` productions, describing syntax the parser no longer
+  accepts. Updated both to `['extends' type]` / `['conforms' type (',' type)*]`. No test
+  covers this file's prose against the grammar, which is how it went stale silently.
+
 - **BREAKING: inheritance is spelled with words. `:` became `extends` and `<:` became
   `conforms`.** `class Dog : Animal <: Greeter` is now
   `class Dog extends Animal conforms Greeter`; the same change applies to `record`,

--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -33,11 +33,11 @@ array_suffix          ::= '[]'
 type_params           ::= '[' type_param (',' type_param)* ']'
 type_param            ::= id ['extends' type]
 
-class_decl            ::= modifiers 'class' id type_params? [':' type]
-                         ['<:' type (',' type)*]
+class_decl            ::= modifiers 'class' id type_params? ['extends' type]
+                         ['conforms' type (',' type)*]
                          '{' default_section? access_section* '}'
 interface_decl        ::= modifiers 'interface' id type_params?
-                         ['<:' type (',' type)*]
+                         ['conforms' type (',' type)*]
                          '{' interface_method_sig* '}'
 record_decl           ::= modifiers 'record' id '(' args? ')'
 


### PR DESCRIPTION
## Summary
- `class_decl` and `interface_decl` in the informal EBNF sketch (`docs/grammar.txt`) still showed the pre-rewrite `[':' type]` / `['<:' type (',' type)*]` productions — syntax the parser no longer accepts now that inheritance is spelled `extends`/`conforms`.
- Updated both productions to `['extends' type]` / `['conforms' type (',' type)*]`, matching `grammar/JJOnionParser.jj`'s `class_decl`/`interface_decl`/`trait_decl` rules.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

No test exercises this file's prose against the grammar, which is how it went stale after the `extends`/`conforms` rewrite touched the parser, hints, API-doc generator, and VS Code grammar but missed this doc.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2590 passed, 0 failed, 1 cancelled (gated dist smoke test)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAUeA31W8qMxxiFR6SUoHo)_