### PR TITLE
feat!: narrow the default static import set to pure classes (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **BREAKING: the default static import set is narrowed to pure classes (#360).**
+  `java.lang.System`, `java.lang.Runtime`, `onion.Files`, `onion.Http` and
+  `onion.DateTime` are no longer imported into every file, so `readText(p)`,
+  `get(url)`, `now()`, `getenv(...)` and `exit(...)` stop resolving bare — an effectful
+  line now looks effectful, which is what makes `requires` clauses readable rather
+  than mysterious. Qualified calls (`Files::readText`) keep working with no import, as
+  before. `onion.IO` stays as the one pragmatic exception: a bare `println` is not
+  what anyone is guarding against. Migration: qualify the call, or use the new
+  explicit prelude import — `import { onion.Files::* }` brings back a whole class's
+  static members, `import { java.lang.System::exit }` a single one (`Class::*` in an
+  import clause is new in this release). No `run/` sample or compiled doc example
+  needed migration.
+
 - **`--plan`: a trustworthy dry run derived from the checked effect set (#359).**
   `onion tool.on <args> --plan` parses the arguments exactly as a real run would, then
   prints what that run *would* do — each declared capability instantiated with the

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -211,7 +211,7 @@ Math::random()
 System::out.println("Java style")
 ```
 
-Default static imports make some class members available without `::` (for example, `println("Hello")` from `onion.IO`). The list lives in `src/main/resources/onion/default-static-imports.txt`.
+Default static imports make some class members available without `::` (for example, `println("Hello")` from `onion.IO`). The default set is deliberately narrow — pure helpers plus `onion.IO` as the one console exception — so an effectful line looks effectful: `Files::readText`, `Http::get`, `DateTime::now` and `System::exit` must be written qualified, or imported explicitly with `import { onion.Files::* }` (a whole class) or `import { java.lang.System::exit }` (one member). The list lives in `src/main/resources/onion/default-static-imports.txt`.
 
 ### Type Casting with `as`
 

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -1223,7 +1223,9 @@ AST.ImportClause import_decl() :{
     ( {sb = new StringBuffer(); alias = null; staticMethod = null; enterSection();}
       (LOOKAHEAD(2) n=import_id() "." {sb.append(c(n)); sb.append(".");})+
       (n=import_id() | star="*" {n = star;}) {s = c(n); sb.append(s);}
-      [ "::" staticMethod=import_id() ]
+      // `Class::member` imports one static member; `Class::*` imports them all —
+      // the migration path for the narrowed default static import set (#360).
+      [ "::" ( staticMethod=import_id() | staticMethod="*" ) ]
       [<K_AS> alias=id() {s = c(alias);}]
       eos_or_block_end()
       {

--- a/src/main/resources/onion/default-static-imports.txt
+++ b/src/main/resources/onion/default-static-imports.txt
@@ -1,13 +1,17 @@
 # Default static import classes (one per line).
-java.lang.System
-java.lang.Runtime
+#
+# Narrowed to pure classes (#360): an effectful line should look effectful, so the
+# effectful stdlib surface (Files, Http, DateTime, System, Runtime) must be called
+# qualified — `Files::readText(p)` — or explicitly imported:
+#
+#   import { onion.Files::*; java.lang.System::exit }
+#
+# onion.IO is the one pragmatic exception: a bare `println` is not what anyone is
+# guarding against, and demanding an import for it would be pure friction.
 java.lang.Math
 onion.IO
 onion.Strings
-onion.Files
 onion.Iterables
 onion.Regex
-onion.DateTime
-onion.Http
 onion.Resources
 onion.Csv

--- a/src/main/scala/onion/compiler/DefaultStaticImports.scala
+++ b/src/main/scala/onion/compiler/DefaultStaticImports.scala
@@ -6,8 +6,6 @@ import java.nio.charset.StandardCharsets
 object DefaultStaticImports {
   private val ResourcePath = "onion/default-static-imports.txt"
   private val Fallback = Seq(
-    "java.lang.System",
-    "java.lang.Runtime",
     "java.lang.Math",
     "onion.IO"
   )

--- a/src/main/scala/onion/compiler/typing/TypingHeaderPass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingHeaderPass.scala
@@ -80,7 +80,8 @@ final class TypingHeaderPass(private val typing: Typing, private val unitContext
         if (typing.table_.loadOrNull(className) == null) {
           typing.report(SemanticError.CLASS_NOT_FOUND, unit.imports, className)
         }
-        staticList.add(new StaticImportItem(className, true, methodName))
+        if (methodName == "*") staticList.add(new StaticImportItem(className, true))
+        else staticList.add(new StaticImportItem(className, true, methodName))
       }
     }
     staticList

--- a/src/test/scala/onion/compiler/tools/DefaultStaticImportSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DefaultStaticImportSpec.scala
@@ -66,5 +66,77 @@ class DefaultStaticImportSpec extends AbstractShellSpec {
       )
       assert(Shell.Success(4.0) == result)
     }
+  
+  describe("the narrowed default set (#360): an effectful line looks effectful") {
+    it("no longer resolves bare calls into Files, Http, DateTime or System") {
+      for (call <- Seq(
+        """readText("x.txt")""",       // onion.Files
+        """get("https://x.example")""",// onion.Http
+        """now()""",                   // onion.DateTime
+        """getenv("HOME")"""           // java.lang.System
+      )) {
+        val r = shell.run(
+          s"""class Test {
+             |public:
+             |  static def main(args: String[]): String {
+             |    $call
+             |    return "ok"
+             |  }
+             |}
+             |""".stripMargin, "None", Array())
+        assert(r.isInstanceOf[Shell.Failure], s"bare `$call` should not resolve: $r")
+      }
+    }
+
+    it("still resolves the same members when called qualified, with no import") {
+      val r = shell.run(
+        """class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val t = DateTime::format(DateTime::of(2026, 7, 26, 0, 0, 0), "yyyy")
+          |    return t
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("2026") == r, r.toString)
+    }
+
+    it("restores bare calls via the explicit prelude import Class::*") {
+      val r = shell.run(
+        """import { onion.DateTime::*; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    return format(of(2026, 7, 26, 0, 0, 0), "yyyy")
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("2026") == r, r.toString)
+    }
+
+    it("imports a single static member via Class::member") {
+      val r = shell.run(
+        """import { java.lang.Integer::parseInt; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int = parseInt("42")
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success(42) == r, r.toString)
+    }
+
+    it("keeps the console exception: bare println still works") {
+      val r = shell.run(
+        """class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    println("still here")
+          |    return "ok"
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("ok") == r, r.toString)
+    }
   }
+}
 }


### PR DESCRIPTION
## What

**Breaking.** `java.lang.System`, `java.lang.Runtime`, `onion.Files`, `onion.Http`, `onion.DateTime` are no longer static-imported into every file: bare `readText(p)` / `get(url)` / `now()` / `exit(1)` stop resolving. Kept: the pure helpers (`Math`, `Strings`, `Iterables`, `Regex`, `Resources`, `Csv`) and **`onion.IO` as the one pragmatic exception** — a bare `println` is not what anyone is guarding against.

## Why

Effect tracking already worked; **legibility** didn't. With effectful members callable unqualified, an effectful line was indistinguishable from a pure one at the call site, which made `requires` clauses look arbitrary. Now the line reads as what it is.

## Migration

Qualified calls always worked with no import. New in this PR: `Class::*` in an import clause static-imports a whole class —

```onion
import { onion.Files::*; java.lang.System::exit }
```

— complementing the existing single-member `Class::member` form.

## Fallout

Zero: no `run/` sample or compiled doc example called the removed classes bare (full suite passed untouched on the narrowed set; docs swept for prose examples too).

## Tests

5 new spec cases (bare-call rejection per class, qualified-no-import, `::*` restore, single-member import, println survival). Full suite **2655 green**.

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)