### PR TITLE
test(typing): add regression coverage for E0068 (OVERRIDE_TARGET_NOT_FOUND)

### DIFF
--- a/src/test/scala/onion/compiler/tools/OverrideTargetNotFoundSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OverrideTargetNotFoundSpec.scala
@@ -1,0 +1,104 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0068 (OVERRIDE_TARGET_NOT_FOUND) is reported when a method marked `override`
+ * does not override any base-class or interface method, but had no regression
+ * coverage at all before this spec.
+ */
+class OverrideTargetNotFoundSpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("a method marked override with no base target") {
+    it("reports E0068 when the base class declares no method of that name") {
+      val results = errors(
+        """
+          |class Base {
+          |public:
+          |  def helper(): Int { return 1; }
+          |}
+          |class Sub extends Base {
+          |public:
+          |  override def notInBase(): Int { return 2; }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return new Sub().notInBase();
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0068")))
+    }
+
+    it("reports E0068 when there is no explicit supertype at all") {
+      val results = errors(
+        """
+          |class Standalone {
+          |public:
+          |  override def phantom(): Int { return 3; }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return new Standalone().phantom();
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0068")))
+    }
+
+    it("does not report E0068 when correctly overriding a base class method") {
+      val results = errors(
+        """
+          |class Base {
+          |public:
+          |  def greet(): String { return "base"; }
+          |}
+          |class Sub extends Base {
+          |public:
+          |  override def greet(): String { return "sub"; }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return new Sub().greet().length();
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0068")))
+    }
+
+    it("does not report E0068 when correctly implementing an interface method") {
+      val results = errors(
+        """
+          |interface Greeter {
+          |  def greet(): String;
+          |}
+          |class G conforms Greeter {
+          |public:
+          |  override def greet(): String { return "hi"; }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return (new G() as Greeter).greet().length();
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0068")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `OVERRIDE_TARGET_NOT_FOUND` (E0068) had zero regression coverage in the test suite despite being a documented, shipped diagnostic (release notes for v0.4.2: "`override` is checked (E0068)").
- Adds `OverrideTargetNotFoundSpec` with 4 cases: an `override def` with no matching base method (both with and without an explicit supertype) reports E0068; a correct base-class override and a correct interface implementation do not.
- Follows the established pattern from the recent E0038/E0016/E0036 coverage PRs (compile via `OnionCompiler` directly, assert on `errorCode`, not message text — locale-independent per `docs/quality-bar.md`).

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.OverrideTargetNotFoundSpec'` — 4/4 pass
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2706 passed, 0 failed, 1 canceled (known distribution-smoke-test gate)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WpiCjdpntEwfVqDiB2UAjP)_