### PR TITLE
fix(typing): break/continue inside a closure body reports E0048/E0049 instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`break`/`continue` inside a lambda body crashed the compiler instead of
+  reporting E0048/E0049.** A closure body is compiled into its own
+  synthesized method with no enclosing loop, so a `break`/`continue`
+  lexically inside a lambda that merely sits inside a loop in the source
+  cannot actually reach that loop. Typing tracked loop/label nesting with a
+  plain counter and label stack that a closure body never reset, so the
+  check wrongly treated the lambda as being inside the loop; the program
+  passed typing and only blew up later in codegen with a raw
+  `[I0000] Internal compiler error ... Break statement outside of loop`.
+  `break`/`continue` inside a closure now correctly report E0048/E0049 at
+  the closure body, matching top-level break/continue diagnostics.
+
 ## [0.10.8] - 2026-07-28
 
 ### Added

--- a/src/main/scala/onion/compiler/LocalContext.scala
+++ b/src/main/scala/onion/compiler/LocalContext.scala
@@ -405,6 +405,26 @@ class LocalContext {
     finally flowNarrowings = saved
   }
 
+  /**
+   * A closure body is compiled into its own synthesized method with no
+   * enclosing loop, so a `break`/`continue` lexically inside a lambda cannot
+   * reach a loop that merely encloses the lambda expression in the source.
+   * Suppress the surrounding loop/label context for the dynamic extent of
+   * typing the closure body, so `break`/`continue` there is correctly flagged
+   * as outside a loop (E0048/E0049) instead of reaching codegen and crashing.
+   */
+  def withoutLoopContext[A](block: => A): A = {
+    val savedDepth = loopDepth
+    val savedLabels = labelStack
+    loopDepth = 0
+    labelStack = Nil
+    try block
+    finally {
+      loopDepth = savedDepth
+      labelStack = savedLabels
+    }
+  }
+
   /** Snapshot of both narrowing maps, used to bound narrowings to a region. */
   final case class NarrowingSnapshot(
     narrowings: Map[String, TypedAST.Type],

--- a/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
@@ -84,7 +84,7 @@ final class TypingBodyPass(private val typing: Typing, private val unitContext: 
       // A flow-sensitive var narrowing (issues #288/#289) is only valid on the
       // straight-line path that installed it; a closure may run later, after the
       // captured var has been reassigned, so suppress them inside the body.
-      context.withoutFlowNarrowings(block)
+      context.withoutFlowNarrowings(context.withoutLoopContext(block))
     }finally{
       if (collecting) context.popReturnTypeCollectionDepth()
       context.setClosure(wasInClosure)

--- a/src/test/scala/onion/compiler/tools/BreakContinueDiagnosticSpec.scala
+++ b/src/test/scala/onion/compiler/tools/BreakContinueDiagnosticSpec.scala
@@ -31,5 +31,35 @@ class BreakContinueDiagnosticSpec extends AbstractShellSpec {
     it("reports E0048 for a labeled break at top level") {
       assert(errorCodes("break outer\nIO::println(\"end\")\n").contains("E0048"))
     }
+    it("reports E0048 for a break inside a closure body nested in a for loop") {
+      val src =
+        """class C {
+          |public:
+          |  static def main(args: String[]): void {
+          |    for var i: Int = 0; i < 3; i = i + 1 {
+          |      val f: () -> Int = () -> { break; return 0 }
+          |      IO::println("" + f.call())
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      assert(errorCodes(src).contains("E0048"))
+    }
+    it("reports E0049 for a continue inside a closure body nested in a while loop") {
+      val src =
+        """class C {
+          |public:
+          |  static def main(args: String[]): void {
+          |    var i: Int = 0;
+          |    while i < 3 {
+          |      val f: () -> Int = () -> { continue; return 0 }
+          |      IO::println("" + f.call())
+          |      i = i + 1
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      assert(errorCodes(src).contains("E0049"))
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `break`/`continue` written inside a lambda body that lexically sits inside a loop used to pass typing unflagged and then crash codegen with a raw `[I0000] Internal compiler error in BytecodeGeneration: Break statement outside of loop` (or the analogous message for `continue`), instead of reporting the existing `E0048`/`E0049` diagnostics.
- Root cause: a closure body is compiled into its own synthesized method with no enclosing loop, so `break`/`continue` there can never actually reach a loop that merely encloses the lambda *expression* in the source. `LocalContext`'s loop-depth counter and label stack were never reset when typing a closure body (`TypingBodyPass.openClosure`), so the `break`/`continue` check wrongly saw "inside a loop" and let it through.
- Fix: added `LocalContext.withoutLoopContext`, mirroring the existing `withoutFlowNarrowings` pattern, and call it around the closure body in `openClosure`. A loop declared *inside* the closure body itself still works normally (verified manually), since loop depth is reset to 0, not disabled.

## Test plan

- [x] Added two regression tests to `BreakContinueDiagnosticSpec.scala` (break inside a closure nested in a `for`, continue inside a closure nested in a `while`) — confirmed red before the fix (`I0000`), green after (`E0048`/`E0049`).
- [x] Manually verified a loop declared inside a closure body still compiles and runs correctly (break inside the closure's own loop is untouched).
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2874 tests, 0 failed, 1 canceled (pre-existing, unrelated distribution-lifecycle integration test).


---
_Generated by [Claude Code](https://claude.ai/code/session_013gUgMFe47xP4fF1B2EYCrD)_