### PR TITLE
test(diagnostics): assert E0070 (not just failure) for nullable field access

### DIFF
--- a/src/test/scala/onion/compiler/tools/NullableMemberAccessSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NullableMemberAccessSpec.scala
@@ -1,6 +1,8 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * Dereferencing a nullable value's field directly (`x.length` where `x: String?`)
@@ -9,6 +11,14 @@ import onion.tools.Shell
  * "Object expected" (E0000) the generic fallback used to produce.
  */
 class NullableMemberAccessSpec extends AbstractShellSpec {
+  private def errorCodes(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.flatMap(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
   it("rejects direct field access on a nullable value") {
     val result = shell.run(
       """
@@ -21,6 +31,22 @@ class NullableMemberAccessSpec extends AbstractShellSpec {
       Array()
     )
     assert(Shell.Failure(-1) == result)
+  }
+
+  it("reports E0070, not the generic E0000 fallback, for direct field access on a nullable value") {
+    val codes = errorCodes(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val x: String? = "abc"
+        |    return x.length
+        |  }
+        |}
+        |""".stripMargin
+    )
+    assert(codes.contains("E0070"), s"expected E0070 in $codes")
+    assert(!codes.contains("E0000"), s"must not fall back to the generic E0000 message: $codes")
   }
 
   it("accepts safe field access on a nullable value") {


### PR DESCRIPTION
## Summary
- `NullableMemberAccessSpec`'s doc comment already explains the point of this diagnostic: dereferencing a nullable value's field directly (`x.length` where `x: String?`) should report the clean **E0070** (`NULLABLE_MEMBER_ACCESS`), not fall back to the generic, misleading **E0000** ("Object expected").
- The test itself only asserted `Shell.Failure(-1)`, so a regression that silently reverted to the E0000 fallback (or reported any other code) would still pass.
- Adds a code-asserting case using the `OnionCompiler`/`CompilerConfig`/`StreamInputSource` pattern already established by `LabelNotFoundSpec` / `BreakContinueDiagnosticSpec`, matching this repo's locale-independent testing convention (assert on error codes, not message text).

Verified: `sbt -Duser.language=en 'testOnly onion.compiler.tools.NullableMemberAccessSpec'` — 3/3 green, confirms E0070 is reported (and E0000 is not). Full suite (`sbt -Duser.language=en test`) now also green: 2765 succeeded, 0 failed (1 pre-existing environment-dependent cancellation in `ProjectDistributionSpec`, unrelated to this diff). CI (push + pull_request) both succeeded on GitHub Actions.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.NullableMemberAccessSpec'` green
- [x] Full `sbt -Duser.language=en test` suite green (2765 passed, 0 failed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc6PA6VnX7HyakdJaqjbMR)_