### PR TITLE
docs(error-codes): list every diagnostic code, and guard the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Every diagnostic code is now listed in the reference (EN+JA).** The page explained
+  the common codes in prose and stopped there, so 59 of the 80 could not be looked up at
+  all — including several added during the past week. A complete table was generated
+  from `SemanticError` and its message bundle, and `ErrorCodeDocCoverageSpec` now fails
+  the build when a code is declared without being documented, or documented after being
+  retired.
+
 - **Execution coverage for 12 `run/` examples that were compile-checked only.**
   `SampleCompilesSpec`/`SampleProgramsSpec` compile every file in `run/`, but
   `RunSamplesSpec` only *executes* a subset of them with an asserted result — a

--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -10,7 +10,7 @@
 
 | # | 次元 | 測定方法 | 現在値（2026-07-27） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2832 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2848 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 64 / 64 compile | すべてコンパイル、rot なし |
 | 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 7（BrokenLogDemo、OrderReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager、ToolDemo） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -302,6 +302,95 @@ select shape {
 Test.on:2:10: Syntax error. Encountered "{", but expecting ";"
 ```
 
+## 診断コード一覧
+
+上の各節は遭遇しやすいコードを例つきで説明しています。この表は全コードの一覧なので、
+ビルドログで見たコードは必ずここで引けます。
+
+| コード | 意味 |
+|--------|------|
+| `I0000` | コンパイラ内部エラー — あなたのプログラムではなくコンパイラのバグです |
+| `E0000` | type … is expected, but type … is used |
+| `E0001` | operator … is not applicable for type … |
+| `E0002` | variable not found |
+| `E0003` | class not found |
+| `E0004` | field ….… is not found |
+| `E0005` | method applicable for ….…(…) is not found |
+| `E0006` | ambiguous method |
+| `E0007` | duplicated local variable definition … |
+| `E0008` | duplicated class definition … |
+| `E0009` | duplicated field definition ….… |
+| `E0010` | duplicated method definition ….…(…) |
+| `E0011` | duplicated global variable definition … |
+| `E0012` | duplicated function definition …(…) |
+| `E0013` | method ….…(…) is not accessible from class … |
+| `E0014` | field ….… is not accessible from class … |
+| `E0015` | class … is not accessible from class … |
+| `E0016` | inheritance relations which includes … have cyclicity |
+| `E0018` | class … do inheritance illegally |
+| `E0019` | method ….… cannot be called |
+| `E0020` | this method cannot return value |
+| `E0021` | constructor not found |
+| `E0022` | ambiguous constructor |
+| `E0023` | interface required, but type … is used |
+| `E0025` | duplicated constructor definition …(…) |
+| `E0026` | duplicated generated method ….…(…) |
+| `E0027` | type … is not boxable type |
+| `E0028` | lvalue is required |
+| `E0029` | duplicated type parameter definition … |
+| `E0030` | type … does not take type arguments |
+| `E0031` | type … expects … type arguments, but … are supplied |
+| `E0032` | type argument … must be a reference type |
+| `E0033` | method ….… does not take type arguments |
+| `E0034` | method ….… expects … type arguments, but … are supplied |
+| `E0035` | Erased JVM signature collision: ….…… |
+| `E0036` | cannot assign to val … |
+| `E0037` | class … must implement abstract method …(…) or be declared abstract |
+| `E0038` | cannot instantiate abstract class … |
+| `E0039` | method …(…) cannot override final method in … |
+| `E0040` | cannot call method … on primitive type … |
+| `E0041` | type … is not a valid method call target |
+| `E0042` | non exhaustive pattern match |
+| `E0043` | unknown parameter name: … |
+| `E0044` | duplicate argument: … |
+| `E0045` | positional argument after named argument is not allowed |
+| `E0046` | wrong number of bindings in destructuring pattern |
+| `E0047` | … is not a record type or does not exist |
+| `E0048` | break is only allowed inside a loop |
+| `E0049` | continue is only allowed inside a loop |
+| `E0050` | current instance is not available in static context |
+| `E0051` | return type is required for method … |
+| `E0052` | lambda parameter … must specify a type |
+| `E0053` | cyclic type alias detected: … |
+| `E0054` | duplicate type alias: … |
+| `E0055` | function … requires a body |
+| `E0057` | value of type parameter … may be null and cannot be dereferenced directly |
+| `E0058` | label … is not defined on any enclosing loop |
+| `E0059` | invalid regular expression literal: … |
+| `E0060` | the regex pattern has … capture group(s) but … binding(s) were given |
+| `E0061` | record component … has type …, which cannot be derived from a `from re"..."` clause |
+| `E0062` | record component … has type …, which derive! cannot serialize |
+| `E0063` | unknown derive! marker `…` |
+| `E0064` | law violation |
+| `E0065` | example failed |
+| `E0066` | raw type … is not allowed; supply type arguments (e.g |
+| `E0067` | method … may reach the end of its body without returning a … |
+| `E0068` | method …(…) is marked override but does not override any method in a base class or interface of … |
+| `E0069` | local val … must be initialized at its declaration |
+| `E0070` | value of type … may be null and cannot be dereferenced directly |
+| `E0071` | … is a variable, not a type |
+| `E0072` | abstract method … cannot have a body (the body would be silently ignored) |
+| `E0073` | a Map (…) cannot be iterated directly by foreach |
+| `E0074` | law parameter not generatable |
+| `E0075` | law class not loadable |
+| `E0076` | unknown shape format `…` |
+| `E0077` | tool `…` performs `…` here (calling …) but does not declare it |
+| `E0078` | tool `…` declares capability `…` but nothing in its body can perform it |
+| `E0079` | tool `…` has an invalid capability `…`: … |
+| `E0080` | class `…` implements onion.Shape but nothing in its file asserts a law |
+| `E0081` | tool parameter not cli convertible |
+| `E0082` | duplicate tool name `…` |
+
 ## 関連項目
 
 - [言語仕様](specification.md)

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -13,7 +13,7 @@ had already drifted after the effect-table / tool-capability / tool-contracts wo
 
 | # | Dimension | How to measure | Current (2026-07-27) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2832 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2848 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 64 / 64 compile | all compile, no rot |
 | 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 7 (BrokenLogDemo, OrderReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager, ToolDemo) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -304,6 +304,95 @@ Parser errors do not carry `E` codes; they report the encountered token and the 
 Test.on:2:10: Syntax error. Encountered "{", but expecting ";"
 ```
 
+## Every diagnostic code
+
+The sections above explain the codes you are most likely to meet, with examples. This
+table lists all of them, so a code seen in a build log can always be looked up.
+
+| Code | Meaning |
+|------|---------|
+| `I0000` | internal compiler error — a bug in the compiler, not your program |
+| `E0000` | type … is expected, but type … is used |
+| `E0001` | operator … is not applicable for type … |
+| `E0002` | variable not found |
+| `E0003` | class not found |
+| `E0004` | field ….… is not found |
+| `E0005` | method applicable for ….…(…) is not found |
+| `E0006` | ambiguous method |
+| `E0007` | duplicated local variable definition … |
+| `E0008` | duplicated class definition … |
+| `E0009` | duplicated field definition ….… |
+| `E0010` | duplicated method definition ….…(…) |
+| `E0011` | duplicated global variable definition … |
+| `E0012` | duplicated function definition …(…) |
+| `E0013` | method ….…(…) is not accessible from class … |
+| `E0014` | field ….… is not accessible from class … |
+| `E0015` | class … is not accessible from class … |
+| `E0016` | inheritance relations which includes … have cyclicity |
+| `E0018` | class … do inheritance illegally |
+| `E0019` | method ….… cannot be called |
+| `E0020` | this method cannot return value |
+| `E0021` | constructor not found |
+| `E0022` | ambiguous constructor |
+| `E0023` | interface required, but type … is used |
+| `E0025` | duplicated constructor definition …(…) |
+| `E0026` | duplicated generated method ….…(…) |
+| `E0027` | type … is not boxable type |
+| `E0028` | lvalue is required |
+| `E0029` | duplicated type parameter definition … |
+| `E0030` | type … does not take type arguments |
+| `E0031` | type … expects … type arguments, but … are supplied |
+| `E0032` | type argument … must be a reference type |
+| `E0033` | method ….… does not take type arguments |
+| `E0034` | method ….… expects … type arguments, but … are supplied |
+| `E0035` | Erased JVM signature collision: ….…… |
+| `E0036` | cannot assign to val … |
+| `E0037` | class … must implement abstract method …(…) or be declared abstract |
+| `E0038` | cannot instantiate abstract class … |
+| `E0039` | method …(…) cannot override final method in … |
+| `E0040` | cannot call method … on primitive type … |
+| `E0041` | type … is not a valid method call target |
+| `E0042` | non exhaustive pattern match |
+| `E0043` | unknown parameter name: … |
+| `E0044` | duplicate argument: … |
+| `E0045` | positional argument after named argument is not allowed |
+| `E0046` | wrong number of bindings in destructuring pattern |
+| `E0047` | … is not a record type or does not exist |
+| `E0048` | break is only allowed inside a loop |
+| `E0049` | continue is only allowed inside a loop |
+| `E0050` | current instance is not available in static context |
+| `E0051` | return type is required for method … |
+| `E0052` | lambda parameter … must specify a type |
+| `E0053` | cyclic type alias detected: … |
+| `E0054` | duplicate type alias: … |
+| `E0055` | function … requires a body |
+| `E0057` | value of type parameter … may be null and cannot be dereferenced directly |
+| `E0058` | label … is not defined on any enclosing loop |
+| `E0059` | invalid regular expression literal: … |
+| `E0060` | the regex pattern has … capture group(s) but … binding(s) were given |
+| `E0061` | record component … has type …, which cannot be derived from a `from re"..."` clause |
+| `E0062` | record component … has type …, which derive! cannot serialize |
+| `E0063` | unknown derive! marker `…` |
+| `E0064` | law violation |
+| `E0065` | example failed |
+| `E0066` | raw type … is not allowed; supply type arguments (e.g |
+| `E0067` | method … may reach the end of its body without returning a … |
+| `E0068` | method …(…) is marked override but does not override any method in a base class or interface of … |
+| `E0069` | local val … must be initialized at its declaration |
+| `E0070` | value of type … may be null and cannot be dereferenced directly |
+| `E0071` | … is a variable, not a type |
+| `E0072` | abstract method … cannot have a body (the body would be silently ignored) |
+| `E0073` | a Map (…) cannot be iterated directly by foreach |
+| `E0074` | law parameter not generatable |
+| `E0075` | law class not loadable |
+| `E0076` | unknown shape format `…` |
+| `E0077` | tool `…` performs `…` here (calling …) but does not declare it |
+| `E0078` | tool `…` declares capability `…` but nothing in its body can perform it |
+| `E0079` | tool `…` has an invalid capability `…`: … |
+| `E0080` | class `…` implements onion.Shape but nothing in its file asserts a law |
+| `E0081` | tool parameter not cli convertible |
+| `E0082` | duplicate tool name `…` |
+
 ## See also
 
 - [Language specification](specification.md)

--- a/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the diagnostic-code reference (release prep for 0.10.6).
+ *
+ * `docs/reference/error-codes.md` explains the common codes in prose and then lists
+ * every one in a table, so a code seen in a build log can always be looked up. 59 of
+ * the 80 codes were missing when the table was added — including several introduced
+ * during the previous week's work — because nothing tied the document to
+ * `SemanticError`. This is that tie.
+ */
+class ErrorCodeDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private lazy val declared: Set[String] =
+    """case object \w+ extends SemanticError\((\d+)\)""".r
+      .findAllMatchIn(read("src/main/scala/onion/compiler/SemanticError.scala"))
+      .map(m => f"E${m.group(1).toInt}%04d")
+      .toSet
+
+  private def check(path: String): Unit = {
+    val doc = read(path)
+    assert(declared.nonEmpty, "no SemanticError cases found — the scan has rotted")
+    val missing = declared.filterNot(doc.contains).toSeq.sorted
+    assert(missing.isEmpty, s"$path does not mention: ${missing.mkString(", ")}")
+
+    // The reverse: a documented code that no longer exists sends readers looking for
+    // a diagnostic they can never see.
+    val documented = """`(E\d{4})`""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+    val stale = (documented -- declared).toSeq.sorted
+    assert(stale.isEmpty, s"$path documents codes that no longer exist: ${stale.mkString(", ")}")
+  }
+
+  it("the English reference mentions every declared code, and no retired one") {
+    check("docs/reference/error-codes.md")
+  }
+
+  it("the Japanese reference mentions every declared code, and no retired one") {
+    check("docs/ja/reference/error-codes.md")
+  }
+}


### PR DESCRIPTION
Release prep for the next version, prompted by #458.

## What

#458 documented `E0080` after it turned out to be missing. Auditing the rest showed **59 of the 80 codes were absent** from `docs/reference/error-codes.md` and its Japanese copy — the page explained the common codes in prose and stopped there, so a code seen in a build log often could not be looked up at all. Several of the missing ones were added during the past week's work.

- A **complete table**, generated from `SemanticError` and its message bundle, appended to both copies. The prose sections keep their worked examples; the table exists so that every code resolves to *something*.
- **`ErrorCodeDocCoverageSpec`** ties document and source together in both directions: a code declared without being documented fails the build, and so does a documented code that has been retired — the three deleted in #427 would have left exactly that kind of dangling entry.

## Tests

**2848 green in both locales.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)