### PR TITLE
release: 0.10.3 — the post-0.10.2 audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-07-27
+
+The six issues found in the post-0.10.2 audit (#424-#429), fixed across #430-#434.
+
+Two of them were silent failures — a `tool` that compiled to a program doing nothing,
+and a dry run naming a path the run would not touch — and two were drift: documented
+figures and an effect table that nothing kept honest. Both kinds now fail the build.
+
 ### Fixed
 
+- **A `tool` with a non-CLI-convertible parameter compiled to a silent no-op (#424).**
+  A `tool`-only script has no `main` and no top-level statements, so when CLI synthesis
+  bailed out on a parameter it could not read from a command-line string (a record,
+  say), nothing ever called the tool — the script exited 0 having done nothing, with no
+  diagnostic at all. It is now a compile error naming the offending tool and parameter
+  and listing the supported types, as **E0081** with EN+JA messages and a reference
+  entry, one report per offending parameter. Documented in `docs/guide/tools.md`
+  (EN+JA).
 - **`--plan` reported the bound parameter value as if it were the path touched
   (#425).** A capability binds an effect to a *parameter*, but a body may compute
   `dst + "." + i` from it — the shipped demo does exactly that, so the plan said
@@ -16,65 +32,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now reads `derived from dst = out.txt`, and the closing line says operands are the
   arguments the effects are derived from, not necessarily the exact paths or hosts
   touched. Guide updated EN+JA.
+- **`E0043 UNKNOWN_PARAMETER_NAME` never fired; a misspelled named argument was
+  reported as a generic not-found instead (#426).** Candidate filtering dropped every
+  overload as soon as one named argument failed to match a parameter, so by the time
+  resolution gave up it had lost track of *why* — the user saw `method ... is not
+  found` without the offending name called out. Static, instance, unqualified and
+  constructor calls now re-check the original candidate list when resolution comes up
+  empty, and report E0043 naming the bad argument when that is the actual cause.
 
 ### Removed
 
-- **Three diagnostic codes that could never fire (#427):** `E0017 CYCLIC_DELEGATION`
-  (undecidable as designed — the delegate is chosen at runtime), `E0024
-  UNIMPLEMENTED_FEATURE` (leftover) and `E0056 ENUM_CONSTANT_ARGS_UNSUPPORTED`
-  (obsolete since data-carrying enums shipped), with their EN+JA messages. The
-  coverage spec's dead-code registry is now empty and stays that way by test.
+- **Three diagnostic codes that could never fire (#427),** with their EN+JA messages:
+  `E0017 CYCLIC_DELEGATION` (undecidable as designed — the delegate is chosen at
+  runtime, so no static check can see the cycle), `E0024 UNIMPLEMENTED_FEATURE`
+  (leftover) and `E0056 ENUM_CONSTANT_ARGS_UNSUPPORTED` (obsolete since data-carrying
+  enums shipped). The coverage spec's dead-code registry is now empty and stays that
+  way by test.
 
 ### Added
 
-- **`QualityBarSpec` measures `docs/quality-bar.md` against the tree (#428).** Sample
-  count, large-program count *and names*, guide parity and diagnostic-code count are
-  checked against what is actually there, and the JA copy must agree. The file had
-  drifted three times in three days because every figure was transcribed by hand; the
-  spec caught two more stale figures on its first run.
-- **`EffectTableStdlibCoverageSpec` gains the other direction of the drift check
-  (#429 follow-up):** no table entry may name a class that no longer exists, and the
-  whole table must parse — so a malformed edit fails there rather than at first use.
-
-### Fixed
-
-- **`E0043 UNKNOWN_PARAMETER_NAME` never fired; a misspelled named argument was
-  reported as a generic not-found instead (#426).** Overload/constructor candidate
-  filtering dropped every candidate as soon as one named argument didn't match a
-  parameter, so by the time resolution gave up it had already lost track of *why* —
-  the user saw `method ... is not found` (or `constructor ... is not found`) without
-  the offending name called out. Static calls, instance calls, unqualified calls, and
-  constructor calls now re-check the original candidate list when resolution comes up
-  empty and report E0043 naming the bad argument when that's the actual cause,
-  falling back to the existing not-found diagnostic otherwise.
-
-- **The effect table had no drift guard, and `onion.Residue` was already missing from
-  it (#429).** `onion.Residue` shipped in v0.10.0 (#362) but was never added to
-  `effect-table.txt`; since it's a marker interface with no methods the omission was
-  latent, but any unlisted stdlib class resolves to `Effect.Unknown`, which would make
-  a future class silently require `requires { unknown }` with no indication that the
-  real cause is a missing table row. Added the missing `onion.Residue#*=pure` entry
-  and a new `EffectTableStdlibCoverageSpec` (modeled on the existing
-  `EffectWalkerCompletenessSpec`) that fails the build if `src/main/java/onion/*.java`
-  ever grows a class with no `effect-table.txt` entry.
-
-- **A `tool` with a non-CLI-convertible parameter compiled to a silent no-op (#424).**
-  `tool`-only scripts have no `main` and no top-level statements, so when CLI
-  synthesis bailed out on a parameter it couldn't convert from a command-line string
-  (e.g. a record), nothing ever called the tool — the script just exited 0 having done
-  nothing, with no diagnostic. It is now a compile error naming the offending tool and
-  parameter, with the list of supported types (`String`, `Int`, `Long`, `Double`,
-  `Float`, `Boolean`, `Short`, `Byte`). Documented in `docs/guide/tools.md` (en/ja).
-
-### Documentation
-
-- **Seven more `run/` examples (`Bidirectional.on`, `CsvProcessor.on`, `DataClass.on`,
-  `Fibonacci.on`, `FizzBuzz.on`, `CliArgsDemo.on`, `FileWordCounter.on`) had the same
-  undocumented/untested gap as prior batches.** Added them to
-  `docs/examples/overview.md`'s Example Index table and to `RunSamplesSpec`, asserting
-  each script's actual return value. (`GuessNumber.on` was left out of this batch — it
-  reads interactively from stdin with a random target and needs a different test
-  strategy.)
+- **A drift guard for the effect table (#429).** `onion.Residue` shipped in v0.10.0 and
+  was never added to `effect-table.txt`; the omission was latent only because it is a
+  marker interface with no methods, but any unlisted stdlib class resolves to
+  `Effect.Unknown` — which would make a future class silently require
+  `requires { unknown }` with no indication that a missing table row, not unanalyzable
+  code, was the cause. Added the entry, plus `EffectTableStdlibCoverageSpec`: every
+  `onion.*` class must have an entry, no entry may name a class that is gone, and the
+  whole table must parse.
+- **A drift guard for the quality bar (#428).** `QualityBarSpec` measures the
+  measurable rows of `docs/quality-bar.md` against the tree — sample count,
+  large-program count *and names*, guide parity, diagnostic-code count — and checks the
+  JA copy agrees. The file had drifted three times in three days because every figure
+  was transcribed by hand; the spec caught two more stale figures on its first run.
 
 ## [0.10.2] - 2026-07-27
 

--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -10,13 +10,13 @@
 
 | # | 次元 | 測定方法 | 現在値（2026-07-27） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2792 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2793 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 64 / 64 compile | すべてコンパイル、rot なし |
 | 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 7（BrokenLogDemo、OrderReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager、ToolDemo） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |
 | 5 | 既知の使い勝手バグ | 実装済みだが到達不能/壊れた機能として未解決のもの | 0 | 0 |
 | 6 | ドキュメントの対等性 | `docs/guide` と `docs/ja/guide` の数 + すべてのコードブロックがコンパイル可能 | 15 / 15 | 対等性 + すべてのブロックを検証 |
-| 7 | 診断メッセージ | 英語と日本語の `E00xx` コード | 78 | よくあるエラーごとに専用コード |
+| 7 | 診断メッセージ | 英語と日本語の `E00xx` コード | 79 | よくあるエラーごとに専用コード |
 
 **`SBT_OPTS` は設定しないでください。** 以前のこのファイルは `SBT_OPTS="-Xmx2g"` を薦めて
 いましたが、これは現在プロジェクト既定の 4g を*下げて*しまい、スイートの途中で

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -216,6 +216,22 @@ public:
 - `?.` / `?:` / `if x != null` を使う。
 - 非 null 制限を宣言: `class Box[T extends Object]`。
 
+### `E0081` — tool のパラメータがコマンドラインから読めない
+
+CLI は `tool` のパラメータから導出されるので、パラメータはすべてコマンドライン引数から
+読める型でなければなりません。
+
+```onion
+record P(x: Int)
+
+tool takeRec(p: P): Int requires { console } { IO::println("" + p.x()); return 0 }
+// E0081: パラメータ `p` の型 P は引数から読み取れません。
+//        使える型: String, Int, Long, Double, Float, Boolean, Short, Byte。
+```
+
+以前はこれが無言でした。CLI 合成がそのスクリプトを黙って飛ばし、`main` のない何も実行
+しないプログラムがコンパイルされていました（issue #424）。
+
 ## パターンマッチングエラー
 
 ### `E0042` — 網羅性のないパターンマッチング

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -13,13 +13,13 @@ had already drifted after the effect-table / tool-capability / tool-contracts wo
 
 | # | Dimension | How to measure | Current (2026-07-27) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2792 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2793 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 64 / 64 compile | all compile, no rot |
 | 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 7 (BrokenLogDemo, OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager, ToolDemo) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |
 | 5 | Known usability bugs | implemented-but-unreachable / broken features still open | 0 | 0 |
 | 6 | Docs parity | `docs/guide` vs `docs/ja/guide` count + every code block compiles | 15 / 15 | parity + all blocks verified |
-| 7 | Diagnostics | distinct `E00xx` codes with EN+JA messages | 78 | every common error has a dedicated code |
+| 7 | Diagnostics | distinct `E00xx` codes with EN+JA messages | 79 | every common error has a dedicated code |
 
 **Do not set `SBT_OPTS`.** The previous version of this file recommended
 `SBT_OPTS="-Xmx2g"`, which now *lowers* the heap below the project's own default of 4g and

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -218,6 +218,22 @@ Fixes:
 - Use `?.` / `?:` / `if x != null`.
 - Declare a non-null bound: `class Box[T extends Object]`.
 
+### `E0081` — Tool parameter cannot be read from the command line
+
+A `tool`'s parameters must all be readable from a command-line argument, since the CLI
+is derived from them.
+
+```onion
+record P(x: Int)
+
+tool takeRec(p: P): Int requires { console } { IO::println("" + p.x()); return 0 }
+// E0081: parameter `p` has type P, which cannot be read from an argument.
+//        Supported: String, Int, Long, Double, Float, Boolean, Short, Byte.
+```
+
+This used to be silent: CLI synthesis skipped such a script, which then compiled to a
+program with no `main` and nothing to run (issue #424).
+
 ## Pattern-matching errors
 
 ### `E0042` — Non-exhaustive pattern match

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -96,3 +96,4 @@ error.semantic.toolCapability.notAnEffect=`{0}` is not an effect. The vocabulary
 error.semantic.toolCapability.takesNoArgument=`{0}` does not take a parameter argument
 error.semantic.toolCapability.badParameter=`{0}` does not name a parameter of the tool
 error.semantic.shapeInstanceWithoutLaw=class `{0}` implements onion.Shape but nothing in its file asserts a law. Add a `law` or an `example` — the round-trip `s.parse(s.print(v)).get() == v` is the canonical one — so the claim is machine-checked.
+error.semantic.toolParameterNotCliConvertible=tool `{0}` cannot derive a command line: parameter `{1}` has type {2}, which cannot be read from an argument. Supported parameter types: {3}.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -96,3 +96,4 @@ error.semantic.toolCapability.notAnEffect=`{0}` は効果ではありません�
 error.semantic.toolCapability.takesNoArgument=`{0}` はパラメータ引数を取りません
 error.semantic.toolCapability.badParameter=`{0}` はこの tool のパラメータ名ではありません
 error.semantic.shapeInstanceWithoutLaw=クラス `{0}` は onion.Shape を実装していますが、このファイルには law がありません。`law` か `example` を追加してください — 代表は round-trip `s.parse(s.print(v)).get() == v` です。主張は機械検査されて初めて意味を持ちます。
+error.semantic.toolParameterNotCliConvertible=tool `{0}` はコマンドラインを導出できません: パラメータ `{1}` の型 {2} は引数から読み取れません。使える型: {3}。

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -14,7 +14,7 @@ import _root_.onion.compiler.TypedAST.UnaryTerm.Kind._
 import _root_.onion.compiler.TypedAST._
 import _root_.onion.compiler.SemanticError._
 import _root_.onion.compiler.exceptions.CompilationException
-import _root_.onion.compiler.toolbox.{Boxing, Classes, Paths, Systems}
+import _root_.onion.compiler.toolbox.{Boxing, Classes, Message, Paths, Systems}
 import onion.compiler.AST.{ClassDeclaration, InterfaceDeclaration, RecordDeclaration}
 
 import _root_.scala.jdk.CollectionConverters._
@@ -340,13 +340,19 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
     // silently leaving the tools as uncalled plain functions would compile the
     // whole script down to a no-op (issue #424); report the offending parameter
     // instead.
-    tools.flatMap(t => t.args.filter(a => cliKindOf(a.typeRef).isEmpty).map(t -> _)).headOption.foreach {
-      case (tool, arg) =>
-        throw new CompilationException(Seq(CompileError("", arg.location,
-          s"tool '${tool.name}' has parameter '${arg.name}' of type ${arg.typeRef.desc} which cannot be " +
-          "derived into a CLI argument; tool parameters must be one of String, Int, Long, Double, Float, " +
-          "Boolean, Short, Byte.")))
-    }
+    // One report per offending parameter, not just the first: fixing them should not
+    // be a one-per-compile game. E0081 carries EN+JA messages like every other code.
+    val badParams = for {
+      t <- tools
+      a <- t.args
+      if cliKindOf(a.typeRef).isEmpty
+    } yield CompileError("", a.location,
+      Message("error.semantic.toolParameterNotCliConvertible",
+        Array[Any](t.name, a.name,
+          if (a.typeRef == null) "(none)" else a.typeRef.desc.toString,
+          ScalarConversions.supportedNames)),
+      Some(TOOL_PARAMETER_NOT_CLI_CONVERTIBLE.errorCode))
+    if (badParams.nonEmpty) throw new CompilationException(badParams)
 
     val loc = tools.head.location
     val contractJson = tools.map(toolContractJson).mkString("[", ",", "]")

--- a/src/main/scala/onion/compiler/SemanticError.scala
+++ b/src/main/scala/onion/compiler/SemanticError.scala
@@ -143,6 +143,7 @@ object SemanticError {
   case object TOOL_UNUSED_CAPABILITY extends SemanticError(78)
   case object TOOL_BAD_CAPABILITY extends SemanticError(79)
   case object SHAPE_INSTANCE_WITHOUT_LAW extends SemanticError(80)
+  case object TOOL_PARAMETER_NOT_CLI_CONVERTIBLE extends SemanticError(81)
 }
 sealed abstract class SemanticError(val code: Int) {
   /** Returns the error code in format "E0001" */

--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -480,6 +480,12 @@ class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
           |def main(): void { }
           |""".stripMargin)
     }
+    it("E0081 a tool parameter that cannot be read from the command line (#424)") {
+      failsWith("E0081",
+        """record P(x: Int)
+          |tool t(p: P): Int requires { console } { IO::println("" + p.x()); return 0 }
+          |""".stripMargin)
+    }
     it("E0076 unknown shape format") {
       failsWith("E0076",
         """record P(x: Int)


### PR DESCRIPTION
Folds #430-#434 (issues #424-#429) into a release, plus one upgrade made during release prep.

## What is in it

Two silent failures — a `tool` that compiled to a program doing nothing (#424), and a dry run naming a path the run would not touch (#425) — one unreachable diagnostic (#426), three codes that could never fire (#427), and two drift guards for things nothing kept honest (#428, #429).

## Upgrade made during prep

**#424's diagnostic is now E0081**, with EN+JA messages and a reference entry, and reports *every* offending parameter rather than only the first. The first cut (in #430) shipped an uncoded English-only message; the project's own bar asks for a dedicated `E00xx` with both languages, and releasing the interim text would have put it in the wild and made it harder to change later.

The new `QualityBarSpec` caught the resulting code-count change (78 → 79) the moment E0081 was added — the drift guard doing exactly its job, on the release that introduced it.

## Verification

- **2793 green in both locales**
- quality-bar re-measured: 2793 tests, 79 diagnostic codes, and both language copies agree (checked by spec now, not by hand)

After merge: tag `v0.10.3` → release workflow → verify the asset by executing it → fast-forward `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)