### PR TITLE
refactor(typing): dedupe the E0083 unreachable-catch-clause check

### DIFF
--- a/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
+++ b/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
@@ -468,25 +468,7 @@ final class BlockElementLowering(
             if (!TypeRules.isSuperType(expected, argType)) {
               bodyContext.report(INCOMPATIBLE_TYPE, argument, expected, argType)
             }
-            // A later clause whose type is already a subtype of (or equal to) an
-            // earlier clause's type can never run. Alternatives of the same
-            // `catch e: A | B` clause are exempt from shadowing each other: the
-            // grammar desugars them to entries sharing one body, but Rewriting's
-            // `block.copy(...)` gives each a fresh object, so `eq` cannot tell them
-            // apart post-rewrite — compare the (structurally-equal) source location
-            // instead, which `.copy` preserves.
-            var j = 0
-            var shadowedBy: Type = null
-            while (j < i && shadowedBy == null) {
-              val earlierBody = node.recClauses(j)._2
-              if (earlierBody.location != body.location && TypeRules.isSuperType(catchTypes(j), argType)) {
-                shadowedBy = catchTypes(j)
-              }
-              j += 1
-            }
-            if (shadowedBy != null) {
-              bodyContext.report(UNREACHABLE_CATCH_CLAUSE, argument, argType, shadowedBy)
-            }
+            DuplicationChecks.checkUnreachableCatchClause(bodyContext, node.recClauses, catchTypes, i, argument, argType, body)
             binds(i) = context.lookupOnlyCurrentScope(argument.name)
             catchBlocks(i) = translate(body, context)
           }

--- a/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
+++ b/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
@@ -174,6 +174,39 @@ private[compiler] object DuplicationChecks {
     }
   }
 
+  /**
+   * Reports E0083 when catch clause `index`'s exception type is already covered by an
+   * earlier clause in the same `try`, making it unreachable. Alternatives of the same
+   * `catch e: A | B` clause are exempt from shadowing each other: the grammar desugars
+   * them to entries sharing one body, but `block.copy(...)` in Rewriting gives each a
+   * fresh object, so `eq` cannot tell them apart post-rewrite — compare the
+   * (structurally-equal) source location instead, which `.copy` preserves. Shared by
+   * both places a `try`/`catch` is typed: `TryExpressionTyping` (try-as-expression) and
+   * `BlockElementLowering` (try-as-statement).
+   */
+  def checkUnreachableCatchClause(
+    bodyContext: onion.compiler.typing.session.TypingBodyContext,
+    recClauses: List[(AST.Argument, AST.BlockExpression)],
+    catchTypes: Array[Type],
+    index: Int,
+    argument: AST.Argument,
+    argType: Type,
+    catchBody: AST.BlockExpression
+  ): Unit = {
+    var j = 0
+    var shadowedBy: Type = null
+    while (j < index && shadowedBy == null) {
+      val earlierBody = recClauses(j)._2
+      if (earlierBody.location != catchBody.location && TypeRules.isSuperType(catchTypes(j), argType)) {
+        shadowedBy = catchTypes(j)
+      }
+      j += 1
+    }
+    if (shadowedBy != null) {
+      bodyContext.report(SemanticError.UNREACHABLE_CATCH_CLAUSE, argument, argType, shadowedBy)
+    }
+  }
+
   def checkErasureSignatureCollisions(typing: Typing, clazz: ClassDefinition, fallback: Location): Unit = {
     val seen = mutable.HashMap[(String, String), Method]()
     for m <- clazz.methods do

--- a/src/main/scala/onion/compiler/typing/TryExpressionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/TryExpressionTyping.scala
@@ -81,25 +81,7 @@ final class TryExpressionTyping(
           if (!TypeRules.isSuperType(expected, argType)) {
             bodyContext.report(INCOMPATIBLE_TYPE, argument, expected, argType)
           }
-          // A later clause whose type is already a subtype of (or equal to) an
-          // earlier clause's type can never run. Alternatives of the same
-          // `catch e: A | B` clause are exempt from shadowing each other: the
-          // grammar desugars them to entries sharing one body, but Rewriting's
-          // `block.copy(...)` gives each a fresh object, so `eq` cannot tell them
-          // apart post-rewrite — compare the (structurally-equal) source location
-          // instead, which `.copy` preserves.
-          var j = 0
-          var shadowedBy: Type = null
-          while (j < i && shadowedBy == null) {
-            val earlierBody = node.recClauses(j)._2
-            if (earlierBody.location != catchBody.location && TypeRules.isSuperType(catchTypes(j), argType)) {
-              shadowedBy = catchTypes(j)
-            }
-            j += 1
-          }
-          if (shadowedBy != null) {
-            bodyContext.report(UNREACHABLE_CATCH_CLAUSE, argument, argType, shadowedBy)
-          }
+          DuplicationChecks.checkUnreachableCatchClause(bodyContext, node.recClauses, catchTypes, i, argument, argType, catchBody)
           binds(i) = context.lookupOnlyCurrentScope(argument.name)
           typeBlockExpression(catchBody, context, branchExpected) match {
             case Some(term) => catchTerms(i) = term


### PR DESCRIPTION
## Summary
- `TryExpressionTyping` (try-as-expression) and `BlockElementLowering` (try-as-statement) each carried an identical shadowing-detection loop for the E0083 "unreachable catch clause" check (added in #461, which called out the duplication).
- Extracted the shared logic into `DuplicationChecks.checkUnreachableCatchClause` and call it from both sites. No behavior change — internal refactor only.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *UnreachableCatchClauseSpec'` — 6/6 passed (covers both the try-as-expression and try-as-statement paths)
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2860 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVW2Hsye3DdpPqtA8fKphL)_