### PR TITLE
test(run): add execution coverage for ShellPipeline.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on by `RunSamplesSpec` instead of only compile-checked by
   `SampleCompilesSpec`.
 
+- **Execution coverage for `ShellPipeline.on`.** Its `Proc::capture`/`Proc::run`
+  calls (`wc`, `sort | head` via `sh -c`, `echo`) only ever hit standard
+  POSIX utilities present on the CI runner and act on a fixed, already
+  alphabetically-sorted input list, so the output is deterministic; now
+  asserted on by `RunSamplesSpec` instead of only compile-checked by
+  `SampleCompilesSpec`.
+
 ### Fixed
 
 - **`break`/`continue` inside a lambda body crashed the compiler instead of

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -280,5 +280,9 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs AsyncDownloader.on") {
       assert(Shell.Success(null) == runSample("run/AsyncDownloader.on"))
     }
+
+    it("runs ShellPipeline.on") {
+      assert(Shell.Success(null) == runSample("run/ShellPipeline.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `ShellPipeline.on` was previously only compile-checked by `SampleCompilesSpec`, never asserted on at runtime.
- Its `Proc::capture`/`Proc::run` calls (`wc`, `sort | head` via `sh -c`, `echo`) only exercise standard POSIX utilities present on the CI runner (`ubuntu-latest`), and act on a fixed, already alphabetically-sorted input list — so the output is deterministic.
- Verified the actual output with `sbt runScript run/ShellPipeline.on` before writing the assertion, then added an execution-coverage test to `RunSamplesSpec` asserting `Shell.Success(null)` for the run.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec -- -z "ShellPipeline"'` — new test green
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite: 2876 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTMtiLJGtea6r1Umrf3z9f)_