### PR TITLE
fix(typing): constructor diamond infers a supertype's type argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A generic ADT enum's singleton case rejected the expected-type constructor
+  diamond.** `val o: Opt[String] = new Nothing()` reported `Nothing` as a raw
+  type (`E0066`) even though the declared type fully determines its type
+  argument — `Nothing` conforms to `Opt[T]` in `enum Opt[T] { case Some(value:
+  T); case Nothing }` by passing its own type parameter straight through. The
+  existing constructor-diamond inference (`val b: Box[String] = new Box("x")`)
+  only matched when the constructed class was exactly the expected type's
+  class, not a subtype of it, so any zero-arg case of a generic sum type
+  needed explicit type arguments (`new Nothing[String]()`) even when the
+  target's declared type already pinned them. The same gap applied to a
+  hand-written `record Empty[T]() conforms Box[T]`.
+
 ## [0.10.5] - 2026-07-28
 
 ### Changed

--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -137,16 +137,53 @@ final class ConstructionTyping(
     expected match {
       case exp: AppliedClassType =>
         typing.mapFrom(node.typeRef) match {
-          case Some(raw: ClassType)
-            if !raw.isInstanceOf[AppliedClassType]
-              && raw.typeParameters.nonEmpty
-              && TypeRelations.sameClass(raw, exp.raw)
-              && exp.typeArguments.length == raw.typeParameters.length =>
-            Some(AppliedClassType(raw, exp.typeArguments.toList))
+          case Some(raw: ClassType) if !raw.isInstanceOf[AppliedClassType] && raw.typeParameters.nonEmpty =>
+            if (TypeRelations.sameClass(raw, exp.raw) && exp.typeArguments.length == raw.typeParameters.length)
+              Some(AppliedClassType(raw, exp.typeArguments.toList))
+            else
+              diamondTypeFromSupertype(raw, exp)
           case _ => None
         }
       case _ => None
     }
+
+  /**
+   * `new C(...)` where `C` conforms to the expected applied type through a
+   * supertype/interface rather than being that exact class -- e.g. a generic
+   * ADT enum's singleton case, `Nothing` in `enum Opt[T] { case Some(value: T);
+   * case Nothing }`, constructed as `val o: Opt[String] = new Nothing()`.
+   * `Nothing` passes its own type parameter straight through to `Opt[T]`, so
+   * `T` can be recovered from `exp`'s arguments the same way [[diamondType]]
+   * already does for an exact-class match.
+   *
+   * Only that exact shape is trusted: `raw`'s conforms/extends clause must
+   * name `exp`'s class with each argument a bare, distinct reference to one
+   * of `raw`'s own type parameters. A concrete type, a nested application, or
+   * a dropped/repeated parameter falls through to `None`, leaving the
+   * existing raw-type diagnostic in place rather than guessing.
+   */
+  private def diamondTypeFromSupertype(raw: ClassType, exp: AppliedClassType): Option[ClassType] = {
+    def rawOf(ct: ClassType): ClassType = ct match {
+      case a: AppliedClassType => a.raw
+      case c => c
+    }
+    val parents = Option(raw.superClass).toSeq ++ raw.interfaces
+    parents.collectFirst {
+      case p: AppliedClassType
+        if TypeRelations.sameClass(rawOf(p), exp.raw) && p.typeArguments.length == exp.typeArguments.length => p
+    }.flatMap { parent =>
+      val bindings = parent.typeArguments.zip(exp.typeArguments).foldLeft(Option(Map.empty[String, Type])) {
+        case (Some(acc), (tv: TypeVariableType, arg)) if raw.typeParameters.exists(_.name == tv.name) && !acc.contains(tv.name) =>
+          Some(acc + (tv.name -> arg))
+        case _ => None
+      }
+      bindings.flatMap { b =>
+        if (raw.typeParameters.forall(tp => b.contains(tp.name)))
+          Some(AppliedClassType(raw, raw.typeParameters.map(tp => b(tp.name)).toList))
+        else None
+      }
+    }
+  }
 
   /**
    * The bare generic class named by `new C(...)`, or None when `C` is not a

--- a/src/test/scala/onion/compiler/tools/GenericAdtEnumSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericAdtEnumSpec.scala
@@ -43,6 +43,37 @@ class GenericAdtEnumSpec extends AbstractShellSpec {
           |""".stripMargin, "None", Array()))
   }
 
+  it("infers the singleton case's type argument from the expected type (constructor diamond)") {
+    // `Nothing` conforms to `Opt[T]` by passing its own type parameter straight
+    // through, so `val o: Opt[String] = new Nothing()` should pin T the same way
+    // `val b: Box[String] = new Box(...)` already does for a same-class
+    // constructor (ConstructorDiamondSpec) -- just via a supertype instead of
+    // an exact class match.
+    assert(Shell.Success("none") == shell.run(
+      optEnum +
+        """def describe(o: Opt[String]): String = select o {
+          |  case s is Some: "some:" + s.value()
+          |  case n is Nothing: "none"
+          |}
+          |def main(args: String[]): String { val o: Opt[String] = new Nothing()
+          |  return describe(o) }
+          |""".stripMargin, "None", Array()))
+  }
+
+  it("infers a hand-written generic sealed hierarchy's singleton case the same way") {
+    assert(Shell.Success("none") == shell.run(
+      """sealed interface Box[T] {}
+        |record Full[T](value: T) conforms Box[T]
+        |record Empty[T]() conforms Box[T]
+        |def get(b: Box[String]): String = select b {
+        |  case f is Full: f.value()
+        |  case e is Empty: "none"
+        |}
+        |def main(args: String[]): String { val b: Box[String] = new Empty()
+        |  return get(b) }
+        |""".stripMargin, "None", Array()))
+  }
+
   it("checks exhaustiveness over a generic sealed hierarchy") {
     // Before, the parameterized scrutinee skipped the sealed check entirely and
     // a missing case compiled, then returned null at runtime.


### PR DESCRIPTION
## Summary

- `val o: Opt[String] = new Nothing()` rejected `Nothing` as a raw type (`E0066`) even though the declared type fully determines its type argument. `Nothing` conforms to `Opt[T]` in a generic ADT enum (`enum Opt[T] { case Some(value: T); case Nothing }`) by passing its own type parameter straight through, so `T` should be recoverable from the expected type the same way `val b: Box[String] = new Box("x")` already works for an exact-class constructor diamond.
- The existing diamond inference (`ConstructionTyping.diamondType`) only matched when the constructed class was exactly the expected type's class. A new `diamondTypeFromSupertype` walks the constructed class's declared super/interface list for an entry matching the expected type's class, and recovers the type argument only when every supertype argument is a bare, distinct reference to one of the constructed class's own type parameters — the exact shape the `case`-enum and `conforms` desugaring produces. Anything else (a concrete type, a nested application, a dropped/repeated parameter) falls through to the existing raw-type diagnostic rather than guessing.
- Also fixes the same gap for a hand-written generic sealed hierarchy (`record Empty[T]() conforms Box[T]`).

Found while probing the "generic ADT enum" feature for usability gaps — no open issue tracked this, so filing directly as a fix with tests.

## Test plan

- [x] Added two red→green tests to `GenericAdtEnumSpec` covering the enum-case and hand-written cases
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.GenericAdtEnumSpec onion.compiler.tools.ConstructorDiamondSpec onion.compiler.tools.GenericConstructorInferenceSpec'` — all pass, no regressions in existing diamond/inference specs
- [x] Full suite: `sbt -Duser.language=en test` — 2834 passed, 0 failed, 1 cancelled (dist smoke test, expected)
- [x] `CHANGELOG.md` updated under `[Unreleased]`


---
_Generated by [Claude Code](https://claude.ai/code/session_01RvrZKLeGCkFRNDHvxCZwZD)_