### PR TITLE
fix(docs): exclude docs/superpowers from mkdocs nav, add a drift guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaults a `tool`'s omitted return type to `void`, same as writing `: void`
   explicitly — matching how the parser already accepted the form.
 
+- **`Deploy MkDocs to GitHub Pages` logged a warning on every build for the seven
+  files under `docs/superpowers/**`** (agent-facing planning material, never part
+  of the public site), because nothing told mkdocs they weren't meant to be in
+  `nav`. `mkdocs.yml` now excludes `superpowers/` via `exclude_docs`, and a new
+  `MkDocsNavCoverageSpec` fails the build if a future doc under `docs/` goes
+  unreferenced by `nav` again without being excluded on purpose. (#486)
+
 ## [0.10.12] - 2026-07-29
 
 ### Fixed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,11 @@ markdown_extensions:
   - toc:
       permalink: true
 
+# Agent-facing planning material, not part of the public site — kept out of the
+# nav-coverage check (mkdocs --strict otherwise warns on every orphaned file).
+exclude_docs: |
+  superpowers/
+
 nav:
   - Home: index.md
   - 日本語:

--- a/src/test/scala/onion/compiler/tools/MkDocsNavCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MkDocsNavCoverageSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Drift guard for mkdocs.yml's nav (issue #486): `mkdocs build --strict` warns about
+ * every file under `docs/` that isn't reachable from `nav`, and nothing before this
+ * tied the two together — `docs/superpowers` (agent-facing planning material, never
+ * meant to be part of the public site) already drifted out of step this way once.
+ * This walks `docs/` and asserts every markdown file is either referenced from `nav`
+ * or named under `exclude_docs`, so a newly orphaned file fails the build instead of
+ * just adding another silent warning line.
+ */
+class MkDocsNavCoverageSpec extends AnyFunSpec {
+
+  private val docsRoot = Path.of("docs")
+  private val mkdocsYml = Files.readString(Path.of("mkdocs.yml"))
+
+  /** Every `foo/bar.md`-shaped token written anywhere in mkdocs.yml (the nav values). */
+  private lazy val referenced: Set[String] =
+    """[\w][\w./-]*\.md""".r.findAllMatchIn(mkdocsYml).map(_.matched).toSet
+
+  /** `exclude_docs:` is a literal-block scalar of one gitignore-style pattern per line. */
+  private lazy val excluded: Set[String] =
+    """(?m)^exclude_docs:\s*\|\s*\n((?:^[ \t]+\S.*\n?)*)""".r
+      .findFirstMatchIn(mkdocsYml)
+      .map(_.group(1).linesIterator.map(_.trim).filter(_.nonEmpty).toSet)
+      .getOrElse(Set.empty)
+
+  private def isExcluded(relPath: String): Boolean =
+    excluded.exists(pat => if (pat.endsWith("/")) relPath.startsWith(pat) else relPath == pat)
+
+  private lazy val allMarkdownFiles: Seq[String] = {
+    val stream = Files.walk(docsRoot)
+    try
+      stream.iterator().asScala
+        .filter(p => Files.isRegularFile(p) && p.toString.endsWith(".md"))
+        .map(p => docsRoot.relativize(p).toString.replace('\\', '/'))
+        .toSeq
+    finally stream.close()
+  }
+
+  it("every docs/**/*.md file is reachable from mkdocs.yml's nav or listed in exclude_docs") {
+    assert(allMarkdownFiles.nonEmpty, "no markdown files found under docs/ — the scan has rotted")
+    val orphans = allMarkdownFiles.filterNot(isExcluded).filterNot(referenced.contains).sorted
+    assert(orphans.isEmpty,
+      s"not in nav and not excluded (mkdocs --strict warns on these): ${orphans.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/superpowers/**` (7 files — agent-facing planning/spec material, not part of the public docs site) had no `nav` entries in `mkdocs.yml`, so `mkdocs build --strict` logged an orphan warning for every one of them on every deploy. This was flagged as a follow-up in #486 but not fixed there.
- `mkdocs.yml` now excludes `superpowers/` from the docs build via `exclude_docs`, since this material was never meant to be on the public site (as opposed to `docs/design/**`, which is already in `nav`).
- Added `MkDocsNavCoverageSpec`, a drift guard (in the style of `StdlibDocDriftSpec`/`ErrorCodeDocCoverageSpec`) that walks `docs/**/*.md` and fails if any file is neither reachable from `nav` nor listed under `exclude_docs`, so a future orphan fails the test suite instead of silently adding another warning line.

## Verification

- Confirmed the new spec fails red before the `mkdocs.yml` change (lists exactly the 7 `superpowers/` files as orphans).
- Confirmed it goes green after adding `exclude_docs`.
- Installed `mkdocs-material` locally and ran the real `mkdocs build --strict` — clean build, no warnings, no errors.
- Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2904 tests, 0 failed, 1 canceled (pre-existing), all green.
- Added a `[Unreleased]` entry to `CHANGELOG.md`.

## Test plan

- [x] `sbt -Duser.language=en test` green (2904 tests)
- [x] `mkdocs build --strict` clean locally
- [x] New spec is red before the fix, green after

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Do6yNXfNkPKBMQHuW3Wesu)_