### PR TITLE
feat(tools): machine-readable contracts and a CLI derived from them (#358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Machine-readable tool contracts, and a CLI derived from them (#358).** A script
+  whose top level declares tools (and has no `main` of its own) is now a command-line
+  program: the compiler builds a JSON contract from the declarations — parameters with
+  types, roles and defaults, the return type, the checked capabilities — and a
+  synthesized `main` hands argv plus that contract to the new `onion.ToolCli`.
+  `--contract` prints the JSON verbatim (what an agent reads); `--help` describes every
+  argument with its type and default and shows the capability line; parsing, typed
+  conversion and error messages are all derived from the same contract, and failures
+  are exit codes — no `System.exit` anywhere on the tool path, which is what makes the
+  whole surface testable in-process. Several tools in one script dispatch
+  subcommand-style. Also fixed: `--help` on the `def main` rest-collector path used to
+  be silently consumed as a positional; `Cli.requireArgs` now recognizes it.
+
 - **`tool` declarations with checked capabilities (#357).** A tool is a function with a
   boundary: `tool ingest(src: String, dst: String) requires { read(src), write(dst) }
   { ... }`. The compiler infers the body's effects (transitively, through ordinary

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -100,3 +100,47 @@ can always see.
 And `tool` / `requires` are soft keywords: only `tool name(` opens a declaration and
 only `requires {` opens the clause, so both remain usable as ordinary identifiers in
 existing code.
+
+## From declaration to command line
+
+A script whose top level declares tools — and has neither its own `main` nor top-level
+statements — *is* a command-line program. The compiler derives everything from the
+declarations:
+
+```bash
+$ onion ingest.on --contract
+[{"tool":"ingest",
+  "params":[{"name":"src","type":"String","role":"positional"},
+            {"name":"dst","type":"String","role":"positional"},
+            {"name":"count","type":"Int","role":"flag","default":"3"},
+            {"name":"loud","type":"Boolean","role":"switch","default":"false"}],
+  "returns":"Int",
+  "capabilities":["read(src)","write(dst)","console"]}]
+
+$ onion ingest.on --help
+usage: ingest.on <src> <dst> [--count <Int>] [--loud]
+  <src>                   String
+  <dst>                   String
+  --count <int>           Int (default: 3)
+  --loud                  Boolean (default: false)
+  requires: read(src), write(dst), console
+```
+
+The contract is the single source. `--contract` prints it verbatim for an agent to
+read; `--help`, flag parsing, typed conversion and error messages are all derived from
+it at runtime, and the typed call into your tool is derived from the same declaration
+at compile time. Required parameters are positionals; defaulted parameters become
+`--name` flags (`--count 5` or `--count=5`); `Boolean` defaults become switches. A
+default that is absent on the command line is evaluated as the original expression, in
+the language — it is never round-tripped through a string.
+
+Failures are exit codes, not `System.exit`: a missing positional, a value that does not
+parse as its declared type, or an unknown option each print a message naming the
+argument and the expected type, then return `1` from `main`. When a script declares
+several tools, the first argument selects one by name, subcommand-style, and the
+contract carries one entry per tool.
+
+The capability line in `--help` and the `capabilities` field in the contract are not
+documentation — they are the checked declaration from the section above. What the
+contract says the tool may do is what the compiler proved it cannot exceed.
+

--- a/docs/ja/guide/tools.md
+++ b/docs/ja/guide/tools.md
@@ -93,3 +93,44 @@ tool が印字するラムダを作るなら、そのラムダが他所でしか
 
 そして `tool` / `requires` はソフトキーワードです。`tool name(` だけが宣言を開き、
 `requires {` だけが節を開くので、既存コードの識別子としては今までどおり使えます。
+
+## 宣言からコマンドラインへ
+
+トップレベルに tool を宣言していて、自前の `main` もトップレベル文もないスクリプトは、
+それ自体がコマンドラインプログラムです。コンパイラがすべてを宣言から導出します：
+
+```bash
+$ onion ingest.on --contract
+[{"tool":"ingest",
+  "params":[{"name":"src","type":"String","role":"positional"},
+            {"name":"dst","type":"String","role":"positional"},
+            {"name":"count","type":"Int","role":"flag","default":"3"},
+            {"name":"loud","type":"Boolean","role":"switch","default":"false"}],
+  "returns":"Int",
+  "capabilities":["read(src)","write(dst)","console"]}]
+
+$ onion ingest.on --help
+usage: ingest.on <src> <dst> [--count <Int>] [--loud]
+  <src>                   String
+  <dst>                   String
+  --count <int>           Int (default: 3)
+  --loud                  Boolean (default: false)
+  requires: read(src), write(dst), console
+```
+
+契約が唯一のソースです。`--contract` はそれをそのまま出力し（エージェントが読むのは
+これ）、`--help`・フラグ解析・型付き変換・エラーメッセージはすべて実行時にそこから
+導出され、あなたの tool への型付き呼び出しはコンパイル時に同じ宣言から導出されます。
+必須パラメータは位置引数、デフォルト付きパラメータは `--name` フラグ（`--count 5` /
+`--count=5`）、`Boolean` のデフォルトはスイッチになります。コマンドラインで省略された
+デフォルトは元の式として言語内で評価されます — 文字列を経由した往復はしません。
+
+失敗は `System.exit` ではなく終了コードです。位置引数の不足、宣言型として解析できない
+値、未知のオプションは、引数名と期待される型を名指しするメッセージを出して `main` から
+`1` を返します。スクリプトが複数の tool を宣言していれば、最初の引数がサブコマンド式に
+名前で選択し、契約には tool ごとのエントリが並びます。
+
+`--help` の capability 行と契約の `capabilities` フィールドはドキュメントではありません —
+上の節で検査された宣言そのものです。契約が「してよい」と言うことは、コンパイラが
+「それを超えられない」と証明したことです。
+

--- a/src/main/java/onion/Cli.java
+++ b/src/main/java/onion/Cli.java
@@ -251,6 +251,15 @@ public final class Cli {
 
     public static void requireArgs(String[] args, int required, String usage) {
         int n = args == null ? 0 : args.length;
+        // `--help` used to be handled only on the all-scalar path, so on the
+        // rest-collector path it was silently consumed as a positional (#358).
+        // Recognize it here with the same behavior the scalar path has.
+        for (int i = 0; i < n; i++) {
+            if ("--help".equals(args[i]) || "-h".equals(args[i])) {
+                System.out.println("usage: " + scriptName() + " " + usage);
+                System.exit(0);
+            }
+        }
         if (n < required) {
             System.err.println("error: expected at least " + required + " argument(s)");
             System.err.println("usage: " + scriptName() + " " + usage);

--- a/src/main/java/onion/ToolCli.java
+++ b/src/main/java/onion/ToolCli.java
@@ -1,0 +1,279 @@
+package onion;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The runtime half of tool CLIs (issue #358).
+ *
+ * A script whose top level declares tools gets a synthesized {@code main} that hands
+ * {@code argv} plus the tools' machine-readable contract (a JSON string built by the
+ * compiler from the declarations) to {@link #dispatch}. Everything the CLI does —
+ * {@code --contract}, {@code --help} with types and defaults, subcommand selection,
+ * flag/positional parsing, typed conversion, error reporting — is derived from that
+ * one contract. There is no spec string, no parallel per-type switch, and no
+ * {@code System.exit} anywhere on this path: failures return an exit code the caller
+ * returns from {@code main}, which is what makes them testable in-process.
+ *
+ * Contract schema (an array; one entry per tool):
+ * <pre>
+ * [{"tool": "ingest",
+ *   "params": [{"name":"src","type":"String","role":"positional"},
+ *              {"name":"count","type":"Int","role":"flag","default":"3"}],
+ *   "returns": "Int",
+ *   "capabilities": ["read(src)","console"]}]
+ * </pre>
+ * Roles: {@code positional} (required, in order), {@code flag} ({@code --name value}
+ * or {@code --name=value}), {@code switch} ({@code --name}, boolean). A defaulted
+ * parameter whose flag is absent yields a {@code null} slot in {@link Result#value};
+ * the synthesized call site evaluates the default expression in-language, so defaults
+ * stay arbitrary expressions, not strings.
+ */
+public final class ToolCli {
+    private ToolCli() {}
+
+    /** What dispatch decided: either exit with a code, or run tool #tool with values. */
+    public static final class Result {
+        private final boolean exit;
+        private final int code;
+        private final int tool;
+        private final Object[] values;
+
+        private Result(boolean exit, int code, int tool, Object[] values) {
+            this.exit = exit; this.code = code; this.tool = tool; this.values = values;
+        }
+        public boolean isExit() { return exit; }
+        public int exitCode() { return code; }
+        public int tool() { return tool; }
+        public Object value(int i) { return values[i]; }
+
+        static Result exit(int code) { return new Result(true, code, -1, null); }
+        static Result run(int tool, Object[] values) { return new Result(false, 0, tool, values); }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Result dispatch(String[] args, String contractJson) {
+        final List<Map<String, Object>> tools;
+        try {
+            tools = (List<Map<String, Object>>) (List<?>) (List<Object>) Json.parse(contractJson);
+        } catch (Exception e) {
+            System.err.println("internal error: malformed tool contract: " + e.getMessage());
+            return Result.exit(70); // EX_SOFTWARE
+        }
+
+        for (String a : args) {
+            if (a.equals("--contract")) { System.out.println(contractJson); return Result.exit(0); }
+        }
+        for (String a : args) {
+            if (a.equals("--help") || a.equals("-h")) { System.out.print(help(tools)); return Result.exit(0); }
+        }
+
+        int toolIndex = 0;
+        String[] rest = args;
+        if (tools.size() > 1) {
+            if (args.length == 0) { System.err.print(help(tools)); return Result.exit(1); }
+            toolIndex = -1;
+            for (int i = 0; i < tools.size(); i++) {
+                if (name(tools.get(i)).equals(args[0])) { toolIndex = i; break; }
+            }
+            if (toolIndex < 0) {
+                System.err.println("unknown tool `" + args[0] + "`. " + toolNames(tools));
+                return Result.exit(1);
+            }
+            rest = new String[args.length - 1];
+            System.arraycopy(args, 1, rest, 0, rest.length);
+        }
+
+        Map<String, Object> tool = tools.get(toolIndex);
+        List<Map<String, Object>> params = params(tool);
+        Object[] values = new Object[params.size()];
+
+        // Index the declared flags/switches; walk argv filling positionals in order.
+        Map<String, Integer> named = new LinkedHashMap<>();
+        List<Integer> positionals = new ArrayList<>();
+        for (int i = 0; i < params.size(); i++) {
+            String role = str(params.get(i), "role");
+            if (role.equals("positional")) positionals.add(i);
+            else named.put("--" + str(params.get(i), "name"), i);
+        }
+
+        int nextPositional = 0;
+        for (int a = 0; a < rest.length; a++) {
+            String arg = rest[a];
+            if (arg.startsWith("--")) {
+                String key = arg;
+                String inline = null;
+                int eq = arg.indexOf('=');
+                if (eq >= 0) { key = arg.substring(0, eq); inline = arg.substring(eq + 1); }
+                Integer idx = named.get(key);
+                if (idx == null) {
+                    System.err.println("unknown option `" + key + "` for tool `" + name(tool) + "`. Try --help.");
+                    return Result.exit(1);
+                }
+                Map<String, Object> p = params.get(idx);
+                if (str(p, "role").equals("switch")) {
+                    if (inline != null) {
+                        System.err.println("switch `" + key + "` does not take a value.");
+                        return Result.exit(1);
+                    }
+                    values[idx] = Boolean.TRUE;
+                } else {
+                    String raw = inline;
+                    if (raw == null) {
+                        if (a + 1 >= rest.length) {
+                            System.err.println("option `" + key + "` needs a value (" + str(p, "type") + ").");
+                            return Result.exit(1);
+                        }
+                        raw = rest[++a];
+                    }
+                    Object converted = convert(raw, str(p, "type"));
+                    if (converted == CONVERSION_FAILED) {
+                        System.err.println("option `" + key + "`: `" + raw + "` is not a valid " + str(p, "type") + ".");
+                        return Result.exit(1);
+                    }
+                    values[idx] = converted;
+                }
+            } else {
+                if (nextPositional >= positionals.size()) {
+                    System.err.println("unexpected argument `" + arg + "`. Try --help.");
+                    return Result.exit(1);
+                }
+                int idx = positionals.get(nextPositional++);
+                Map<String, Object> p = params.get(idx);
+                Object converted = convert(arg, str(p, "type"));
+                if (converted == CONVERSION_FAILED) {
+                    System.err.println("argument `" + str(p, "name") + "`: `" + arg + "` is not a valid " + str(p, "type") + ".");
+                    return Result.exit(1);
+                }
+                values[idx] = converted;
+            }
+        }
+
+        if (nextPositional < positionals.size()) {
+            StringBuilder sb = new StringBuilder("missing argument");
+            List<String> missing = new ArrayList<>();
+            for (int i = nextPositional; i < positionals.size(); i++) {
+                Map<String, Object> p = params.get(positionals.get(i));
+                missing.add("<" + str(p, "name") + ": " + str(p, "type") + ">");
+            }
+            sb.append(missing.size() > 1 ? "s " : " ").append(String.join(" ", missing));
+            System.err.println(sb);
+            System.err.print(usage(tool, tools.size() > 1));
+            return Result.exit(1);
+        }
+        return Result.run(toolIndex, values);
+    }
+
+    // ---- help / usage, straight from the contract -------------------------------
+
+    private static String help(List<Map<String, Object>> tools) {
+        StringBuilder sb = new StringBuilder();
+        boolean sub = tools.size() > 1;
+        for (Map<String, Object> tool : tools) {
+            sb.append(usage(tool, sub));
+            for (Map<String, Object> p : params(tool)) {
+                sb.append("  ").append(pad(paramLabel(p), 24)).append(paramDoc(p)).append('\n');
+            }
+            List<Object> caps = list(tool, "capabilities");
+            if (!caps.isEmpty()) {
+                List<String> rendered = new ArrayList<>();
+                for (Object c : caps) rendered.add(String.valueOf(c));
+                sb.append("  requires: ").append(String.join(", ", rendered)).append('\n');
+            }
+        }
+        sb.append("  ").append(pad("--contract", 24)).append("print the machine-readable contract\n");
+        sb.append("  ").append(pad("--help, -h", 24)).append("show this help\n");
+        return sb.toString();
+    }
+
+    private static String usage(Map<String, Object> tool, boolean sub) {
+        StringBuilder sb = new StringBuilder("usage: ");
+        String script = System.getProperty("onion.cli.script", "<script>");
+        sb.append(script);
+        if (sub) sb.append(' ').append(name(tool));
+        for (Map<String, Object> p : params(tool)) {
+            String role = str(p, "role");
+            if (role.equals("positional")) sb.append(" <").append(str(p, "name")).append('>');
+            else if (role.equals("switch")) sb.append(" [--").append(str(p, "name")).append(']');
+            else sb.append(" [--").append(str(p, "name")).append(" <").append(str(p, "type")).append(">]");
+        }
+        sb.append('\n');
+        return sb.toString();
+    }
+
+    private static String paramLabel(Map<String, Object> p) {
+        String role = str(p, "role");
+        if (role.equals("positional")) return "<" + str(p, "name") + ">";
+        if (role.equals("switch")) return "--" + str(p, "name");
+        return "--" + str(p, "name") + " <" + str(p, "type").toLowerCase() + ">";
+    }
+
+    private static String paramDoc(Map<String, Object> p) {
+        StringBuilder sb = new StringBuilder(str(p, "type"));
+        Object dflt = p.get("default");
+        if (dflt != null) sb.append(" (default: ").append(dflt).append(')');
+        return sb.toString();
+    }
+
+    private static String pad(String s, int width) {
+        if (s.length() >= width) return s + ' ';
+        StringBuilder sb = new StringBuilder(s);
+        while (sb.length() < width) sb.append(' ');
+        return sb.toString();
+    }
+
+    private static String toolNames(List<Map<String, Object>> tools) {
+        List<String> names = new ArrayList<>();
+        for (Map<String, Object> t : tools) names.add(name(t));
+        return "Tools: " + String.join(", ", names);
+    }
+
+    // ---- conversion --------------------------------------------------------------
+
+    private static final Object CONVERSION_FAILED = new Object();
+
+    private static Object convert(String raw, String type) {
+        try {
+            switch (type) {
+                case "String":  return raw;
+                case "Int":     return Integer.valueOf(raw.trim());
+                case "Long":    return Long.valueOf(raw.trim());
+                case "Double":  return Double.valueOf(raw.trim());
+                case "Float":   return Float.valueOf(raw.trim());
+                case "Short":   return Short.valueOf(raw.trim());
+                case "Byte":    return Byte.valueOf(raw.trim());
+                case "Boolean":
+                    String t = raw.trim().toLowerCase();
+                    if (t.equals("true")) return Boolean.TRUE;
+                    if (t.equals("false")) return Boolean.FALSE;
+                    return CONVERSION_FAILED;
+                default:        return CONVERSION_FAILED;
+            }
+        } catch (NumberFormatException e) {
+            return CONVERSION_FAILED;
+        }
+    }
+
+    // ---- tiny typed views over the parsed contract -------------------------------
+
+    private static String name(Map<String, Object> tool) { return str(tool, "tool"); }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> params(Map<String, Object> tool) {
+        Object v = tool.get("params");
+        return v == null ? new ArrayList<>() : (List<Map<String, Object>>) (List<?>) v;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> list(Map<String, Object> m, String key) {
+        Object v = m.get(key);
+        return v == null ? new ArrayList<>() : (List<Object>) v;
+    }
+
+    private static String str(Map<String, Object> m, String key) {
+        Object v = m.get(key);
+        return v == null ? "" : String.valueOf(v);
+    }
+}

--- a/src/main/resources/onion/effect-table.txt
+++ b/src/main/resources/onion/effect-table.txt
@@ -280,3 +280,4 @@ java.lang.Class#getSimpleName=pure
 
 # System::out / System::err are PrintStreams
 java.io.PrintStream#*=console
+onion.ToolCli#*=console

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -196,6 +196,7 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
       case otherwise =>
         newToplevels += otherwise
     }
+    appendToolCliMain(newToplevels)
     appendAutoCliCall(newToplevels)
     unit.copy(toplevels = newToplevels.toList)
   }
@@ -305,6 +306,115 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
       case AST.ArrayType(AST.ReferenceType("java.lang.String", _)) => true
       case _ => false
     })
+
+  /**
+   * Tool CLI synthesis (issue #358). A script whose top level declares `tool`s and has
+   * neither a user `main` nor executable top-level statements gets a synthesized
+   * `main(args: String[]): Int` that hands argv plus the tools' contract — a JSON
+   * string built here, from the declarations — to `onion.ToolCli.dispatch`. The
+   * contract is the single source: `--contract` prints it verbatim, `--help` and all
+   * parsing are derived from it at runtime, and this method derives the typed call
+   * from the same declarations. No spec string, no `System.exit` on this path.
+   */
+  private def appendToolCliMain(toplevels: Buffer[AST.Toplevel]): Unit = {
+    def isTool(f: AST.FunctionDeclaration): Boolean = f.annotations.exists(_.name == "onion.tool")
+    val tools = toplevels.collect { case f: AST.FunctionDeclaration if isTool(f) => f }.toList
+    if (tools.isEmpty) return
+    // A user main or a top-level statement keeps script semantics untouched.
+    if (toplevels.exists { case f: AST.FunctionDeclaration => f.name == "main"; case _ => false }) return
+    if (toplevels.exists(_.isInstanceOf[AST.BlockElement])) return
+    // Every parameter of every tool must be CLI-convertible, or the CLI cannot be
+    // derived; such a script keeps its tools as plain functions.
+    if (!tools.forall(_.args.forall(a => cliKindOf(a.typeRef).isDefined))) return
+
+    val loc = tools.head.location
+    val contractJson = tools.map(toolContractJson).mkString("[", ",", "]")
+
+    val toolCliType = AST.TypeNode(loc, AST.ReferenceType("onion.ToolCli", true), false)
+    val resVar = "__toolCli"
+    val res = AST.Id(loc, resVar)
+    val statements = Buffer[AST.BlockElement](
+      AST.LocalVariableDeclaration(loc, AST.M_FINAL, resVar, null,
+        AST.StaticMethodCall(loc, toolCliType, "dispatch",
+          List(AST.Id(loc, "args"), AST.StringLiteral(loc, contractJson)))),
+      AST.IfExpression(loc,
+        AST.MethodCall(loc, res, "isExit", Nil),
+        AST.BlockExpression(loc, List(AST.ReturnExpression(loc, AST.MethodCall(loc, res, "exitCode", Nil)))),
+        null)
+    )
+    for ((tool, index) <- tools.zipWithIndex) {
+      val callArgs = tool.args.zipWithIndex.map { case (a, j) =>
+        val raw = AST.MethodCall(loc, res, "value", List(AST.IntegerLiteral(loc, j)))
+        val cast = AST.Cast(loc, raw, a.typeRef)
+        if (a.defaultValue == null) cast
+        else AST.IfExpression(loc,
+          AST.Equal(loc, raw, AST.NullLiteral(loc)),
+          AST.BlockExpression(loc, List(rewriteExpression(a.defaultValue))),
+          AST.BlockExpression(loc, List(cast)))
+      }
+      val call = AST.UnqualifiedMethodCall(loc, tool.name, callArgs)
+      // An Int-returning tool's result is the exit code; anything else exits 0.
+      val body =
+        if (cliKindOf(tool.returnType).contains("Int"))
+          List(AST.ReturnExpression(loc, call))
+        else
+          List(call, AST.ReturnExpression(loc, AST.IntegerLiteral(loc, 0)))
+      statements += AST.IfExpression(loc,
+        AST.Equal(loc, AST.MethodCall(loc, res, "tool", Nil), AST.IntegerLiteral(loc, index)),
+        AST.BlockExpression(loc, body),
+        null)
+    }
+    statements += AST.ReturnExpression(loc, AST.IntegerLiteral(loc, 0))
+
+    toplevels += AST.FunctionDeclaration(
+      loc, 0, "main",
+      List(AST.Argument(loc, "args",
+        AST.TypeNode(loc, AST.ArrayType(AST.ReferenceType("String", false)), false))),
+      AST.TypeNode(loc, AST.PrimitiveType(AST.KInt), false),
+      AST.BlockExpression(loc, statements.toList),
+      Nil, Nil, Nil)
+  }
+
+  /** One tool's contract entry: everything an agent (or `--help`) needs to call it. */
+  private def toolContractJson(tool: AST.FunctionDeclaration): String = {
+    def esc(s: String): String =
+      s.flatMap {
+        case '"'  => "\\\""
+        case '\\' => "\\\\"
+        case '\n' => "\\n"
+        case '\r' => "\\r"
+        case '\t' => "\\t"
+        case c if c < ' ' => f"\\u${c.toInt}%04x"
+        case c    => c.toString
+      }
+    def defaultRendering(e: AST.Expression): Option[String] = e match {
+      case AST.IntegerLiteral(_, v)   => Some(v.toString)
+      case AST.LongLiteral(_, v)      => Some(v.toString)
+      case AST.DoubleLiteral(_, v)    => Some(v.toString)
+      case AST.FloatLiteral(_, v)     => Some(v.toString)
+      case AST.BooleanLiteral(_, v)   => Some(v.toString)
+      case AST.StringLiteral(_, v)    => Some(v)
+      case AST.CharacterLiteral(_, v) => Some(v.toString)
+      case _                          => Some("<computed>")
+    }
+    val params = tool.args.map { a =>
+      val kind = cliKindOf(a.typeRef).get
+      val role =
+        if (a.defaultValue == null) "positional"
+        else if (kind == "Boolean") "switch"
+        else "flag"
+      val dflt = Option(a.defaultValue).flatMap(defaultRendering)
+        .map(d => s""","default":"${esc(d)}"""").getOrElse("")
+      s"""{"name":"${esc(a.name)}","type":"$kind","role":"$role"$dflt}"""
+    }.mkString("[", ",", "]")
+    val returns = cliKindOf(tool.returnType).getOrElse(
+      if (tool.returnType == null) "void" else esc(tool.returnType.desc.toString))
+    val caps = tool.annotations.collect {
+      case AST.Annotation(_, name) if name.startsWith("requires:") =>
+        s""""${esc(name.stripPrefix("requires:"))}""""
+    }.mkString("[", ",", "]")
+    s"""{"tool":"${esc(tool.name)}","params":$params,"returns":"$returns","capabilities":$caps}"""
+  }
 
   private def appendAutoCliCall(toplevels: Buffer[AST.Toplevel]): Unit = {
     val allScalar = (f: AST.FunctionDeclaration) => f.args.forall(a => cliKindOf(a.typeRef).isDefined)

--- a/src/test/scala/onion/compiler/tools/ToolContractCliSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ToolContractCliSpec.scala
@@ -1,0 +1,146 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * The tool CLI is derived from the machine-readable contract (issue #358): one
+ * declaration yields `--contract` (what an agent reads), `--help` with types and
+ * defaults, typed parsing, and exit codes instead of `System.exit` — which is why
+ * every case here runs in-process.
+ */
+class ToolContractCliSpec extends AbstractShellSpec {
+
+  private val script =
+    """tool greet(name: String, count: Int = 2, loud: Boolean = false): Int
+      |  requires { console }
+      |{
+      |  var i = 0
+      |  while i < count {
+      |    if loud { IO::println(name.toUpperCase()) } else { IO::println(name) }
+      |    i = i + 1
+      |  }
+      |  return 0
+      |}
+      |""".stripMargin
+
+  describe("--contract") {
+    it("prints the machine-readable contract: params, types, roles, defaults, capabilities") {
+      val (r, out) = run(script, "--contract")
+      assert(Shell.Success(0) == r, r.toString)
+      assert(out.contains(""""tool":"greet""""), out)
+      assert(out.contains(""""name":"name","type":"String","role":"positional""""), out)
+      assert(out.contains(""""name":"count","type":"Int","role":"flag","default":"2""""), out)
+      assert(out.contains(""""name":"loud","type":"Boolean","role":"switch","default":"false""""), out)
+      assert(out.contains(""""capabilities":["console"]"""), out)
+      assert(out.contains(""""returns":"Int""""), out)
+    }
+  }
+
+  describe("--help") {
+    it("describes every argument with its type and default, and the capabilities") {
+      val (r, out) = run(script, "--help")
+      assert(Shell.Success(0) == r, r.toString)
+      assert(out.contains("<name>"), out)
+      assert(out.contains("--count <int>"), out)
+      assert(out.contains("(default: 2)"), out)
+      assert(out.contains("--loud"), out)
+      assert(out.contains("requires: console"), out)
+      assert(out.contains("--contract"), out)
+    }
+  }
+
+  describe("parsing") {
+    it("binds positionals, flags and switches, and runs the tool") {
+      val (r, out) = run(script, "world", "--count", "1", "--loud")
+      assert(Shell.Success(0) == r, r.toString)
+      assert(out.contains("WORLD"), out)
+    }
+
+    it("accepts the --name=value form and evaluates absent defaults in-language") {
+      val (r, out) = run(script, "hi", "--count=3")
+      assert(Shell.Success(0) == r, r.toString)
+      assert(out.linesIterator.count(_ == "hi") == 3, out)
+    }
+
+    it("reports a missing positional by name and type, with exit code 1") {
+      val (r, out) = run(script)
+      assert(Shell.Success(1) == r, r.toString)
+      assert(out.contains("<name: String>"), out)
+      assert(out.contains("usage:"), out)
+    }
+
+    it("reports a bad value naming the option and the expected type") {
+      val (r, out) = run(script, "x", "--count", "many")
+      assert(Shell.Success(1) == r, r.toString)
+      assert(out.contains("--count"), out)
+      assert(out.contains("Int"), out)
+    }
+
+    it("rejects an unknown option") {
+      val (r, out) = run(script, "x", "--nope")
+      assert(Shell.Success(1) == r, r.toString)
+      assert(out.contains("--nope"), out)
+    }
+  }
+
+  describe("several tools in one script") {
+    val multi =
+      """tool add(a: Int, b: Int): Int requires { console } { IO::println("" + (a + b)); return 0 }
+        |tool mul(a: Int, b: Int): Int requires { console } { IO::println("" + (a * b)); return 0 }
+        |""".stripMargin
+
+    it("dispatches on the first argument as a subcommand") {
+      val (r1, out1) = run(multi, "add", "20", "22")
+      assert(Shell.Success(0) == r1, r1.toString)
+      assert(out1.contains("42"), out1)
+      val (r2, out2) = run(multi, "mul", "6", "7")
+      assert(Shell.Success(0) == r2, r2.toString)
+      assert(out2.contains("42"), out2)
+    }
+
+    it("lists the tools when the subcommand is unknown") {
+      val (r, out) = run(multi, "div", "1", "2")
+      assert(Shell.Success(1) == r, r.toString)
+      assert(out.contains("add") && out.contains("mul"), out)
+    }
+
+    it("emits one contract entry per tool") {
+      val (r, out) = run(multi, "--contract")
+      assert(Shell.Success(0) == r, r.toString)
+      assert(out.contains(""""tool":"add"""") && out.contains(""""tool":"mul""""), out)
+    }
+  }
+
+  describe("synthesis stays out of the way") {
+    it("does not fire when the script has its own main") {
+      val own = script +
+        """def main(): void { IO::println("own main") }
+          |""".stripMargin
+      val (r, out) = run(own)
+      assert(r.isInstanceOf[Shell.Success], r.toString) // void main: value is not 0
+      assert(out.contains("own main"), out)
+    }
+
+    it("does not fire when the script has top-level statements") {
+      val stmts = script + "\nIO::println(\"script body\")\n"
+      val (r, out) = run(stmts)
+      assert(r.isInstanceOf[Shell.Success], r.toString)
+      assert(out.contains("script body"), out)
+    }
+  }
+
+  /** Compiles and runs in-process, capturing both streams. */
+  private def run(source: String, args: String*): (Shell.Result, String) = {
+    val buf = new java.io.ByteArrayOutputStream()
+    val ps = new java.io.PrintStream(buf, true, "UTF-8")
+    val (savedOut, savedErr) = (System.out, System.err)
+    val result =
+      try {
+        System.setOut(ps); System.setErr(ps)
+        Console.withOut(ps) { Console.withErr(ps) {
+          shell.run(source, "None", args.toArray)
+        }}
+      } finally { System.setOut(savedOut); System.setErr(savedErr) }
+    (result, new String(buf.toByteArray, "UTF-8"))
+  }
+}


### PR DESCRIPTION
## What

A script whose top level declares tools **is** a command-line program, and the contract is the single source:

```bash
$ onion ingest.on --contract   # what an agent reads — params/types/roles/defaults/capabilities
$ onion ingest.on --help       # types, defaults, and the checked capability line
$ onion ingest.on in.txt out.txt --count 2 --loud
```

## How

- **Rewriting** builds a JSON contract from each tool declaration and synthesizes `main(args): Int` handing argv + contract to the new **`onion.ToolCli`** (only when the script has no `main` of its own and no top-level statements). The typed call into the tool is derived from the same declaration — a `null` slot for an absent flag evaluates the original default **expression** in-language.
- **`ToolCli`** derives `--contract`, `--help`, flag/positional parsing, typed conversion and all error messages from the contract. No spec string; **no `System.exit`** on this path — failures are exit codes, so every case has an in-process spec.
- Capabilities in the contract are the **checked** declaration (E0077/E0078 force declared == inferred), so what the contract promises is what the compiler proved.
- Multi-tool scripts dispatch subcommand-style; one contract entry per tool.
- Audit gap fixed: `--help` on the `def main` rest-collector path was silently consumed as a positional; `Cli.requireArgs` now recognizes it.

## Tests

12 new in-process specs (contract golden checks, --help content, positional/flag/switch/`=` forms, missing-positional and bad-value exit codes, unknown option, subcommand dispatch + unknown subcommand, synthesis staying out of the way of user mains and script bodies). Full suite **2644 green**.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)