### PR TITLE
test(run): execute ConfigApp, JsonYamlShapeDemo, ShapeFirst instead of compile-checking only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no-stdin/file/network/GUI examples that were previously only compile-checked
   by `SampleCompilesSpec`, not asserted on runtime output by `RunSamplesSpec`.
 
+- **Execution coverage for 3 more `run/` examples: `ConfigApp.on`,
+  `JsonYamlShapeDemo.on`, `ShapeFirst.on`.** Same treatment as above, for the
+  next batch of deterministic, no-stdin/file/network/GUI examples.
+
 ## [0.10.7] - 2026-07-28
 
 New diagnostic E0083 catches a shadowed `catch` clause that previously compiled

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -260,5 +260,17 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs UnitConverter.on") {
       assert(Shell.Success(null) == runSample("run/UnitConverter.on"))
     }
+
+    it("runs ConfigApp.on") {
+      assert(Shell.Success(null) == runSample("run/ConfigApp.on"))
+    }
+
+    it("runs JsonYamlShapeDemo.on") {
+      assert(Shell.Success(0) == runSample("run/JsonYamlShapeDemo.on"))
+    }
+
+    it("runs ShapeFirst.on") {
+      assert(Shell.Success(null) == runSample("run/ShapeFirst.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `ConfigApp.on`, `JsonYamlShapeDemo.on`, and `ShapeFirst.on` were only compile-checked by `SampleCompilesSpec`, not asserted on runtime output by `RunSamplesSpec`.
- All three are deterministic (fixed temp files, no stdin/network/GUI/randomness), so they get the same treatment as prior batches: `RunSamplesSpec` now runs each and asserts on `Shell.Success`.
- `CHANGELOG.md` `[Unreleased]` updated accordingly.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec -- -z "ConfigApp.on" -z "JsonYamlShapeDemo.on" -z "ShapeFirst.on"'` — green
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2868 succeeded, 0 failed, 1 canceled (pre-existing `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Gi6babVQPLJEeZZN78Zz7)_