### PR TITLE
test(diagnostics): cover E0000-E0012 basic type/name/duplicate codes

### DIFF
--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -107,6 +107,104 @@ class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
     }
   }
 
+  describe("basic type and name resolution") {
+    it("E0000 incompatible type in a val's declared type") {
+      failsWith("E0000",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: Int = "a"
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0001 incompatible operand type for +") {
+      failsWith("E0001",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1 + true
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0002 variable not found") {
+      failsWith("E0002",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int { return undefinedVar }
+          |}
+          |""".stripMargin)
+    }
+    it("E0003 class not found") {
+      failsWith("E0003",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val a: NoSuchClass = null
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0004 field not found") {
+      failsWith("E0004",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val s = "a".noSuchField
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0005 method not found") {
+      failsWith("E0005",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val s = "a".noSuchMethod()
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+    it("E0007 duplicate local variable") {
+      failsWith("E0007",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    val x = 2
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+  }
+
+  describe("more declaration-level duplicates") {
+    it("E0010 duplicate method") {
+      failsWith("E0010",
+        """class Test {
+          |public:
+          |  def m(): Int = 1
+          |  def m(): Int = 2
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin)
+    }
+    it("E0012 duplicate top-level function") {
+      failsWith("E0012",
+        """def f(): Int = 1
+          |def f(): Int = 2
+          |def main(): void { }
+          |""".stripMargin)
+    }
+  }
+
   describe("inheritance and interfaces") {
     it("E0018 illegal inheritance (extending a final class)") {
       failsWith("E0018",


### PR DESCRIPTION
## Summary

Continues the per-code diagnostic coverage sweep started in #407-#412 and continued through #415-#417. `SemanticErrorCodeCoverageSpec` previously had 45 declared error codes with a live report site but no dedicated regression test. This adds triggers for the 9 easiest/most fundamental ones:

- **E0000** `INCOMPATIBLE_TYPE` — `val x: Int = "a"`
- **E0001** `INCOMPATIBLE_OPERAND_TYPE` — `1 + true`
- **E0002** `VARIABLE_NOT_FOUND` — reference to an undeclared identifier
- **E0003** `CLASS_NOT_FOUND` — reference to an unknown type name
- **E0004** `FIELD_NOT_FOUND` — paren-less selection of a nonexistent member
- **E0005** `METHOD_NOT_FOUND` — call to a nonexistent method
- **E0007** `DUPLICATE_LOCAL_VARIABLE` — two `val x` in the same block
- **E0010** `DUPLICATE_METHOD` — two identical-signature methods in a class
- **E0012** `DUPLICATE_FUNCTION` — two top-level `def` with the same signature

Each test compiles a minimal snippet through `Shell.run` and asserts on the locale-independent error code, per this repo's testing convention (see `CLAUDE.md`).

Note: I initially also drafted an E0011 (`DUPLICATE_GLOBAL_VARIABLE`) test but discovered top-level `var x: Int = 1; var x: Int = 2` compiles successfully rather than erroring (redeclaring a top-level var with an initializer appears to be treated as reassignment sugar rather than a duplicate declaration). Since that snippet doesn't actually trigger the code, I dropped it from this batch rather than land a misleading test — it, along with the remaining ~35 uncovered codes (mostly generics/records/law-DSL/regex, which need more setup), is left for a future pass.

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.SemanticErrorCodeCoverageSpec'` — 39/39 green
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite, 2756/2756 passed, 1 canceled (pre-existing, environment-gated `onion.dist.path` smoke test, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019RpjhfqErg5scignh91dMn)_