### PR TITLE
test(typing): add regression coverage for E0016 (CYCLIC_INHERITANCE)

### DIFF
--- a/src/test/scala/onion/compiler/tools/CyclicInheritanceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CyclicInheritanceSpec.scala
@@ -1,0 +1,73 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0016 (CYCLIC_INHERITANCE) is reported for both classes and interfaces
+ * whose supertype chain loops back on itself, but had no regression
+ * coverage at all before this spec.
+ */
+class CyclicInheritanceSpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("cyclic inheritance") {
+    it("reports E0016 for a direct class self-cycle") {
+      val results = errors(
+        """
+          |class A extends A {
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0016")))
+    }
+
+    it("reports E0016 for an indirect class cycle") {
+      val results = errors(
+        """
+          |class A extends B {
+          |}
+          |class B extends A {
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0016")))
+    }
+
+    it("reports E0016 for an interface cycle") {
+      val results = errors(
+        """
+          |interface I conforms J {
+          |}
+          |interface J conforms I {
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0016")))
+    }
+
+    it("does not report E0016 for a normal, non-cyclic inheritance chain") {
+      val results = errors(
+        """
+          |class A {
+          |}
+          |class B extends A {
+          |}
+          |class C extends B {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0016")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `E0016` (`CYCLIC_INHERITANCE`) is reported from two sites in `TypingOutlinePass` (class and interface declarations) but had zero regression coverage.
- Adds `CyclicInheritanceSpec` asserting on the error code across: a direct class self-cycle (`class A extends A`), an indirect two-class cycle, an interface cycle (via `conforms`), and a normal non-cyclic chain as a sanity check that no false positive fires.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.CyclicInheritanceSpec'` — 4/4 passed
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2698 passed, 0 failed, 1 canceled (the `ProjectDistributionSpec` smoke test, which self-skips without `-Donion.dist.path` — pre-existing, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_0196vRfJVZ8A5YGrqseGDiZQ)_