### PR TITLE
test(run): execute 3 more run/ examples instead of compile-checking only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Swing UI or `Select.on`'s `Math::random()`), so `RunSamplesSpec` now runs each
   and asserts on `Shell.Success`.
 
+- **Execution coverage for 3 more `run/` examples: `SchemePrefix.on`,
+  `TextAnalyzer.on`, `StatsApp.on`.** Same treatment as above, for the next batch
+  of deterministic, no-stdin/file/network/GUI examples that were previously
+  untested by `RunSamplesSpec`.
+
 ### Fixed
 
 - **A later `catch` clause already covered by an earlier one compiled silently and

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -240,5 +240,17 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs RegexLogParser.on") {
       assert(Shell.Success("Average response time: 65ms") == runSample("run/RegexLogParser.on"))
     }
+
+    it("runs SchemePrefix.on") {
+      assert(Shell.Success(null) == runSample("run/SchemePrefix.on"))
+    }
+
+    it("runs TextAnalyzer.on") {
+      assert(Shell.Success(null) == runSample("run/TextAnalyzer.on"))
+    }
+
+    it("runs StatsApp.on") {
+      assert(Shell.Success(null) == runSample("run/StatsApp.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `RunSamplesSpec` runs `SchemePrefix.on`, `TextAnalyzer.on`, and `StatsApp.on` and asserts on `Shell.Success`, extending the execution-coverage work started in 0.10.6/0.10.7 for `run/` examples that were previously only compile-checked (or untested).
- All three are deterministic with no stdin/file/network/GUI dependency, so their outputs are stable across runs.
- `CHANGELOG.md` `[Unreleased]` updated.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *RunSamplesSpec'` — 48/48 passing
- [x] `sbt -Duser.language=en test` (full suite) — 2863 succeeded, 0 failed, 1 pre-existing unrelated cancellation

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4HxymKSzz38KuPk3KQFCd)_