### PR TITLE
test(typing): cover E0011 for modifier-qualified duplicate globals (#445)

### DIFF
--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -1267,6 +1267,12 @@ AST.Toplevel top_level():{int mset = 0; AST.Toplevel top;}{
     top=type_alias_decl(mset)
   | top=type_decl(mset)
   | top=fun_decl(mset)
+  // var_decl() (AST.GlobalVariableDeclaration) is only reachable through this
+  // modifier-gated branch: a bare top-level `var`/`val` (no `static`/`final`/...)
+  // is matched earlier by the LOOKAHEAD(2) block_element() alternative above and
+  // becomes a local variable of the synthesized script body instead. So E0011
+  // (duplicated global variable) only fires for modifier-qualified globals, e.g.
+  // two `static var x: Int = ...` -- see issue #445.
   | top=var_decl(mset)
   )
 ) {return top;}

--- a/src/test/scala/onion/compiler/tools/DuplicateGlobalVariableSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DuplicateGlobalVariableSpec.scala
@@ -1,0 +1,54 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0011 (duplicated global variable definition). See issue #445: a *bare* top-level
+ * `var`/`val` (no modifier) parses as a local variable of the synthesized script body
+ * (`top_level()`'s `LOOKAHEAD(2) top=block_element()` alternative in
+ * grammar/JJOnionParser.jj wins over `var_decl()` for that input), so it never reaches
+ * `TypingDuplicationPass` and two bare `var x` lines are ordinary local redeclaration,
+ * not a duplicate-global error. `var_decl()` — and this E0011 check — is only reachable
+ * when a modifier keyword (`static`, `final`, `internal`, ...) precedes `var`/`val` at
+ * top level.
+ */
+class DuplicateGlobalVariableSpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("duplicate top-level global variable definitions") {
+    it("reports E0011 for two modifier-qualified globals with the same name") {
+      val results = errors(
+        """
+          |static var x: Int = 1
+          |static var x: Int = 2
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0011")))
+    }
+
+    it("does not report E0011 for two bare top-level vars (they are script-local, not global)") {
+      val results = errors(
+        """
+          |var x: Int = 1
+          |var x: Int = 2
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0011")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes the diagnosis half of #445 (leaves the actual design question — should a bare top-level `var`/`val` become a global? — for the owner, as the prior comment on that issue already flagged).

- #445's repro (`var x: Int = 1` twice, no modifier) never reaches `TypingDuplicationPass`: a bare top-level `var`/`val` is matched by the `LOOKAHEAD(2) block_element()` alternative in `top_level()` and becomes a local variable of the synthesized script body, not an `AST.GlobalVariableDeclaration`.
- `var_decl()` — and E0011 — is only reachable when a modifier keyword (`static`, `final`, ...) precedes `var`/`val` at top level, and E0011 already fires correctly in that case.
- Adds `DuplicateGlobalVariableSpec` to lock in both: E0011 firing for `static var x` declared twice, and no E0011 for the bare-var case (documenting current local-var semantics rather than silently "missing" behavior).
- Adds a short comment on `var_decl()`'s modifier-gated reachability in `grammar/JJOnionParser.jj`.

No behavior change — test coverage and documentation only.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.DuplicateGlobalVariableSpec'` — 2/2 green
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2812 succeeded, 0 failed, 1 canceled (pre-existing, unrelated)

---
_Generated by [Claude Code](https://claude.ai/code/session_016x1hV8g4TpcG1PEyurPAnA)_