### PR TITLE
fix: onionc/onion report malformed CLI options instead of crashing or failing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `JsonYamlShapeDemo.on`, `ShapeFirst.on`.** Same treatment as above, for the
   next batch of deterministic, no-stdin/file/network/GUI examples.
 
+### Fixed
+
+- **A malformed `onionc`/`onion` command line either crashed with a raw stack
+  trace or failed with no message at all, instead of reporting the bad
+  option.** `onionc` looked up the message key `error.command..noArgument`
+  (a stray extra dot) for an option missing its required argument, so
+  `Message.apply` threw an uncaught `MissingResourceException` — e.g.
+  `onionc -classpath` with nothing after it crashed instead of printing a
+  diagnostic. Separately, `onion`'s failure reporting only ever inspected
+  lacked-argument options, never unrecognized ones, so a typo'd flag (e.g.
+  `-maxErrorReports`, the exact misspelling this project's own docs used to
+  carry — see below) failed silently with exit code -1 and empty stderr. Both
+  frontends also leaked the option wrapper's `toString` into the message
+  (`ValuedParam(-foo) is invalid argument.`) instead of the bare flag name.
+  Fixed all three: the typo'd resource key, `onion` now reports unrecognized
+  options the same way `onionc` does, and both print the plain flag name.
+
+- **Docs and README documented a CLI flag that doesn't exist.** `-maxErrorReports`
+  (plural) was never a real option — the actual flag is `-maxErrorReport`
+  (singular) — so following the docs literally tripped the silent-failure bug
+  above. Corrected in `CLAUDE.md`, `docs/ja/CLAUDE_ja.md`,
+  `docs/tools/compiler.md`, `docs/ja/tools/compiler.md`,
+  `docs/tools/script-runner.md`, `docs/ja/tools/script-runner.md`, and
+  `README.md` (which also had "comiplation" for "compilation").
+
 ## [0.10.7] - 2026-07-28
 
 New diagnostic E0083 catches a shadowed `catch` clause that previously compiled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Onion is a statically-typed, object-oriented programming language that compiles 
 - `-classpath <path>` - Set classpath for compilation
 - `-encoding <encoding>` - Set source file encoding
 - `-d <dir>` - Set output directory for class files
-- `-maxErrorReports <n>` - Limit number of errors reported
+- `-maxErrorReport <n>` - Limit number of errors reported
 - `--dump-ast` - Print parsed AST to stderr
 - `--dump-typed-ast` - Print typed AST summary to stderr
 - `--warn <off|on|error>` - Set warning level

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ onionc [options] source files...
 * -classpath <classpath> Set classpath of source files in compilation.
 * -encoding <encoding> Set encoding of source files.
 * -d <output directory> Set output directory of results.
-* -maxErrorReports <error count> Set the maximum number of comiplation errors reported.
+* -maxErrorReport <error count> Set the maximum number of compilation errors reported.
 * --dump-ast Print parsed AST to stderr.
 * --dump-typed-ast Print typed AST summary to stderr.
 * --profile-compile Emit a phase-by-phase compile profile.
@@ -326,7 +326,7 @@ For example, if source files which module name is "org.onion_lang" is compiled, 
 #### Available options
 * -classpath <classpath> classpath of source files in compilation.
 * -encoding <encoding> encoding of source files.
-* -maxErrorReports <error count> the maximum number of comiplation errors reported.
+* -maxErrorReport <error count> the maximum number of compilation errors reported.
 * --dump-ast Print parsed AST to stderr.
 * --dump-typed-ast Print typed AST summary to stderr.
 * --profile-compile Emit a phase-by-phase compile profile.

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -30,7 +30,7 @@ Onionは、JVMバイトコードにコンパイルされる静的型付けのオ
 - `-classpath <path>` - コンパイル用のクラスパスを設定
 - `-encoding <encoding>` - ソースファイルのエンコーディングを設定
 - `-d <dir>` - クラスファイルの出力ディレクトリを設定
-- `-maxErrorReports <n>` - 報告するエラーの数を制限
+- `-maxErrorReport <n>` - 報告するエラーの数を制限
 - `--dump-ast` - パースされたASTを標準エラー出力に表示
 - `--dump-typed-ast` - 型付けされたASTの概要を標準エラー出力に表示
 - `--warn <off|on|error>` - 警告レベルを設定

