### PR TITLE
fix(grammar): allow ; to separate ADT enum case clauses

### DIFF
--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -1704,7 +1704,7 @@ AST.EnumDeclaration enum_decl(int mset) : {
     // in the Rewriting phase to a sealed interface + one record per case.
     LOOKAHEAD({la("case")})
     (
-      constant = enum_case_constant() {append(constants, constant);}
+      constant = enum_case_constant() {append(constants, constant);} [";"]
     )+
     (sec=access_section() {append(sections, sec);})*
   |

--- a/src/test/scala/onion/compiler/tools/AdtEnumSpec.scala
+++ b/src/test/scala/onion/compiler/tools/AdtEnumSpec.scala
@@ -80,6 +80,23 @@ class AdtEnumSpec extends AbstractShellSpec {
       assert(Shell.Success("red|custom") == r)
     }
 
+    it("accepts semicolon-separated case clauses on a single line (CLAUDE.md-documented form)") {
+      val r = shell.run(
+        """
+          |enum Shape { case Circle(radius: Double); case Square(side: Double); case Origin; public: def area(): Double = select this { case c is Circle: c.radius() * c.radius() * 3.14; case s is Square: s.side() * s.side(); case o is Origin: 0.0 } }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val a: Double = (new Circle(2.0) as Shape).area()
+          |    val b: Double = (new Square(3.0) as Shape).area()
+          |    val c: Double = (new Origin() as Shape).area()
+          |    return "" + a + "|" + b + "|" + c
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("12.56|9.0|0.0") == r)
+    }
+
     it("reports E0042 when a select over the ADT enum omits a case") {
       val r = shell.run(
         """


### PR DESCRIPTION
## Summary
- `enum Shape { case Circle(radius: Double); case Square(side: Double); case Origin; public: ... }` is CLAUDE.md's own documented "✓ correct" single-line form for a Scala-3-style ADT (`case`) enum, but the grammar only accepted a newline between `case` clauses. Even the minimal `enum Color { RED; GREEN; BLUE }` failed to parse with a syntax error.
- `enum_decl()` in `grammar/JJOnionParser.jj` now consumes an optional `;` after each `case` clause, matching how `;` already works as a statement/declaration separator elsewhere in the grammar (via `eos()`).

## Test plan
- [x] Added a regression test in `AdtEnumSpec` using the exact semicolon-separated single-line form from CLAUDE.md; confirmed it failed before the grammar change (RED) and passes after (GREEN).
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2745 succeeded, 0 failed, 1 canceled (expected: distribution smoke test gated behind `-Donion.dist.path`).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKtP7wPfRcPaKHiMS6264T)_