### PR TITLE
test(run): execute Select.on and LineCounter.on instead of compile-checking only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   asserted on by `RunSamplesSpec` instead of only compile-checked by
   `SampleCompilesSpec`.
 
+- **Execution coverage for `Select.on` and `LineCounter.on`.** `Shell.run`
+  reports `Success` on the reflected return value of `main`, not captured
+  stdout, so both samples are deterministic to assert on (`Success(null)`)
+  even though `Select.on` branches on `Math::random()` and `LineCounter.on`'s
+  printed count depends on the current repo tree; now asserted on by
+  `RunSamplesSpec` instead of only compile-checked by `SampleCompilesSpec`.
+
 ### Fixed
 
 - **`break`/`continue` inside a lambda body crashed the compiler instead of

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -284,5 +284,13 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs ShellPipeline.on") {
       assert(Shell.Success(null) == runSample("run/ShellPipeline.on"))
     }
+
+    it("runs Select.on") {
+      assert(Shell.Success(null) == runSample("run/Select.on"))
+    }
+
+    it("runs LineCounter.on") {
+      assert(Shell.Success(null) == runSample("run/LineCounter.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `run/Select.on` and `run/LineCounter.on` were only compile-checked by `SampleCompilesSpec`; add them to `RunSamplesSpec` so they're actually executed.
- Both are safe to assert on exactly despite non-deterministic-looking content: `Shell.run` wraps `main`'s reflected return value (`Shell.Success(...)`), not captured stdout. `Select.on`'s printed branch depends on `Math::random()` and `LineCounter.on`'s printed count depends on the current repo tree, but both `main` methods return `void`, so both always yield `Shell.Success(null)` regardless.
- Other still-uncovered `run/` samples (`Calculator.on` — Swing GUI, `JsonApiClient.on` — live network call, `GuessNumber.on`/`TodoApp.on`/`LineFilter.on` — read `System::in`, and `Test / fork` isn't set so stdin isn't reliably redirectable in-process) were left alone as unsuitable for deterministic execution tests; converting them would need explicit stdin injection support that doesn't exist yet.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2878 succeeded, 0 failed, 1 canceled (pre-existing), full run green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0166CoU3cfrY5drGKY5HRKaz)_