--- a/docs/ja/tools/compiler.md
+++ b/docs/ja/tools/compiler.md
@@ -38,12 +38,12 @@ onionc -d build/classes MyProgram.on
 - Unix系: `org/onion_lang/MyClass.class`
 - Windows: `org\onion_lang\MyClass.class`
 
-### `-maxErrorReports <count>`
+### `-maxErrorReport <count>`
 
 報告するコンパイルエラーの最大数を制限します。大量のエラーがある大規模プロジェクトで便利です。
 
 ```bash
-onionc -maxErrorReports 10 MyProgram.on
+onionc -maxErrorReport 10 MyProgram.on
 ```
 
 ### `--dump-ast`
@@ -172,7 +172,7 @@ onionc \
   -d build/classes \
   -classpath lib/external.jar \
   -encoding UTF-8 \
-  -maxErrorReports 20 \
+  -maxErrorReport 20 \
   src/*.on
 ```
 

--- a/docs/ja/tools/script-runner.md
+++ b/docs/ja/tools/script-runner.md
@@ -26,12 +26,12 @@ onion -classpath lib/mylib.jar MyScript.on
 onion -encoding UTF-8 MyScript.on
 ```
 
-### `-maxErrorReports <count>`
+### `-maxErrorReport <count>`
 
 報告するコンパイルエラーの最大数を制限します。
 
 ```bash
-onion -maxErrorReports 10 MyScript.on
+onion -maxErrorReport 10 MyScript.on
 ```
 
 ### `--dump-ast`

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -38,12 +38,12 @@ Class files are organized by module name:
 - Unix-like: `org/onion_lang/MyClass.class`
 - Windows: `org\onion_lang\MyClass.class`
 
-### `-maxErrorReports <count>`
+### `-maxErrorReport <count>`
 
 Limit the number of compilation errors reported. Useful for large projects with many errors.
 
 ```bash
-onionc -maxErrorReports 10 MyProgram.on
+onionc -maxErrorReport 10 MyProgram.on
 ```
 
 ### `--dump-ast`
@@ -173,7 +173,7 @@ onionc \
   -d build/classes \
   -classpath lib/external.jar \
   -encoding UTF-8 \
-  -maxErrorReports 20 \
+  -maxErrorReport 20 \
   src/*.on
 ```
 

--- a/docs/tools/script-runner.md
+++ b/docs/tools/script-runner.md
@@ -26,12 +26,12 @@ Specify the character encoding of source files.
 onion -encoding UTF-8 MyScript.on
 ```
 
-### `-maxErrorReports <count>`
+### `-maxErrorReport <count>`
 
 Limit the number of compilation errors reported.
 
 ```bash
-onion -maxErrorReports 10 MyScript.on
+onion -maxErrorReport 10 MyScript.on
 ```
 
 ### `--dump-ast`

--- a/src/main/scala/onion/tools/CompilerFrontend.scala
+++ b/src/main/scala/onion/tools/CompilerFrontend.scala
@@ -170,8 +170,8 @@ class CompilerFrontend {
       case failure: ParseFailure =>
         val lackedOptions = failure.lackedOptions
         val invalidOptions = failure.invalidOptions
-        invalidOptions.foreach{opt => printError(Message.apply("error.command.invalidArgument", opt)) }
-        lackedOptions.foreach{opt => printError(Message.apply("error.command..noArgument", opt)) }
+        invalidOptions.foreach{opt => printError(Message.apply("error.command.invalidArgument", opt.value)) }
+        lackedOptions.foreach{opt => printError(Message.apply("error.command.noArgument", opt.value)) }
         None
     }
   }

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -274,8 +274,11 @@ class ScriptRunner {
   }
 
   private def printFailure(failure: ParseFailure): Unit = {
-    failure.lackedOptions.zipWithIndex.foreach{ case (lackedOption, i) =>
-      err.println(Message("error.command.noArgument", lackedOption))
+    failure.invalidOptions.foreach { invalidOption =>
+      err.println(Message("error.command.invalidArgument", invalidOption.value))
+    }
+    failure.lackedOptions.foreach { lackedOption =>
+      err.println(Message("error.command.noArgument", lackedOption.value))
     }
   }
 

--- a/src/test/scala/onion/tools/CliInvalidOptionSpec.scala
+++ b/src/test/scala/onion/tools/CliInvalidOptionSpec.scala
@@ -1,0 +1,59 @@
+package onion.tools
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Both CLI entry points reject a malformed command line before touching any source file, but
+ * they did so inconsistently:
+ *
+ *   - `CompilerFrontend` looked up the message key `error.command..noArgument` (a stray extra
+ *     dot) for an option missing its required argument (e.g. `onionc -classpath` with nothing
+ *     after it). The key does not exist, so `Message.apply` threw an uncaught
+ *     `MissingResourceException` instead of printing a diagnostic — a CLI-level crash reachable
+ *     from a plain typo, not just malformed source.
+ *   - `ScriptRunner`'s `printFailure` only walked `failure.lackedOptions`, never
+ *     `failure.invalidOptions`, so an unrecognized flag (e.g. `onion -maxErrorReports 5 x.on`,
+ *     the exact typo `-maxErrorReports` vs. the real `-maxErrorReport` that used to be
+ *     documented) failed with no message at all: exit code -1 and empty stderr.
+ */
+class CliInvalidOptionSpec extends AnyFunSuite with Matchers:
+  private def captureErr(body: => Int): (Int, String) =
+    val buf = new ByteArrayOutputStream()
+    val ps = new PrintStream(buf, true, "UTF-8")
+    val saved = System.err
+    val exitCode =
+      try
+        System.setErr(ps)
+        Console.withErr(ps)(body)
+      finally System.setErr(saved)
+    (exitCode, new String(buf.toByteArray, StandardCharsets.UTF_8))
+
+  test("CompilerFrontend reports a value-option missing its argument instead of crashing"):
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-classpath"))
+
+    exitCode shouldBe -1
+    err should include("-classpath")
+    err should not include "MissingResourceException"
+    err should not include "ValuedParam"
+
+  test("CompilerFrontend reports an unrecognized option"):
+    val (exitCode, err) = captureErr:
+      new CompilerFrontend().run(Array("-maxErrorReports", "5", "Hello.on"))
+
+    exitCode shouldBe -1
+    err should include("-maxErrorReports")
+    err should not include "ValuedParam"
+
+  test("ScriptRunner reports an unrecognized option instead of failing silently"):
+    val (exitCode, err) = captureErr:
+      new ScriptRunner().run(Array("-maxErrorReports", "5", "Hello.on"))
+
+    exitCode shouldBe -1
+    err should include("-maxErrorReports")
+    err should not include "ValuedParam"


