### PR TITLE
fix(typing): report E0043 for an unknown named-argument name (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`E0043 UNKNOWN_PARAMETER_NAME` never fired; a misspelled named argument was
+  reported as a generic not-found instead (#426).** Overload/constructor candidate
+  filtering dropped every candidate as soon as one named argument didn't match a
+  parameter, so by the time resolution gave up it had already lost track of *why* —
+  the user saw `method ... is not found` (or `constructor ... is not found`) without
+  the offending name called out. Static calls, instance calls, unqualified calls, and
+  constructor calls now re-check the original candidate list when resolution comes up
+  empty and report E0043 naming the bad argument when that's the actual cause,
+  falling back to the existing not-found diagnostic otherwise.
+
 - **The effect table had no drift guard, and `onion.Residue` was already missing from
   it (#429).** `onion.Residue` shipped in v0.10.0 (#362) but was never added to
   `effect-table.txt`; since it's a marker interface with no methods the omission was

--- a/src/main/scala/onion/compiler/typing/ArgumentHelpers.scala
+++ b/src/main/scala/onion/compiler/typing/ArgumentHelpers.scala
@@ -58,6 +58,29 @@ private[typing] object ArgumentHelpers {
     }.toList
 
   /**
+   * Find the first named argument whose name is not a parameter of any candidate.
+   *
+   * Candidate filtering (`filterByNamedArgs`) drops every overload as soon as one
+   * named argument doesn't match, so by the time the caller sees an empty result it
+   * no longer knows *why*. This re-checks the original (unfiltered) candidates to
+   * tell a genuine arity/type mismatch apart from a misspelled argument name, so the
+   * caller can report UNKNOWN_PARAMETER_NAME (E0043) instead of a generic not-found.
+   *
+   * @param candidates Original candidates, before named-argument filtering
+   * @param args Argument list as written at the call site
+   * @return The first offending named argument, if any
+   */
+  def findUnknownNamedArg(candidates: Iterable[Method], args: Seq[AST.Expression]): Option[AST.NamedArgument] = {
+    if (candidates.isEmpty) None
+    else {
+      val paramNameSets = candidates.map(_.argumentsWithDefaults.map(_.name).toSet)
+      args.collectFirst {
+        case named: AST.NamedArgument if !paramNameSets.exists(_.contains(named.name)) => named
+      }
+    }
+  }
+
+  /**
    * Fill missing arguments with default values.
    *
    * If params array is smaller than the method's parameter count,

--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -491,11 +491,26 @@ final class ConstructionTyping(
     val candidates = filterConstructorsByNamedArgs(typeRef.constructors.toIndexedSeq, namedInfo)
 
     if (candidates.isEmpty) {
-      // Type the arguments anyway to provide better error messages
-      val parameters = typedTerms(node.args.toArray.filterNot(_.isInstanceOf[AST.NamedArgument]), context)
-      bodyContext.report(CONSTRUCTOR_NOT_FOUND, node, typeRef,
-        if (parameters != null) types(parameters) else Array.empty[Type],
-        typeRef.constructors)
+      val unknownNamed = typeRef.constructors.collectFirst { case cd: ConstructorDefinition => cd } match {
+        case Some(_) =>
+          val paramNameSets = typeRef.constructors.collect {
+            case cd: ConstructorDefinition => cd.argumentsWithDefaults.map(_.name).toSet
+          }
+          node.args.collectFirst {
+            case named: AST.NamedArgument if !paramNameSets.exists(_.contains(named.name)) => named
+          }
+        case None => None
+      }
+      unknownNamed match {
+        case Some(named) =>
+          bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+        case None =>
+          // Type the arguments anyway to provide better error messages
+          val parameters = typedTerms(node.args.toArray.filterNot(_.isInstanceOf[AST.NamedArgument]), context)
+          bodyContext.report(CONSTRUCTOR_NOT_FOUND, node, typeRef,
+            if (parameters != null) types(parameters) else Array.empty[Type],
+            typeRef.constructors)
+      }
       return None
     }
 

--- a/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
@@ -1,10 +1,13 @@
 package onion.compiler.typing
 
 import onion.compiler.*
+import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
 import onion.compiler.typing.session.TypingBodyContext
 
 import java.util.{TreeSet => JTreeSet}
+
+import scala.jdk.CollectionConverters.*
 
 import ArgumentHelpers.hasNamedArguments
 
@@ -219,7 +222,10 @@ private[compiler] final class InstanceMethodCallSupport(
 
     overloadSupport.selectNamedArgumentMethod(candidates, node.args) match {
       case CandidateSelection.NoMatch =>
-        calls.reportMethodNotFound(node, targetType, node.name, Array[Type]())
+        ArgumentHelpers.findUnknownNamedArg(candidates.asScala, node.args) match {
+          case Some(named) => bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+          case None => calls.reportMethodNotFound(node, targetType, node.name, Array[Type]())
+        }
         None
       case CandidateSelection.Ambiguous(first, second) =>
         calls.reportAmbiguousMethod(node, first, second, node.name)

--- a/src/main/scala/onion/compiler/typing/StaticMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/StaticMethodCallSupport.scala
@@ -302,7 +302,10 @@ private[compiler] final class StaticMethodCallSupport(
 
     overloadSupport.selectNamedArgumentMethod(candidates, node.args) match {
       case CandidateSelection.NoMatch =>
-        calls.reportMethodNotFound(node, typeRef, node.name, Array[Type]())
+        ArgumentHelpers.findUnknownNamedArg(candidates.asScala, node.args) match {
+          case Some(named) => typing.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+          case None => calls.reportMethodNotFound(node, typeRef, node.name, Array[Type]())
+        }
         None
       case CandidateSelection.Ambiguous(first, second) =>
         calls.reportAmbiguousMethod(node, first, second, node.name)

--- a/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
@@ -1,10 +1,13 @@
 package onion.compiler.typing
 
 import onion.compiler.*
+import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
 import onion.compiler.typing.session.TypingBodyContext
 
 import java.util.{TreeSet => JTreeSet}
+
+import scala.jdk.CollectionConverters.*
 
 private[compiler] final class UnqualifiedMethodCallSupport(
   bodyContext: TypingBodyContext,
@@ -288,7 +291,10 @@ private[compiler] final class UnqualifiedMethodCallSupport(
 
     overloadSupport.selectNamedArgumentMethod(candidates, node.args) match {
       case CandidateSelection.NoMatch =>
-        calls.reportMethodNotFound(node, targetType, node.name, Array[Type]())
+        ArgumentHelpers.findUnknownNamedArg(candidates.asScala, node.args) match {
+          case Some(named) => bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+          case None => calls.reportMethodNotFound(node, targetType, node.name, Array[Type]())
+        }
         None
       case CandidateSelection.Ambiguous(first, second) =>
         calls.reportAmbiguousMethod(node, first, second, node.name)

--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -14,10 +14,6 @@ import onion.tools.Shell
  *     below fails if one of them comes back to life (or dies) unnoticed.
  *   - E0075 LAW_CLASS_NOT_LOADABLE — reachable only through an environment failure
  *     (a compiled check class failing to load), which has no honest in-process trigger.
- *   - E0043 UNKNOWN_PARAMETER_NAME — its report sites are shadowed by candidate
- *     filtering: an unknown argument name eliminates every candidate first, so the
- *     user sees not-found (with the named-arg spelled out in the message) before the
- *     dedicated check can run.
  *   - E0032 TYPE_ARGUMENT_MUST_BE_REFERENCE — has live report sites (checked whenever
  *     a *written* type argument maps to `void`), but is not registered dead here: the
  *     drift guard below only asks whether a report call exists, and it does. What has
@@ -293,6 +289,56 @@ class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
           |public:
           |  static def f(x: Int, y: Int): Int = x + y
           |  static def main(args: String[]): Int { return f(x = 1, 2) }
+          |}
+          |""".stripMargin)
+    }
+    it("E0043 unknown named argument on a static call (#426)") {
+      failsWith("E0043",
+        """class T {
+          |public:
+          |  static def f(x: Int, y: Int): Int = x + y
+          |  static def main(args: String[]): Int { return f(x = 1, nope = 2) }
+          |}
+          |""".stripMargin)
+    }
+    it("E0043 unknown named argument on an instance call") {
+      failsWith("E0043",
+        """class T {
+          |public:
+          |  def this {}
+          |  def f(x: Int, y: Int): Int = x + y
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return new T().f(x = 1, nope = 2) }
+          |}
+          |""".stripMargin)
+    }
+    it("E0043 unknown named argument on an unqualified call") {
+      failsWith("E0043",
+        """class T {
+          |public:
+          |  def this {}
+          |  def f(x: Int, y: Int): Int = x + y
+          |  def g(): Int = f(x = 1, nope = 2)
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return new T().g() }
+          |}
+          |""".stripMargin)
+    }
+    it("E0043 unknown named argument on a constructor call") {
+      failsWith("E0043",
+        """class P {
+          |  val x: Int
+          |  val y: Int
+          |public:
+          |  def this(x: Int, y: Int) { self.x = x; self.y = y }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { val p = new P(x = 1, nope = 2); return 0 }
           |}
           |""".stripMargin)
     }


### PR DESCRIPTION
## Summary
- Overload/constructor candidate filtering dropped every candidate as soon as one named argument didn't match a parameter name, so a misspelled name (`f(x = 1, nope = 2)`) surfaced as a generic not-found error instead of the dedicated `E0043 UNKNOWN_PARAMETER_NAME`.
- Static calls, instance calls, unqualified calls, and constructor calls now re-check the *original* (unfiltered) candidate list when resolution comes up empty, and report `E0043` naming the offending argument when that's the actual cause — falling back to the existing not-found diagnostic otherwise.
- Removed `E0043` from `SemanticErrorCodeCoverageSpec`'s "shadowed, can't reach" doc note and added coverage for all four call shapes (static/instance/unqualified/constructor).

Fixes #426.

## Test plan
- [x] Added 4 new cases to `SemanticErrorCodeCoverageSpec` (static/instance/unqualified/constructor unknown named argument → E0043)
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2784 succeeded, 0 failed, 1 canceled (pre-existing, unrelated `dist` integration test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UW1ARfpbtitWXRuEMT85tZ)_