### PR TITLE
test(typing): add regression coverage for E0004 (FIELD_NOT_FOUND)

### DIFF
--- a/src/test/scala/onion/compiler/tools/FieldNotFoundSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FieldNotFoundSpec.scala
@@ -1,0 +1,88 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0004 (FIELD_NOT_FOUND) is reported when a member selection resolves to
+ * neither a field, a getter method, nor an array's `length`/`size`, but had
+ * no regression coverage at all before this spec.
+ */
+class FieldNotFoundSpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("a member selection with no matching field or getter") {
+    it("reports E0004 when reading an undeclared field on a class instance") {
+      val results = errors(
+        """
+          |class Point {
+          |public:
+          |  val x: Int = 1
+          |  val y: Int = 2
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return new Point().z;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0004")))
+    }
+
+    it("reports E0004 for an undeclared member on an array (only length/size exist)") {
+      val results = errors(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val a: Int[] = new Int[3];
+          |    return a.count;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0004")))
+    }
+
+    it("does not report E0004 when accessing a declared field") {
+      val results = errors(
+        """
+          |class Point {
+          |public:
+          |  val x: Int = 1
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return new Point().x;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0004")))
+    }
+
+    it("does not report E0004 when accessing an array's length") {
+      val results = errors(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val a: Int[] = new Int[3];
+          |    return a.length;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0004")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `E0004` (`FIELD_NOT_FOUND`) had zero regression test coverage. This adds `FieldNotFoundSpec.scala`, following the same pattern as the recent `E0016`/`E0036`/`E0038`/`E0068` coverage additions.
- Covers: reading an undeclared field on a class instance, an undeclared member on an array (arrays only expose `length`/`size`), and the two matching non-error cases (declared field access, `array.length`).

Internal test-only change — no CHANGELOG entry, matching precedent for prior error-code coverage PRs.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.FieldNotFoundSpec'` — 4/4 passed
- [x] Full suite: `sbt -Duser.language=en test` — 2710 tests, 0 failed, 1 canceled (pre-existing `ProjectDistributionSpec` smoke test requiring `-Donion.dist.path`)


---
_Generated by [Claude Code](https://claude.ai/code/session_011UujMjEZMmsjj94cChzEh8)_