### PR DESCRIPTION
## Summary

- `onionc` looked up the message key `error.command..noArgument` (a stray extra dot) for an option missing its required argument, so `Message.apply` threw an uncaught `MissingResourceException` instead of printing a diagnostic — e.g. `onionc -classpath` with nothing after it crashed with a raw stack trace.
- `onion`'s failure reporting only ever inspected lacked-argument options, never unrecognized ones, so a typo'd flag (e.g. `-maxErrorReports`) failed silently: exit code -1, empty stderr, no indication of what went wrong.
- Both frontends also leaked the option wrapper's `toString` into the message (`ValuedParam(-foo) is invalid argument.`) instead of the bare flag name.
- `CLAUDE.md`, `docs/ja/CLAUDE_ja.md`, `docs/tools/compiler.md`, `docs/ja/tools/compiler.md`, `docs/tools/script-runner.md`, `docs/ja/tools/script-runner.md`, and `README.md` documented a CLI flag that never existed — `-maxErrorReports` (plural) — instead of the real `-maxErrorReport` (singular). Following the docs literally is exactly what trips the silent-failure bug above. Fixed all seven, plus a "comiplation" typo in README.

## Test plan

- [x] Added `src/test/scala/onion/tools/CliInvalidOptionSpec.scala` (TDD: confirmed red against the bugs, green after the fix)
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2871 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging integration test that cancels when no packaged dist is built in this environment)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01QctcZnACJGRpabrhVe1NRY)_