### PR TITLE
test(run-samples): execute 12 run/ examples that were compile-checked only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Execution coverage for 12 `run/` examples that were compile-checked only.**
+  `SampleCompilesSpec`/`SampleProgramsSpec` compile every file in `run/`, but
+  `RunSamplesSpec` only *executes* a subset of them with an asserted result — a
+  runtime regression (wrong output, an exception) in an example outside that
+  subset could land undetected even though the file still compiled. `Factorial.on`,
+  `Generics.on`, `List.on`, `Array.on`, `StringCat.on`, `Foreach.on`, `Hello.on`,
+  `NullSafety.on`, `StaticImports.on`, `Delegation.on`, `Extension.on`, and
+  `ExprEval.on` are deterministic and have no stdin/file/network dependency, so
+  `RunSamplesSpec` now runs each and asserts `Shell.Success(null)`.
+
 ### Fixed
 
 - **A generic ADT enum's singleton case rejected the expected-type constructor

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -168,5 +168,53 @@ class RunSamplesSpec extends AbstractShellSpec {
         shell.run(load("run/FileWordCounter.on"), "run/FileWordCounter.on", args.toArray)
       assert(Shell.Success("Total words: 7") == run(f.toString))
     }
+
+    it("runs Factorial.on") {
+      assert(Shell.Success(null) == runSample("run/Factorial.on"))
+    }
+
+    it("runs Generics.on") {
+      assert(Shell.Success(null) == runSample("run/Generics.on"))
+    }
+
+    it("runs List.on") {
+      assert(Shell.Success(null) == runSample("run/List.on"))
+    }
+
+    it("runs Array.on") {
+      assert(Shell.Success(null) == runSample("run/Array.on"))
+    }
+
+    it("runs StringCat.on") {
+      assert(Shell.Success(null) == runSample("run/StringCat.on"))
+    }
+
+    it("runs Foreach.on") {
+      assert(Shell.Success(null) == runSample("run/Foreach.on"))
+    }
+
+    it("runs Hello.on") {
+      assert(Shell.Success(null) == runSample("run/Hello.on"))
+    }
+
+    it("runs NullSafety.on") {
+      assert(Shell.Success(null) == runSample("run/NullSafety.on"))
+    }
+
+    it("runs StaticImports.on") {
+      assert(Shell.Success(null) == runSample("run/StaticImports.on"))
+    }
+
+    it("runs Delegation.on") {
+      assert(Shell.Success(null) == runSample("run/Delegation.on"))
+    }
+
+    it("runs Extension.on") {
+      assert(Shell.Success(null) == runSample("run/Extension.on"))
+    }
+
+    it("runs ExprEval.on") {
+      assert(Shell.Success(null) == runSample("run/ExprEval.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `SampleCompilesSpec`/`SampleProgramsSpec` compile every file in `run/`, but `RunSamplesSpec` only *executes* a subset of them with an asserted result. A runtime regression (wrong output, an uncaught exception) in an example outside that subset could land undetected even though the file still compiled.
- `Factorial.on`, `Generics.on`, `List.on`, `Array.on`, `StringCat.on`, `Foreach.on`, `Hello.on`, `NullSafety.on`, `StaticImports.on`, `Delegation.on`, `Extension.on`, and `ExprEval.on` are deterministic with no stdin/file/network dependency, so `RunSamplesSpec` now runs each and asserts `Shell.Success(null)`, following the existing pattern used for `Primes.on`/`Fibonacci.on`/etc.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — 39/39 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2846/2846 passed (0 failed, 1 canceled — a pre-existing, environment-gated distribution smoke test unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgxHJLoEaYxc7Gunjb663E)_