### PR TITLE
fix(cli): reject a repeated tool CLI flag instead of silently taking the last value (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A repeated tool CLI flag silently took the last value (#438).** `ToolCli.dispatch`
+  assigned into a flag's or switch's slot on every occurrence with no check for one
+  already filled, so `--n 2 --n 3` accepted `3` without comment — the same class of
+  mistake `E0044`/`DUPLICATE_ARGUMENT` already rejects for a named argument in source.
+  A flag or switch given more than once now reports `option `--name` was given more
+  than once` and exits 1.
+
 ## [0.10.3] - 2026-07-27
 
 The six issues found in the post-0.10.2 audit (#424-#429), fixed across #430-#434.

--- a/src/main/java/onion/ToolCli.java
+++ b/src/main/java/onion/ToolCli.java
@@ -124,6 +124,10 @@ public final class ToolCli {
                     return Result.exit(1);
                 }
                 Map<String, Object> p = params.get(idx);
+                if (values[idx] != null) {
+                    System.err.println("option `" + key + "` was given more than once.");
+                    return Result.exit(1);
+                }
                 if (str(p, "role").equals("switch")) {
                     if (inline != null) {
                         System.err.println("switch `" + key + "` does not take a value.");

--- a/src/test/scala/onion/compiler/tools/ToolContractCliSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ToolContractCliSpec.scala
@@ -81,6 +81,20 @@ class ToolContractCliSpec extends AbstractShellSpec {
       assert(Shell.Success(1) == r, r.toString)
       assert(out.contains("--nope"), out)
     }
+
+    it("rejects a flag given more than once instead of silently taking the last value") {
+      val (r, out) = run(script, "x", "--count", "1", "--count", "2")
+      assert(Shell.Success(1) == r, r.toString)
+      assert(out.contains("--count"), out)
+      assert(out.contains("more than once"), out)
+    }
+
+    it("rejects a switch given more than once") {
+      val (r, out) = run(script, "x", "--loud", "--loud")
+      assert(Shell.Success(1) == r, r.toString)
+      assert(out.contains("--loud"), out)
+      assert(out.contains("more than once"), out)
+    }
   }
 
   describe("several tools in one script") {


### PR DESCRIPTION
## Summary
- Fixes #438: `ToolCli.dispatch` assigned into a flag's/switch's value slot on every occurrence with no check for a slot already filled, so `--n 2 --n 3` silently took `3`.
- A flag or switch given more than once now reports `` option `--name` was given more than once `` and exits 1, consistent with how E0044/`DUPLICATE_ARGUMENT` already treats a repeated named argument at the language level.
- Added `[Unreleased]` CHANGELOG entry.

## Test plan
- [x] Added two failing-first (TDD) tests in `ToolContractCliSpec` covering a repeated flag and a repeated switch; confirmed red before the fix.
- [x] Full suite green: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2795 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated dist smoke test).

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9x8Y1KYgdxeA94ZLpxBzT)_