### PR TITLE
test(cli): cover the --effects flag end to end

### DIFF
--- a/src/test/scala/onion/tools/EffectsCliSpec.scala
+++ b/src/test/scala/onion/tools/EffectsCliSpec.scala
@@ -1,0 +1,79 @@
+package onion.tools
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * `--effects` (documented in docs/reference/effects.md): prints each compiled method's
+ * inferred effect set to stderr. Exercised end to end through the real CLI entry points
+ * — `EffectInferenceSpec` covers the inference logic itself, this covers the flag wiring
+ * in `CompilerFrontend`/`ScriptRunner` (`emitEffects`, gated on `!result.hasErrors`).
+ */
+class EffectsCliSpec extends AnyFunSuite with Matchers:
+  private def captureErr(body: => Int): (Int, String) =
+    val buf = new ByteArrayOutputStream()
+    val ps = new PrintStream(buf, true, "UTF-8")
+    val saved = System.err
+    val exitCode =
+      try
+        System.setErr(ps)
+        Console.withErr(ps)(body)
+      finally System.setErr(saved)
+    (exitCode, new String(buf.toByteArray, StandardCharsets.UTF_8))
+
+  private val source =
+    """class App {
+      |public:
+      |  static def f(p: String): String = Files::readText(p)
+      |}
+      |""".stripMargin
+
+  test("CompilerFrontend --effects prints the inferred effect set to stderr"):
+    val output = Files.createTempDirectory("onion-effects-cli")
+    val src = Files.createTempFile("onion-effects-cli", ".on")
+    Files.writeString(src, source, StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-d", output.toString, "--effects", src.toString))
+
+    exitCode shouldBe 0
+    err should include("App#f")
+    err should include("read")
+
+  test("CompilerFrontend without --effects prints nothing about effects"):
+    val output = Files.createTempDirectory("onion-effects-cli")
+    val src = Files.createTempFile("onion-effects-cli", ".on")
+    Files.writeString(src, source, StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-d", output.toString, src.toString))
+
+    exitCode shouldBe 0
+    err should not include "App#f"
+
+  test("CompilerFrontend --effects is silent when compilation fails"):
+    val output = Files.createTempDirectory("onion-effects-cli")
+    val src = Files.createTempFile("onion-effects-cli-bad", ".on")
+    Files.writeString(src, "class App { public: static def f(: String\n", StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-d", output.toString, "--effects", src.toString))
+
+    exitCode shouldBe -1
+    err should not include "App#f"
+
+  test("ScriptRunner --effects prints the inferred effect set to stderr"):
+    val src = Files.createTempFile("onion-effects-cli-script", ".on")
+    Files.writeString(src, source + "\ndef main: void {}\n", StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new ScriptRunner().run(Array("--effects", src.toString))
+
+    exitCode shouldBe 0
+    err should include("App#f")
+    err should include("read")


### PR DESCRIPTION
## Summary
- `--effects` is a shipped, documented CLI flag (`docs/reference/effects.md`, `docs/ja/reference/effects.md`) that prints each compiled method's inferred effect set to stderr, wired in both `CompilerFrontend.emitEffects` and `ScriptRunner`'s equivalent block.
- The underlying `EffectInference` logic has good unit coverage (`EffectInferenceSpec`, `EffectTableSpec`, etc.), but nothing exercised the actual CLI wiring — the flag could regress silently (e.g. stop firing, or fire on a failed compile) with no test catching it.
- Adds `src/test/scala/onion/tools/EffectsCliSpec.scala`, invoking `CompilerFrontend`/`ScriptRunner` directly (same pattern as `CompiledClassWriterSpec`), asserting:
  - `--effects` prints the rendered effect line to stderr on success
  - effects output is absent without the flag
  - effects output is suppressed when compilation fails (the flag is gated on `!result.hasErrors`)
  - the same behavior holds for `ScriptRunner`

Test-only change; no production code touched.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.tools.EffectsCliSpec'` — 4/4 passing
- [x] `sbt -Duser.language=en test` — full suite: 2804 tests, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging integration test), all green

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP4o2AaRDetY7xptjwxktP)_