### PR TITLE
fix: present uncaught runtime errors as diagnostics, and guard the stdlib docs (#450, #449 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **An uncaught runtime error is now presented like a diagnostic (#450).** It used to
+  reach the JVM's default handler, which printed the synthesized `start`/`main`
+  wrappers, the reflective launcher, and — for a `StackOverflowError` — thousands of
+  identical frames. A script error now reads:
+
+  ```
+  a.on:2: error: division by zero
+    (run with --stacktrace for the full JVM trace)
+  ```
+
+  Frames the user did not write are dropped, the failure is named in the language's own
+  vocabulary where there is one (`division by zero`, `array index out of range`, `null
+  value used`), the call path is shown but capped with a count of what was elided, and a
+  stack overflow explains what it usually means (non-terminating recursion, or recursion
+  deeper than the JVM stack — TCO covers direct and mutual self-calls only). The exit
+  code is unchanged, and **`--stacktrace`** restores the untouched trace.
+
+### Fixed
+
+- **`Rand`'s methods were documented under old names in the Japanese reference and in
+  `CLAUDE.md` (#449 follow-up):** `Rand::int`/`long`/`double`/`boolean` do not exist —
+  the names are `nextInt`, `nextLong`, `nextDouble`, `nextBoolean`, as the English
+  reference already said.
+
+### Added
+
+- **A drift guard for the whole standard-library reference (#449).**
+  `AssertStdlibDocSpec` covered `Assert` after every documented name on that class
+  turned out to be wrong; `StdlibDocDriftSpec` now checks *every* `Class::method` in
+  both copies of `stdlib.md`, and the module list in `CLAUDE.md`, against the real
+  classes by reflection. It found the `Rand` drift above on its first run. Aliases
+  (`JInteger`, …), JDK types and example-local record types are excluded by an explicit
+  list, since those are the false positives that made the original `Assert` breakage
+  hard to see.
+
 ### Fixed
 
 - **`docs/reference/stdlib.md` (EN+JA) and `CLAUDE.md` documented `Assert` methods that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Onion is a statically-typed, object-oriented programming language that compiles 
 - `--Wno <codes>` - Suppress specific warnings (e.g., W0001,unused-parameter)
 - `--no-check-laws` - Do not execute record `law`/`example` clauses (they run at compile time by default; the LSP always has them off)
 - `--law-seed <n>` / `--law-samples <n>` - Control law sampling; a falsified law reports the settings that produced its counterexample
+- `--stacktrace` - Print the raw JVM trace for an uncaught runtime error (the default is a diagnostic-style report with the script's own frames only)
 
 ## High-Level Architecture
 
@@ -151,7 +152,7 @@ All phases extend `Processor[A, B]` trait and can be composed using `andThen()`:
 **Standard Library** (`src/main/java/onion/`):
 - `IO` - Console I/O (println, readLine)
 - `Strings` - String utilities
-- `Rand` - Random number generation (int, long, double, boolean, nextInt, shuffle)
+- `Rand` - Random number generation (nextInt, nextLong, nextDouble, nextBoolean, shuffle, uuid)
 - `Assert` - Testing assertions (isTrue, equals, notNull, fail)
 - `Timing` - Time measurement (nanos, millis, measure, time, sleep)
 - `Files` - File operations

--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -10,7 +10,7 @@
 
 | # | 次元 | 測定方法 | 現在値（2026-07-27） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2800 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2832 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 64 / 64 compile | すべてコンパイル、rot なし |
 | 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 7（BrokenLogDemo、OrderReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager、ToolDemo） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -274,18 +274,18 @@ val result: Int = add.call(3, 7)
 
 `onion.Rand`による乱数生成ユーティリティ。
 
-### Rand::int / Rand::long / Rand::double
+### Rand::nextInt / nextLong / nextDouble / nextBoolean
 
 乱数を生成：
 
 ```onion
-val randomInt: Int = Rand::int()           // ランダムなInt
-val randomLong: Long = Rand::long()        // ランダムなLong
-val randomDouble: Double = Rand::double()  // 0.0から1.0
-val randomBool: Boolean = Rand::boolean()  // ランダムなBoolean
+val randomInt: Int = Rand::nextInt()            // ランダムなInt
+val randomLong: Long = Rand::nextLong()         // ランダムなLong
+val randomDouble: Double = Rand::nextDouble()   // 0.0から1.0
+val randomBool: Boolean = Rand::nextBoolean()   // ランダムなBoolean
 ```
 
-### Rand::nextInt
+### Rand::nextInt（範囲指定）
 
 範囲内の乱数整数を生成：
 

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -13,7 +13,7 @@ had already drifted after the effect-table / tool-capability / tool-contracts wo
 
 | # | Dimension | How to measure | Current (2026-07-27) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2800 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2832 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 64 / 64 compile | all compile, no rot |
 | 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 7 (BrokenLogDemo, OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager, ToolDemo) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |

--- a/src/main/scala/onion/tools/RuntimeErrorReporter.scala
+++ b/src/main/scala/onion/tools/RuntimeErrorReporter.scala
@@ -1,0 +1,127 @@
+package onion.tools
+
+/**
+ * Presents an uncaught runtime error the way the compiler presents a diagnostic
+ * (issue #450).
+ *
+ * Letting the exception reach the JVM's default handler printed frames the user never
+ * wrote and cannot act on — the synthesized `start`/`main` wrappers, the reflective
+ * launcher, and for a `StackOverflowError` thousands of identical lines. Compile-time
+ * diagnostics were polished repeatedly; this is the same information rendered with the
+ * same care.
+ *
+ * Nothing here changes what is thrown or the exit code: it is presentation only, and
+ * `--stacktrace` restores the untouched trace for when the JVM detail is the point.
+ */
+object RuntimeErrorReporter {
+
+  private val hiddenPrefixes = Seq(
+    "java.base/", "java.", "jdk.", "sun.", "scala.",
+    "onion.tools.", "onion.compiler."
+  )
+
+  /**
+   * A short, human-readable name for the failure, or `None` when the exception has no
+   * better name than its own. Kept deliberately small: a wrong friendly name is worse
+   * than a class name the user can search for.
+   */
+  private def friendlyName(t: Throwable): Option[String] = t match {
+    case _: ArithmeticException if isDivideByZero(t) => Some("division by zero")
+    case _: ArrayIndexOutOfBoundsException           => Some("array index out of range")
+    case _: StringIndexOutOfBoundsException          => Some("string index out of range")
+    case _: IndexOutOfBoundsException                => Some("index out of range")
+    case _: NullPointerException                     => Some("null value used")
+    case _: ClassCastException                       => Some("invalid cast")
+    case _: NumberFormatException                    => Some("malformed number")
+    case _: StackOverflowError                       => Some("stack overflow")
+    case _: OutOfMemoryError                         => Some("out of memory")
+    case _                                           => None
+  }
+
+  private def isDivideByZero(t: Throwable): Boolean =
+    Option(t.getMessage).exists(_.contains("zero"))
+
+  /** Extra context worth saying once, where the plain message leaves a user stuck. */
+  private def note(t: Throwable): Option[String] = t match {
+    case _: StackOverflowError =>
+      Some("this usually means recursion that does not terminate, or recursion too " +
+           "deep to run on the JVM stack. Tail-call optimization applies to direct " +
+           "and mutual self-recursion only.")
+    case _: NullPointerException =>
+      Some("a nullable value (`T?`) was used without a null check, or a Java method " +
+           "returned null where a value was expected.")
+    case _ => None
+  }
+
+  /**
+   * Whether a stack frame is one the user's own source produced.
+   *
+   * A script compiles to `<name>Main` with a synthesized `start` wrapper and a
+   * `main(String[])` entry point around the user's top level, so those frames repeat
+   * the same file with either no line number or the line of the top-level statement
+   * that started everything. Drop the ones carrying no position; keep the rest, since
+   * for a script whose body IS `main` the useful line lives there.
+   */
+  private def isUserFrame(f: StackTraceElement): Boolean = {
+    val cls = f.getClassName
+    if (hiddenPrefixes.exists(cls.startsWith)) return false
+    if (f.getFileName == null || !f.getFileName.endsWith(".on")) return false
+    if (f.getLineNumber <= 0) return false
+    // `start` is purely a wrapper; its line points at the top of the file.
+    !(cls.endsWith("Main") && f.getMethodName == "start")
+  }
+
+  /**
+   * Renders `t` for an end user. `scriptName` is used only when no frame carries a
+   * position, so the message still says which script failed.
+   */
+  def render(t: Throwable, scriptName: String): String = {
+    val sb = new StringBuilder
+    val headline = friendlyName(t) match {
+      case Some(name) => name
+      case None       => simpleName(t)
+    }
+    val message = Option(t.getMessage).filter(_.nonEmpty)
+
+    val frames = t.getStackTrace.filter(isUserFrame)
+    val where = frames.headOption
+      .map(f => s"${f.getFileName}:${f.getLineNumber}")
+      .getOrElse(scriptName)
+
+    sb.append(s"$where: error: $headline")
+    // Only add the JVM's own message when it says something the headline does not —
+    // "division by zero: / by zero" helps nobody.
+    message.foreach { m =>
+      val normalized = m.toLowerCase.replace("/", "").trim
+      val covered = friendlyName(t).exists(n => normalized.split("\\s+").forall(n.contains))
+      if (!covered) sb.append(s": $m")
+    }
+    sb.append('\n')
+
+    // The frames below the first are the call path that reached it; a stack overflow
+    // repeats them endlessly, so cap it and say so.
+    val rest = frames.drop(1)
+    val shown = rest.take(10)
+    shown.foreach { f =>
+      sb.append(s"  called from ${f.getFileName}:${f.getLineNumber} (${f.getMethodName})\n")
+    }
+    if (rest.length > shown.length) {
+      sb.append(s"  ... and ${rest.length - shown.length} more frames\n")
+    }
+
+    note(t).foreach(n => sb.append(s"  note: $n\n"))
+    if (frames.isEmpty) {
+      sb.append("  note: the failure happened outside the script's own code; " +
+                "run with --stacktrace for the full trace.\n")
+    } else {
+      sb.append("  (run with --stacktrace for the full JVM trace)\n")
+    }
+    sb.toString
+  }
+
+  private def simpleName(t: Throwable): String = {
+    val n = t.getClass.getName
+    val short = n.substring(n.lastIndexOf('.') + 1).replace('$', '.')
+    short
+  }
+}

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -69,13 +69,21 @@ object ScriptRunner {
       runWatching(filteredArgs, verbose)
       return 0
     }
+    // An uncaught runtime error used to be rethrown so the JVM's default handler
+    // printed it, which meant synthesized wrappers and launcher frames the user never
+    // wrote (issue #450). Render it like a diagnostic instead; --stacktrace keeps the
+    // untouched trace for when the JVM detail is the point.
+    val wantTrace = prefix.exists(_ == STACKTRACE)
     try {
-      new ScriptRunner().run(filteredArgs, verbose)
+      new ScriptRunner().run(filteredArgs.filterNot(_ == STACKTRACE), verbose)
     }
     catch {
-      case e: ScriptException => {
-        throw e.getCause
-      }
+      case e: ScriptException =>
+        val cause = e.getCause
+        if (wantTrace) throw cause
+        val script = args.lift(scriptIndex(args)).getOrElse("<script>")
+        System.err.print(RuntimeErrorReporter.render(cause, script))
+        1
     }
   }
 
@@ -148,6 +156,7 @@ object ScriptRunner {
   private final val LAW_SEED: String = "--law-seed"
   private final val LAW_SAMPLES: String = "--law-samples"
   private final val SHOW_EFFECTS: String = "--effects"
+  private final val STACKTRACE: String = "--stacktrace"
   private final val DEFAULT_CLASSPATH: Array[String] = Array[String](".")
   private final val DEFAULT_ENCODING: String = System.getProperty("file.encoding")
   private final val DEFAULT_MAX_ERROR: Int = 10

--- a/src/test/scala/onion/compiler/tools/StdlibDocDriftSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocDriftSpec.scala
@@ -1,0 +1,100 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the whole standard-library reference (issue #449).
+ *
+ * `AssertStdlibDocSpec` covers `Assert` specifically, after every documented name on
+ * that class turned out to be wrong. The same rot can happen to any of the ~30 stdlib
+ * classes, so this checks all of them: every `Class::method` written in
+ * `docs/reference/stdlib.md` and its Japanese copy must exist as a public member of
+ * the corresponding `onion.*` class.
+ *
+ * Two categories are deliberately excluded, because they are not `onion.*` members and
+ * a naive scan reports them as missing (which is exactly the false positive that made
+ * the real `Assert` breakage hard to spot):
+ *
+ *   - **import aliases** — `JInteger`, `JLong`, … name `java.lang` types
+ *   - **JDK classes** reachable by default (`Math`, `System`, `Thread`, …)
+ *
+ * Methods synthesized on a user's own record by `derive!` (`toYaml`, `fromJson`, …) are
+ * documented on the *user's* type, not on an `onion.*` class, so they never reach the
+ * check.
+ */
+class StdlibDocDriftSpec extends AnyFunSpec {
+
+  /** Names in `Class::member` position that are not `onion.*` standard-library types. */
+  private val notStdlibClasses = Set(
+    // import aliases for java.lang wrappers
+    "JInteger", "JLong", "JDouble", "JFloat", "JShort", "JByte", "JBoolean", "JCharacter",
+    "JString", "JObject",
+    // JDK types usable without an onion.* counterpart
+    "Math", "System", "Thread", "Runtime", "Integer", "Long", "Double", "Float",
+    "Short", "Byte", "Boolean", "Character", "String", "Object", "Class", "Arrays",
+    "Collections", "Objects", "Optional", "Pattern", "Matcher", "StringBuilder",
+    "LocalDate", "LocalDateTime", "Duration", "Instant", "BigInteger", "BigDecimal",
+    // record types defined by the examples themselves; `derive!` synthesizes
+    // `toJson`/`fromYaml`/… onto the USER's type, not onto an onion.* class
+    "ServerConfig", "User", "Point", "Person", "Pt"
+  )
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  /** `Class::member` occurrences, restricted to classes that exist under `onion.`. */
+  private def documentedCalls(doc: String): Set[(String, String)] =
+    """\b([A-Z][A-Za-z0-9]*)::([a-zA-Z][A-Za-z0-9_]*)""".r
+      .findAllMatchIn(doc)
+      .map(m => (m.group(1), m.group(2)))
+      .filterNot { case (cls, _) => notStdlibClasses.contains(cls) }
+      .toSet
+
+  /** Public member names (methods and fields) of `onion.<name>`, or None if absent. */
+  private def membersOf(simpleName: String): Option[Set[String]] =
+    try {
+      val c = Class.forName(s"onion.$simpleName")
+      Some(c.getMethods.map(_.getName).toSet ++ c.getFields.map(_.getName).toSet)
+    } catch {
+      case _: ClassNotFoundException => None
+    }
+
+  private def check(path: String): Unit = {
+    val calls = documentedCalls(read(path))
+    assert(calls.nonEmpty, s"no Class::method occurrences found in $path — the scan has rotted")
+
+    val unknownClasses = calls.map(_._1).filter(membersOf(_).isEmpty)
+    assert(unknownClasses.isEmpty,
+      s"$path documents these as `Class::…` but no `onion.<Class>` exists (add them to " +
+      s"notStdlibClasses if they are aliases or JDK types): ${unknownClasses.toSeq.sorted.mkString(", ")}")
+
+    val missing = calls.collect {
+      case (cls, m) if membersOf(cls).exists(!_.contains(m)) => s"$cls::$m"
+    }
+    assert(missing.isEmpty,
+      s"$path documents members that do not exist: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("every stdlib call documented in the English reference exists") {
+    check("docs/reference/stdlib.md")
+  }
+
+  it("every stdlib call documented in the Japanese reference exists") {
+    check("docs/ja/reference/stdlib.md")
+  }
+
+  it("CLAUDE.md's stdlib summary names real classes") {
+    // CLAUDE.md lists the modules in prose rather than as `Class::method`, so only the
+    // class names are checkable — which is what went wrong there for Assert.
+    // Only the "Standard Library" bullet list — the surrounding sections list compiler
+    // internals (BasicType, ClassType, …), which are not onion.* stdlib classes.
+    val lines = read("CLAUDE.md").linesIterator.toSeq
+    val start = lines.indexWhere(_.contains("**Standard Library**"))
+    assert(start >= 0, "CLAUDE.md has no Standard Library section — the scan has rotted")
+    val section = lines.drop(start + 1).takeWhile(_.trim.startsWith("- `"))
+    assert(section.nonEmpty, "the Standard Library section listed no modules")
+    val named = section.flatMap("""- `([A-Z][A-Za-z0-9]*)`""".r.findFirstMatchIn(_).map(_.group(1)))
+    val unknown = named.filter(n => !notStdlibClasses.contains(n) && membersOf(n).isEmpty)
+    assert(unknown.isEmpty, s"CLAUDE.md names stdlib modules that do not exist: ${unknown.mkString(", ")}")
+  }
+}

--- a/src/test/scala/onion/tools/OnionCliSpec.scala
+++ b/src/test/scala/onion/tools/OnionCliSpec.scala
@@ -319,7 +319,7 @@ class OnionCliSpec extends AnyFunSuite with Matchers:
     stdout.toString(StandardCharsets.UTF_8) should include("Usage: onion [options] <source_file>")
     stdout.toString(StandardCharsets.UTF_8) should include(s"Onion Script Runner version ${ScriptRunner.VERSION}")
 
-  test("ScriptRunner runMain unwraps exceptions thrown by a script"):
+  test("ScriptRunner runMain reports a script's exception instead of rethrowing it"):
     val source = Files.createTempFile("onion-cli-throws", ".on")
     Files.writeString(
       source,
@@ -333,8 +333,24 @@ class OnionCliSpec extends AnyFunSuite with Matchers:
       StandardCharsets.UTF_8
     )
 
-    val thrown = intercept[RuntimeException] {
-      ScriptRunner.runMain(Array("--verbose", "--Wno", "unused-parameter", source.toString))
-    }
+    // Since #450 an uncaught runtime error is rendered like a diagnostic and the exit
+    // code carries the failure; rethrowing it made the JVM print synthesized wrappers
+    // and launcher frames the user never wrote. `--stacktrace` keeps the old behavior.
+    val err = new java.io.ByteArrayOutputStream()
+    val savedErr = System.err
+    val exit =
+      try {
+        System.setErr(new java.io.PrintStream(err, true, "UTF-8"))
+        ScriptRunner.runMain(Array("--verbose", "--Wno", "unused-parameter", source.toString))
+      } finally System.setErr(savedErr)
 
-    thrown.getMessage shouldBe "boom"
+    exit shouldBe 1
+    val text = new String(err.toByteArray, StandardCharsets.UTF_8)
+    text should include("boom")
+    text should include("--stacktrace")
+
+    val rethrown = intercept[RuntimeException] {
+      ScriptRunner.runMain(
+        Array("--verbose", "--stacktrace", "--Wno", "unused-parameter", source.toString))
+    }
+    rethrown.getMessage shouldBe "boom"

--- a/src/test/scala/onion/tools/RuntimeErrorReporterSpec.scala
+++ b/src/test/scala/onion/tools/RuntimeErrorReporterSpec.scala
@@ -1,0 +1,106 @@
+package onion.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Runtime errors are presented like diagnostics (issue #450): the position the user
+ * can act on, frames they actually wrote, a name in the language's own vocabulary, and
+ * an escape hatch to the untouched JVM trace.
+ */
+class RuntimeErrorReporterSpec extends AnyFunSpec {
+
+  /** A throwable carrying a stack trace shaped like a real compiled script's. */
+  private def withTrace(t: Throwable, frames: (String, String, String, Int)*): Throwable = {
+    t.setStackTrace(frames.map { case (cls, method, file, line) =>
+      new StackTraceElement(cls, method, file, line)
+    }.toArray)
+    t
+  }
+
+  private val scriptFrames = Seq(
+    ("aMain", "main", "a.on", 2),
+    ("aMain", "start", "a.on", 1),      // synthesized wrapper
+    ("aMain", "main", "a.on", -1),      // synthesized entry, no position
+    ("jdk.internal.reflect.DirectMethodHandleAccessor", "invoke", "X.java", 104),
+    ("java.lang.reflect.Method", "invoke", "Method.java", 565)
+  )
+
+  describe("what the user is shown") {
+    it("leads with the position of the first frame they wrote") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new ArithmeticException("/ by zero"), scriptFrames: _*), "a.on")
+      assert(out.startsWith("a.on:2: error:"), out)
+    }
+
+    it("names the failure in the language's vocabulary, not the JVM class") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new ArithmeticException("/ by zero"), scriptFrames: _*), "a.on")
+      assert(out.contains("division by zero"), out)
+      assert(!out.contains("ArithmeticException"), out)
+    }
+
+    it("does not repeat the JVM message when the headline already says it") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new ArithmeticException("/ by zero"), scriptFrames: _*), "a.on")
+      assert(!out.contains("division by zero: / by zero"), out)
+    }
+
+    it("keeps a JVM message that adds information") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new ArrayIndexOutOfBoundsException("Index 5 out of bounds for length 2"),
+          ("bMain", "main", "b.on", 3)), "b.on")
+      assert(out.contains("array index out of range"), out)
+      assert(out.contains("Index 5 out of bounds for length 2"), out)
+    }
+
+    it("hides synthesized wrappers and everything below the launcher") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new ArithmeticException("/ by zero"), scriptFrames: _*), "a.on")
+      assert(!out.contains("start"), out)
+      assert(!out.contains("DirectMethodHandleAccessor"), out)
+      assert(!out.contains("Method.java"), out)
+    }
+
+    it("shows the call path, capped, saying how many were dropped") {
+      val deep = (1 to 40).map(i => ("cMain", if (i % 2 == 0) "g" else "f", "c.on", i % 2 + 1))
+      val out = RuntimeErrorReporter.render(
+        withTrace(new StackOverflowError(), deep: _*), "c.on")
+      assert(out.contains("called from c.on:"), out)
+      assert(out.contains("more frames"), out)
+      assert(out.linesIterator.count(_.contains("called from")) <= 10, out)
+    }
+
+    it("explains a stack overflow instead of just naming it") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new StackOverflowError(), ("cMain", "f", "c.on", 1)), "c.on")
+      assert(out.contains("stack overflow"), out)
+      assert(out.contains("tail-call optimization") || out.contains("Tail-call optimization"), out)
+    }
+
+    it("points at --stacktrace") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new RuntimeException("boom"), ("aMain", "main", "a.on", 2)), "a.on")
+      assert(out.contains("--stacktrace"), out)
+    }
+  }
+
+  describe("failures with nothing of the user's in the trace") {
+    it("falls back to the script name and says why there is no position") {
+      val out = RuntimeErrorReporter.render(
+        withTrace(new RuntimeException("internal"),
+          ("java.util.ArrayList", "get", "ArrayList.java", 10)), "z.on")
+      assert(out.startsWith("z.on: error:"), out)
+      assert(out.contains("outside the script's own code"), out)
+    }
+  }
+
+  describe("an exception with no friendly name") {
+    it("uses the simple class name rather than inventing one") {
+      class WeirdProblem(msg: String) extends RuntimeException(msg)
+      val out = RuntimeErrorReporter.render(
+        withTrace(new WeirdProblem("odd"), ("aMain", "main", "a.on", 5)), "a.on")
+      assert(out.contains("WeirdProblem"), out)
+      assert(out.contains("odd"), out)
+    }
+  }
+}


