### PR TITLE
test(diagnostics): assert E0067/E0042 error codes explicitly

### DIFF
--- a/src/test/scala/onion/compiler/tools/MissingReturnSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MissingReturnSpec.scala
@@ -1,6 +1,8 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * A value-returning method whose block body can complete without returning must
@@ -9,38 +11,47 @@ import onion.tools.Shell
  * JVM default (0 / null) with no diagnostic.
  */
 class MissingReturnSpec extends AbstractShellSpec {
-  private def compileFails(program: String): Boolean =
-    shell.run(program, "None", Array()) == Shell.Failure(-1)
+  private def errorCodes(program: String): Seq[Option[String]] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val inputs = Seq(new StreamInputSource(() => new StringReader(program), "MissingReturn.on"))
+    new OnionCompiler(config).compile(inputs) match {
+      case CompilationOutcome.Failure(errs) => errs.map(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
 
   describe("missing return") {
     it("rejects a value-returning body with no return") {
-      assert(compileFails(
+      val codes = errorCodes(
         """
           |class Foo {
           |public:
           |  def bar(): Int { IO::println("x") }
           |}
-          |""".stripMargin))
+          |""".stripMargin)
+      assert(codes.contains(Some("E0067")), s"expected E0067, got: $codes")
     }
 
     it("rejects a body whose tail expression is not returned") {
-      assert(compileFails(
+      val codes = errorCodes(
         """
           |class Foo {
           |public:
           |  def compute(): Int { 5 + 10 }
           |}
-          |""".stripMargin))
+          |""".stripMargin)
+      assert(codes.contains(Some("E0067")), s"expected E0067, got: $codes")
     }
 
     it("rejects a body that returns on only some paths") {
-      assert(compileFails(
+      val codes = errorCodes(
         """
           |class Foo {
           |public:
           |  def bar(n: Int): Int { if n > 0 { return 1 } }
           |}
-          |""".stripMargin))
+          |""".stripMargin)
+      assert(codes.contains(Some("E0067")), s"expected E0067, got: $codes")
     }
 
     it("accepts explicit return, = expr, if/else, and while-true bodies") {

--- a/src/test/scala/onion/compiler/tools/SealedExhaustivenessSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SealedExhaustivenessSpec.scala
@@ -1,6 +1,8 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * A `select` over a sealed type must be exhaustive. Subtypes declared with an
@@ -8,16 +10,25 @@ import onion.tools.Shell
  * compile error (E0042) rather than a silent `null` at runtime.
  */
 class SealedExhaustivenessSpec extends AbstractShellSpec {
+  private def errorCodes(program: String): Seq[Option[String]] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val inputs = Seq(new StreamInputSource(() => new StringReader(program), "SealedExhaustiveness.on"))
+    new OnionCompiler(config).compile(inputs) match {
+      case CompilationOutcome.Failure(errs) => errs.map(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
   describe("sealed exhaustiveness") {
     it("rejects a non-exhaustive select over a sealed class with class subtypes") {
-      val r = shell.run(
+      val codes = errorCodes(
         """
           |sealed class Expr {}
           |class Num extends Expr { public: def this { } }
           |class Add extends Expr { public: def this { } }
           |def kind(e: Expr): String { return select e { case n is Num: "num" } }
-          |""".stripMargin, "None", Array())
-      assert(Shell.Failure(-1) == r)
+          |""".stripMargin)
+      assert(codes.contains(Some("E0042")), s"expected E0042, got: $codes")
     }
     it("accepts an exhaustive select over a sealed class") {
       val r = shell.run(
@@ -36,14 +47,14 @@ class SealedExhaustivenessSpec extends AbstractShellSpec {
       assert(Shell.Success("add") == r)
     }
     it("rejects a non-exhaustive select over a sealed interface with class subtypes") {
-      val r = shell.run(
+      val codes = errorCodes(
         """
           |sealed interface Shape {}
           |class Circle conforms Shape { public: def this { } }
           |class Square conforms Shape { public: def this { } }
           |def name(s: Shape): String { return select s { case c is Circle: "circle" } }
-          |""".stripMargin, "None", Array())
-      assert(Shell.Failure(-1) == r)
+          |""".stripMargin)
+      assert(codes.contains(Some("E0042")), s"expected E0042, got: $codes")
     }
   }
 }


### PR DESCRIPTION
## Summary
- `MissingReturnSpec` and `SealedExhaustivenessSpec` only asserted `Shell.Failure(-1)` (or `isInstanceOf[Shell.Failure]`), never the specific error code their own doc comments already named (E0067 `MISSING_RETURN`, E0042 `NON_EXHAUSTIVE_PATTERN_MATCH`).
- Both specs now compile via `OnionCompiler` directly (same pattern as `ClassAccessibilitySpec`) and assert `errorCode` explicitly, so a future regression that swaps in a different/generic error code will be caught instead of silently passing as long as compilation merely fails.
- No production code changes — test-only.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.MissingReturnSpec onion.compiler.tools.SealedExhaustivenessSpec'` — 7/7 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite: 2896 succeeded, 0 failed, 1 canceled (pre-existing, opt-in dist smoke test gated on `-Donion.dist.path`, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Lo9hN7RzVCEe43A73uh53)_