### PR TITLE
test(run): execute HttpJsonClient.on instead of compile-checking only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `JsonYamlShapeDemo.on`, `ShapeFirst.on`.** Same treatment as above, for the
   next batch of deterministic, no-stdin/file/network/GUI examples.
 
+- **Execution coverage for `HttpJsonClient.on`.** Its no-args invocation hits
+  the early usage-message return before any network call, so it is
+  deterministic and now asserted on by `RunSamplesSpec` instead of only
+  compile-checked by `SampleCompilesSpec`.
+
 ### Fixed
 
 - **A malformed `onionc`/`onion` command line either crashed with a raw stack

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -272,5 +272,9 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs ShapeFirst.on") {
       assert(Shell.Success(null) == runSample("run/ShapeFirst.on"))
     }
+
+    it("runs HttpJsonClient.on with no args (usage message, no network call)") {
+      assert(Shell.Success("Usage: HttpJsonClient <url>") == runSample("run/HttpJsonClient.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds an execution-coverage test for `run/HttpJsonClient.on` in `RunSamplesSpec`, continuing the batch pattern from #463-#465
- The no-args invocation hits the early usage-message return before any network call, so the output is deterministic (`"Usage: HttpJsonClient <url>"`) and safe to assert on
- Notes the addition in `CHANGELOG.md`

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — 54/54 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2872/2872 passed, 1 canceled (pre-existing opt-in `ProjectDistributionSpec` smoke test requiring `-Donion.dist.path`, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GVBAaxqktoCHvhBbVKh64J)_