### PR TITLE
fix(effects): add onion.Residue to effect-table.txt + drift guard (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The effect table had no drift guard, and `onion.Residue` was already missing from
+  it (#429).** `onion.Residue` shipped in v0.10.0 (#362) but was never added to
+  `effect-table.txt`; since it's a marker interface with no methods the omission was
+  latent, but any unlisted stdlib class resolves to `Effect.Unknown`, which would make
+  a future class silently require `requires { unknown }` with no indication that the
+  real cause is a missing table row. Added the missing `onion.Residue#*=pure` entry
+  and a new `EffectTableStdlibCoverageSpec` (modeled on the existing
+  `EffectWalkerCompletenessSpec`) that fails the build if `src/main/java/onion/*.java`
+  ever grows a class with no `effect-table.txt` entry.
+
 - **A `tool` with a non-CLI-convertible parameter compiled to a silent no-op (#424).**
   `tool`-only scripts have no `main` and no top-level statements, so when CLI
   synthesis bailed out on a parameter it couldn't convert from a command-line string

--- a/src/main/resources/onion/effect-table.txt
+++ b/src/main/resources/onion/effect-table.txt
@@ -284,3 +284,6 @@ java.lang.Class#getSimpleName=pure
 # System::out / System::err are PrintStreams
 java.io.PrintStream#*=console
 onion.ToolCli#*=console
+
+# marker interface for Lossless residues (no methods)
+onion.Residue#*=pure

--- a/src/test/scala/onion/compiler/effects/EffectTableStdlibCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/effects/EffectTableStdlibCoverageSpec.scala
@@ -1,0 +1,46 @@
+package onion.compiler.effects
+
+import org.scalatest.funspec.AnyFunSpec
+
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Drift guard for the effect table (issue #429).
+ *
+ * `effect-table.txt` classifies `onion.*` stdlib classes by hand, and nothing checks
+ * that it keeps up with the `.java` sources under `src/main/java/onion`. This spec fails when a stdlib
+ * class has no `onion.Class#*=` wildcard and no `onion.Class#method=` entry at all,
+ * which is exactly how `onion.Residue` (shipped in v0.10.0, #362) went unregistered
+ * and would silently resolve every one of its (currently nonexistent) methods to
+ * `Effect.Unknown`.
+ */
+class EffectTableStdlibCoverageSpec extends AnyFunSpec {
+
+  private def stdlibClassNames: Set[String] = {
+    val dir = Path.of("src/main/java/onion")
+    Files.list(dir).iterator().asScala
+      .map(_.getFileName.toString)
+      .filter(_.endsWith(".java"))
+      .map(_.stripSuffix(".java"))
+      .toSet
+  }
+
+  private def registeredClasses: Set[String] = {
+    val lines = Files.readAllLines(Path.of("src/main/resources/onion/effect-table.txt")).asScala.iterator
+    val parsed = EffectTable.parseLines(lines)
+    val fromWildcards = parsed.wildcard.keySet
+    val fromExact = parsed.exact.keySet.map(_._1)
+    (fromWildcards ++ fromExact)
+      .filter(_.startsWith("onion."))
+      .map(_.stripPrefix("onion."))
+  }
+
+  it("every src/main/java/onion/*.java class has an effect-table.txt entry") {
+    val classes = stdlibClassNames
+    assert(classes.nonEmpty, "source scan found no onion.* stdlib classes — the scan has rotted")
+    val missing = classes -- registeredClasses
+    assert(missing.isEmpty,
+      s"onion.* stdlib classes with no effect-table.txt entry (add a Class#*= or Class#method= row): ${missing.toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
Fixes #429.

## Summary
- `onion.Residue` shipped in v0.10.0 (#362) but was never added to `effect-table.txt`. It's a marker interface with no methods, so the gap was latent — but any unlisted `onion.*` stdlib class silently resolves every method to `Effect.Unknown`, with no signal that the real cause is a missing table row rather than genuinely unanalyzable code.
- Added the missing `onion.Residue#*=pure` entry.
- Added `EffectTableStdlibCoverageSpec` (modeled on the existing `EffectWalkerCompletenessSpec`) that fails the build if `src/main/java/onion` ever grows a class with no `effect-table.txt` entry — the drift guard the issue asked for.
- Updated `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] Added spec first, confirmed it failed red on `Residue` before the fix
- [x] Added the `effect-table.txt` entry, confirmed the new spec and `EffectWalkerCompletenessSpec` pass
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2780 succeeded, 0 failed, 1 canceled (pre-existing, requires an unpacked dist path)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTAAkrT75PiZ7g4DKvqpaj)_