### PR TITLE
docs(stdlib): fix Assert method names, add drift guard (#449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`docs/reference/stdlib.md` (EN+JA) and `CLAUDE.md` documented `Assert` methods that
+  do not exist (#449).** `Assert::assertTrue`/`assertFalse`/`assertEquals`/`assertNotEquals`/
+  `assertNotNull`/`assertNull` were never the real API — copying the example straight out
+  of the reference failed to compile with **E0005**. The real names (`isTrue`, `isFalse`,
+  `equals`, `notEquals`, `notNull`, `isNull`) are used everywhere else in the codebase; the
+  docs now match, and a new drift-guard spec (`AssertStdlibDocSpec`) checks the documented
+  names against `onion.Assert` via reflection so this can't rot silently again. Also
+  renamed the `Yaml` module's example record from `Config` to `ServerConfig` in
+  `stdlib.md`, since it shadowed the unrelated `onion.Config` module documented later in
+  the same file and was a likely source of the confusion.
 - **A duplicate bare top-level `var`/`val` went completely unreported (#445).** A
   modifier-qualified global (`static var x = ...` twice) already reported **E0011**, but
   a *bare* top-level `var`/`val` — which is promoted to a `public static` field of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ All phases extend `Processor[A, B]` trait and can be composed using `andThen()`:
 - `IO` - Console I/O (println, readLine)
 - `Strings` - String utilities
 - `Rand` - Random number generation (int, long, double, boolean, nextInt, shuffle)
-- `Assert` - Testing assertions (assertTrue, assertEquals, assertNotNull, fail)
+- `Assert` - Testing assertions (isTrue, equals, notNull, fail)
 - `Timing` - Time measurement (nanos, millis, measure, time, sleep)
 - `Files` - File operations
 - `DateTime` - Date/time utilities

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -315,17 +315,17 @@ Rand::shuffle(list)  // その場でシャッフル
 ### 基本アサーション
 
 ```onion
-Assert::assertTrue(x > 0)
-Assert::assertFalse(list.isEmpty())
-Assert::assertEquals(expected, actual)
-Assert::assertNotEquals(a, b)
+Assert::isTrue(x > 0)
+Assert::isFalse(list.isEmpty())
+Assert::equals(expected, actual)
+Assert::notEquals(a, b)
 ```
 
 ### Nullアサーション
 
 ```onion
-Assert::assertNotNull(result)
-Assert::assertNull(errorMessage)
+Assert::notNull(result)
+Assert::isNull(errorMessage)
 ```
 
 ### 明示的な失敗

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -737,17 +737,17 @@ Testing assertions via `onion.Assert`. Throws `AssertionError` on failure.
 ### Basic Assertions
 
 ```onion
-Assert::assertTrue(x > 0)
-Assert::assertFalse(list.isEmpty())
-Assert::assertEquals(expected, actual)
-Assert::assertNotEquals(a, b)
+Assert::isTrue(x > 0)
+Assert::isFalse(list.isEmpty())
+Assert::equals(expected, actual)
+Assert::notEquals(a, b)
 ```
 
 ### Null Assertions
 
 ```onion
-Assert::assertNotNull(result)
-Assert::assertNull(errorMessage)
+Assert::notNull(result)
+Assert::isNull(errorMessage)
 ```
 
 ### Explicit Failure
@@ -953,13 +953,13 @@ record; see [Records — derive!](specification.md#derive-record-serde-derivatio
 for the full contract.
 
 ```onion
-record Config(host: String, port: Int, debug: Boolean) derive!(Yaml)
+record ServerConfig(host: String, port: Int, debug: Boolean) derive!(Yaml)
 
-val cfg = new Config("localhost", 8080, false)
-val yaml = Config::toYaml(cfg)
+val cfg = new ServerConfig("localhost", 8080, false)
+val yaml = ServerConfig::toYaml(cfg)
 // "host: localhost\nport: 8080\ndebug: false\n"
 
-val cfg2 = Config::fromYaml(yaml)   // Config? — null on parse/convert failure
+val cfg2 = ServerConfig::fromYaml(yaml)   // ServerConfig? — null on parse/convert failure
 ```
 
 `derive!(Json, Yaml)` is also valid; both formats share the internal

--- a/src/test/scala/onion/compiler/tools/AssertStdlibDocSpec.scala
+++ b/src/test/scala/onion/compiler/tools/AssertStdlibDocSpec.scala
@@ -1,0 +1,58 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the `Assert` module docs (issue #449).
+ *
+ * `docs/reference/stdlib.md`, its Japanese copy, and `CLAUDE.md` documented
+ * `assertTrue`/`assertFalse`/`assertEquals`/`assertNotEquals`/`assertNotNull`/`assertNull`,
+ * none of which exist on `onion.Assert` (the real names are `isTrue`, `isFalse`, `equals`,
+ * `notEquals`, `notNull`, `isNull`). Every documented `Assert::name` is checked here
+ * against the actual public static method names via reflection, so a future rename on
+ * either side fails the build instead of silently rotting again.
+ */
+class AssertStdlibDocSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Assert::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] =
+    classOf[onion.Assert].getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == classOf[onion.Assert])
+      .map(_.getName)
+      .toSet
+
+  it("actual onion.Assert exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Assert found no static methods — the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents only Assert methods that actually exist") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = documented -- actualNames
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md documents Assert:: names not on onion.Assert: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents only Assert methods that actually exist") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = documented -- actualNames
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md documents Assert:: names not on onion.Assert: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("CLAUDE.md's Assert bullet names only methods that actually exist") {
+    val claudeMd = read("CLAUDE.md")
+    val bulletLine = claudeMd.linesIterator.find(_.contains("`Assert`")).getOrElse(
+      fail("CLAUDE.md no longer has an `Assert` bullet — update this guard"))
+    val named = """\b([a-zA-Z]+)\b""".r.findAllMatchIn(
+      bulletLine.substring(bulletLine.indexOf('('))).map(_.group(1)).toSet
+    val missing = named -- actualNames
+    assert(missing.isEmpty,
+      s"CLAUDE.md's Assert bullet names methods not on onion.Assert: ${missing.toSeq.sorted.mkString(", ")} (line: $bulletLine)")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md` (EN+JA) and `CLAUDE.md` documented `Assert::assertTrue`/`assertFalse`/`assertEquals`/`assertNotEquals`/`assertNotNull`/`assertNull`, none of which exist on `onion.Assert` — copying the example straight out of the reference failed to compile with **E0005**. Fixed to the real names: `isTrue`, `isFalse`, `equals`, `notEquals`, `notNull`, `isNull` (already used correctly everywhere else in the codebase, e.g. `AssertSpec.scala`).
- Renamed the `Yaml` module's example record in `stdlib.md` from `Config` to `ServerConfig`, since it shadowed the unrelated `onion.Config` stdlib module documented later in the same file — a likely source of the confusion in the original report.
- Added `AssertStdlibDocSpec`, a reflection-based drift guard (in the shape of `EffectTableStdlibCoverageSpec`/`QualityBarSpec`) that checks every documented `Assert::` name in both language copies of `stdlib.md` and in `CLAUDE.md` against `onion.Assert`'s real static methods, so this can't rot silently again.

Fixes #449 (the `Assert` portion; the `Config::toYaml`/`fromYaml` part of that issue was a misreading of a `derive!(Yaml)` example using an unfortunately-named local record, not a real API gap — confirmed by compiling the example — and is addressed by the rename above).

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.AssertStdlibDocSpec'` — red before the doc fix, green after
- [x] Manually compiled/ran the corrected `Assert::isTrue` and renamed `ServerConfig` derive!(Yaml) examples to confirm they work as documented
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2819/2819 passed (1 canceled, an environment-gated distribution smoke test unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_016h37oAjMRed3JDwVdpUeib)_