### PR TITLE
fix(runtime): report uncaught script errors without JDK/compiler plumbing (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A `--stacktrace` flag for `onion`** falls back to the full raw Java stack trace on
+  an uncaught runtime error, for when the JVM detail is what you actually want.
+
 ### Fixed
+
+- **An uncaught runtime error printed a raw Java stack trace, compiler internals
+  included (#450).** `println("" + (1 / 0))` used to surface as a bare
+  `ArithmeticException` with `aMain.start`/`aMain.main` wrapper frames the user never
+  wrote, a `jdk.internal.reflect` launcher chain, and even `onion.tools.Shell`/
+  `ScriptRunner` frames from the runner itself. `onion` now reports the error the way
+  its own diagnostics read: a friendly one-line header naming the failure in the
+  language's own vocabulary (division by zero, index out of range, null reference,
+  invalid type cast, ...), followed only by the script's own `file:line` frames — no
+  compiler or JDK plumbing. `StackOverflowError` gets a short explanatory note instead
+  of thousands of repeated frames (TCO covers only direct and mutual self-recursion, so
+  this is usually the cause). The full trace is one `--stacktrace` away.
 
 - **`docs/reference/stdlib.md` (EN+JA) and `CLAUDE.md` documented `Assert` methods that
   do not exist (#449).** `Assert::assertTrue`/`assertFalse`/`assertEquals`/`assertNotEquals`/

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -98,3 +98,12 @@ error.semantic.toolCapability.badParameter=`{0}` does not name a parameter of th
 error.semantic.shapeInstanceWithoutLaw=class `{0}` implements onion.Shape but nothing in its file asserts a law. Add a `law` or an `example` — the round-trip `s.parse(s.print(v)).get() == v` is the canonical one — so the claim is machine-checked.
 error.semantic.toolParameterNotCliConvertible=tool `{0}` cannot derive a command line: parameter `{1}` has type {2}, which cannot be read from an argument. Supported parameter types: {3}.
 error.semantic.duplicateToolName=duplicate tool name `{0}`. A tool is selected on the command line by name alone, so a second tool with the same name can never be invoked and the contract cannot address either one. Rename one of them.
+runtime.divisionByZero=division by zero
+runtime.indexOutOfRange=index out of range
+runtime.nullReference=null reference
+runtime.invalidCast=invalid type cast
+runtime.negativeArraySize=negative array size
+runtime.invalidNumberFormat=invalid number format
+runtime.stackOverflow=stack overflow — likely deep non-tail recursion (tail-call optimization only covers direct and mutual self-calls)
+runtime.generic={0}
+runtime.stacktraceHint=(run with --stacktrace to see the full Java stack trace)

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -98,3 +98,12 @@ error.semantic.toolCapability.badParameter=`{0}` はこの tool のパラメー�
 error.semantic.shapeInstanceWithoutLaw=クラス `{0}` は onion.Shape を実装していますが、このファイルには law がありません。`law` か `example` を追加してください — 代表は round-trip `s.parse(s.print(v)).get() == v` です。主張は機械検査されて初めて意味を持ちます。
 error.semantic.toolParameterNotCliConvertible=tool `{0}` はコマンドラインを導出できません: パラメータ `{1}` の型 {2} は引数から読み取れません。使える型: {3}。
 error.semantic.duplicateToolName=tool 名 `{0}` が重複しています。コマンドラインでは名前だけで tool を選ぶため、同名の2つ目は呼び出せず、契約からもどちらも指定できません。どちらかを改名してください。
+runtime.divisionByZero=ゼロ除算
+runtime.indexOutOfRange=範囲外のインデックスアクセス
+runtime.nullReference=null参照
+runtime.invalidCast=不正な型キャスト
+runtime.negativeArraySize=負の配列サイズ
+runtime.invalidNumberFormat=不正な数値フォーマット
+runtime.stackOverflow=スタックオーバーフロー — 末尾以外の深い再帰の可能性があります（末尾呼び出し最適化は直接・相互の自己呼び出しのみ対応）
+runtime.generic={0}
+runtime.stacktraceHint=(完全な Java スタックトレースを見るには --stacktrace を付けて実行してください)

--- a/src/main/scala/onion/tools/RuntimeErrorReporter.scala
+++ b/src/main/scala/onion/tools/RuntimeErrorReporter.scala
@@ -1,0 +1,75 @@
+/* ************************************************************** *
+ *                                                                *
+ * Copyright (c) 2016-, Kota Mizushima, All rights reserved.  *
+ *                                                                *
+ *                                                                *
+ * This software is distributed under the modified BSD License.   *
+ * ************************************************************** */
+package onion.tools
+
+import java.io.PrintStream
+import onion.compiler.toolbox.Message
+
+/**
+ * Formats an uncaught exception from a running script for a user who did not
+ * write the JVM plumbing around their code (see issue #450): the raw trace
+ * mixes the script's own frames with compiler-synthesized wrapper methods
+ * (`EntryPointSupport.createStartMethod`/`createMain`) and the reflective
+ * launcher (`Shell.run` invokes the compiled `main` via `Method.invoke`).
+ */
+object RuntimeErrorReporter {
+  /** Hardcoded synthetic wrapper method name every compiled script gets
+   *  (see `EntryPointSupport.createStartMethod`) — never user-authored. */
+  private val SyntheticStartMethod = "start"
+
+  /**
+   * The leading run of frames belonging to the script's own source file,
+   * with the compiler's synthetic wrapper frames removed: the `start`
+   * dispatcher (always synthetic) and any frame with no line number (the
+   * synthetic static JVM-entry `main` built by `EntryPointSupport.createMain`
+   * has a null `Location`, so it never gets one). Stops at the first frame
+   * from a different file — that's the reflective launcher and everything
+   * below it, none of which the user wrote.
+   */
+  private[tools] def relevantFrames(error: Throwable, scriptFileName: String): Seq[StackTraceElement] =
+    error.getStackTrace.toIndexedSeq
+      .takeWhile(f => f.getFileName != null && f.getFileName == scriptFileName)
+      .filterNot(f => f.getMethodName == SyntheticStartMethod || f.getLineNumber <= 0)
+
+  private def friendlyName(error: Throwable): String = error match {
+    case a: ArithmeticException if Option(a.getMessage).exists(_.contains("by zero")) =>
+      Message("runtime.divisionByZero")
+    case _: ArrayIndexOutOfBoundsException | _: StringIndexOutOfBoundsException | _: IndexOutOfBoundsException =>
+      Message("runtime.indexOutOfRange")
+    case _: NullPointerException =>
+      Message("runtime.nullReference")
+    case _: ClassCastException =>
+      Message("runtime.invalidCast")
+    case _: NegativeArraySizeException =>
+      Message("runtime.negativeArraySize")
+    case _: NumberFormatException =>
+      Message("runtime.invalidNumberFormat")
+    case other =>
+      Message("runtime.generic", other.getClass.getSimpleName)
+  }
+
+  /** Renders a short, script-relative report: a friendly one-line header
+   *  naming the failure the way the language's own diagnostics would,
+   *  the script's own stack frames (no compiler/JDK noise), and a hint
+   *  for recovering the full Java trace. */
+  def render(error: Throwable, scriptFileName: String): String = {
+    val nl = System.lineSeparator()
+    val hint = s"  ${Message("runtime.stacktraceHint")}"
+    if (error.isInstanceOf[StackOverflowError]) {
+      Seq(s"error: ${Message("runtime.stackOverflow")}", hint).mkString(nl)
+    } else {
+      val msg = Option(error.getMessage).filter(_.nonEmpty)
+      val header = msg.map(m => s"${friendlyName(error)}: $m").getOrElse(friendlyName(error))
+      val frameLines = relevantFrames(error, scriptFileName).map(f => s"  at ${f.getFileName}:${f.getLineNumber}")
+      (Seq(s"error: $header") ++ frameLines ++ Seq(hint)).mkString(nl)
+    }
+  }
+
+  def report(error: Throwable, scriptFileName: String, out: PrintStream = System.err): Unit =
+    out.println(render(error, scriptFileName))
+}

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -45,8 +45,30 @@ object ScriptRunner {
   }
 
   def main(args: Array[String]): Unit = {
-    val exitCode = runMain(args)
+    val exitCode = runMainCatching(args, err)
     if (exitCode != 0) System.exit(exitCode)
+  }
+
+  /**
+   * Same as `runMain`, except an exception thrown by the running script is
+   * caught and reported the way a user reads it — a friendly one-line
+   * header plus the script's own frames, no compiler/JDK plumbing (#450) —
+   * instead of propagating to the caller as a raw Throwable. `--stacktrace`
+   * opts back into the original behavior (rethrows, letting the caller print
+   * the full Java trace).
+   */
+  private[tools] def runMainCatching(args: Array[String], err: java.io.PrintStream): Int = {
+    val prefix = args.take(scriptIndex(args))
+    val rawStacktrace = prefix.exists(_ == "--stacktrace")
+    try {
+      runMain(args)
+    } catch {
+      case e: Throwable if !rawStacktrace =>
+        val si = scriptIndex(args)
+        val scriptFile = if (si < args.length) new java.io.File(args(si)).getName else ""
+        RuntimeErrorReporter.report(e, scriptFile, err)
+        1
+    }
   }
 
   def runMain(args: Array[String]): Int = {
@@ -64,7 +86,7 @@ object ScriptRunner {
     val verbose = prefix.exists(_ == "--verbose")
     val watch = prefix.exists(_ == "--watch")
     val si = scriptIndex(args)
-    val filteredArgs = args.take(si).filterNot(a => a == "--verbose" || a == "--watch") ++ args.drop(si)
+    val filteredArgs = args.take(si).filterNot(a => a == "--verbose" || a == "--watch" || a == "--stacktrace") ++ args.drop(si)
     if (watch) {
       runWatching(filteredArgs, verbose)
       return 0
@@ -256,6 +278,7 @@ class ScriptRunner {
          |  --no-check-laws             Do not execute record `law`/`example` clauses
          |  --law-seed <n>              RNG seed for law sample generation
          |  --law-samples <n>           Number of samples generated per law parameter
+         |  --stacktrace                Show the full Java stack trace on an uncaught error
          |  -h, --help                  Show this help message
          |  -v, --version               Show version information
          |

--- a/src/test/scala/onion/tools/RuntimeErrorReporterSpec.scala
+++ b/src/test/scala/onion/tools/RuntimeErrorReporterSpec.scala
@@ -1,0 +1,80 @@
+package onion.tools
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class RuntimeErrorReporterSpec extends AnyFunSuite with Matchers:
+
+  /** Build a Throwable whose stack trace mimics what the compiler actually
+   *  emits for `def main(): void { ... }` scripts (see EntryPointSupport):
+   *  the real frame, a synthetic `start` wrapper (has a line number), a
+   *  synthetic static `main` JVM entry (no line number), then JDK/harness
+   *  frames that must never reach the user. */
+  private def scriptLikeError(scriptFile: String): RuntimeException = {
+    val e = new RuntimeException("/ by zero")
+    e.setStackTrace(Array(
+      new StackTraceElement("aMain", "main", scriptFile, 2),
+      new StackTraceElement("aMain", "start", scriptFile, 1),
+      new StackTraceElement("aMain", "main", scriptFile, -1),
+      new StackTraceElement("java.lang.reflect.Method", "invoke", "Method.java", 580),
+      new StackTraceElement("onion.tools.Shell", "run", "Shell.scala", 60),
+      new StackTraceElement("onion.tools.ScriptRunner$", "main", "ScriptRunner.scala", 48)
+    ))
+    e
+  }
+
+  test("drops the synthetic start/no-line wrapper frames and everything past the script file") {
+    val frames = RuntimeErrorReporter.relevantFrames(scriptLikeError("a.on"), "a.on")
+    frames.map(f => (f.getMethodName, f.getLineNumber)) shouldBe Seq(("main", 2))
+  }
+
+  test("keeps multiple genuine same-file frames (real user call chain)") {
+    val e = new RuntimeException("boom")
+    e.setStackTrace(Array(
+      new StackTraceElement("aMain", "helper", "deep.on", 5),
+      new StackTraceElement("aMain", "main", "deep.on", 2),
+      new StackTraceElement("aMain", "start", "deep.on", 1),
+      new StackTraceElement("aMain", "main", "deep.on", -1),
+      new StackTraceElement("java.lang.reflect.Method", "invoke", "Method.java", 580)
+    ))
+    val frames = RuntimeErrorReporter.relevantFrames(e, "deep.on")
+    frames.map(_.getMethodName) shouldBe Seq("helper", "main")
+  }
+
+  test("renders a friendly header for division by zero, naming the language's own vocabulary") {
+    val e = new ArithmeticException("/ by zero")
+    e.setStackTrace(Array(new StackTraceElement("aMain", "main", "a.on", 2)))
+    val rendered = RuntimeErrorReporter.render(e, "a.on")
+    rendered should include("division by zero")
+    rendered should include("a.on:2")
+    rendered should include("--stacktrace")
+  }
+
+  test("renders a friendly header for array index out of bounds") {
+    val e = new ArrayIndexOutOfBoundsException("Index 3 out of bounds for length 2")
+    e.setStackTrace(Array(new StackTraceElement("aMain", "main", "a.on", 4)))
+    RuntimeErrorReporter.render(e, "a.on") should include("index out of range")
+  }
+
+  test("renders a friendly header for a null reference") {
+    val e = new NullPointerException()
+    e.setStackTrace(Array(new StackTraceElement("aMain", "main", "a.on", 7)))
+    RuntimeErrorReporter.render(e, "a.on") should include("null reference")
+  }
+
+  test("StackOverflowError gets a short explanatory message, not thousands of frames") {
+    val e = new StackOverflowError()
+    e.setStackTrace(Array.fill(2000)(new StackTraceElement("aMain", "recurse", "so.on", 3)))
+    val rendered = RuntimeErrorReporter.render(e, "so.on")
+    rendered should include("stack overflow")
+    rendered should include("recursion")
+    rendered.linesIterator.size should be < 10
+  }
+
+  test("unknown exception types fall back to the class's simple name") {
+    class WeirdException(msg: String) extends RuntimeException(msg)
+    val e = new WeirdException("odd")
+    e.setStackTrace(Array(new StackTraceElement("aMain", "main", "a.on", 9)))
+    RuntimeErrorReporter.render(e, "a.on") should include("WeirdException")
+    RuntimeErrorReporter.render(e, "a.on") should include("odd")
+  }

--- a/src/test/scala/onion/tools/ScriptRunnerRuntimeErrorSpec.scala
+++ b/src/test/scala/onion/tools/ScriptRunnerRuntimeErrorSpec.scala
@@ -1,0 +1,81 @@
+package onion.tools
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** End-to-end coverage for #450: an uncaught runtime error must read like an
+ *  Onion diagnostic, not a raw Java stack trace dump. */
+class ScriptRunnerRuntimeErrorSpec extends AnyFunSuite with Matchers:
+
+  private def captureErr(args: Array[String]): (Int, String) = {
+    val buffer = new ByteArrayOutputStream()
+    val err = new PrintStream(buffer, true, StandardCharsets.UTF_8)
+    val exitCode = ScriptRunner.runMainCatching(args, err)
+    (exitCode, buffer.toString(StandardCharsets.UTF_8))
+  }
+
+  test("an uncaught division by zero is reported without JDK/compiler plumbing") {
+    val source = Files.createTempFile("onion-runtime-err", ".on")
+    Files.writeString(
+      source,
+      """def main(): void {
+        |  println("" + (1 / 0))
+        |}
+        |""".stripMargin,
+      StandardCharsets.UTF_8
+    )
+
+    val (exitCode, stderr) = captureErr(Array(source.toString))
+
+    exitCode shouldBe 1
+    stderr should include("division by zero")
+    stderr should include(s"${source.getFileName}:2")
+    stderr should include("--stacktrace")
+    stderr should not include "jdk.internal.reflect"
+    stderr should not include "onion.tools.Shell"
+    stderr should not include "java.lang.reflect.Method"
+  }
+
+  test("--stacktrace opts back into the raw exception (unwrapped, uncaught)") {
+    val source = Files.createTempFile("onion-runtime-err-raw", ".on")
+    Files.writeString(
+      source,
+      """def main(): void {
+        |  println("" + (1 / 0))
+        |}
+        |""".stripMargin,
+      StandardCharsets.UTF_8
+    )
+
+    val buffer = new ByteArrayOutputStream()
+    val err = new PrintStream(buffer, true, StandardCharsets.UTF_8)
+    intercept[ArithmeticException] {
+      ScriptRunner.runMainCatching(Array("--stacktrace", source.toString), err)
+    }
+  }
+
+  test("a deep non-tail recursion reports stack overflow concisely, not thousands of frames") {
+    val source = Files.createTempFile("onion-runtime-err-so", ".on")
+    Files.writeString(
+      source,
+      """def boom(n: Int): Int {
+        |  return 1 + boom(n + 1)
+        |}
+        |def main(): void {
+        |  println("" + boom(0))
+        |}
+        |""".stripMargin,
+      StandardCharsets.UTF_8
+    )
+
+    val (exitCode, stderr) = captureErr(Array(source.toString))
+
+    exitCode shouldBe 1
+    stderr should include("stack overflow")
+    stderr.linesIterator.size should be < 10
+  }


### PR DESCRIPTION
## Summary

- Closes #450. An uncaught runtime error (e.g. `println("" + (1 / 0))`) used to surface as a bare Java stack trace mixing the user's own script frames with compiler-synthesized wrapper frames (`EntryPointSupport`'s `start`/`main`), the reflective launcher (`jdk.internal.reflect`, `Method.invoke`), and even `onion.tools.Shell`/`ScriptRunner`'s own frames.
- `onion` now prints a short, friendly report: a one-line header naming the failure in the language's own vocabulary (division by zero, index out of range, null reference, invalid type cast, negative array size, invalid number format), followed only by the script's own `file:line` frames — no compiler or JDK noise.
- `StackOverflowError` gets a short explanatory note (deep non-tail recursion — TCO only covers direct/mutual self-calls) instead of thousands of repeated frames.
- New `--stacktrace` runner flag opts back into the original raw-trace behavior for debugging.
- New bilingual (`errorMessage.properties` / `_ja`) message keys under `runtime.*`, consistent with how compile-time diagnostics are localized.
- `ScriptRunner.runMain`'s existing behavior (rethrows the script's raw cause) is untouched — a new `runMainCatching` wraps it for `main()`'s use, keeping the existing `OnionCliSpec` "unwraps exceptions" test valid as-is.

Out of scope (left for follow-up, per the issue's own note): `Json$JsonParseException` reporting a line/column instead of a raw character offset — a separate, smaller thread the issue calls out on its own.

## Test plan

- [x] New unit tests: `RuntimeErrorReporterSpec` (frame filtering of synthetic `start`/no-line frames, friendly headers per exception type, `StackOverflowError` shortening, unknown-type fallback)
- [x] New integration tests: `ScriptRunnerRuntimeErrorSpec` (real compiled scripts: division-by-zero report has no JDK/Shell/reflection frames; `--stacktrace` rethrows the raw exception; deep non-tail recursion reports concisely)
- [x] Existing `OnionCliSpec` "ScriptRunner runMain unwraps exceptions thrown by a script" test still passes unchanged
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2829 tests, 0 failed, 1 canceled (pre-existing, unrelated), all green

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UVMCnEPoXkXiTiPvtw7VFD)_