### PR TITLE
fix(cli): ScriptRunner honors main's returned Int as the process exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `tool` CLI's own validation failures (missing argument, unknown option, a
+  value that fails to parse) printed the right message but exited 0 instead of
+  1**, so a shell script checking `$?` after a misused tool CLI saw success.
+  `docs/guide/tools.md` documents these failures as returning `1` from `main`,
+  and `ToolCli.dispatch` did return that `1` — but `ScriptRunner.run`, the real
+  `onion` command-line entry point, discarded every script's returned `Int` and
+  always reported exit code 0 for a successful (non-throwing) run
+  (`case Shell.Success(_) => 0`). Any script using the `args: String[]` main
+  shape to signal a specific exit code via its return value hit the same gap.
+  `ScriptRunner` now uses `main`'s returned `Int` as the process exit code when
+  one is returned, and still exits 0 for a `void` main.
+
 - **`docs/design/roadmap.md` still read as an open plan for v0.6-v0.8**, describing
   `Shape[T]`, `Outcome`/`Defect`, `tool` declarations, effects, and lossless shapes as
   future work with links to open issues — but all 19 tracking issues (#346-#364) are

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -234,6 +234,10 @@ class ScriptRunner {
               // `usage: myscript.on <arg>` instead of the literal `<script>`.
               System.setProperty("onion.cli.script", new java.io.File(params.head).getName)
               new Shell(classOf[OnionClassLoader].getClassLoader, config.classPath).run(result.classes, scriptArgs) match {
+                // main's returned Int is the documented exit code (docs/guide/tools.md's
+                // "Failures are exit codes ... return 1 from main"); a void main (or any
+                // other return type) has no such meaning, so it keeps exiting 0.
+                case Shell.Success(value: java.lang.Integer) => value.intValue()
                 case Shell.Success(_) => 0
                 case Shell.Failure(code) => code
               }

--- a/src/test/scala/onion/tools/ScriptRunnerExitCodeSpec.scala
+++ b/src/test/scala/onion/tools/ScriptRunnerExitCodeSpec.scala
@@ -1,0 +1,105 @@
+package onion.tools
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * `ScriptRunner.run` translated every successful `main` invocation to process exit
+ * code 0, discarding the `Int` `main` actually returned. `Shell.run` already carries
+ * that value correctly (`Shell.Success(value)` -- see `ToolContractCliSpec`, which
+ * asserts on the wrapped value directly), but `ScriptRunner`, the real `onion` CLI
+ * entry point, threw it away: `case Shell.Success(_) => 0`. `docs/guide/tools.md`
+ * documents a failing tool CLI as returning `1` "from main"; nothing translated that
+ * into the OS-level exit code the actual command line reports, so a missing argument
+ * or unknown option printed the right message and still exited 0.
+ */
+class ScriptRunnerExitCodeSpec extends AnyFunSuite with Matchers:
+  private def captureOut(body: => Int): (Int, String) =
+    val buf = new ByteArrayOutputStream()
+    val ps = new PrintStream(buf, true, "UTF-8")
+    val (savedOut, savedErr) = (System.out, System.err)
+    val exitCode =
+      try
+        System.setOut(ps); System.setErr(ps)
+        Console.withOut(ps)(Console.withErr(ps)(body))
+      finally { System.setOut(savedOut); System.setErr(savedErr) }
+    (exitCode, new String(buf.toByteArray, StandardCharsets.UTF_8))
+
+  private def writeScript(source: String): String =
+    val src = Files.createTempFile("onion-exitcode", ".on")
+    Files.writeString(src, source, StandardCharsets.UTF_8)
+    src.toString
+
+  test("a main returning a non-zero Int becomes the process exit code"):
+    val path = writeScript(
+      """def main(args: String[]): Int {
+        |  IO::println("about to fail")
+        |  return 1
+        |}
+        |""".stripMargin)
+
+    val (exitCode, out) = captureOut(new ScriptRunner().run(Array(path)))
+
+    exitCode shouldBe 1
+    out should include("about to fail")
+
+  test("a main returning 0 keeps exiting 0"):
+    val path = writeScript(
+      """def main(args: String[]): Int {
+        |  return 0
+        |}
+        |""".stripMargin)
+
+    captureOut(new ScriptRunner().run(Array(path)))._1 shouldBe 0
+
+  test("a void main still exits 0"):
+    val path = writeScript(
+      """def main(): void {
+        |  IO::println("ok")
+        |}
+        |""".stripMargin)
+
+    captureOut(new ScriptRunner().run(Array(path)))._1 shouldBe 0
+
+  test("a tool CLI's missing-argument failure exits 1, not 0 (docs/guide/tools.md)"):
+    val path = writeScript(
+      """tool greet(name: String): Int requires { console } {
+        |  IO::println("hello " + name)
+        |  return 0
+        |}
+        |""".stripMargin)
+
+    val (exitCode, out) = captureOut(new ScriptRunner().run(Array(path)))
+
+    exitCode shouldBe 1
+    out should include("missing argument")
+
+  test("a tool CLI's unknown-option failure exits 1"):
+    val path = writeScript(
+      """tool greet(name: String): Int requires { console } {
+        |  IO::println("hello " + name)
+        |  return 0
+        |}
+        |""".stripMargin)
+
+    val (exitCode, _) = captureOut(new ScriptRunner().run(Array(path, "world", "--badflag")))
+
+    exitCode shouldBe 1
+
+  test("a tool CLI's successful run still exits 0"):
+    val path = writeScript(
+      """tool greet(name: String): Int requires { console } {
+        |  IO::println("hello " + name)
+        |  return 0
+        |}
+        |""".stripMargin)
+
+    val (exitCode, out) = captureOut(new ScriptRunner().run(Array(path, "world")))
+
+    exitCode shouldBe 0
+    out should include("hello world")


### PR DESCRIPTION
## Summary

- `ScriptRunner.run` (the real `onion` command-line entry point) discarded every script's returned `Int` and always reported process exit code 0 for a non-throwing run (`case Shell.Success(_) => 0`).
- `docs/guide/tools.md` documents a `tool` CLI's own validation failures (missing argument, unknown option, a value that fails to parse) as printing a message and returning `1` from `main`. `ToolCli.dispatch` does return that `1`, and `Shell.run` carries it correctly (`Shell.Success(1)`, already asserted by `ToolContractCliSpec`) — but `ScriptRunner` threw the value away, so a misused tool CLI printed the right message and still exited 0. A shell script checking `$?` after invoking it saw success.
- The same gap applies to any `def main(args: String[]): Int` script that signals a specific exit code through its return value.
- `ScriptRunner` now uses `main`'s returned `Int` as the process exit code when one is returned, and still exits 0 for a `void` main (unchanged).

Found via a practicality gap-probe sweep across several language domains; confirmed as a real bug (not a repro mistake) by re-running the minimal repro against a fresh build.

Scope note: a *zero-argument* top-level `def main(): Int` goes through a separate code path (`Rewriting.appendAutoCliCall`'s zero-arg wrapper, which calls `main()` as a top-level statement and discards its result) and is unaffected by this fix — that is a distinct gap, out of scope here.

## Test plan

- [x] Added `ScriptRunnerExitCodeSpec` (TDD: confirmed red against the prior behavior, green after the fix) covering: non-zero `Int` main, zero `Int` main, `void` main, tool-CLI missing-argument failure, tool-CLI unknown-option failure, tool-CLI successful run.
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2884 passed, 0 failed, 1 canceled (expected: the distribution smoke test, gated behind `-Donion.dist.path`).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TamSrqH4JXJVQqBWvqoRoB)_