### PR TITLE
docs(examples): document and cover 5 undocumented run/ samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Five `run/` examples (`Primes.on`, `LogSummary.on`, `DeptReport.on`, `WordStats.on`,
+  `AdtExpr.on`) were undocumented.** They existed in the repository but had no entry
+  in the Examples Overview index, and no regression coverage confirmed they still ran.
+  Added them to `docs/examples/overview.md`'s Example Index table and to
+  `RunSamplesSpec` so drift between the docs and the scripts is caught automatically.
+
 ### Fixed
 
 - **Semicolon-separated ADT enum case clauses didn't parse (#415).** The single-line

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -61,15 +61,20 @@ java Hello
 | `LineFilter.on` | Lambda filtering | Lambdas, closures |
 | `LineCounter.on` | File processing | Recursion, I/O |
 | `Factorial.on` | Recursion | Recursive functions |
+| `Primes.on` | Sieve of Eratosthenes + factorization | Boolean arrays, for/while loops |
 | `Delegation.on` | Delegation pattern | Interfaces, forward |
 | `Calculator.on` | GUI calculator | Swing, event handling |
 | `Bean.on` | JavaBean pattern | Serialization, getters/setters |
 | `OrderReport.on` | Larger data pipeline | Records, enums, collection pipelines |
+| `DeptReport.on` | CSV group-by/aggregate pipeline | Csv, records, `Maps::groupBy`, Stats |
 | `ExprEval.on` | Expression evaluator | Interfaces, polymorphism |
+| `AdtExpr.on` | Expression evaluator, as an ADT enum | `enum` `case` cases, `select`, exhaustiveness |
 | `StatsApp.on` | Statistics processing | Generics, extension methods |
 | `TodoManager.on` | Task manager | Records, enums, extension methods |
 | `ShapeProcessor.on` | Geometry shapes | Inheritance, extension methods |
 | `TextAnalyzer.on` | Text statistics | String/List extension methods |
+| `WordStats.on` | Word-frequency text statistics | Strings, `Maps::countBy`, records |
+| `LogSummary.on` | Shape-first log analysis | `record ... from re"..."`, `Maps::countBy` |
 | `ConfigApp.on` | CLI + config file | Args, YAML, `derive!(Yaml)` |
 | `JsonApiClient.on` | JSON + HTTP client | Http, Json, records |
 | `AsyncDownloader.on` | Concurrent futures | Future, do-notation |

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -90,5 +90,25 @@ class RunSamplesSpec extends AbstractShellSpec {
       // log with every 200th line truncated.
       assert(Shell.Success(5) == runSample("run/BrokenLogDemo.on"))
     }
+
+    it("runs Primes.on") {
+      assert(Shell.Success(null) == runSample("run/Primes.on"))
+    }
+
+    it("runs LogSummary.on") {
+      assert(Shell.Success(null) == runSample("run/LogSummary.on"))
+    }
+
+    it("runs DeptReport.on") {
+      assert(Shell.Success(null) == runSample("run/DeptReport.on"))
+    }
+
+    it("runs WordStats.on") {
+      assert(Shell.Success(null) == runSample("run/WordStats.on"))
+    }
+
+    it("runs AdtExpr.on") {
+      assert(Shell.Success(null) == runSample("run/AdtExpr.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `run/Primes.on`, `run/LogSummary.on`, `run/DeptReport.on`, `run/WordStats.on`, and `run/AdtExpr.on` existed in the repo with no entry in `docs/examples/overview.md`'s Example Index table and no regression test confirming they still run.
- Added a row for each to the Example Index table.
- Added a `RunSamplesSpec` case per example (each asserts `Shell.Success(null)`, matching `void main`'s exit convention) so future drift between the docs and the scripts is caught automatically.
- Added a `[Unreleased]` CHANGELOG entry.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — 15/15 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2761 passed, 0 failed, 1 pre-existing environment-only cancellation (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013wd3T48TouBF1u2Svo3iaA)_