### PR TITLE
test(typing): add regression coverage for E0015 (CLASS_NOT_ACCESSIBLE)

### DIFF
--- a/src/test/scala/onion/compiler/tools/ClassAccessibilitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/ClassAccessibilitySpec.scala
@@ -1,0 +1,72 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0015 (CLASS_NOT_ACCESSIBLE) is reported when a *field* is selected on a
+ * value whose static type is an `internal` class declared in a different
+ * module (the check lives in the field/getter member-selection path, not the
+ * method-call path), but had no regression coverage at all before this spec.
+ * Accessibility is module-scoped (`hasSamePackage` compares the dotted prefix
+ * before the last dot of the class name), so triggering it needs two
+ * compilation units with distinct `module` declarations.
+ */
+class ClassAccessibilitySpec extends AbstractShellSpec {
+  private def errors(sources: (String, String)*): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val inputs = sources.map { case (name, src) => new StreamInputSource(() => new StringReader(src), name) }
+    new OnionCompiler(config).compile(inputs) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("selecting a member on an internal class from another module") {
+    it("reports E0015 when the class is internal to a different module") {
+      val results = errors(
+        "a.on" ->
+          """module pkg.a
+            |internal class Hidden {
+            |public:
+            |  var n: Int
+            |  def this { n = 1 }
+            |}
+            |""".stripMargin,
+        "b.on" ->
+          """module pkg.b
+            |import { pkg.a.Hidden }
+            |class UseIt {
+            |public:
+            |  static def main(args: String[]): Int {
+            |    val h: Hidden = null
+            |    return h.n
+            |  }
+            |}
+            |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0015")), s"expected E0015, got: $results")
+    }
+
+    it("still allows access to an internal class from within its own module") {
+      val results = errors(
+        "a.on" ->
+          """module pkg.a
+            |internal class Hidden {
+            |public:
+            |  var n: Int
+            |  def this { n = 1 }
+            |}
+            |class UseIt {
+            |public:
+            |  static def main(args: String[]): Int {
+            |    val h = new Hidden()
+            |    return h.n
+            |  }
+            |}
+            |""".stripMargin
+      )
+      assert(results.isEmpty, s"expected no errors, got: $results")
+    }
+  }
+}

--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -18,6 +18,15 @@ import onion.tools.Shell
  *     filtering: an unknown argument name eliminates every candidate first, so the
  *     user sees not-found (with the named-arg spelled out in the message) before the
  *     dedicated check can run.
+ *   - E0032 TYPE_ARGUMENT_MUST_BE_REFERENCE — has live report sites (checked whenever
+ *     a *written* type argument maps to `void`), but is not registered dead here: the
+ *     drift guard below only asks whether a report call exists, and it does. What has
+ *     no honest in-process trigger is the *input*: `type()` in the grammar (used for
+ *     every type-argument and type-alias-target position) never routes through
+ *     `void_type()` — only `return_type()` does — so `void`/`Unit` cannot be written
+ *     as a type argument at all (`new Box[void]()`, `Box[void]`, `type T = void` are
+ *     all syntax errors, not E0032). The check appears to guard a substitution the
+ *     current grammar cannot produce.
  */
 class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
 


### PR DESCRIPTION
## Summary
- E0015 (`CLASS_NOT_ACCESSIBLE`) has a live report site (`MemberAccess.ensureTypeAccessible`, reached from the field/getter member-selection path) but had no regression coverage.
- Triggering it needs two compilation units with distinct `module` declarations, since accessibility is scoped to the dotted module prefix and a single source file can't declare two modules — so this gets its own spec file (`ClassAccessibilitySpec`) rather than a case in `SemanticErrorCodeCoverageSpec`, matching the pattern used for E0004/E0016/E0036/E0038/E0068 in #407-#412.
- Also documents (without registering as dead — it does have report sites, so the drift guard would reject that) why E0032 (`TYPE_ARGUMENT_MUST_BE_REFERENCE`) has no test case: the grammar's `type()` production, used for every type-argument and type-alias position, never routes through `void_type()` — only `return_type()` does — so `void`/`Unit` cannot be written as a type argument today (`new Box[void]()`, `Box[void]`, `type T = void` are all syntax errors, not E0032).

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2747 passed, 0 failed, 1 canceled (pre-existing/unrelated), full suite green.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vwj3nP6nW5pudNHzN2CBu3)_