### PR TITLE
fix(runtime): onion.IO stdin readers rebind after System.setIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`onion.IO`'s stdin readers (`readLine`, `readln`, `readInt`, `readLines`,
+  `eachLine`, ...) ignored a `System.setIn` swap made after the class had
+  already loaded.** The reader was a `BufferedReader` cached once in a static
+  field over whatever `System.in` was at class-init time, so redirecting
+  stdin afterwards (embedding hosts, REPLs, or tests) silently kept reading
+  from the original stream. It now re-wraps `System.in` whenever the current
+  stream differs from the one last wrapped. `run/ReadLine.on` — which reads
+  via `IO::readln`, unlike the samples that build their own reader — is now
+  asserted on by `RunSamplesSpec` with a redirected stdin.
+
 ## [0.10.10] - 2026-07-29
 
 ### Added

--- a/src/main/java/onion/IO.java
+++ b/src/main/java/onion/IO.java
@@ -6,7 +6,20 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 
 public class IO {
-    private static final BufferedReader STDIN = new BufferedReader(new InputStreamReader(System.in));
+    private static java.io.InputStream stdinSource;
+    private static BufferedReader stdinReader;
+
+    // Re-wraps System.in when it has been swapped out (e.g. System.setIn in a test
+    // or an embedding host) since the last read, instead of latching onto whatever
+    // System.in was the first time this class happened to load.
+    private static synchronized BufferedReader stdin() {
+        java.io.InputStream current = System.in;
+        if (stdinReader == null || stdinSource != current) {
+            stdinSource = current;
+            stdinReader = new BufferedReader(new InputStreamReader(current));
+        }
+        return stdinReader;
+    }
 
     public static void print(Object o) {
         System.out.print(o);
@@ -18,7 +31,7 @@ public class IO {
 
     public static String readLine() {
         try {
-            return STDIN.readLine();
+            return stdin().readLine();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -35,7 +48,7 @@ public class IO {
     public static String input(String prompt) {
         System.out.print(prompt);
         try {
-            return STDIN.readLine();
+            return stdin().readLine();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -73,7 +86,7 @@ public class IO {
     // Type-safe input methods
     public static int readInt() {
         try {
-            String line = STDIN.readLine();
+            String line = stdin().readLine();
             if (line == null) throw new UncheckedIOException(new IOException("End of input"));
             return Integer.parseInt(line.trim());
         } catch (IOException e) {
@@ -90,7 +103,7 @@ public class IO {
 
     public static long readLong() {
         try {
-            String line = STDIN.readLine();
+            String line = stdin().readLine();
             if (line == null) throw new UncheckedIOException(new IOException("End of input"));
             return Long.parseLong(line.trim());
         } catch (IOException e) {
@@ -107,7 +120,7 @@ public class IO {
 
     public static double readDouble() {
         try {
-            String line = STDIN.readLine();
+            String line = stdin().readLine();
             if (line == null) throw new UncheckedIOException(new IOException("End of input"));
             return Double.parseDouble(line.trim());
         } catch (IOException e) {
@@ -124,7 +137,7 @@ public class IO {
 
     public static boolean readBoolean() {
         try {
-            String line = STDIN.readLine();
+            String line = stdin().readLine();
             if (line == null) throw new UncheckedIOException(new IOException("End of input"));
             String trimmed = line.trim().toLowerCase();
             if (trimmed.equals("true") || trimmed.equals("yes") || trimmed.equals("1")) {
@@ -148,7 +161,7 @@ public class IO {
     public static Integer tryReadInt(String prompt) {
         System.out.print(prompt);
         try {
-            String line = STDIN.readLine();
+            String line = stdin().readLine();
             if (line == null) return null;
             return Integer.parseInt(line.trim());
         } catch (IOException | NumberFormatException e) {
@@ -159,7 +172,7 @@ public class IO {
     public static Double tryReadDouble(String prompt) {
         System.out.print(prompt);
         try {
-            String line = STDIN.readLine();
+            String line = stdin().readLine();
             if (line == null) return null;
             return Double.parseDouble(line.trim());
         } catch (IOException | NumberFormatException e) {
@@ -170,7 +183,7 @@ public class IO {
     public static Long tryReadLong(String prompt) {
         System.out.print(prompt);
         try {
-            String line = STDIN.readLine();
+            String line = stdin().readLine();
             if (line == null) return null;
             return Long.parseLong(line.trim());
         } catch (IOException | NumberFormatException e) {
@@ -184,7 +197,7 @@ public class IO {
         java.util.List<String> lines = new java.util.ArrayList<>();
         try {
             String line;
-            while ((line = STDIN.readLine()) != null) {
+            while ((line = stdin().readLine()) != null) {
                 lines.add(line);
             }
         } catch (IOException e) {
@@ -197,7 +210,7 @@ public class IO {
     public static void eachLine(Function1<String, ?> action) {
         try {
             String line;
-            while ((line = STDIN.readLine()) != null) {
+            while ((line = stdin().readLine()) != null) {
                 action.call(line);
             }
         } catch (IOException e) {

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -24,6 +24,14 @@ class RunSamplesSpec extends AbstractShellSpec {
     finally System.setIn(originalIn)
   }
 
+  private def runSampleWithStdinCapturingStdout(path: String, stdin: String): (Shell.Result, String) = {
+    val originalOut = System.out
+    val buffer = new java.io.ByteArrayOutputStream()
+    System.setOut(new java.io.PrintStream(buffer, true, "UTF-8"))
+    try (runSampleWithStdin(path, stdin), buffer.toString("UTF-8"))
+    finally System.setOut(originalOut)
+  }
+
   describe("run/ samples") {
     it("runs ValVarInference.on") {
       assert(Shell.Success(60) == runSample("run/ValVarInference.on"))
@@ -314,6 +322,12 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs TodoApp.on: add, list, done, then quit") {
       assert(Shell.Success(null) ==
         runSampleWithStdin("run/TodoApp.on", "add buy milk\nlist\ndone 1\nlist\nquit\n"))
+    }
+
+    it("runs ReadLine.on, reading its answer via onion.IO from the redirected stdin") {
+      val (result, output) = runSampleWithStdinCapturingStdout("run/ReadLine.on", "hello there\n")
+      assert(Shell.Success(null) == result)
+      assert(output.contains("You input: hello there"))
     }
   }
 }


### PR DESCRIPTION
## Summary
- `onion.IO` cached a `BufferedReader` over `System.in` in a static field at class-init time, so redirecting stdin afterwards (embedding hosts, REPLs, tests) was silently ignored by `readLine`/`readln`/`readInt`/`readLines`/`eachLine`/etc.
- It now re-wraps `System.in` whenever the current stream differs from the one last wrapped.
- `run/ReadLine.on` reads via `IO::readln` (unlike the other `run/` samples, which build their own `BufferedReader` and were therefore unaffected), so it was the one example left out of `RunSamplesSpec`'s stdin coverage — now added, with a redirected stdin, and verified to reproduce the bug ("You input: null" instead of the injected line) before this fix.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — confirmed the new test fails against the pre-fix `IO.java` (red), then passes after the fix (green).
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite: 2888 tests, 0 failed, 1 canceled (pre-existing, env-gated `ProjectDistributionSpec` smoke test requiring `-Donion.dist.path`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMSawas2cAzqbV7BccSUXY)_