### PR DESCRIPTION
## #450 — runtime errors

Before, an uncaught error reached the JVM's default handler:

```
Exception in thread "main" java.lang.ArithmeticException: / by zero
	at aMain.main(a.on:2)
	at aMain.start(a.on:1)          ← synthesized wrapper
	at aMain.main(a.on)             ← synthesized entry
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(...)
	...
```

After:

```
a.on:2: error: division by zero
  (run with --stacktrace for the full JVM trace)
```

- Frames the user did not write are dropped; the position they can act on leads.
- Named in the language's vocabulary where one exists (`division by zero`, `array index out of range`, `null value used`, `invalid cast`, `stack overflow`).
- The JVM message is appended **only when it adds something** — `division by zero: / by zero` cannot happen, while `array index out of range: Index 5 out of bounds for length 2` keeps the useful part.
- The call path is shown, capped at 10 with a count of the rest — a `StackOverflowError` used to print thousands of identical lines.
- `StackOverflowError` explains what it usually means, naming TCO's actual limits.
- **Exit code unchanged**; `--stacktrace` restores the untouched trace. `OnionCliSpec`'s existing "unwraps exceptions" test now pins *both* halves of the contract.

## #449 follow-up — a general stdlib doc guard

`AssertStdlibDocSpec` covered `Assert` after every documented name on it turned out wrong. `StdlibDocDriftSpec` generalizes that to **every** `Class::method` in both copies of `stdlib.md` plus `CLAUDE.md`'s module list, resolved by reflection.

**It found real drift on its first run:** `Rand::int` / `long` / `double` / `boolean` in the Japanese reference and in `CLAUDE.md` — the actual names are `nextInt`/`nextLong`/`nextDouble`/`nextBoolean`, which the English reference already had right. Fixed here.

Aliases (`JInteger`…), JDK types and example-local records are excluded by an explicit list — those false positives are exactly what made the original `Assert` breakage hard to spot.

## Tests

**2832 green in both locales.** 10 new cases for the reporter (position, vocabulary, no message duplication, wrapper hiding, capped path, overflow note, `--stacktrace` pointer, no-user-frames fallback, unknown exception) and 3 for the doc guard.

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)