### PR TITLE
feat(demo): run/ToolDemo.on — the Contracts-and-capabilities demo (#361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **`run/ToolDemo.on` — the "Contracts and capabilities" demo (#361).** One `tool`
+  declaration, four artifacts: CLI, `--help`, `--contract`, `--plan`. The demo digests
+  an access log through a `shape` boundary (bad lines become positioned defects, never
+  silence) inside a capability boundary (`requires { read(src), write(out), console }`
+  — checked, so deleting `write(out)` stops the build with E0077 at the
+  `Files::writeText` call). The spec runs the whole agent sequence: read the contract,
+  `--plan` and prove nothing was written, then execute and check the report. New
+  labeled examples page EN+JA (`docs/examples/tools.md`) with the three-command
+  transcript.
+
 - **BREAKING: the default static import set is narrowed to pure classes (#360).**
   `java.lang.System`, `java.lang.Runtime`, `onion.Files`, `onion.Http` and
   `onion.DateTime` are no longer imported into every file, so `readText(p)`,

--- a/docs/examples/tools.md
+++ b/docs/examples/tools.md
@@ -1,0 +1,48 @@
+# Tools
+
+A `tool` is a function with a checked capability boundary. One declaration yields a
+CLI, `--help`, a machine-readable contract, and a `--plan` dry run — and the compiler
+proves the body cannot exceed the declaration (`E0077` at the offending call site if
+it tries; `E0078` if it overclaims).
+
+The three-command sequence an agent follows:
+
+```bash
+$ onion Snapshot.on --contract
+[{"tool":"snapshot","params":[{"name":"src","type":"String","role":"positional"},
+  {"name":"dst","type":"String","role":"positional"},
+  {"name":"tag","type":"String","role":"flag","default":"latest"}],
+  "returns":"Int","capabilities":["read(src)","write(dst)","console"]}]
+
+$ onion Snapshot.on notes.txt backup.txt --plan
+plan: `snapshot` would
+  read    src = notes.txt
+  write   dst = backup.txt
+  console
+(nothing was executed)
+
+$ onion Snapshot.on notes.txt backup.txt --tag nightly
+snapshot [nightly]: 1 file copied
+```
+
+**Snapshot.on**
+
+```onion
+tool snapshot(src: String, dst: String, tag: String = "latest"): Int
+  requires { read(src), write(dst), console }
+{
+  val data = Files::readText(src)
+  Files::writeText(dst, data)
+  IO::println("snapshot [" + tag + "]: 1 file copied")
+  return 0
+}
+```
+
+Required parameters become positionals; defaulted parameters become `--name` flags; a
+`Boolean` default becomes a switch. An absent flag's default is evaluated as the
+original expression, in the language.
+
+The full demo — a log-digesting tool that combines a `shape` boundary for the messy
+input with a capability boundary for the effects — is `run/ToolDemo.on` in the
+repository, and the guide chapter walks through every piece:
+[Tools and Capabilities](../guide/tools.md).

--- a/docs/ja/examples/tools.md
+++ b/docs/ja/examples/tools.md
@@ -1,0 +1,46 @@
+# tool
+
+`tool` は検査済み capability 境界を持つ関数です。一つの宣言から CLI・`--help`・機械可読
+契約・`--plan` ドライランが導出され、本体が宣言を超えられないことをコンパイラが証明
+します（超えようとすれば違反呼び出しの位置で `E0077`、過大申告なら `E0078`）。
+
+エージェントがたどる3コマンドの手順：
+
+```bash
+$ onion Snapshot.on --contract
+[{"tool":"snapshot","params":[{"name":"src","type":"String","role":"positional"},
+  {"name":"dst","type":"String","role":"positional"},
+  {"name":"tag","type":"String","role":"flag","default":"latest"}],
+  "returns":"Int","capabilities":["read(src)","write(dst)","console"]}]
+
+$ onion Snapshot.on notes.txt backup.txt --plan
+plan: `snapshot` would
+  read    src = notes.txt
+  write   dst = backup.txt
+  console
+(nothing was executed)
+
+$ onion Snapshot.on notes.txt backup.txt --tag nightly
+snapshot [nightly]: 1 file copied
+```
+
+**Snapshot.on**
+
+```onion
+tool snapshot(src: String, dst: String, tag: String = "latest"): Int
+  requires { read(src), write(dst), console }
+{
+  val data = Files::readText(src)
+  Files::writeText(dst, data)
+  IO::println("snapshot [" + tag + "]: 1 file copied")
+  return 0
+}
+```
+
+必須パラメータは位置引数に、デフォルト付きパラメータは `--name` フラグに、`Boolean` の
+デフォルトはスイッチになります。省略されたフラグのデフォルトは元の式として言語内で
+評価されます。
+
+完全なデモ —— 雑な入力のための `shape` 境界と効果のための capability 境界を一つの
+ファイルで組み合わせた、ログ集計 tool —— はリポジトリの `run/ToolDemo.on` にあり、
+ガイド章が各部品を解説しています：[tool と capability](../guide/tools.md)。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
           - 概要: ja/examples/index.md
           - 基本例: ja/examples/basic.md
           - オブジェクト指向の例: ja/examples/oop.md
+          - tool: ja/examples/tools.md
           - 関数型の例: ja/examples/functional.md
           - スクリプティングとCLI: ja/examples/scripting.md
           - JSONとHTTP: ja/examples/json-http.md
@@ -145,6 +146,7 @@ nav:
       - Overview: examples/overview.md
       - Basic Programs: examples/basic.md
       - Object-Oriented Examples: examples/oop.md
+      - Tools: examples/tools.md
       - Functional Programming: examples/functional.md
       - Scripting & CLI: examples/scripting.md
       - JSON & HTTP: examples/json-http.md

--- a/run/ToolDemo.on
+++ b/run/ToolDemo.on
@@ -1,0 +1,110 @@
+// ToolDemo — one declaration, four artifacts (the "Contracts and capabilities" demo).
+//
+// The `tool` below is an ordinary function with a boundary. From its single
+// declaration the compiler derives:
+//
+//   1. a CLI          onion ToolDemo.on access.log report.txt --top 5 --loud
+//   2. --help         every argument with its type and default, plus the capability line
+//   3. --contract     machine-readable JSON: what an agent reads before calling
+//   4. --plan         what a run WOULD do, bound to the actual arguments, executing nothing
+//
+// The sequence an agent follows:
+//
+//   $ onion ToolDemo.on --contract
+//   [{"tool":"digest","params":[{"name":"src","type":"String","role":"positional"}, ...
+//   $ onion ToolDemo.on access.log report.txt --plan
+//   plan: `digest` would
+//     read    src = access.log
+//     write   out = report.txt
+//     console
+//   (nothing was executed)
+//   $ onion ToolDemo.on access.log report.txt
+//   digest: 6 lines read, 1 not read, report written
+//
+// And the boundary is checked, not decorative: delete `write(out)` from the
+// requires clause and this file stops compiling, with E0077 pointing at the
+// Files::writeText call.
+
+// The data side of the same thesis: a shape names the boundary between messy
+// text and typed values, and failure is a positioned defect, never a null.
+record Access(ip: String, method: String, path: String, status: Int)
+  shape common = re"(\S+) (\w+) (\S+) (\d+)"
+
+class ToolDemoSupport {
+public:
+  static def countByStatus(rows: List[Access], status: Int): Int {
+    var n = 0
+    foreach a: Access in rows {
+      if a.status() == status { n = n + 1 }
+    }
+    return n
+  }
+
+  static def topPaths(rows: List[Access], limit: Int): List[String] {
+    val counts = [:]
+    foreach a: Access in rows {
+      val key = a.path()
+      val seen = counts[key]
+      if seen == null { counts[key] = 1 } else { counts[key] = (seen as Int) + 1 }
+    }
+    // Selection by repeated maximum: small, dependency-free, good enough for a report.
+    val out = new java.util.ArrayList[String]()
+    var round = 0
+    while round < limit {
+      var bestPath: String? = null
+      var bestCount = -1
+      foreach (k, v) in counts {
+        val c = (v as Int)
+        if c > bestCount {
+          bestCount = c
+          bestPath = (k as String)
+        }
+      }
+      if bestPath == null { break }
+      out.add(bestPath + " (" + bestCount + ")")
+      counts.remove(bestPath)
+      round = round + 1
+    }
+    return out
+  }
+
+  static def buildReport(rows: List[Access], bad: List[Defect], top: Int): String {
+    val sb = new StringBuilder()
+    sb.append("access report\n")
+    sb.append("=============\n")
+    sb.append("lines read:    " + rows.size + "\n")
+    sb.append("lines skipped: " + bad.size + "\n")
+    foreach d: Defect in bad {
+      sb.append("  line " + d.origin().line() + ": " + d.expected() + "\n")
+    }
+    sb.append("status 200:    " + countByStatus(rows, 200) + "\n")
+    sb.append("status 404:    " + countByStatus(rows, 404) + "\n")
+    sb.append("top paths:\n")
+    foreach p: String in topPaths(rows, top) {
+      sb.append("  " + p + "\n")
+    }
+    return sb.toString()
+  }
+}
+
+// The boundary. `requires` is the whole promise: this tool can read the file you
+// name as `src`, write the file you name as `out`, and talk to the console —
+// and the compiler proved it cannot do anything else. `--plan` shows exactly
+// these three lines with your arguments bound in.
+tool digest(src: String, out: String, top: Int = 3, loud: Boolean = false): Int
+  requires { read(src), write(out), console }
+{
+  val origin = Origin::atLine(src, 1)
+  val outcomes = Access::common().eachLine(Files::readText(src), origin)
+  val rows = Outcome::values(outcomes)
+  val bad = Outcome::defects(outcomes)
+
+  val report = ToolDemoSupport::buildReport(rows, bad, top)
+  Files::writeText(out, report)
+
+  if loud {
+    IO::println(report)
+  }
+  IO::println("digest: " + rows.size + " lines read, " + bad.size + " not read, report written")
+  return 0
+}

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -39,6 +39,26 @@ class RunSamplesSpec extends AbstractShellSpec {
       assert(Shell.Success("ok") == runSample("run/RecordLaws.on"))
     }
 
+    it("runs ToolDemo.on: contract, plan (no effects), then execution") {
+      val dir = java.nio.file.Files.createTempDirectory("tool-demo-spec")
+      val src = dir.resolve("access.log"); val out = dir.resolve("report.txt")
+      java.nio.file.Files.writeString(src,
+        "10.0.0.1 GET /index 200\nbroken\n10.0.0.2 GET /about 404\n")
+      def run(args: String*): Shell.Result =
+        shell.run(load("run/ToolDemo.on"), "run/ToolDemo.on", args.toArray)
+
+      assert(Shell.Success(0) == run("--contract"))
+      // --plan binds the real arguments and performs nothing.
+      assert(Shell.Success(0) == run(src.toString, out.toString, "--plan"))
+      assert(!java.nio.file.Files.exists(out), "--plan wrote the report")
+      // The real run writes it.
+      assert(Shell.Success(0) == run(src.toString, out.toString, "--top", "1"))
+      val report = java.nio.file.Files.readString(out)
+      assert(report.contains("lines read:    2"), report)
+      assert(report.contains("lines skipped: 1"), report)
+      assert(report.contains("line 2"), report)
+    }
+
     it("runs BrokenLogDemo.on") {
       // Returns the number of lines it refused to pretend it had read: a thousand-line
       // log with every 200th line truncated.


### PR DESCRIPTION
## What

The v0.7 killer demo, now merely three commands:

```bash
$ onion run/ToolDemo.on --contract          # what an agent reads
$ onion run/ToolDemo.on access.log report.txt --plan   # what a run would do — nothing executed
$ onion run/ToolDemo.on access.log report.txt --top 2  # the run itself
```

`run/ToolDemo.on` combines both boundaries of the thesis in ~120 lines: a `shape` for the messy input (bad log lines become positioned defects) inside a checked capability boundary — delete `write(out)` from the requires clause and the build fails with E0077 at the `Files::writeText` call.

## Tests & docs

- `RunSamplesSpec` runs the whole agent sequence in-process, including the proof that `--plan` writes nothing.
- `docs/examples/tools.md` EN+JA with a labeled, compile-checked example and the transcript; mkdocs nav.
- The demo is automatically a mutation-fuzz seed (everything under `run/` is).
- No crashes surfaced during v0.7 → no new crash-corpus entries.

Full suite **2659 green**.

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)