### PR TITLE
docs: mark the v0.6-v0.8 roadmap as shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`docs/design/roadmap.md` still read as an open plan for v0.6-v0.8**, describing
+  `Shape[T]`, `Outcome`/`Defect`, `tool` declarations, effects, and lossless shapes as
+  future work with links to open issues — but all 19 tracking issues (#346-#364) are
+  closed and every item already ships in v0.10.9 (see `CLAUDE.md`'s "Tools, capabilities
+  and effects" section). Marked the page as a shipped historical record, pointing readers
+  at `CLAUDE.md` and `docs/reference/stdlib.md` for the current syntax; updated the
+  mkdocs nav label to match.
+
 ## [0.10.9] - 2026-07-28
 
 ### Added

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -1,8 +1,17 @@
 # Roadmap — v0.6 to v0.8
 
-Status: **index.** The roadmap itself lives on GitHub, because a roadmap in a file goes
-stale the moment work starts. This page exists so a reader who is not looking at the
-issue tracker can see the shape of the plan and follow it to the detail.
+Status: **shipped.** Every issue below (#346-#364) is closed, and the current release
+(v0.10.9) already implements `Shape[T]`, `Outcome`/`Defect`, `tool` declarations with
+effect inference and `--plan`, and lossless shapes with `edit`/`render` — see
+[CLAUDE.md](../../CLAUDE.md) ("Tools, capabilities and effects") and
+[docs/reference/stdlib.md](../reference/stdlib.md) for the syntax as it exists today.
+This page is kept as a historical record of the plan and its rationale; a few line
+items shipped with different scope than originally planned (e.g. #351's `zip` combinator
+was not deferred after all — see its issue for what changed).
+
+The roadmap itself used to live on GitHub, updated as work landed; this page exists so a
+reader not looking at the issue tracker can see the shape of the plan and follow it to
+the detail.
 
 - Why: [onion-v0.5-audit.md](onion-v0.5-audit.md) — what v0.5 is, with citations
 - What: [typed-boundaries.md](typed-boundaries.md) — the design thesis

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,7 +174,7 @@ nav:
   - Design Notes:
       - "Typed Boundaries (thesis)": design/typed-boundaries.md
       - v0.5 Audit: design/onion-v0.5-audit.md
-      - "Roadmap: v0.6-v0.8": design/roadmap.md
+      - "Roadmap: v0.6-v0.8 (shipped)": design/roadmap.md
       - README Rewrite Proposal: design/readme-rewrite-proposal.md
       - Type Classes: design/type-classes.md
       - Generics Design: GENERICS_DESIGN.md


### PR DESCRIPTION
## Summary
- `docs/design/roadmap.md` (linked from the published docs site nav as "Roadmap: v0.6-v0.8") still read as an open plan, describing `Shape[T]`, `Outcome`/`Defect`, `tool` declarations with effect inference, `--plan`, and lossless shapes as future work with links to open issues.
- All 19 tracking issues it references (#346-#364) are closed, and every one of those features already ships in v0.10.9 — documented in `CLAUDE.md`'s "Tools, capabilities and effects (v0.10)" section.
- Added a "shipped" status banner at the top of the roadmap page pointing readers at `CLAUDE.md` and `docs/reference/stdlib.md` for current syntax, kept the rest as a historical record of the plan/rationale, updated the mkdocs nav label to match, and added a `CHANGELOG.md` entry.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2878 succeeded, 0 failed, 1 pre-existing environment-conditional cancellation (`ProjectDistributionSpec`, requires `-Donion.dist.path`, unrelated to this change)
- Docs-only change; no compiler/runtime code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_0141KFau4U2TAsczouRSem1m)_