### PR TITLE
test(run): add execution coverage for AsyncDownloader.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Execution coverage for `AsyncDownloader.on`.** Its futures aggregate via
+  `Future::all`, which preserves input order regardless of completion
+  timing, so the concurrent-download output is deterministic; now asserted
+  on by `RunSamplesSpec` instead of only compile-checked by
+  `SampleCompilesSpec`.
+
 ### Fixed
 
 - **`break`/`continue` inside a lambda body crashed the compiler instead of

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -276,5 +276,9 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs HttpJsonClient.on with no args (usage message, no network call)") {
       assert(Shell.Success("Usage: HttpJsonClient <url>") == runSample("run/HttpJsonClient.on"))
     }
+
+    it("runs AsyncDownloader.on") {
+      assert(Shell.Success(null) == runSample("run/AsyncDownloader.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `run/AsyncDownloader.on` was previously only compile-checked by `SampleCompilesSpec`. Its concurrent futures aggregate via `Future::all`, which preserves input order regardless of completion timing, so the output is deterministic.
- Added an execution assertion to `RunSamplesSpec`, matching the pattern used for prior batches (`TodoManager.on`, `UnitConverter.on`, `ConfigApp.on`, etc.).
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *RunSamplesSpec'` — 55 tests, all green
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite, 2875 succeeded / 0 failed / 1 canceled (environment-gated `ProjectDistributionSpec` smoke test, expected outside an unpacked distribution)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv6R8PBvx5QQMuzjUCDPyB)_