### PR TITLE
fix(typing): tool declaration's omitted return type defaults to void (E0051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with how `Json::stringify` has always quoted keys; the parser already
   supported reading a quoted key, so no parser change was needed.
 
+- **A `tool` declaration with no explicit return type failed to compile with
+  `[E0051] return type is required`,** even though the grammar and the
+  documented syntax (`tool name(args) [: T] [requires { caps }] { body }`)
+  both treat the return type as optional. `TypingOutlinePass` required an
+  explicit return type on every top-level function unconditionally; it now
+  defaults a `tool`'s omitted return type to `void`, same as writing `: void`
+  explicitly — matching how the parser already accepted the form.
+
 ## [0.10.12] - 2026-07-29
 
 ### Fixed

--- a/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
@@ -535,8 +535,16 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
       val argsOption = typesOf(node.args)
       val returnTypeOption =
         if (node.returnType == null) {
-          report(SemanticError.RETURN_TYPE_REQUIRED, node, node.name)
-          None
+          // A `tool` declaration's return type is genuinely optional, both in the
+          // grammar (`tool_decl`'s `[":" ty=return_type()]`) and in the documented
+          // syntax (`tool name(args) [: T] ...`); an omitted one defaults to void,
+          // same as writing `: void` explicitly. Every other top-level function still
+          // requires an explicit return type.
+          if (node.annotations.exists(_.name == "onion.tool")) Some(BasicType.VOID)
+          else {
+            report(SemanticError.RETURN_TYPE_REQUIRED, node, node.name)
+            None
+          }
         } else mapFrom(node.returnType)
       for (args <- argsOption; returnType <- returnTypeOption) {
         loadTopClass match {

--- a/src/test/scala/onion/compiler/tools/ToolImplicitVoidReturnSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ToolImplicitVoidReturnSpec.scala
@@ -1,0 +1,41 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `tool name(args) [: T] [requires { caps }] { body }` documents the return type as
+ * optional, and the grammar backs that up (`tool_decl`'s `[":" ty=return_type()]` is
+ * genuinely optional). But the type checker's `processFunctionDeclaration` treated a
+ * missing return type as always an error (E0051), so a `tool` written without `: T`
+ * failed to compile even though nothing about the `tool` form requires one — an
+ * omitted return type should default to `void`, same as it would if the author had
+ * written `: void` explicitly.
+ */
+class ToolImplicitVoidReturnSpec extends AbstractShellSpec {
+
+  describe("a tool with no declared return type") {
+    it("compiles and runs, defaulting to void") {
+      val (r, out) = run(
+        """tool greet(name: String) requires { console } {
+          |  IO::println("Hello, " + name)
+          |}
+          |""".stripMargin, "world")
+      assert(Shell.Success(0) == r, r.toString)
+      assert(out.contains("Hello, world"), out)
+    }
+  }
+
+  private def run(source: String, args: String*): (Shell.Result, String) = {
+    val buf = new java.io.ByteArrayOutputStream()
+    val ps = new java.io.PrintStream(buf, true, "UTF-8")
+    val (savedOut, savedErr) = (System.out, System.err)
+    val result =
+      try {
+        System.setOut(ps); System.setErr(ps)
+        Console.withOut(ps) { Console.withErr(ps) {
+          shell.run(source, "None", args.toArray)
+        }}
+      } finally { System.setOut(savedOut); System.setErr(savedErr) }
+    (result, new String(buf.toByteArray, "UTF-8"))
+  }
+}


### PR DESCRIPTION
## Summary
- `tool name(args) requires { caps } { body }` with no `: T` failed to compile with `[E0051] return type is required for method ...`, even though `tool_decl`'s `[":" ty=return_type()]` grammar production and the documented syntax (`tool name(args) [: T] [requires { caps }] { body }` in CLAUDE.md) both treat the return type as optional.
- `TypingOutlinePass.processFunctionDeclaration` required an explicit return type unconditionally for every top-level function. A `tool`-annotated declaration (identified via the `onion.tool` annotation added by `tool_decl`) with a missing return type now defaults to `void`, matching what happens when the author writes `: void` explicitly.
- Added `ToolImplicitVoidReturnSpec` (TDD: confirmed red against the old behavior, green after the fix) and a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] New regression test `onion.compiler.tools.ToolImplicitVoidReturnSpec` passes
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2903 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CXX7KmNNBf6NazAXSAZyTb)_