### PR TITLE
fix(docs): roadmap.md link to CLAUDE.md broke the strict mkdocs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Deploy MkDocs to GitHub Pages` failed on every push since before v0.10.11.**
+  `docs/design/roadmap.md` linked to `../../CLAUDE.md` — a real repo-root file,
+  but one that lives outside mkdocs' `docs_dir` (`docs/`), so `mkdocs build
+  --strict` reported it as broken and aborted the deploy even though the link
+  resolved fine on GitHub. The link now points at the GitHub blob URL instead,
+  which isn't subject to mkdocs' local-file link resolution. (#486)
+
 ## [0.10.12] - 2026-07-29
 
 ### Fixed

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -3,7 +3,7 @@
 Status: **shipped.** Every issue below (#346-#364) is closed, and the current release
 (v0.10.9) already implements `Shape[T]`, `Outcome`/`Defect`, `tool` declarations with
 effect inference and `--plan`, and lossless shapes with `edit`/`render` — see
-[CLAUDE.md](../../CLAUDE.md) ("Tools, capabilities and effects") and
+[CLAUDE.md](https://github.com/onion-lang/onion/blob/main/CLAUDE.md) ("Tools, capabilities and effects") and
 [docs/reference/stdlib.md](../reference/stdlib.md) for the syntax as it exists today.
 This page is kept as a historical record of the plan and its rationale; a few line
 items shipped with different scope than originally planned (e.g. #351's `zip` combinator


### PR DESCRIPTION
## Summary
- `docs/design/roadmap.md` linked to `../../CLAUDE.md`, a real repo-root file that lives outside mkdocs' `docs_dir` (`docs/`). `mkdocs build --strict` only resolves relative links against files inside `docs_dir`, so this link has failed every Pages deploy since before v0.10.11, even though it resolves fine on GitHub.
- Point the link at the GitHub blob URL (`https://github.com/onion-lang/onion/blob/main/CLAUDE.md`) instead, which sidesteps mkdocs' local-file link resolution entirely.
- Reproduced the failure locally (`pip install mkdocs-material mkdocs-glightbox && mkdocs build --strict`) before the fix, and confirmed a clean `Documentation built in ...` with exit code 0 after.

Fixes #486

## Test plan
- [x] `mkdocs build --strict` exits 0 locally (previously aborted with the exact warning from #486)
- [ ] `sbt -Duser.language=en test` (full suite) — running; this PR is marked **draft** until it completes and is confirmed green, per this repo's release-safety policy

Opened as draft while the full sbt test suite (unrelated to this docs-only change, but required by policy before any merge) finishes running.

---
_Generated by [Claude Code](https://claude.ai/code/session_012YVWenjaAkNzk8KDSSgheA)_