### PR TITLE
test(diagnostics): assert E0071/E0072 by code, not just Failure(-1)

### DIFF
--- a/src/test/scala/onion/compiler/tools/AbstractMethodBodySpec.scala
+++ b/src/test/scala/onion/compiler/tools/AbstractMethodBodySpec.scala
@@ -1,6 +1,8 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * An explicitly `abstract` method with a body is rejected (E0072): the body would
@@ -8,6 +10,14 @@ import onion.tools.Shell
  * with no `abstract` keyword) and a bodiless abstract method are unaffected.
  */
 class AbstractMethodBodySpec extends AbstractShellSpec {
+  private def errorCodes(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.flatMap(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
   it("rejects an abstract method that has a body") {
     val result = shell.run(
       """
@@ -19,6 +29,18 @@ class AbstractMethodBodySpec extends AbstractShellSpec {
         | static def main(args: String[]): Int { return new I().foo() }
       """.stripMargin, "None", Array())
     assert(Shell.Failure(-1) == result)
+  }
+
+  it("reports the E0072 code specifically (not just a generic failure)") {
+    assert(errorCodes(
+      """
+        |abstract class B {
+        |public:
+        |  abstract def foo(): Int { return 99 }
+        |}
+        |class I extends B { public: override def foo(): Int = 1 }
+        |""".stripMargin
+    ).contains("E0072"))
   }
 
   it("allows a bodiless abstract method") {

--- a/src/test/scala/onion/compiler/tools/StaticCallOnInstanceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StaticCallOnInstanceSpec.scala
@@ -1,6 +1,8 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * `s::m()` where `s` is a local variable is the Java/Kotlin habit of using the
@@ -9,6 +11,14 @@ import onion.tools.Shell
  * static call on a type name is unaffected.
  */
 class StaticCallOnInstanceSpec extends AbstractShellSpec {
+  private def errorCodes(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.flatMap(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
   it("reports E0071 for :: on a local variable") {
     val result = shell.run(
       """
@@ -18,6 +28,20 @@ class StaticCallOnInstanceSpec extends AbstractShellSpec {
         | }
       """.stripMargin, "None", Array())
     assert(Shell.Failure(-1) == result)
+  }
+
+  it("reports the E0071 code specifically (not just a generic failure)") {
+    assert(errorCodes(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val s: String = "hi"
+        |    IO::println(s::length())
+        |  }
+        |}
+        |""".stripMargin
+    ).contains("E0071"))
   }
 
   it("still allows a genuine static call on a type") {


### PR DESCRIPTION
## Summary
- `StaticCallOnInstanceSpec` and `AbstractMethodBodySpec` only asserted `Shell.Failure(-1)` for the E0071 (`STATIC_CALL_ON_INSTANCE`) and E0072 (`ABSTRACT_METHOD_WITH_BODY`) diagnostics, so a regression that kept the compile failing but changed or dropped the specific error code would slip through unnoticed.
- Added an `errorCodes()` helper (`OnionCompiler.compile` + `CompilationOutcome.Failure`) to each spec, matching the locale-independent, code-asserting pattern already used by `LabelNotFoundSpec` and the other per-code coverage specs, and added one test per code asserting it appears in the diagnostics.
- No production code changes — test hardening only.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.StaticCallOnInstanceSpec onion.compiler.tools.AbstractMethodBodySpec'` — 8/8 green
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2815 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_019rYwiSTLb5y12wAZcyW9SN)_