### PR TITLE
fix(shapes): config shape refuses a value that would corrupt the line-based format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `config` lossless shape (`shape name = config`) silently corrupted a document
+  when a printed or edited value's text contained a line break.** `key = value` lines
+  run to the end of the line, so rendering such a value split it into a bogus extra
+  line indistinguishable from a real entry — e.g. editing a `String` field to
+  `"evil\nport = 9999"` injected a fake `port` entry that a later `parseLossless`
+  either read back with the wrong value or rejected as a duplicate, with no error at
+  the point of corruption. `ConfigShape.print` and `.printLossless` now throw
+  `IllegalArgumentException` naming the offending field instead of misrendering,
+  consistent with the shape's documented L1 guarantee (`parse(print(v)) == Ok(v)`)
+  and the "refuse rather than pretend" handling already used for a foreign residue.
+
 ## [0.10.11] - 2026-07-29
 
 ### Fixed

--- a/src/main/java/onion/ConfigShape.java
+++ b/src/main/java/onion/ConfigShape.java
@@ -121,9 +121,25 @@ public final class ConfigShape<T> implements Shape<T> {
         List<Object> parts = explode.call(value);
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < names.size(); i++) {
-            sb.append(names.get(i)).append(" = ").append(render(parts.get(i))).append('\n');
+            String rendered = render(parts.get(i));
+            requireRenderable(names.get(i), rendered);
+            sb.append(names.get(i)).append(" = ").append(rendered).append('\n');
         }
         return sb.toString();
+    }
+
+    /**
+     * A `key = value` line runs to the end of the line, so a value whose rendered form
+     * contains a line break cannot be represented at all: printing it would silently
+     * split into an extra line indistinguishable from a real entry, corrupting the
+     * document instead of merely failing L2. Refuse rather than misrender.
+     */
+    private static void requireRenderable(String name, String rendered) {
+        if (rendered.indexOf('\n') >= 0 || rendered.indexOf('\r') >= 0) {
+            throw new IllegalArgumentException(
+                "config value for '" + name + "' contains a line break, which the line-based "
+                    + "`key = value` format cannot represent: " + rendered);
+        }
     }
 
     @Override
@@ -211,7 +227,9 @@ public final class ConfigShape<T> implements Shape<T> {
             Object now = parts.get(c);
             Object was = r.parsedValues.get(c);
             if (!java.util.Objects.equals(now, was)) {
-                replacements.put(at, render(now));
+                String rendered = render(now);
+                requireRenderable(names.get(c), rendered);
+                replacements.put(at, rendered);
             }
         }
 

--- a/src/test/scala/onion/compiler/tools/ConfigLosslessShapeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ConfigLosslessShapeSpec.scala
@@ -139,6 +139,46 @@ class ConfigLosslessShapeSpec extends AbstractShellSpec {
     }
   }
 
+  describe("a value that the line-based format cannot represent") {
+    it("print refuses rather than silently splitting a value containing a newline into a bogus extra line") {
+      val r = shell.run(decl +
+        """class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val v = new Server("evil\nport = 9999", 8080, true)
+          |    try {
+          |      Server::cfg().print(v)
+          |      return "no exception"
+          |    } catch e: IllegalArgumentException {
+          |      return "refused"
+          |    }
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("refused") == r, r.toString)
+    }
+
+    it("printLossless refuses the same way, instead of injecting an indistinguishable extra entry") {
+      val r = shell.run(decl +
+        """class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val text = "host = h\nport = 8080\ndebug = true\n"
+          |    val got = Server::cfg().parseLossless(text).get()
+          |    val edited = got.value().copy(host = "evil\nport = 9999")
+          |    try {
+          |      Server::cfg().printLossless(edited, got.residue())
+          |      return "no exception"
+          |    } catch e: IllegalArgumentException {
+          |      return "refused"
+          |    }
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("refused") == r, r.toString)
+    }
+  }
+
   describe("losslessness is a claim, not a default") {
     it("a lossy shape refuses parseLossless instead of pretending") {
       val r = shell.run(


### PR DESCRIPTION
## Summary

- `shape name = config` (the lossless `key = value` config shape, #362/#363) silently corrupted a document when a printed or edited value's rendered text contained a line break. Since a `key = value` line runs to the end of the line, such a value split into a bogus extra line indistinguishable from a real entry — e.g. editing a `String` field to `"evil\nport = 9999"` injected a fake `port` entry that a later `parseLossless` either read back with the wrong value or rejected as a duplicate, with **no error at the point of corruption**.
- `ConfigShape.print` and `.printLossless` now throw `IllegalArgumentException` naming the offending field instead of misrendering, matching the shape's documented L1 guarantee (`parse(print(v)) == Ok(v)`) and the existing "refuse rather than pretend" handling already used for a foreign residue in the same file.
- Added `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] Added two red→green tests to `ConfigLosslessShapeSpec` covering `print` and `printLossless` with an embedded-newline value; confirmed they failed before the fix and pass after.
- [x] `sbt -Duser.language=en 'testOnly *ConfigLosslessShapeSpec' 'testOnly *ConfigLensSpec'` — all green.
- [x] Full suite: `sbt -Duser.language=en test` — 2892 succeeded, 0 failed, 1 cancelled (the pre-existing distribution smoke test, gated behind `-Donion.dist.path`).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLDjocV9WymakANfBDREbe)_