### PR TITLE
fix(stdlib): Yaml::stringify quotes map keys that would collide with the key: value separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolved fine on GitHub. The link now points at the GitHub blob URL instead,
   which isn't subject to mkdocs' local-file link resolution. (#486)
 
+- **`Yaml::stringify` silently corrupted a map whose key contained `: ` (or
+  leading/trailing whitespace) instead of failing.** The value side already
+  double-quoted a string that would be misread on parse-back (containing `:`,
+  `#`, a newline, or looking like a number/boolean — the `[0.10.12]` fixes
+  below hardened the same hazard for `lines()`/`sepBy()`/`config` shapes), but
+  the *key* was written raw. A key like `"a: b"` rendered as `a: b: 1`, which
+  `Yaml::parse` read back as key `"a"` with value `"b: 1"` (a String) — the
+  original key silently disappeared with no exception. `Yaml::stringify` now
+  quotes the key under the same rule it already applies to values, symmetric
+  with how `Json::stringify` has always quoted keys; the parser already
+  supported reading a quoted key, so no parser change was needed.
+
 ## [0.10.12] - 2026-07-29
 
 ### Fixed

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -668,7 +668,7 @@ val obj = Yaml::parse("name: ko\nage: 3")    // Object（実体は Map）
 val text = Yaml::stringify(obj)               // "name: ko\nage: 3\n"
 ```
 
-scalar の型推論は Json と一致します（`3`→Long、`3.5`→Double、`true`→Boolean、`null`→null）。自分が出力した範囲を読み戻せる round-trip サブセットで、`record ... derive!(Yaml)` の土台になっています。
+scalar の型推論は Json と一致します（`3`→Long、`3.5`→Double、`true`→Boolean、`null`→null）。自分が出力した範囲を読み戻せる round-trip サブセットで、`record ... derive!(Yaml)` の土台になっています。`:` や前後の空白を含むキーは `key: value` の区切りと衝突しないよう自動的にダブルクォートされます(値側の quoting ルールと同じ)。
 
 ## Config モジュール
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -937,7 +937,10 @@ val yaml = Yaml::stringify(m)
 
 String values that would be misread on parse-back (those containing `:`,
 `#`, newlines, or that look like numbers or booleans) are automatically
-double-quoted. Numbers and booleans are rendered verbatim.
+double-quoted. Numbers and booleans are rendered verbatim. Map **keys** are
+quoted under the same rule — a key containing `:` or leading/trailing
+whitespace is double-quoted so it doesn't collide with the `key: value`
+separator on parse-back.
 
 ### Round-trip guarantee
 

--- a/src/main/java/onion/Yaml.java
+++ b/src/main/java/onion/Yaml.java
@@ -49,7 +49,11 @@ public final class Yaml {
 
     /**
      * Convert a Java object (Map or scalar) to YAML flat block mapping text.
-     * Each map entry is rendered as {@code key: value\n}.
+     * Each map entry is rendered as {@code key: value\n}. Keys go through the same
+     * quoting rule as string values ({@link #needsQuoting}), so a key containing
+     * {@code :}, {@code #}, whitespace at either end, or a newline round-trips
+     * through {@link #parse} instead of colliding with the {@code key: value}
+     * separator.
      *
      * @param obj Object to serialize. Must be a Map&lt;?,?&gt; or a scalar
      *            (String/Long/Double/Float/Integer/Short/Byte/Boolean/null).
@@ -62,7 +66,7 @@ public final class Yaml {
         if (obj instanceof Map<?, ?> map) {
             StringBuilder sb = new StringBuilder();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
-                String key = entry.getKey().toString();
+                String key = renderString(entry.getKey().toString());
                 sb.append(key);
                 sb.append(": ");
                 sb.append(renderScalar(entry.getValue()));

--- a/src/test/scala/onion/compiler/tools/YamlKeyQuotingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/YamlKeyQuotingSpec.scala
@@ -1,0 +1,78 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `Yaml::stringify` quotes a String *value* that would be misread on parse-back
+ * (contains `:`, `#`, a newline, or looks like a number/boolean — see
+ * docs/reference/stdlib.md's Yaml::stringify section) but historically left the
+ * map *key* unquoted. A key containing `": "` collided with the `key: value`
+ * separator the parser looks for, silently losing part of the key into the value
+ * instead of failing — the same "misread on parse-back" hazard the value side
+ * already guards against.
+ */
+class YamlKeyQuotingSpec extends AbstractShellSpec {
+  describe("Yaml::stringify key quoting") {
+    it("round-trips a key containing a colon-space delimiter") {
+      val result = shell.run(
+        """
+          |import { onion.Yaml::*; java.util.Map; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val m = ["a: b": 1L]
+          |    val y = Yaml::stringify(m)
+          |    val back = (Yaml::parse(y) as Map)
+          |    if !back.containsKey("a: b") { return "key lost" }
+          |    val v = (back.get("a: b") as Long)
+          |    if v != 1L { return "value corrupted: " + v }
+          |    return "ok"
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("ok") == result)
+    }
+
+    it("round-trips a key with leading/trailing whitespace") {
+      val result = shell.run(
+        """
+          |import { onion.Yaml::*; java.util.Map; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val m = [" pad ": 1L]
+          |    val y = Yaml::stringify(m)
+          |    val back = (Yaml::parse(y) as Map)
+          |    if !back.containsKey(" pad ") { return "key lost" }
+          |    return "ok"
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("ok") == result)
+    }
+
+    it("still renders a plain identifier-like key unquoted") {
+      val result = shell.run(
+        """
+          |import { onion.Yaml::*; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val m = ["name": "Alice"]
+          |    return Yaml::stringify(m)
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("name: Alice\n") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `Yaml::stringify` quoted a String **value** that would be misread on parse-back (containing `:`, `#`, a newline, or looking like a number/boolean), but wrote the map **key** raw and unquoted. A key such as `"a: b"` rendered as `a: b: 1\n`, which `Yaml::parse` read back as key `"a"` with value `"b: 1"` (a `String`) — the original key silently vanished, with no exception, no `Defect`, nothing.
- The parser already supported a quoted key (`unquote()` in `Yaml.java`), so the fix is symmetric: `stringify` now quotes the key with the same `needsQuoting`/`renderString` rule already applied to values — matching how `Json::stringify` has always quoted keys. No parser change needed.
- Updated `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md` to document that keys are quoted under the same rule as values, and added a `CHANGELOG.md` entry.

## Test plan

- [x] Added `YamlKeyQuotingSpec.scala` (TDD: confirmed red against the pre-fix code, green after the fix) covering: a key containing `: `, a key with leading/trailing whitespace, and confirming a plain identifier-like key still renders unquoted.
- [x] Full suite green in the English locale: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2902 tests, 0 failed, 1 canceled (matches baseline before this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwt9Xt7XZHRnNLZ7ceuQAB)_