### PR TITLE
test(examples): cover 5 more undocumented, untested run/ samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Added them to `docs/examples/overview.md`'s Example Index table and to
   `RunSamplesSpec` so drift between the docs and the scripts is caught automatically.
 
+- **Five more `run/` examples (`SetOperations.on`, `PrimitivePredicate.on`,
+  `PrimitiveFunctionalInterfaces.on`, `SortWithPrimitiveComparator.on`,
+  `CollectionUtilities.on`) had the same gap.** Same fix: added to the Examples
+  Overview index and to `RunSamplesSpec`, asserting each script's actual return
+  value.
+
 ### Fixed
 
 - **Semicolon-separated ADT enum case clauses didn't parse (#415).** The single-line

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -82,6 +82,11 @@ java Hello
 | `ResultValidation.on` | Validation with errors | Option, Result |
 | `StaticImports.on` | Static method imports | `import { Class::method }` |
 | `UnitConverter.on` | CLI unit converter | Extension methods, Args |
+| `SetOperations.on` | Set algebra | `onion.Sets` (union, intersection, difference) |
+| `PrimitivePredicate.on` | Filtering with a primitive predicate | `java.util.function.Predicate[Int]`, `removeIf` |
+| `PrimitiveFunctionalInterfaces.on` | Primitive-typed Java functional interfaces | `Predicate`, `Supplier`, `Function` with primitive type args |
+| `SortWithPrimitiveComparator.on` | Sorting with a primitive comparator | `java.util.Comparator[Int]`, primitive lambda bridging |
+| `CollectionUtilities.on` | Map/list utilities | `onion.Maps`, `onion.Iterables`, custom sort |
 
 ## Learning Path
 

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -110,5 +110,27 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs AdtExpr.on") {
       assert(Shell.Success(null) == runSample("run/AdtExpr.on"))
     }
+
+    it("runs SetOperations.on") {
+      assert(Shell.Success("union=[apple, banana, cherry, date] intersection=[banana, cherry] diff=[apple]") ==
+        runSample("run/SetOperations.on"))
+    }
+
+    it("runs PrimitivePredicate.on") {
+      assert(Shell.Success("[1, 3, 5]") == runSample("run/PrimitivePredicate.on"))
+    }
+
+    it("runs PrimitiveFunctionalInterfaces.on") {
+      assert(Shell.Success("[isPositive(5) = true, answer.get() = 42, doubleIt(21) = 42]") ==
+        runSample("run/PrimitiveFunctionalInterfaces.on"))
+    }
+
+    it("runs SortWithPrimitiveComparator.on") {
+      assert(Shell.Success("[10, 20, 30] [10, 20, 30]") == runSample("run/SortWithPrimitiveComparator.on"))
+    }
+
+    it("runs CollectionUtilities.on") {
+      assert(Shell.Success("[Bob, Alice, Charlie]") == runSample("run/CollectionUtilities.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `SetOperations.on`, `PrimitivePredicate.on`, `PrimitiveFunctionalInterfaces.on`, `SortWithPrimitiveComparator.on`, and `CollectionUtilities.on` existed in `run/` with no entry in the Examples Overview index and no regression coverage.
- Adds each to `RunSamplesSpec`, asserting the script's actual `Shell.Success` return value (captured by running each script and reading its real output).
- Adds each to `docs/examples/overview.md`'s Example Index table.
- Notes the change in `CHANGELOG.md`'s `[Unreleased]` section.

This follows the same pattern as the previous batch (`Primes.on`, `LogSummary.on`, `DeptReport.on`, `WordStats.on`, `AdtExpr.on`).

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *RunSamplesSpec'` — 20/20 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2770 succeeded, 0 failed, 1 canceled (pre-existing `ProjectDistributionSpec` smoke test gated on `-Donion.dist.path`, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLqPWgwShcCMg9nGamYgsK)_