### PR TITLE
fix(shapes): lines()/sepBy() refuse an element that would corrupt the format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `IllegalArgumentException` naming the offending field instead of misrendering,
   consistent with the shape's documented L1 guarantee (`parse(print(v)) == Ok(v)`)
   and the "refuse rather than pretend" handling already used for a foreign residue.
+- **`Shape#lines()` and `Shape#sepBy(separator)` had the same silent-corruption bug as
+  the `config` shape, one level down.** Printing a list where an element's own rendering
+  contained a newline (`lines()`) or the separator text (`sepBy`) split that one element
+  into two on read-back, indistinguishable from a real boundary — the shapes' own
+  Javadoc already warned L1 depended on this not happening, but nothing enforced it.
+  `LineShape.print` and `SepByShape.print` now throw `IllegalArgumentException` naming
+  the offending element's index instead of misrendering.
 
 ## [0.10.11] - 2026-07-29
 

--- a/src/main/java/onion/LineShape.java
+++ b/src/main/java/onion/LineShape.java
@@ -25,11 +25,29 @@ final class LineShape<T> implements Shape<List<T>> {
     @Override
     public String print(List<T> values) {
         StringBuilder sb = new StringBuilder();
+        int i = 0;
         for (T v : values) {
+            String rendered = element.print(v);
+            requireRenderable(i, rendered);
             if (sb.length() > 0) sb.append('\n');
-            sb.append(element.print(v));
+            sb.append(rendered);
+            i++;
         }
         return sb.toString();
+    }
+
+    /**
+     * One value per line runs to the end of the line, so an element whose rendering
+     * contains a line break cannot be represented at all: printing it would silently
+     * split into an extra line indistinguishable from a real element, corrupting the
+     * document instead of merely failing L1. Refuse rather than misrender.
+     */
+    private static void requireRenderable(int index, String rendered) {
+        if (rendered.indexOf('\n') >= 0 || rendered.indexOf('\r') >= 0) {
+            throw new IllegalArgumentException(
+                "element at index " + index + " contains a line break, which the "
+                    + "one-per-line format cannot represent: " + rendered);
+        }
     }
 
     @Override

--- a/src/main/java/onion/SepByShape.java
+++ b/src/main/java/onion/SepByShape.java
@@ -34,11 +34,28 @@ final class SepByShape<T> implements Shape<List<T>> {
     @Override
     public String print(List<T> values) {
         StringBuilder sb = new StringBuilder();
+        int i = 0;
         for (T v : values) {
+            String rendered = element.print(v);
+            requireRenderable(i, rendered);
             if (sb.length() > 0) sb.append(separator);
-            sb.append(element.print(v));
+            sb.append(rendered);
+            i++;
         }
         return sb.toString();
+    }
+
+    /**
+     * An element rendering that contains the separator is indistinguishable from a real
+     * boundary on reparse, so printing it would silently split one element into two
+     * instead of merely failing L1. Refuse rather than misrender.
+     */
+    private void requireRenderable(int index, String rendered) {
+        if (rendered.contains(separator)) {
+            throw new IllegalArgumentException(
+                "element at index " + index + " contains the separator '" + separator
+                    + "', which this sepBy shape cannot represent: " + rendered);
+        }
     }
 
     @Override

--- a/src/main/java/onion/Shape.java
+++ b/src/main/java/onion/Shape.java
@@ -149,7 +149,9 @@ public interface Shape<T> {
      * One value per line, all or nothing — every bad line's defect is reported together.
      *
      * <p>Prints one value per line, so L1 holds for the list as long as it holds for the
-     * element and no printed element contains a newline.
+     * element. An element whose rendering contains a newline cannot be represented at
+     * all — it would split into a bogus extra line — so {@link #print} refuses
+     * ({@link IllegalArgumentException}) rather than corrupt the document.
      */
     default Shape<java.util.List<T>> lines() {
         return new LineShape<>(this);
@@ -161,7 +163,10 @@ public interface Shape<T> {
      * <p>The separator is literal text, not a pattern: a shape describes a correspondence
      * and a regex separator would have no unique rendering, so {@link #print} could not
      * exist. Defects are positioned on the element they came from by index rather than by
-     * line, since a separated list need not be laid out one per line.
+     * line, since a separated list need not be laid out one per line. An element whose
+     * rendering contains the separator is indistinguishable from a real boundary on
+     * reparse, so {@link #print} refuses ({@link IllegalArgumentException}) rather than
+     * corrupt the document.
      */
     default Shape<java.util.List<T>> sepBy(String separator) {
         return new SepByShape<>(this, separator);

--- a/src/test/scala/onion/runtime/ShapeCombinatorSpec.scala
+++ b/src/test/scala/onion/runtime/ShapeCombinatorSpec.scala
@@ -31,6 +31,15 @@ class ShapeCombinatorSpec extends AnyFunSpec {
 
   private val src = Origin.atLine("points.txt", 1)
 
+  private def withPrinter(printer: Pt => String): Shape[Pt] = Shapes.regex(
+    "(-?\\d+),(-?\\d+)",
+    jlist(Seq("x", "y")),
+    jlist(Seq("Int", "Int")),
+    ((parts: java.util.List[Object]) =>
+      Pt(parts.get(0).asInstanceOf[Int], parts.get(1).asInstanceOf[Int])): Function1[java.util.List[Object], Pt],
+    new Function1[Pt, String] { def call(p: Pt): String = printer(p) }
+  )
+
   describe("eachLine — the good rows and the bad ones, both") {
     val text = "1,2\nbroken\n3,4\nalso bad\n5,6"
 
@@ -84,6 +93,17 @@ class ShapeCombinatorSpec extends AnyFunSpec {
       val vs = jlist(Seq(Pt(0, 0), Pt(-1, 2), Pt(30, -40)))
       assert(point.lines.parse(point.lines.print(vs), src).get == vs)
     }
+
+    it("refuses to print an element whose rendering embeds a newline") {
+      // A `\n` inside a printed element is indistinguishable from a real line break,
+      // so printing it would silently split one element into two bogus lines instead
+      // of merely failing L1 (the same corruption `ConfigShape.print` refuses, #478).
+      val evil = withPrinter(p => s"${p.x}\n${p.y}")
+      val ex = intercept[IllegalArgumentException] {
+        evil.lines.print(jlist(Seq(Pt(1, 2))))
+      }
+      assert(ex.getMessage.contains("\\n") || ex.getMessage.toLowerCase.contains("line"))
+    }
   }
 
   describe("sepBy — repetition with a literal separator") {
@@ -109,6 +129,17 @@ class ShapeCombinatorSpec extends AnyFunSpec {
       val r = point.sepBy(",,").parse("bad,,1,2,,worse", src)
       assert(r.isBad)
       assert(r.defects.size == 2, r.describe)
+    }
+
+    it("refuses to print an element whose rendering embeds the separator") {
+      // An element rendering that contains the separator is indistinguishable from a
+      // real boundary on reparse, so printing it would silently split one element into
+      // two on read-back instead of merely failing L1.
+      val evil = withPrinter(p => s"${p.x} | ${p.y}")
+      val ex = intercept[IllegalArgumentException] {
+        evil.sepBy(" | ").print(jlist(Seq(Pt(1, 2))))
+      }
+      assert(ex.getMessage.contains("|"))
     }
   }
 


### PR DESCRIPTION
## Summary
- `Shape#lines()` and `Shape#sepBy(separator)` printed a list by joining each element's rendering with the delimiter, without checking that an element's own rendering didn't already contain it. An element whose `print()` embeds the delimiter split into a bogus extra element on read-back, silently breaking the shape's own L1 guarantee (`parse(print(v)) == Ok(v)`) — the same corruption class the `ConfigShape` fix (`8dc1d6c2`, #478) addressed one level up. Both `lines()`'s and `sepBy()`'s own Javadoc already warned L1 depended on this not happening, but nothing enforced it.
- `LineShape.print` and `SepByShape.print` now throw `IllegalArgumentException` naming the offending element's index instead of misrendering, matching `ConfigShape`'s "refuse rather than corrupt" handling.
- Updated `Shape.lines()`/`Shape.sepBy()` Javadoc to describe the new refusal instead of just warning about the risk.
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] Added two regression tests to `ShapeCombinatorSpec` (`refuses to print an element whose rendering embeds a newline` / `... the separator`), confirmed red before the fix, green after.
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2894 succeeded, 0 failed, 1 canceled (pre-existing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn3R7vV8hnJzhMRsd5TmZw)_