### PR TITLE
docs(ja): complete stdlib Math and Function Interfaces section parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`docs/ja/reference/stdlib.md` trailed off partway through the "Math Module"
+  and "Function Interfaces" sections,** missing `Math::floor`/`Math::ceil`/
+  `Math::round`, `Math::sin`/`Math::cos`/`Math::tan`, the Math Constants
+  subsection, and `Function3` through `Function10` — all present in the
+  English `docs/reference/stdlib.md`. Translated the missing subsections and
+  added `StdlibDocMathAndFunctionInterfacesParitySpec` so a future subsection
+  added only in English fails the build instead of silently widening the gap
+  again.
+
 - **`docs/ja/examples/index.md` was a stale 38-line stub that predated most of
   the "Example Index" table in `docs/examples/overview.md`,** missing 64 of
   the `run/*.on` example entries (and the Learning Path section) entirely.

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -102,6 +102,33 @@ val max: Int = Math::max(10, 20)    // 20
 val min: Int = Math::min(10, 20)    // 10
 ```
 
+### Math::floor / Math::ceil / Math::round
+
+丸め処理：
+
+```onion
+val floor: Double = Math::floor(3.7)  // 3.0
+val ceil: Double = Math::ceil(3.2)    // 4.0
+val round: Long = Math::round(3.5)    // 4
+```
+
+### Math::sin / Math::cos / Math::tan
+
+三角関数（ラジアン）：
+
+```onion
+val sine: Double = Math::sin(Math::PI / 2)    // 1.0
+val cosine: Double = Math::cos(0.0)           // 1.0
+val tangent: Double = Math::tan(Math::PI / 4) // 1.0
+```
+
+### Math Constants
+
+```onion
+val pi: Double = Math::PI       // 3.14159...
+val e: Double = Math::E         // 2.71828...
+```
+
 ## Origin
 
 値がどのテキストのどこから来たかを表します。コンパイラが持つソース位置の、実行時版です。
@@ -269,6 +296,10 @@ val result: Int = double.call(5)
 val add: Function2[Int, Int, Int] = (x: Int, y: Int) -> { return x + y; }
 val result: Int = add.call(3, 7)
 ```
+
+### Function3 から Function10 まで
+
+3〜10パラメータの関数も同じパターンです。
 
 ## ラッパークラス
 

--- a/src/test/scala/onion/compiler/tools/StdlibDocMathAndFunctionInterfacesParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocMathAndFunctionInterfacesParitySpec.scala
@@ -1,0 +1,41 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Math Module" and "Function Interfaces" sections of
+ * docs/reference/stdlib.md against their Japanese translation in
+ * docs/ja/reference/stdlib.md, which trails off partway through both sections
+ * (`StdlibDocDriftSpec` can't catch this: it only checks that documented
+ * `Class::method` calls exist somewhere, not that a section is complete).
+ */
+class StdlibDocMathAndFunctionInterfacesParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def subheadingsUnder(doc: String, heading: String): Seq[String] = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).filter(_.trim.startsWith("### "))
+  }
+
+  it("has the same number of Math Module subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/reference/stdlib.md"), "## Math Module")
+    val ja = subheadingsUnder(read("docs/ja/reference/stdlib.md"), "## Math モジュール")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Math Module section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/reference/stdlib.md has ${en.size} Math Module subsections but " +
+      s"docs/ja/reference/stdlib.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+
+  it("has the same number of Function Interfaces subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/reference/stdlib.md"), "## Function Interfaces")
+    val ja = subheadingsUnder(read("docs/ja/reference/stdlib.md"), "## 関数インターフェース")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Function Interfaces section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/reference/stdlib.md has ${en.size} Function Interfaces subsections but " +
+      s"docs/ja/reference/stdlib.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/ja/reference/stdlib.md` trailed off partway through the "Math Module" and "Function Interfaces" sections: it was missing `Math::floor`/`Math::ceil`/`Math::round`, `Math::sin`/`Math::cos`/`Math::tan`, the Math Constants subsection, and `Function3` through `Function10` — all present in the English `docs/reference/stdlib.md`.
- Translated the missing subsections into Japanese.
- Added `StdlibDocMathAndFunctionInterfacesParitySpec`, following the same pattern as the existing `StdlibDocWrapperAndCommonJavaClassesParitySpec`, so a future subsection added only to the English doc fails the build instead of silently widening the gap again.
- Added a `[Unreleased]` entry to `CHANGELOG.md`.

## Test plan
- [x] New spec fails before the doc fix (confirmed red), passes after (confirmed green)
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2907 succeeded, 0 failed, 1 canceled (network-dependent test, expected in this sandboxed environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5ZySnQ7ZeWg6sjUehX5et)_