### PR TITLE
test(typing): add regression coverage for E0036 (CANNOT_ASSIGN_TO_VAL)

### DIFF
--- a/src/test/scala/onion/compiler/tools/CannotAssignToValSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CannotAssignToValSpec.scala
@@ -1,0 +1,105 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0036 (CANNOT_ASSIGN_TO_VAL) has several distinct report sites (local val,
+ * instance field, static field, pre/post-increment) but had no regression
+ * coverage at all before this spec.
+ */
+class CannotAssignToValSpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("assigning to a val") {
+    it("reports E0036 when reassigning a local val") {
+      val results = errors(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: Int = 1;
+          |    x = 2;
+          |    return x;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0036")))
+    }
+
+    it("reports E0036 when post-incrementing a local val") {
+      val results = errors(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: Int = 1;
+          |    x++;
+          |    return x;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0036")))
+    }
+
+    it("reports E0036 when assigning an instance val field from outside the constructor") {
+      val results = errors(
+        """
+          |class Test {
+          |  val x: Int = 1
+          |public:
+          |  def bump(): void {
+          |    this.x = 2;
+          |  }
+          |  static def main(args: String[]): Int {
+          |    return 0;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0036")))
+    }
+
+    it("allows initializing an instance val field from within the constructor") {
+      val results = errors(
+        """
+          |class Test {
+          |  val x: Int
+          |public:
+          |  def this {
+          |    this.x = 1;
+          |  }
+          |  static def main(args: String[]): Int {
+          |    return new Test().x;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0036")))
+    }
+
+    it("does not report E0036 when reassigning a local var") {
+      val results = errors(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    var x: Int = 1;
+          |    x = 2;
+          |    return x;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0036")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `SemanticError.CANNOT_ASSIGN_TO_VAL` (E0036) has four distinct report sites in the typer (`AssignmentTyping.scala` for local vals and instance/static val fields, `OperatorTyping.scala` for post-increment/decrement on a local or a field) but had zero test coverage anywhere in the suite.
- Adds `CannotAssignToValSpec`, asserting on the error code (not localized message text, per this repo's locale-independence convention) across:
  - reassigning a local `val`
  - post-incrementing (`x++`) a local `val`
  - assigning `this.x = ...` to an instance `val` field from outside the constructor
  - the positive case: initializing a `val` field from within the constructor must **not** raise E0036
  - the positive case: reassigning a local `var` must **not** raise E0036

No production code changed — this is a test-only addition confirming existing behavior is correct.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.CannotAssignToValSpec'` — 5/5 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green: 2694 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated distribution-packaging test, unrelated to this change), 0 ignored


---
_Generated by [Claude Code](https://claude.ai/code/session_013h3v8BNSDG7wc6kNVwN4af)_