### PR TITLE
test(typing): add regression coverage for E0007 (DUPLICATE_LOCAL_VARIABLE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added regression test coverage for **E0007** (`DUPLICATE_LOCAL_VARIABLE`),
+  which previously had no dedicated test file.
+
 ## [0.10.0] - 2026-07-26
 
 - **`Shape` opened to user-written instances, with a law gate (#364).** A class

--- a/src/test/scala/onion/compiler/tools/DuplicateLocalVariableSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DuplicateLocalVariableSpec.scala
@@ -1,0 +1,72 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0007 (DUPLICATE_LOCAL_VARIABLE) is reported when a name is bound twice in
+ * the same scope (a redeclared local, or a destructuring pattern that repeats
+ * a binding name), but had no regression coverage at all before this spec.
+ */
+class DuplicateLocalVariableSpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("a name bound twice in the same scope") {
+    it("reports E0007 when a local variable is redeclared in the same block") {
+      val results = errors(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: Int = 1;
+          |    val x: Int = 2;
+          |    return x;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0007")))
+    }
+
+    it("reports E0007 when a destructuring declaration repeats a binding name") {
+      val results = errors(
+        """
+          |record Pair(a: Int, b: Int)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    var (a, a) = new Pair(1, 2);
+          |    return a;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0007")))
+    }
+
+    it("does not report E0007 when an inner block shadows an outer local") {
+      val results = errors(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: Int = 1;
+          |    if x == 1 {
+          |      val x: Int = 2;
+          |      IO::println(x);
+          |    }
+          |    return x;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0007")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- E0007 (`DUPLICATE_LOCAL_VARIABLE`) had no dedicated regression test file, unlike several other error codes that recently gained coverage (E0004, E0016, E0036, E0038, E0068).
- Adds `DuplicateLocalVariableSpec` covering: a plain redeclared local in the same block, a destructuring declaration that repeats a binding name, and confirms inner-block shadowing is correctly *not* flagged.
- Notes the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.DuplicateLocalVariableSpec'` — 3/3 pass
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2713 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging integration test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VDFkSjYCdhCEFzAERqvAKv)_