### PR TITLE
test: execute 6 more run/ examples instead of compile-checking only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Execution coverage for 6 more `run/` examples that were compile-checked only.**
+  `RunSamplesSpec` covered a first batch of previously compile-only examples in
+  0.10.6, but `Bean.on`, `JavaGenerics.on`, `OrderReport.on`, `RegexLogParser.on`,
+  `ResultValidation.on`, and `ShapeProcessor.on` were still only checked for
+  successful compilation, not for correct runtime behavior. All six are
+  deterministic with no stdin/file/network/GUI dependency (unlike `Calculator.on`'s
+  Swing UI or `Select.on`'s `Math::random()`), so `RunSamplesSpec` now runs each
+  and asserts on `Shell.Success`.
+
 ## [0.10.6] - 2026-07-28
 
 Documentation and coverage: every diagnostic code is now looked-up-able, twelve more

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -216,5 +216,29 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs ExprEval.on") {
       assert(Shell.Success(null) == runSample("run/ExprEval.on"))
     }
+
+    it("runs JavaGenerics.on") {
+      assert(Shell.Success(null) == runSample("run/JavaGenerics.on"))
+    }
+
+    it("runs Bean.on") {
+      assert(Shell.Success(null) == runSample("run/Bean.on"))
+    }
+
+    it("runs ResultValidation.on") {
+      assert(Shell.Success(null) == runSample("run/ResultValidation.on"))
+    }
+
+    it("runs ShapeProcessor.on") {
+      assert(Shell.Success(null) == runSample("run/ShapeProcessor.on"))
+    }
+
+    it("runs OrderReport.on") {
+      assert(Shell.Success(null) == runSample("run/OrderReport.on"))
+    }
+
+    it("runs RegexLogParser.on") {
+      assert(Shell.Success("Average response time: 65ms") == runSample("run/RegexLogParser.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `RunSamplesSpec` covered a first batch of previously compile-only `run/` examples in 0.10.6 (`SampleCompilesSpec`/`SampleProgramsSpec` compile every file in `run/`, but only a subset was actually *executed* with an asserted result).
- Extends that coverage to `Bean.on`, `JavaGenerics.on`, `OrderReport.on`, `RegexLogParser.on`, `ResultValidation.on`, and `ShapeProcessor.on`.
- All six are deterministic with no stdin/file/network/GUI dependency (unlike `Calculator.on`'s Swing UI or `Select.on`'s `Math::random()`), so each is now run and asserted on `Shell.Success`.
- `CHANGELOG.md` `[Unreleased]` updated.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2854 succeeded, 0 failed, 1 canceled (pre-existing), all green.
- [x] Verified expected output for each new sample via `sbt runScript` before asserting.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdeGeTAA5Nq8Y2LyLeVMxy)_