### PR TITLE
fix(typing): E0011 for a duplicate bare top-level var/val (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A duplicate bare top-level `var`/`val` went completely unreported (#445).** A
+  modifier-qualified global (`static var x = ...` twice) already reported **E0011**, but
+  a *bare* top-level `var`/`val` — which is promoted to a `public static` field of the
+  script's synthetic class, so it's just as global — took a different code path that
+  silently swallowed the redeclaration. Depending on the mix of `var`/`val` this either
+  compiled clean with the second declaration quietly shadowing the first, or misreported
+  the unrelated **E0007** (duplicate local). Both now report **E0011**, consistent with
+  the modifier-qualified form.
 - **`--dump-ast` and `--dump-typed-ast` were silently no-ops.** Both flags parsed into
   `CompilerConfig` in `onionc`/`onion`, but nothing ever read them back, so the
   documented "print parsed/typed AST to stderr" behavior never happened — the compiler

--- a/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
@@ -350,7 +350,17 @@ final class TypingBodyPass(private val typing: Typing, private val unitContext: 
     context: LocalContext
   ): Option[ActionStatement] = {
     if (node.init == null) return None
-    if (klass.field(node.name) != null) return None
+    if (klass.field(node.name) != null) {
+      // A second bare top-level `var`/`val` with this name (issue #445). It is just as
+      // global as a modifier-qualified one (both become a `public static` field of the
+      // script's synthetic class), so it's the same error, reported the same way here
+      // rather than falling through to `translate` — which would either silently
+      // introduce an unrelated shadowing local (when the first declaration was a `var`,
+      // so never bound a local itself) or misreport E0007 (when the first declaration
+      // was a `val`, so did bind one).
+      typing.report(DUPLICATE_GLOBAL_VARIABLE, node, node.name)
+      return Some(new StatementBlock(node.location))
+    }
     // A mutable top-level `var` must be single-storage: local-first promotion (below) gives a
     // `var` two backing stores — later top-level statements write the local, defs write the
     // field — which silently diverge. So for a `var` use FIELD-ONLY promotion (the pre-#165

--- a/src/test/scala/onion/compiler/tools/DuplicateGlobalVariableSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DuplicateGlobalVariableSpec.scala
@@ -8,10 +8,13 @@ import java.io.StringReader
  * `var`/`val` (no modifier) parses as a local variable of the synthesized script body
  * (`top_level()`'s `LOOKAHEAD(2) top=block_element()` alternative in
  * grammar/JJOnionParser.jj wins over `var_decl()` for that input), so it never reaches
- * `TypingDuplicationPass` and two bare `var x` lines are ordinary local redeclaration,
- * not a duplicate-global error. `var_decl()` — and this E0011 check — is only reachable
- * when a modifier keyword (`static`, `final`, `internal`, ...) precedes `var`/`val` at
- * top level.
+ * `TypingDuplicationPass` — that check only sees the `AST.GlobalVariableDeclaration`
+ * node produced by a modifier-qualified top-level `var`/`val`.
+ *
+ * A bare top-level `var`/`val` is instead promoted to a `public static` field of the
+ * script's synthetic class by `TypingBodyPass.processTopLevelVarDeclaration`, so it is
+ * just as global as the modifier-qualified form. That method reports the duplicate
+ * itself (reusing E0011) when the field already exists.
  */
 class DuplicateGlobalVariableSpec extends AbstractShellSpec {
   private def errors(src: String): Seq[(Option[String], String)] = {
@@ -37,7 +40,7 @@ class DuplicateGlobalVariableSpec extends AbstractShellSpec {
       assert(results.map(_._1).contains(Some("E0011")))
     }
 
-    it("does not report E0011 for two bare top-level vars (they are script-local, not global)") {
+    it("reports E0011 for two bare top-level vars with the same name") {
       val results = errors(
         """
           |var x: Int = 1
@@ -48,7 +51,21 @@ class DuplicateGlobalVariableSpec extends AbstractShellSpec {
           |}
           |""".stripMargin
       )
-      assert(!results.map(_._1).contains(Some("E0011")))
+      assert(results.map(_._1).contains(Some("E0011")))
+    }
+
+    it("reports E0011 for a bare top-level val re-declared as a var") {
+      val results = errors(
+        """
+          |val x: Int = 1
+          |var x: Int = 2
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0011")))
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #445. A modifier-qualified top-level global (`static var x = ...` declared twice) already reports **E0011** via `TypingDuplicationPass`. A *bare* top-level `var`/`val` takes a different path — `TypingBodyPass.processTopLevelVarDeclaration` promotes it to a `public static` field of the script's synthetic class (so it's just as global) — and that path silently returned `None` when the field already existed.

Depending on the `var`/`val` mix, this either:
- let a second bare `var x` quietly shadow the first with **no diagnostic at all** (the original repro in #445), or
- misreported the unrelated **E0007** (duplicate local) when the first declaration was a `val` (an accidental side effect of the "local-first" promotion strategy for `val`).

Both cases now report **E0011**, consistent with the modifier-qualified form.

## Changes

- `TypingBodyPass.processTopLevelVarDeclaration`: report `DUPLICATE_GLOBAL_VARIABLE` (E0011) when the backing field already exists, instead of silently falling through.
- `DuplicateGlobalVariableSpec`: updated/added cases for two bare top-level `var`s and a `val` re-declared as a `var`.
- `CHANGELOG.md`: `[Unreleased]` entry.

## Test plan

- [x] New/updated unit tests in `DuplicateGlobalVariableSpec` (red before the fix, green after)
- [x] `DuplicateLocalVariableSpec` still green (no regression on the E0007 path)
- [x] Full suite: `sbt -Duser.language=en test` — 2813 succeeded, 0 failed, 1 canceled (pre-existing opt-in dist smoke test, unrelated)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Di1sHgkP6fMnc6XgayyFVj)_