### PR TITLE
docs(shapes): document the refuse-rather-than-corrupt behavior of lines()/sepBy()/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LineShape.print` and `SepByShape.print` now throw `IllegalArgumentException` naming
   the offending element's index instead of misrendering.
 
+### Documentation
+
+- **`docs/guide/shapes.md` (en/ja) never documented the "refuse rather than corrupt"
+  behavior of `lines()`, `sepBy(separator)`, and `shape name = config`.** The guide's
+  "Writing" section described the L1 round-trip guarantee but said nothing about the
+  `IllegalArgumentException` these shapes throw when a value's own rendering would be
+  indistinguishable from a real delimiter on read-back — behavior shipped by the two
+  fixes above. Added a short explanation with an example to both language versions.
+
 ## [0.10.11] - 2026-07-29
 
 ### Fixed

--- a/docs/guide/shapes.md
+++ b/docs/guide/shapes.md
@@ -97,6 +97,23 @@ Pt::loose().canPrint()     // false
 
 This is a question you can ask, rather than a method that silently does not exist.
 
+Some shapes can print but still refuse a particular value, when printing it would break
+the round-trip. `lines()` and `sepBy(separator)` join each element's rendering with a
+delimiter — a newline, or the separator text — so a real boundary can be told apart from
+an element's own content on read-back. If an element's rendering already contains that
+delimiter, joining would silently split it into a bogus extra element instead. Both throw
+`IllegalArgumentException` naming the offending element's index rather than misrender:
+
+```onion
+val intList: Shape[List[Int]] = intShape.sepBy(",")
+intList.print(evilInts)   // throws: element at index 1 contains the separator, ...
+```
+
+`shape name = config` has the same protection one level up: a `key = value` line runs to
+the end of the line, so a value whose text contains a line break cannot be represented
+either — `print` and `printLossless` throw naming the offending field instead of
+injecting a fake extra entry.
+
 ## Documents
 
 Naming a format instead of a pattern reads a structured document, with the component names

--- a/docs/ja/guide/shapes.md
+++ b/docs/ja/guide/shapes.md
@@ -97,6 +97,22 @@ Pt::loose().canPrint()     // false
 
 「メソッドが黙って存在しない」ではなく、**問い合わせられる**という点が違います。
 
+書き戻しができる shape でも、往復性を壊す値は拒否することがあります。`lines()` と
+`sepBy(separator)` は各要素の書き戻し結果を区切り文字（改行、または区切り文字列）で
+つなぎますが、これは読み戻すときに「本物の境界」と「要素自身の内容」を区別するための
+ものです。要素の書き戻し結果がすでにその区切り文字を含んでいると、つなぐ際に黙って
+偽の要素へ分裂してしまいます。両者とも誤った結果を返す代わりに、問題の要素の
+インデックスを添えて `IllegalArgumentException` を投げます。
+
+```onion
+val intList: Shape[List[Int]] = intShape.sepBy(",")
+intList.print(evilInts)   // throws: element at index 1 contains the separator, ...
+```
+
+`shape name = config` も一段下で同じ保護を持ちます。`key = value` は行末までが値なので、
+改行を含む値も同様に表現できません —— `print` と `printLossless` は、偽のエントリを
+挿入する代わりに、問題のフィールド名を添えて例外を投げます。
+
 ## 文書を読む
 
 パターンの代わりにフォーマット名を書くと、成分名をキーとして構造化文書を読みます。


### PR DESCRIPTION
## Summary
- The two most recent fixes (`8dc1d6c2`, `94c0c3bd`) made `lines()`, `sepBy(separator)`, and `shape name = config` throw `IllegalArgumentException` instead of silently corrupting a document when a value's own rendering would be indistinguishable from a real delimiter on read-back — but `docs/guide/shapes.md` and its `docs/ja/guide/shapes.md` mirror never mentioned this.
- Added a short paragraph + example to the "Writing" section of both language versions, and a `CHANGELOG.md` entry under `[Unreleased] / Documentation`.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2894 tests, 0 failed (green)
- [x] Docs-only change; no code paths touched

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01PLyZC97uHKebFnHZGxVqDL)_