### PR TITLE
test(diagnostics): cover E0058 (LABEL_NOT_FOUND) with code-asserting tests

### DIFF
--- a/src/test/scala/onion/compiler/tools/LabelNotFoundSpec.scala
+++ b/src/test/scala/onion/compiler/tools/LabelNotFoundSpec.scala
@@ -1,0 +1,65 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * break/continue with a label that isn't bound to any enclosing labeled loop
+ * must report E0058 (LABEL_NOT_FOUND), not just fail generically.
+ */
+class LabelNotFoundSpec extends AbstractShellSpec {
+  private def errorCodes(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.flatMap(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("undefined label diagnostics") {
+    it("reports E0058 for break with an unbound label") {
+      assert(errorCodes(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): void {
+          |    foreach i: Int in 0..3 {
+          |      break nosuch
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).contains("E0058"))
+    }
+
+    it("reports E0058 for continue with an unbound label") {
+      assert(errorCodes(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): void {
+          |    foreach i: Int in 0..3 {
+          |      continue nosuch
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).contains("E0058"))
+    }
+
+    it("does not report E0058 when the label is correctly bound") {
+      assert(!errorCodes(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): void {
+          |    outer: foreach i: Int in 0..3 {
+          |      break outer
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).contains("E0058"))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Continues the per-code diagnostic coverage sweep (#407-#412, #415-#418).
- `break`/`continue` with a label unbound to any enclosing labeled loop already reports **E0058** (`BlockElementLowering.scala`), but the only existing coverage — `LabeledLoopSpec`'s "reports E0058 for an undefined label" — asserted just `Shell.Failure(-1)`, not the error code itself. A regression that swapped in a different diagnostic (e.g. a parse error) would still pass that test.
- Adds `LabelNotFoundSpec.scala` with code-asserting tests for both `break nosuch` and `continue nosuch`, plus a negative case confirming a correctly bound label does *not* report E0058 — following the `OnionCompiler`/`CompilerConfig`/`StreamInputSource` pattern used by `BreakContinueDiagnosticSpec`.
- Test-only change; no CHANGELOG entry (not user-visible), matching the convention of prior coverage-sweep PRs (#417, #418).

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.LabelNotFoundSpec'` — 3/3 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2764 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution test)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB3bWxJ8EzWahWVatfPqq9)_