### PR TITLE
docs(error-codes): document E0080 (shape instance without a law)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target's declared type already pinned them. The same gap applied to a
   hand-written `record Empty[T]() conforms Box[T]`.
 
+### Documentation
+
+- **`E0080` (a user-written `Shape` asserting no law) had no entry in
+  `docs/reference/error-codes.md` / `docs/ja/reference/error-codes.md`.** The
+  code has been implemented, tested, and referenced by name from
+  `docs/guide/shapes.md` since issue #364, but the reference page jumped from
+  `E0079` straight to `E0057`/`E0081`/`E0082` with no `E0080` section. Added it
+  (EN + JA) next to the other shape/law codes (`E0074`-`E0076`), with the
+  fixed-width `Shape[Person]` example already used in the guide and test suite.
+
 ## [0.10.5] - 2026-07-28
 
 ### Changed

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -145,6 +145,39 @@ record Pt(x: Int, y: Int)
 
 インラインのパターンを書く場合は `shape name = re"..."` としてください。
 
+### `E0080` — 自作の `Shape` に law がない
+
+`onion.Shape[T]` を（`shape`/`from re"..."` による導出ではなく）直接実装した具象クラスは、
+そのファイル内で機械検査される `law` か `example` を最低1つ主張しなければなりません。
+導出された shape は round-trip が構造的に保証されますが、手書きのものは**主張するだけ**
+なので、その主張を検査する必要があります。
+
+```onion
+class FixedWidth conforms Shape[Person] {
+public:
+  def this {}
+  def parse(text: String, origin: Origin): Outcome[Person] { ... }
+  def canPrint(): Boolean = true
+  def print(v: Person): String { ... }
+  def describe(): String = "fixed-width Person"
+}
+// E0080: FixedWidth の law を主張している箇所がこのファイルにない
+```
+
+対処: トップレベルの `example`（またはクラス自身の `law`）を追加してください——代表的な
+主張は round-trip `s.parse(s.print(v)).get() == v` です。
+
+```onion
+example fixedWidthL1 {
+  val s = new FixedWidth()
+  val v = new Person("KOTA", 42)
+  s.parse(s.print(v)).get() == v
+}
+```
+
+パース専用の shape（`canPrint(): false`）は、読み取り方向にある law を代わりに主張します。
+主張が偽であれば、他の `example` と同様に `E0065` になります。
+
 ## Capability エラー
 
 `tool` 宣言は `requires { ... }` 節で境界を引きます。コンパイラは本体全体の効果を

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -145,6 +145,39 @@ record Pt(x: Int, y: Int)
 
 For an inline pattern, write `shape name = re"..."`.
 
+### `E0080` — A user-written `Shape` asserts no law
+
+A concrete class implementing `onion.Shape[T]` directly (rather than deriving one via
+`shape`/`from re"..."`) must assert at least one machine-checked `law` or `example` in
+its file. A derived shape's round-trip is guaranteed by construction; a hand-written
+one only *claims* it, so the claim must be checked.
+
+```onion
+class FixedWidth conforms Shape[Person] {
+public:
+  def this {}
+  def parse(text: String, origin: Origin): Outcome[Person] { ... }
+  def canPrint(): Boolean = true
+  def print(v: Person): String { ... }
+  def describe(): String = "fixed-width Person"
+}
+// E0080: nothing in this file asserts a law for FixedWidth
+```
+
+Fix: add a top-level `example` (or the class's own `law`) — the canonical claim is the
+round-trip `s.parse(s.print(v)).get() == v`:
+
+```onion
+example fixedWidthL1 {
+  val s = new FixedWidth()
+  val v = new Person("KOTA", 42)
+  s.parse(s.print(v)).get() == v
+}
+```
+
+A parse-only shape (`canPrint(): false`) instead asserts whatever laws its reading
+direction has. A false claim is `E0065`, the same as any other falsified `example`.
+
 ## Capability errors
 
 A `tool` declaration draws a boundary with a `requires { ... }` clause; the compiler


### PR DESCRIPTION
## Summary

- `SHAPE_INSTANCE_WITHOUT_LAW` (E0080) is implemented (`ShapeInstanceLawPass`), has EN/JA messages, is tested (`UserShapeInstanceSpec`), and is referenced by name from `docs/guide/shapes.md` since issue #364 — but `docs/reference/error-codes.md` / `docs/ja/reference/error-codes.md` never documented it, jumping straight from E0079 to E0057/E0081/E0082.
- Added an `E0080` section (EN + JA) next to the other shape/law codes (E0074-E0076), using the fixed-width `Shape[Person]` example already used in the guide and test suite.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` → Documentation.

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2846 passed, 0 failed, 1 canceled (gated dist smoke test), same as the pre-change baseline. Docs-only change, no source touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcqTYarMsGHmSd5937N4yq)_