### PR TITLE
docs(examples): add 20 missing entries to the example index table

### DIFF
--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -94,6 +94,27 @@ java Hello
 | `CsvProcessor.on` | CSV header parsing + aggregation | `Csv::parseWithHeader` |
 | `CliArgsDemo.on` | Manual CLI argument parsing | `onion.Args` |
 | `FileWordCounter.on` | Word count from a file | File I/O, `BufferedReader` |
+| `Generics.on` | Generic box class | Generic classes, type parameters |
+| `PairSample.on` | Generic pair class | Generic classes, multiple type parameters |
+| `Extension.on` | Extension methods on a built-in type | `extension` blocks |
+| `NullSafety.on` | Nullable types and safe navigation | `T?`, `?.` safe call operator |
+| `ValVarInference.on` | `val`/`var` type inference | Local type inference, mutable vs. immutable |
+| `PrimitivePrint.on` | Printing primitives | `IO::println`/`IO::print` |
+| `FunctionTypesSample.on` | Function-typed parameters | Function types, lambdas |
+| `JavaCollectionsSample.on` | Java collections interop | `java.util.ArrayList`, `Collections` |
+| `JavaGenerics.on` | Java generics interop | `java.util.ArrayList[String]` |
+| `GuessNumber.on` | Number-guessing game | `BufferedReader`, control flow |
+| `TodoApp.on` | Interactive CLI todo list | `ArrayList`, console I/O |
+| `HttpJsonClient.on` | HTTP + JSON client | `onion.Http` |
+| `RegexLogParser.on` | Log line parsing | `re"..."` regex select patterns |
+| `RecordLaws.on` | Record `law`/`example` clauses | `law`, `example`, compile-time checking |
+| `SchemePrefix.on` | User-definable scheme-prefixed literals | `prefix"..."` raw string literals |
+| `ShapeFirst.on` | Shape-first scripting tour | `re"..."`, pipelines, do-notation, auto-CLI |
+| `FixedWidthDemo.on` | User-written `Shape` instance | `onion.Shape`, Outcome/Defect, `law` |
+| `JsonYamlShapeDemo.on` | Named JSON/YAML shape on a record | `shape name = json`/`yaml` |
+| `ConfigEditDemo.on` | Lossless config editing | Lens, `Residue`, comment/order preservation |
+| `BrokenLogDemo.on` | Partial-failure log parsing | `onion.Shape`, `Outcome::values`/`defects` |
+| `ToolDemo.on` | CLI derived from a `tool` declaration | `tool`, capabilities, `--help`/`--contract`/`--plan` |
 
 ## Learning Path
 


### PR DESCRIPTION
## Summary
- `run/` has grown to 64 example programs, but `docs/examples/overview.md`'s "Example Index" table only listed 42 of them.
- Adds the 20 missing rows (e.g. `ToolDemo.on`, `ShapeFirst.on`, `RecordLaws.on`, the Shape/lens family, generics/Java-interop samples) so the index matches `run/` exactly.
- Docs-only change, no code touched.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2834 tests succeeded, 0 failed, 1 canceled (pre-existing, unrelated), 0 aborted suites.
- [x] Verified every `.on` file under `run/` now has a corresponding row in the table (`comm` diff empty).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkyfjuBcccDnZV7fjs8fQL)_