### PR TITLE
release: 0.10.1 — diagnostic coverage sweep, three real fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added regression test coverage for **E0007** (`DUPLICATE_LOCAL_VARIABLE`),
-  which previously had no dedicated test file.
+## [0.10.1] - 2026-07-27
+
+A quality release: the diagnostic surface is now covered code by code, and the sweep
+that built that coverage found and fixed three real defects.
+
+### Fixed
+
+- **Extending a final class crashed instead of erroring.** `class A extends
+  java.lang.String` escaped the type checker entirely; bytecode was generated and the
+  JVM rejected it at class-loading time (`IncompatibleClassChangeError` inside the
+  law-check phase). It is now a proper **E0018** at the supertype reference, and the
+  crash is pinned in the crash corpus (`030-final-superclass.on`).
+- **E0053/E0054 rendered as `Unknown error: <NAME>`.** Cyclic and duplicate type
+  aliases were reported through the normal reporter path but never wired to their
+  message definitions, so users saw the internal enum name instead of the message
+  (which existed, in both languages, all along). Both now render; the coverage spec
+  asserts `Unknown error` never comes back.
+- **Wrong type-argument arity was accepted in nullable annotations (#413).**
+  `val b: Box[String, String]? = null` compiled silently while the same arity failed
+  on `new` — the validator did not look through the nullable wrapper. Both now report
+  **E0031**.
+
+### Added
+
+- **Per-code diagnostic coverage** (continuing #407-#412, which covered E0036, E0016,
+  E0038, E0068, E0004 and E0007): `SemanticErrorCodeCoverageSpec` adds one trigger per
+  previously-unasserted reachable code — 27 more codes, from E0008 to E0076 — plus a
+  drift guard that scans the sources and fails when a code's report-site status
+  changes: the three genuinely dead codes (E0017, E0024, E0056) are registered as
+  dead, and a code losing its last report site is flagged instead of rotting silently.
+  E0043 is documented as shadowed by candidate filtering; E0075 as reachable only
+  through an environment failure.
+
+### Documentation
+
+- `docs/quality-bar.md` (EN+JA) re-measured: 2744 tests, 64/64 samples, 7 large
+  programs, 81 diagnostic codes.
+- `CLAUDE.md` catches up with v0.10: the narrowed default static imports (bare
+  `readText`/`get`/`now`/`exit` no longer resolve), `tool`/`requires`/`--contract`/
+  `--plan`, lossless `config` shapes and the lens, user-written `Shape` instances with
+  the E0080 law gate, and top-level `example`.
 
 ## [0.10.0] - 2026-07-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,18 @@ These are frequently confused with other languages. **Always check these:**
 | `using r = expr { }` | `try (val r = expr) { }` - try-with-resources; multiple via `;`, closed in reverse order |
 | `catch (Type e)` | `catch e: Type` - no parens, type after colon |
 
+### Tools, capabilities and effects (v0.10)
+
+| Wrong | Correct (Onion) |
+|-------|-----------------|
+| bare `readText(p)` / `get(url)` / `now()` / `exit(1)` | **No longer resolve** — default static imports were narrowed to pure classes. Qualify (`Files::readText`) or import explicitly: `import { onion.Files::*; java.lang.System::exit }`. Bare `println` still works (`onion.IO` is the one exception) |
+| a CLI function with hand-rolled arg parsing | `tool name(args) [: T] [requires { caps }] { body }` — a top-level tool; a script whose top level declares tools (and has no `main`) IS a CLI: `--help`, `--contract` (machine-readable JSON), `--plan` (dry run showing bound effects, executing nothing) all derive from the declaration |
+| undeclared side effects in a tool | E0077 at the call site — the body's effects are inferred transitively and checked against `requires { read(src), write(dst), console, unknown }`. Overclaiming is E0078; a bad capability is E0079. An unlisted Java call is `unknown` and must be admitted explicitly |
+| `shape doc = json` when you need comments preserved | `shape doc = config` — a LOSSLESS shape over commented `key = value` files: `parseLossless` keeps a `Residue` (comments, spacing, key order, unknown keys, value spellings), `r.edit { v => v.copy(port = 9090) }.render()` rewrites exactly one value slot |
+| implementing a custom format ad hoc | `class MyShape conforms Shape[T]` — user-written shapes get the combinators and Outcome/Defect for free, but the file MUST assert a law (`example l1 { s.parse(s.print(v)).get() == v }`) or the class is E0080 |
+| a law only checkable inside a record | top-level `example [name] { boolExpr }` — runs at build time like a record example; false claim is E0065 |
+| `--effects` unknown | `onionc --effects` / `onion --effects file.on` prints every method's inferred effect set (`read write net exec env clock rand console unknown`; empty = `pure`) |
+
 ### Miscellaneous
 
 | Wrong | Correct (Onion) |

--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -2,21 +2,21 @@
 
 「実用的品質」は意図的に曖昧な表現なので、このファイルではそれを**客観的に測定可能な指標**のセットに固定します。各行には実行可能な測定方法と閾値があり、すべての行が通過したときに言語は基準に達したとみなされます。
 
-ベースライン数値は 2026-07-26 時点（develop @ c2126299）の実測値です。前回のベースライン
-（2026-07-26 @ 871fe5a1）は、effect-table / tool-capability / tool-contracts の作業
+ベースライン数値は 2026-07-27 時点（develop @ c2126299）の実測値です。前回のベースライン
+（2026-07-27 @ 871fe5a1）は、effect-table / tool-capability / tool-contracts の作業
 （#356、#357、#358）が入った後にはすでに乖離していました——テスト数は 2590 と記録されて
 いましたが実際は 2644、ガイドは 14/14 に対し 15/15（`docs/guide/tools.md` が #357 で追加）、
 診断コードは 77 に対し 80（capability boundary が追加した `E0077`–`E0079`）でした。
 
-| # | 次元 | 測定方法 | 現在値（2026-07-26） | 合格閾値 |
+| # | 次元 | 測定方法 | 現在値（2026-07-27） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2655 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
-| 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 61 / 61 compile | すべてコンパイル、rot なし |
-| 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 6（BrokenLogDemo、OrderReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager） | ≥ 5 |
+| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2744 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 64 / 64 compile | すべてコンパイル、rot なし |
+| 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 6（BrokenLogDemo、OrderReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager、ToolDemo） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |
 | 5 | 既知の使い勝手バグ | 実装済みだが到達不能/壊れた機能として未解決のもの | 0 | 0 |
 | 6 | ドキュメントの対等性 | `docs/guide` と `docs/ja/guide` の数 + すべてのコードブロックがコンパイル可能 | 15 / 15 | 対等性 + すべてのブロックを検証 |
-| 7 | 診断メッセージ | 英語と日本語の `E00xx` コード | 80 | よくあるエラーごとに専用コード |
+| 7 | 診断メッセージ | 英語と日本語の `E00xx` コード | 81 | よくあるエラーごとに専用コード |
 
 **`SBT_OPTS` は設定しないでください。** 以前のこのファイルは `SBT_OPTS="-Xmx2g"` を薦めて
 いましたが、これは現在プロジェクト既定の 4g を*下げて*しまい、スイートの途中で

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -11,15 +11,15 @@ had already drifted after the effect-table / tool-capability / tool-contracts wo
 15/15 (`docs/guide/tools.md` shipped with #357), and 77 diagnostic codes against 80
 (`E0077`–`E0079` added by the capability boundary).
 
-| # | Dimension | How to measure | Current (2026-07-26) | Pass threshold |
+| # | Dimension | How to measure | Current (2026-07-27) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2655 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
-| 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 61 / 61 compile | all compile, no rot |
-| 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 6 (BrokenLogDemo, OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager) | ≥ 5 |
+| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2744 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 64 / 64 compile | all compile, no rot |
+| 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 7 (BrokenLogDemo, OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager, ToolDemo) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |
 | 5 | Known usability bugs | implemented-but-unreachable / broken features still open | 0 | 0 |
 | 6 | Docs parity | `docs/guide` vs `docs/ja/guide` count + every code block compiles | 15 / 15 | parity + all blocks verified |
-| 7 | Diagnostics | distinct `E00xx` codes with EN+JA messages | 80 | every common error has a dedicated code |
+| 7 | Diagnostics | distinct `E00xx` codes with EN+JA messages | 81 | every common error has a dedicated code |
 
 **Do not set `SBT_OPTS`.** The previous version of this file recommended
 `SBT_OPTS="-Xmx2g"`, which now *lowers* the heap below the project's own default of 4g and

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -438,6 +438,17 @@ class SemanticErrorReporter(threshold: Int) {
       "error.semantic.shapeInstanceWithoutLaw",
       Seq(items => asString(items(0)))
     ),
+    // Reported through the normal reporter path (NameResolution / TypingHeaderPass)
+    // but never wired here, so both rendered as "Unknown error: <NAME>" (found while
+    // sweeping E-code coverage for 0.10.1).
+    SemanticError.CYCLIC_TYPE_ALIAS -> ErrorDef(
+      "error.semantic.cyclicTypeAlias",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.DUPLICATE_TYPE_ALIAS -> ErrorDef(
+      "error.semantic.duplicateTypeAlias",
+      Seq(items => asString(items(0)))
+    ),
 
     // Other errors
     SemanticError.UNIMPLEMENTED_FEATURE -> ErrorDef(

--- a/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
@@ -706,6 +706,13 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
           case _ => null
       report(SemanticError.ILLEGAL_INHERITANCE, location, typeRef.name)
     }
+    // A final superclass used to escape typing entirely and blow up only when the
+    // generated class was loaded (JVM IncompatibleClassChangeError at the law-check
+    // step — an uncaught crash, found by the 0.10.1 E-code sweep). Report it where
+    // the user can see it, on the supertype reference itself.
+    if (!mustBeInterface && !isInterface && Modifier.isFinal(typeRef.modifier)) {
+      report(SemanticError.ILLEGAL_INHERITANCE, node, typeRef.name)
+    }
     typeRef
   }
 

--- a/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
+++ b/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
@@ -137,9 +137,21 @@ final class TypingTypeSupport(private val typing: Typing) {
   }
 
   private def validateTypeApplication(typeNode: AST.TypeNode, mappedType: Type): Unit = {
-    typeNode.desc match {
+    // `Box[String, String]?` arrives as NullableType(ParameterizedType(..)) and used to
+    // fall through both matches below, so a wrong arity in a nullable annotation was
+    // accepted silently while the same arity failed on `new` (issue #413). Validate
+    // through the nullable wrapper.
+    val desc = typeNode.desc match {
+      case AST.NullableType(inner) => inner
+      case other                   => other
+    }
+    val mapped = mappedType match {
+      case n: TypedAST.NullableType => n.innerType
+      case other                    => other
+    }
+    desc match {
       case AST.ParameterizedType(_, _) | AST.FunctionType(_, _) =>
-        mappedType match {
+        mapped match {
           case applied: TypedAST.AppliedClassType =>
             val rawParams = applied.raw.typeParameters
             if (rawParams.isEmpty) {

--- a/src/test/resources/crash-corpus/030-final-superclass.on
+++ b/src/test/resources/crash-corpus/030-final-superclass.on
@@ -1,0 +1,13 @@
+// Extending a final class escaped the type checker entirely: bytecode was generated
+// and the JVM rejected it at class-loading time (IncompatibleClassChangeError inside
+// the law-check phase) — an uncaught crash instead of a diagnostic. It must be a
+// proper E0018 ILLEGAL_INHERITANCE at the supertype reference. (found by the 0.10.1
+// E-code coverage sweep)
+class A extends java.lang.String {
+public:
+  def this {}
+}
+
+def main(args: String[]): void {
+  IO::println("should not compile")
+}

--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -1,0 +1,364 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * One trigger per reachable-but-previously-unasserted diagnostic code (0.10.1 quality
+ * sweep, continuing the per-code coverage #407-#412 started). Each case compiles a
+ * minimal program and asserts the *code* appears in the diagnostics — codes are
+ * locale-independent where message text is not.
+ *
+ * Deliberately absent:
+ *   - E0017 CYCLIC_DELEGATION, E0024 UNIMPLEMENTED_FEATURE, E0056
+ *     ENUM_CONSTANT_ARGS_UNSUPPORTED — dead: no report site exists. The drift guard
+ *     below fails if one of them comes back to life (or dies) unnoticed.
+ *   - E0075 LAW_CLASS_NOT_LOADABLE — reachable only through an environment failure
+ *     (a compiled check class failing to load), which has no honest in-process trigger.
+ *   - E0043 UNKNOWN_PARAMETER_NAME — its report sites are shadowed by candidate
+ *     filtering: an unknown argument name eliminates every candidate first, so the
+ *     user sees not-found (with the named-arg spelled out in the message) before the
+ *     dedicated check can run.
+ */
+class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
+
+  private val deadCodes = Set("CYCLIC_DELEGATION", "UNIMPLEMENTED_FEATURE", "ENUM_CONSTANT_ARGS_UNSUPPORTED")
+
+  private def failsWith(code: String, source: String): Unit = {
+    val buf = new java.io.ByteArrayOutputStream()
+    val ps = new java.io.PrintStream(buf, true, "UTF-8")
+    val (o, e) = (System.out, System.err)
+    val r =
+      try {
+        System.setOut(ps); System.setErr(ps)
+        Console.withOut(ps) { Console.withErr(ps) { shell.run(source, "None", Array()) } }
+      } finally { System.setOut(o); System.setErr(e) }
+    val out = new String(buf.toByteArray, "UTF-8")
+    assert(r.isInstanceOf[Shell.Failure], s"expected a compile failure for $code, got $r\n$out")
+    assert(out.contains(code), s"expected $code in diagnostics, got:\n$out")
+  }
+
+  describe("declaration-level duplicates and cycles") {
+    it("E0008 duplicate class") {
+      failsWith("E0008",
+        """class A { public: def this {} }
+          |class A { public: def this {} }
+          |""".stripMargin)
+    }
+    it("E0009 duplicate field") {
+      failsWith("E0009",
+        """class A {
+          |  var x: Int
+          |  var x: Int
+          |public:
+          |  def this {}
+          |}
+          |""".stripMargin)
+    }
+    it("E0025 duplicate constructor") {
+      failsWith("E0025",
+        """class A {
+          |public:
+          |  def this(x: Int) {}
+          |  def this(y: Int) {}
+          |}
+          |""".stripMargin)
+    }
+    it("E0029 duplicate type parameter") {
+      failsWith("E0029",
+        """class Box[T, T] { public: def this {} }
+          |""".stripMargin)
+    }
+    it("E0053 cyclic type alias — and it renders its message, not `Unknown error`") {
+      val buf = new java.io.ByteArrayOutputStream()
+      val ps = new java.io.PrintStream(buf, true, "UTF-8")
+      val (o, e) = (System.out, System.err)
+      try {
+        System.setOut(ps); System.setErr(ps)
+        Console.withOut(ps) { Console.withErr(ps) {
+          shell.run("type A = B\ntype B = A\n", "None", Array())
+        }}
+      } finally { System.setOut(o); System.setErr(e) }
+      val out = new String(buf.toByteArray, "UTF-8")
+      assert(out.contains("E0053"), out)
+      assert(!out.contains("Unknown error"), s"E0053 must render its message:\n$out")
+    }
+    it("E0054 duplicate type alias — same rendering guarantee") {
+      val buf = new java.io.ByteArrayOutputStream()
+      val ps = new java.io.PrintStream(buf, true, "UTF-8")
+      val (o, e) = (System.out, System.err)
+      try {
+        System.setOut(ps); System.setErr(ps)
+        Console.withOut(ps) { Console.withErr(ps) {
+          shell.run("type A = java.lang.String\ntype A = java.lang.Integer\n", "None", Array())
+        }}
+      } finally { System.setOut(o); System.setErr(e) }
+      val out = new String(buf.toByteArray, "UTF-8")
+      assert(out.contains("E0054"), out)
+      assert(!out.contains("Unknown error"), s"E0054 must render its message:\n$out")
+    }
+  }
+
+  describe("inheritance and interfaces") {
+    it("E0018 illegal inheritance (extending a final class)") {
+      failsWith("E0018",
+        """class A extends java.lang.String { public: def this {} }
+          |""".stripMargin)
+    }
+    it("E0023 a forward-delegation field requires an interface type") {
+      failsWith("E0023",
+        """class A {
+          |  forward val x: String
+          |public:
+          |  def this { x = "a" }
+          |}
+          |""".stripMargin)
+    }
+    it("E0037 unimplemented abstract method") {
+      failsWith("E0037",
+        """interface I { def m(): Int }
+          |class A conforms I { public: def this {} }
+          |""".stripMargin)
+    }
+    it("E0039 overriding a final method") {
+      failsWith("E0039",
+        """class A {
+          |public:
+          |  def this {}
+          |  final def m(): Int = 1
+          |}
+          |class B extends A {
+          |public:
+          |  def this {}
+          |  override def m(): Int = 2
+          |}
+          |""".stripMargin)
+    }
+  }
+
+  describe("calls, constructors and arguments") {
+    it("E0021 constructor not found") {
+      failsWith("E0021",
+        """class A { public: def this {} }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { val a = new A(1, 2); return 0 }
+          |}
+          |""".stripMargin)
+    }
+    it("E0022 ambiguous constructor") {
+      failsWith("E0022",
+        """class C {
+          |public:
+          |  def this(a: String) {}
+          |  def this(b: StringBuilder) {}
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { val c = new C(null); return 0 }
+          |}
+          |""".stripMargin)
+    }
+    it("E0019 calling a static method through an instance receiver") {
+      failsWith("E0019",
+        """class A {
+          |public:
+          |  def this {}
+          |  static def s(): Int = 1
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return new A().s() }
+          |}
+          |""".stripMargin)
+    }
+    it("E0044 duplicate named argument") {
+      failsWith("E0044",
+        """class Test {
+          |public:
+          |  static def f(x: Int, y: Int): Int = x + y
+          |  static def main(args: String[]): Int { return f(x = 1, x = 2) }
+          |}
+          |""".stripMargin)
+    }
+    it("E0045 positional after named") {
+      failsWith("E0045",
+        """class Test {
+          |public:
+          |  static def f(x: Int, y: Int): Int = x + y
+          |  static def main(args: String[]): Int { return f(x = 1, 2) }
+          |}
+          |""".stripMargin)
+    }
+  }
+
+  describe("generics") {
+    it("E0031 type argument arity mismatch") {
+      failsWith("E0031",
+        """class Box[T] { public: def this {} }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val b = new Box[String, String]()
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0031 also fires in a nullable type annotation (issue #413)") {
+      failsWith("E0031",
+        """class Box[T] { public: def this {} }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val b: Box[String, String]? = null
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0033 method is not generic") {
+      failsWith("E0033",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int { return "abc".length[String]() }
+          |}
+          |""".stripMargin)
+    }
+    it("E0034 method type argument arity mismatch") {
+      failsWith("E0034",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val l = java.util.Collections::emptyList[String, String]()
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0035 erasure signature collision") {
+      failsWith("E0035",
+        """class C {
+          |public:
+          |  def this {}
+          |  def f(x: java.util.List[String]): Int = 1
+          |  def f(x: java.util.List[Integer]): Int = 2
+          |}
+          |""".stripMargin)
+    }
+  }
+
+  describe("statements and expressions") {
+    it("E0020 a bare return in a value-returning method") {
+      failsWith("E0020",
+        """class Test {
+          |public:
+          |  static def f(): Int { return }
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin)
+    }
+    it("E0027 void is not boxable") {
+      failsWith("E0027",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val s = "a" + IO::println("b")
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0028 assignment needs an lvalue") {
+      failsWith("E0028",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    "a".length() = 3
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0040 calling a method on a void result") {
+      failsWith("E0040",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    IO::println("a").toString()
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0050 `this` in a static context") {
+      failsWith("E0050",
+        """class Test {
+          |public:
+          |  static def s(): Int { return this.hashCode() }
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin)
+    }
+    it("E0073 a Map is not directly iterable") {
+      failsWith("E0073",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foreach x: Object in ["a": 1] { }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+  }
+
+  describe("declaration shapes") {
+    it("E0051 recursive function needs a return type") {
+      failsWith("E0051",
+        """def f(n: Int) = f(n)
+          |def main(): void { }
+          |""".stripMargin)
+    }
+    it("E0055 a function needs a body") {
+      failsWith("E0055",
+        """def f(): Int;
+          |def main(): void { }
+          |""".stripMargin)
+    }
+    it("E0076 unknown shape format") {
+      failsWith("E0076",
+        """record P(x: Int)
+          |  shape d = toml
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin)
+    }
+  }
+
+  describe("drift guard: the dead-code registry") {
+    it("codes listed as dead have no report site; every other code has one") {
+      val srcDir = java.nio.file.Path.of("src/main/scala")
+      val sources = java.nio.file.Files.walk(srcDir).iterator()
+      val sb = new StringBuilder
+      sources.forEachRemaining { p =>
+        // The reporter is rendering, not reporting — it names every code by design.
+        if (p.toString.endsWith(".scala") && !p.toString.endsWith("SemanticError.scala")
+            && !p.toString.endsWith("SemanticErrorReporter.scala"))
+          sb.append(java.nio.file.Files.readString(p)).append('\n')
+      }
+      val allMain = sb.toString
+      val declared = """case object (\w+) extends SemanticError""".r
+        .findAllMatchIn(java.nio.file.Files.readString(
+          java.nio.file.Path.of("src/main/scala/onion/compiler/SemanticError.scala")))
+        .map(_.group(1)).toSet
+      val undeadDead = deadCodes.filter(allMain.contains)
+      assert(undeadDead.isEmpty,
+        s"codes listed as dead now have report sites — cover them and update the registry: $undeadDead")
+      val newlyDead = (declared -- deadCodes).filterNot(allMain.contains)
+      assert(newlyDead.isEmpty,
+        s"codes with no report site anywhere — dead diagnostics deserve flagging: $newlyDead")
+    }
+  }
+}


### PR DESCRIPTION
## What

The quality release for the goal「next release。品質重視で」. The E-code coverage sweep found and fixed three real defects while covering the diagnostic surface.

## Fixed

1. **`class A extends java.lang.String` crashed the compiler** — escaped typing, JVM `IncompatibleClassChangeError` at class load. Now E0018 at the supertype reference; crash-corpus `030`.
2. **E0053/E0054 rendered `Unknown error: <NAME>`** — never wired to their (existing, bilingual) messages. Wired; spec asserts the regression can't return.
3. **#413: wrong type-arg arity accepted in nullable annotations** (`Box[String,String]?`) while failing on `new`. The validator now looks through the nullable wrapper; both E0031.

## Added

`SemanticErrorCodeCoverageSpec`: 27 more per-code triggers (E0008..E0076) + a source-scanning drift guard — dead codes (E0017/E0024/E0056) are registered, and a code gaining/losing a report site fails the build. E0043 documented as shadowed by candidate filtering; E0075 as environment-only.

## Docs

quality-bar re-measured EN+JA (2744 / 64 samples / 7 large / 81 codes); CLAUDE.md catches up with all of v0.10.

## Verification

- 2744 green in **both** locales
- crash corpus 96/96
- packaged jar smoked end to end: `--version`, `--contract`, `--plan` (nothing executed), real run, config lens (`007` spacing preserved, one-line diff)

After merge: tag `v0.10.1` on the merge commit → release workflow → verify the asset by executing it → fast-forward `main`.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)