### PR TITLE
test(examples): cover 7 more undocumented, untested run/ samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Seven more `run/` examples (`Bidirectional.on`, `CsvProcessor.on`, `DataClass.on`,
+  `Fibonacci.on`, `FizzBuzz.on`, `CliArgsDemo.on`, `FileWordCounter.on`) had the same
+  undocumented/untested gap as prior batches.** Added them to
+  `docs/examples/overview.md`'s Example Index table and to `RunSamplesSpec`, asserting
+  each script's actual return value. (`GuessNumber.on` was left out of this batch — it
+  reads interactively from stdin with a random target and needs a different test
+  strategy.)
+
 ## [0.10.2] - 2026-07-27
 
 ### Documentation

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -87,6 +87,13 @@ java Hello
 | `PrimitiveFunctionalInterfaces.on` | Primitive-typed Java functional interfaces | `Predicate`, `Supplier`, `Function` with primitive type args |
 | `SortWithPrimitiveComparator.on` | Sorting with a primitive comparator | `java.util.Comparator[Int]`, primitive lambda bridging |
 | `CollectionUtilities.on` | Map/list utilities | `onion.Maps`, `onion.Iterables`, custom sort |
+| `FizzBuzz.on` | Classic FizzBuzz | Loops, modulo, conditionals |
+| `Fibonacci.on` | Recursive vs. iterative Fibonacci | Recursion, loops, `Timing` |
+| `DataClass.on` | Record `equals`/`hashCode`/`copy` demo | Records, `toString`, `copy` |
+| `Bidirectional.on` | One record, every direction | `from re"..."`, `derive!(Json, Yaml)`, `example` |
+| `CsvProcessor.on` | CSV header parsing + aggregation | `Csv::parseWithHeader` |
+| `CliArgsDemo.on` | Manual CLI argument parsing | `onion.Args` |
+| `FileWordCounter.on` | Word count from a file | File I/O, `BufferedReader` |
 
 ## Learning Path
 

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -132,5 +132,41 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs CollectionUtilities.on") {
       assert(Shell.Success("[Bob, Alice, Charlie]") == runSample("run/CollectionUtilities.on"))
     }
+
+    it("runs Bidirectional.on") {
+      assert(Shell.Success(null) == runSample("run/Bidirectional.on"))
+    }
+
+    it("runs CsvProcessor.on") {
+      assert(Shell.Success("Processed 4 rows, average score = 87") == runSample("run/CsvProcessor.on"))
+    }
+
+    it("runs DataClass.on") {
+      assert(Shell.Success(null) == runSample("run/DataClass.on"))
+    }
+
+    it("runs Fibonacci.on") {
+      assert(Shell.Success(null) == runSample("run/Fibonacci.on"))
+    }
+
+    it("runs FizzBuzz.on") {
+      assert(Shell.Success(null) == runSample("run/FizzBuzz.on"))
+    }
+
+    it("runs CliArgsDemo.on") {
+      def run(args: String*): Shell.Result =
+        shell.run(load("run/CliArgsDemo.on"), "run/CliArgsDemo.on", args.toArray)
+      assert(Shell.Success("output=out.txt, paths=[a.txt, b.txt], verbose=true") ==
+        run("--verbose", "--output=out.txt", "a.txt", "b.txt"))
+    }
+
+    it("runs FileWordCounter.on") {
+      val dir = java.nio.file.Files.createTempDirectory("file-word-counter-spec")
+      val f = dir.resolve("words.txt")
+      java.nio.file.Files.writeString(f, "hello world\nfoo bar baz\n\ngood day\n")
+      def run(args: String*): Shell.Result =
+        shell.run(load("run/FileWordCounter.on"), "run/FileWordCounter.on", args.toArray)
+      assert(Shell.Success("Total words: 7") == run(f.toString))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `Bidirectional.on`, `CsvProcessor.on`, `DataClass.on`, `Fibonacci.on`, `FizzBuzz.on`, `CliArgsDemo.on`, and `FileWordCounter.on` existed in `run/` but had no entry in the Examples Overview index and no regression coverage confirming they still ran.
- Same fix as the two prior batches (see CHANGELOG 0.10.2): add each to `docs/examples/overview.md`'s Example Index table and to `RunSamplesSpec`, asserting each script's actual return value.
- `GuessNumber.on` is intentionally left out of this batch — it reads interactively from stdin against a randomly generated target and needs a different test strategy (simulated stdin) than the other scripts here.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2777 succeeded, 0 failed, 1 canceled (pre-existing, unrelated), all green.
- [x] `sbt -Duser.language=en 'testOnly *RunSamplesSpec'` — 27/27 passing including the 7 new cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXts752YM9oZzue28AktHv)_