### PR TITLE
fix(cli): wire up --dump-ast and --dump-typed-ast, which were silent no-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--dump-ast` and `--dump-typed-ast` were silently no-ops.** Both flags parsed into
+  `CompilerConfig` in `onionc`/`onion`, but nothing ever read them back, so the
+  documented "print parsed/typed AST to stderr" behavior never happened — the compiler
+  ran normally and printed nothing extra. Both CLIs now render the AST captured in the
+  pipeline's debug artifacts (`--dump-ast` even when a later phase fails, since the
+  parsed AST is still available).
+
 ## [0.10.4] - 2026-07-27
 
 The five issues found in the post-0.10.3 audit (#436-#440), fixed across #441-#442.

--- a/src/main/scala/onion/tools/CompilerFrontend.scala
+++ b/src/main/scala/onion/tools/CompilerFrontend.scala
@@ -115,6 +115,8 @@ class CompilerFrontend {
           case None => -1
           case Some(config) =>
             val result = compile(config, params)
+            if (config.dumpAst) emitAstDump(result)
+            if (config.dumpTypedAst) emitTypedAstDump(result)
             emitDiagnostics(result)
             emitProfile(config, result)
             if (!result.hasErrors && success.options.contains(SHOW_EFFECTS)) emitEffects(result)
@@ -270,6 +272,14 @@ class CompilerFrontend {
       System.err.println(me.render)
     }
   }
+
+  /** `--dump-ast`: the parsed AST, to stderr. Available even if a later phase fails. */
+  private def emitAstDump(result: CompilationResult): Unit =
+    result.debugArtifacts.parsedUnits.foreach(DiagnosticRenderer.dumpAst(_))
+
+  /** `--dump-typed-ast`: the typed AST summary, to stderr. */
+  private def emitTypedAstDump(result: CompilationResult): Unit =
+    result.debugArtifacts.typedClasses.foreach(DiagnosticRenderer.dumpTyped(_))
 
   private def emitProfile(config: CompilerConfig, result: CompilationResult): Unit = {
     if (config.verbose) {

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -208,6 +208,8 @@ class ScriptRunner {
           case Some(config) =>
             val scriptArgs = passThroughArgs
             val result = compile(config, Array(params.head))
+            if (config.dumpAst) result.debugArtifacts.parsedUnits.foreach(DiagnosticRenderer.dumpAst(_))
+            if (config.dumpTypedAst) result.debugArtifacts.typedClasses.foreach(DiagnosticRenderer.dumpTyped(_))
             emitDiagnostics(result)
             emitProfile(config, result)
             if (!result.hasErrors && success.options.contains(SHOW_EFFECTS)) {

--- a/src/test/scala/onion/tools/DumpAstCliSpec.scala
+++ b/src/test/scala/onion/tools/DumpAstCliSpec.scala
@@ -1,0 +1,106 @@
+package onion.tools
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * `--dump-ast` / `--dump-typed-ast` (documented in CLAUDE.md and both CLIs' usage text):
+ * print the parsed/typed AST to stderr. Exercised end to end through the real CLI entry
+ * points — `CompilerFrontend`/`ScriptRunner` parsed the flags into `CompilerConfig` but
+ * never read them back, so both flags were silently no-ops.
+ */
+class DumpAstCliSpec extends AnyFunSuite with Matchers:
+  private def captureErr(body: => Int): (Int, String) =
+    val buf = new ByteArrayOutputStream()
+    val ps = new PrintStream(buf, true, "UTF-8")
+    val saved = System.err
+    val exitCode =
+      try
+        System.setErr(ps)
+        Console.withErr(ps)(body)
+      finally System.setErr(saved)
+    (exitCode, new String(buf.toByteArray, StandardCharsets.UTF_8))
+
+  private val source =
+    """class App {
+      |public:
+      |  static def f(p: String): String = p
+      |}
+      |""".stripMargin
+
+  test("CompilerFrontend --dump-ast prints the parsed AST to stderr"):
+    val output = Files.createTempDirectory("onion-dump-ast-cli")
+    val src = Files.createTempFile("onion-dump-ast-cli", ".on")
+    Files.writeString(src, source, StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-d", output.toString, "--dump-ast", src.toString))
+
+    exitCode shouldBe 0
+    err should include("[AST]")
+
+  test("CompilerFrontend --dump-typed-ast prints the typed AST to stderr"):
+    val output = Files.createTempDirectory("onion-dump-ast-cli")
+    val src = Files.createTempFile("onion-dump-ast-cli", ".on")
+    Files.writeString(src, source, StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-d", output.toString, "--dump-typed-ast", src.toString))
+
+    exitCode shouldBe 0
+    err should include("[Typed AST]")
+    err should include("App")
+
+  test("CompilerFrontend without --dump-ast/--dump-typed-ast prints neither"):
+    val output = Files.createTempDirectory("onion-dump-ast-cli")
+    val src = Files.createTempFile("onion-dump-ast-cli", ".on")
+    Files.writeString(src, source, StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-d", output.toString, src.toString))
+
+    exitCode shouldBe 0
+    err should not include "[AST]"
+    err should not include "[Typed AST]"
+
+  test("CompilerFrontend --dump-ast still prints the parsed AST when typing later fails"):
+    val output = Files.createTempDirectory("onion-dump-ast-cli")
+    val src = Files.createTempFile("onion-dump-ast-cli-bad", ".on")
+    Files.writeString(src,
+      """class App {
+        |public:
+        |  static def f(): Int = "not an int"
+        |}
+        |""".stripMargin, StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-d", output.toString, "--dump-ast", src.toString))
+
+    exitCode shouldBe -1
+    err should include("[AST]")
+
+  test("ScriptRunner --dump-ast prints the parsed AST to stderr"):
+    val src = Files.createTempFile("onion-dump-ast-cli-script", ".on")
+    Files.writeString(src, source + "\ndef main: void {}\n", StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new ScriptRunner().run(Array("--dump-ast", src.toString))
+
+    exitCode shouldBe 0
+    err should include("[AST]")
+
+  test("ScriptRunner --dump-typed-ast prints the typed AST to stderr"):
+    val src = Files.createTempFile("onion-dump-ast-cli-script", ".on")
+    Files.writeString(src, source + "\ndef main: void {}\n", StandardCharsets.UTF_8)
+
+    val (exitCode, err) = captureErr:
+      new ScriptRunner().run(Array("--dump-typed-ast", src.toString))
+
+    exitCode shouldBe 0
+    err should include("[Typed AST]")
+    err should include("App")


### PR DESCRIPTION
## Summary

- `--dump-ast` and `--dump-typed-ast` are documented (CLAUDE.md, `docs/tools/compiler.md`, `docs/tools/script-runner.md`) as printing the parsed/typed AST to stderr, and both `onionc` (`CompilerFrontend`) and `onion` (`ScriptRunner`) parse the flags into `CompilerConfig.dumpAst` / `dumpTypedAst`. But neither field was ever read back anywhere in the pipeline — the compiler just ran normally and printed nothing extra. Confirmed empirically: `onion --dump-ast Script.on` produced no output at all.
- Both CLIs now check the flag after compiling and render the AST already captured in `CompilationResult.debugArtifacts` (`parsedUnits` / `typedClasses`) via the existing `DiagnosticRenderer.dumpAst` / `dumpTyped`, mirroring how `--effects` already reads `debugArtifacts.typedClasses`.
- `--dump-ast` prints even when a later phase (e.g. typing) fails, since the parsed AST is available as soon as parsing succeeds — this matches the flag's use case (debugging syntax/parse issues) and is covered by a dedicated test.

## Test plan

- [x] Added `src/test/scala/onion/tools/DumpAstCliSpec.scala` (6 cases: both flags × `CompilerFrontend`/`ScriptRunner`, a negative case with neither flag, and a case where typing fails after a successful parse) — confirmed red before the fix, green after.
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2810 passed / 0 failed / 1 cancelled (the pre-existing distribution smoke test, gated behind `-Donion.dist.path`).
- [x] `CHANGELOG.md` `[Unreleased]` updated.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01JP19wDu552TuNxUU93mVZX)_