### PR TITLE
test(run): add execution coverage for JsonApiClient.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via `IO::readln`, unlike the samples that build their own reader — is now
   asserted on by `RunSamplesSpec` with a redirected stdin.
 
+### Added
+
+- **Execution coverage for `JsonApiClient.on`.** The only remaining `run/`
+  sample that was compile-checked only (besides the Swing GUI `Calculator.on`,
+  which needs a display); its `Http::get` call against a live URL falls back
+  gracefully when the network is unreachable, so it is now asserted on by
+  `RunSamplesSpec` alongside the other network-calling samples.
+
 ## [0.10.10] - 2026-07-29
 
 ### Added

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -299,6 +299,10 @@ class RunSamplesSpec extends AbstractShellSpec {
       assert(Shell.Success(null) == runSample("run/AsyncDownloader.on"))
     }
 
+    it("runs JsonApiClient.on (network call falls back gracefully when unreachable)") {
+      assert(Shell.Success(null) == runSample("run/JsonApiClient.on"))
+    }
+
     it("runs ShellPipeline.on") {
       assert(Shell.Success(null) == runSample("run/ShellPipeline.on"))
     }


### PR DESCRIPTION
## Summary
- `run/JsonApiClient.on` was the last `run/` sample checked only for compilation (besides the Swing GUI `Calculator.on`, which needs a display).
- Its `Http::get` call against a live URL falls back gracefully (try/catch) when the network is unreachable, so it's now asserted on by `RunSamplesSpec` alongside the other network-calling samples (`AsyncDownloader.on`, `HttpJsonClient.on`).
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — 63/63 green, including the new test
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green (2889 succeeded, 0 failed, 1 canceled — the pre-existing conditional dist-smoke test that only runs with `-Donion.dist.path` set)


---
_Generated by [Claude Code](https://claude.ai/code/session_013QvwkK8ZhZiTk78y5UL27n)_