### PR TITLE
test(run): execute TodoManager.on and UnitConverter.on instead of compile-checking only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Execution coverage for 2 more `run/` examples: `TodoManager.on`,
+  `UnitConverter.on`.** Same treatment as prior batches — deterministic,
+  no-stdin/file/network/GUI examples that were previously only compile-checked
+  by `SampleCompilesSpec`, not asserted on runtime output by `RunSamplesSpec`.
+
 ## [0.10.7] - 2026-07-28
 
 New diagnostic E0083 catches a shadowed `catch` clause that previously compiled

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -252,5 +252,13 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs StatsApp.on") {
       assert(Shell.Success(null) == runSample("run/StatsApp.on"))
     }
+
+    it("runs TodoManager.on") {
+      assert(Shell.Success(null) == runSample("run/TodoManager.on"))
+    }
+
+    it("runs UnitConverter.on") {
+      assert(Shell.Success(null) == runSample("run/UnitConverter.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `RunSamplesSpec` gains execution coverage for two more `run/` examples: `TodoManager.on` and `UnitConverter.on`. Both are deterministic (no stdin/file/network/GUI dependency), so their runtime output can be asserted, not just their compilability (already covered by `SampleCompilesSpec`).
- Follows the same incremental pattern as the 0.10.6 and 0.10.7 batches.
- `CHANGELOG.md` `[Unreleased]` updated with a one-line entry.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2865 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test unrelated to this change), all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRgL99i26ariKSzWYpd3vD)_