### PR TITLE
docs(ja): translate the missing Wrapper Classes / Common Java Classes sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   save them from a test that passes locally but fails only in CI. Added the translation
   and a new `ClaudeMdTestingLocaleIndependenceParitySpec` drift guard so a future
   omission fails the build instead of silently rotting.
+- **`docs/ja/reference/stdlib.md` was missing the "Wrapper Classes" (`JInteger`,
+  `JLong`, `JDouble`, `JBoolean`) and "Common Java Classes" (`String`,
+  `StringBuilder`, `ArrayList`, `HashMap`, `File`, `BufferedReader`,
+  `BufferedWriter`) sections present in `docs/reference/stdlib.md`, even though
+  both languages' "at a glance" tables promise this coverage. `StdlibDocDriftSpec`
+  couldn't catch it — those names are deliberately excluded there as JDK types /
+  import aliases rather than `onion.*` stdlib classes. Added the translation and a
+  new `StdlibDocWrapperAndCommonJavaClassesParitySpec` drift guard.
 
 ## [0.10.11] - 2026-07-29
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -270,6 +270,169 @@ val add: Function2[Int, Int, Int] = (x: Int, y: Int) -> { return x + y; }
 val result: Int = add.call(3, 7)
 ```
 
+## ラッパークラス
+
+プリミティブ型に対応するJavaのラッパークラス（文脈によっては`J`接頭辞でアクセス）。
+
+### JInteger
+
+Integer操作:
+
+```onion
+val i: Int = JInteger::parseInt("42")
+val s: String = JInteger::toString(42)
+val max: Int = JInteger::MAX_VALUE
+val min: Int = JInteger::MIN_VALUE
+```
+
+### JLong
+
+Long操作:
+
+```onion
+val l: Long = JLong::parseLong("1234567890")
+val s: String = JLong::toString(1234567890L)
+```
+
+### JDouble
+
+Double操作:
+
+```onion
+val d: Double = JDouble::parseDouble("3.14")
+val s: String = JDouble::toString(3.14)
+```
+
+### JBoolean
+
+Boolean操作:
+
+```onion
+val b: Boolean = JBoolean::parseBoolean("true")
+val s: String = JBoolean::toString(true)
+```
+
+## よく使うJavaクラス
+
+よく使われるJava標準ライブラリのクラス。
+
+### String
+
+文字列操作（自動的に利用可能）:
+
+```onion
+val text: String = "Hello, World!"
+val upper: String = text.toUpperCase()
+val lower: String = text.toLowerCase()
+val length: Int = text.length()
+val sub: String = text.substring(0, 5)
+val contains: Boolean = text.contains("World")
+val starts: Boolean = text.startsWith("Hello")
+val ends: Boolean = text.endsWith("!")
+```
+
+### StringBuilder
+
+効率的な文字列構築:
+
+```onion
+import { java.lang.StringBuilder; }
+
+val builder: StringBuilder = new StringBuilder()
+builder.append("Hello")
+builder.append(" ")
+builder.append("World")
+val result: String = builder.toString()
+```
+
+### ArrayList
+
+動的配列:
+
+```onion
+import { java.util.ArrayList; }
+
+val list: ArrayList[String] = new ArrayList[String]
+list.add("First")
+list << "Second"  // <<演算子を使用
+val size: Int = list.size()
+val item: Object = list.get(0)
+list.remove(0)
+val empty: Boolean = list.isEmpty()
+```
+
+### HashMap
+
+キーバリューマップ:
+
+```onion
+import { java.util.HashMap; }
+
+val map: HashMap[String, String] = new HashMap[String, String]
+map.put("key1", "value1")
+map.put("key2", "value2")
+val value: Object = map.get("key1")
+val has: Boolean = map.containsKey("key1")
+val size: Int = map.size()
+```
+
+### File
+
+ファイル操作:
+
+```onion
+import { java.io.File; }
+
+val file: File = new File("data.txt")
+val exists: Boolean = file.exists()
+val isFile: Boolean = file.isFile()
+val isDir: Boolean = file.isDirectory()
+val name: String = file.getName()
+val path: String = file.getPath()
+val length: Long = file.length()
+```
+
+### BufferedReader
+
+テキストの読み取り:
+
+```onion
+import {
+  java.io.BufferedReader;
+  java.io.FileReader;
+}
+
+val reader: BufferedReader = new BufferedReader(
+  new FileReader("file.txt")
+)
+
+var line: String = null
+while (line = reader.readLine()) != null {
+  IO::println(line)
+}
+
+reader.close()
+```
+
+### BufferedWriter
+
+テキストの書き込み:
+
+```onion
+import {
+  java.io.BufferedWriter;
+  java.io.FileWriter;
+}
+
+val writer: BufferedWriter = new BufferedWriter(
+  new FileWriter("output.txt")
+)
+
+writer.write("Hello, World!")
+writer.newLine()
+writer.close()
+```
+
 ## Rand モジュール
 
 `onion.Rand`による乱数生成ユーティリティ。

--- a/src/test/scala/onion/compiler/tools/StdlibDocWrapperAndCommonJavaClassesParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocWrapperAndCommonJavaClassesParitySpec.scala
@@ -1,0 +1,41 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Wrapper Classes" and "Common Java Classes" sections of
+ * docs/reference/stdlib.md against their Japanese translation in
+ * docs/ja/reference/stdlib.md, which is missing both top-level sections entirely
+ * (`StdlibDocDriftSpec` can't catch this: `JInteger`/`String`/`StringBuilder`/... are
+ * deliberately excluded there as non-`onion.*` aliases and JDK types).
+ */
+class StdlibDocWrapperAndCommonJavaClassesParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def subheadingsUnder(doc: String, heading: String): Seq[String] = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).filter(_.trim.startsWith("### "))
+  }
+
+  it("has the same number of Wrapper Classes subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/reference/stdlib.md"), "## Wrapper Classes")
+    val ja = subheadingsUnder(read("docs/ja/reference/stdlib.md"), "## ラッパークラス")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Wrapper Classes section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/reference/stdlib.md has ${en.size} Wrapper Classes subsections but " +
+      s"docs/ja/reference/stdlib.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+
+  it("has the same number of Common Java Classes subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/reference/stdlib.md"), "## Common Java Classes")
+    val ja = subheadingsUnder(read("docs/ja/reference/stdlib.md"), "## よく使うJavaクラス")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Common Java Classes section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/reference/stdlib.md has ${en.size} Common Java Classes subsections but " +
+      s"docs/ja/reference/stdlib.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/ja/reference/stdlib.md` was missing the "Wrapper Classes" (`JInteger`, `JLong`, `JDouble`, `JBoolean`) and "Common Java Classes" (`String`, `StringBuilder`, `ArrayList`, `HashMap`, `File`, `BufferedReader`, `BufferedWriter`) sections present in `docs/reference/stdlib.md`, even though both languages' "at a glance" tables already promise this coverage.
- `StdlibDocDriftSpec` didn't catch this because those class names are deliberately excluded there as JDK types / import aliases rather than `onion.*` stdlib classes.
- Added the missing translation (placed to match the English doc's section adjacency: right after "Function Interfaces" / "関数インターフェース") plus a new targeted drift-guard spec, `StdlibDocWrapperAndCommonJavaClassesParitySpec`, asserting the subsection counts match between the two languages.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan

- [x] `sbt -Duser.language=en "testOnly *StdlibDocWrapperAndCommonJavaClassesParitySpec"` — confirmed red before the translation, green after.
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green (2899 succeeded, 0 failed, 1 canceled).

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhLtP226DPWV6jEa7jmqDG)_