### PR TITLE
test(run): execute GuessNumber.on, LineFilter.on, and TodoApp.on instead of compile-checking only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Execution coverage for `GuessNumber.on`, `LineFilter.on`, and `TodoApp.on`.**
+  These samples build their own `BufferedReader` over `System::in` at execution
+  time (unlike `onion.IO`'s stdin reader, a static field bound to whatever
+  `System.in` was when that class first loaded), so feeding a fixed
+  `System.setIn` stream before each run makes them deterministic to assert on;
+  now asserted on by `RunSamplesSpec` instead of only compile-checked by
+  `SampleCompilesSpec`.
+
 ### Fixed
 
 - **`docs/design/roadmap.md` still read as an open plan for v0.6-v0.8**, describing

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -14,6 +14,16 @@ class RunSamplesSpec extends AbstractShellSpec {
   private def runSample(path: String): Shell.Result =
     shell.run(load(path), path, Array())
 
+  // Only for samples that build their own `BufferedReader` over `System::in` at
+  // execution time (not `onion.IO`, whose stdin reader is a static field bound to
+  // whatever `System.in` was when that class first loaded).
+  private def runSampleWithStdin(path: String, stdin: String): Shell.Result = {
+    val originalIn = System.in
+    System.setIn(new java.io.ByteArrayInputStream(stdin.getBytes(java.nio.charset.StandardCharsets.UTF_8)))
+    try runSample(path)
+    finally System.setIn(originalIn)
+  }
+
   describe("run/ samples") {
     it("runs ValVarInference.on") {
       assert(Shell.Success(60) == runSample("run/ValVarInference.on"))
@@ -291,6 +301,19 @@ class RunSamplesSpec extends AbstractShellSpec {
 
     it("runs LineCounter.on") {
       assert(Shell.Success(null) == runSample("run/LineCounter.on"))
+    }
+
+    it("runs GuessNumber.on: EOF on the first prompt exits immediately regardless of the random answer") {
+      assert(Shell.Success(null) == runSampleWithStdin("run/GuessNumber.on", ""))
+    }
+
+    it("runs LineFilter.on") {
+      assert(Shell.Success(null) == runSampleWithStdin("run/LineFilter.on", "hello\nworld\n"))
+    }
+
+    it("runs TodoApp.on: add, list, done, then quit") {
+      assert(Shell.Success(null) ==
+        runSampleWithStdin("run/TodoApp.on", "add buy milk\nlist\ndone 1\nlist\nquit\n"))
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds execution coverage in `RunSamplesSpec` for three `run/` samples that were previously only compile-checked by `SampleCompilesSpec`: `GuessNumber.on`, `LineFilter.on`, and `TodoApp.on`.
- These samples build their own `BufferedReader` over `System::in` at execution time rather than going through `onion.IO`'s cached stdin reader (a static field bound to whatever `System.in` was when that class first loaded), so feeding a fixed stream via `System.setIn` before each run makes them deterministic.
- Each sample's `main` returns `void`, so — following the same technique already used for `Select.on`/`LineCounter.on` — the assertion is on the reflected `Shell.Success(null)` return value rather than captured stdout, keeping it deterministic regardless of exact printed content.
- `GuessNumber.on` reads a random answer via `Rand::nextInt`, but feeding EOF on the very first prompt exits before any comparison, so the test is deterministic regardless of the random answer.
- `Calculator.on` (Swing GUI) and `JsonApiClient.on` (real network call) remain compile-checked only, since they can't be made deterministic this way.
- `ReadLine.on` also remains compile-checked only, since it goes through `onion.IO::readln`'s statically-cached stdin reader rather than a fresh `BufferedReader`, so `System.setIn` at test time doesn't reliably affect it.
- One `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly *RunSamplesSpec'` — 61/61 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite, 2881 succeeded, 0 failed (1 pre-existing cancellation unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01MPjKDRK3gphxpAA1hJLJqf)_