### PR TITLE
test(typing): E0006 AMBIGUOUS_METHOD positive-trigger coverage

### DIFF
--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -169,6 +169,21 @@ class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
           |}
           |""".stripMargin)
     }
+    it("E0006 ambiguous method (null argument fits two unrelated overloads equally)") {
+      failsWith("E0006",
+        """class A {}
+          |class B {}
+          |class Test {
+          |public:
+          |  static def foo(x: A): Int = 1
+          |  static def foo(x: B): Int = 2
+          |  static def main(args: String[]): Int {
+          |    foo(null)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
     it("E0007 duplicate local variable") {
       failsWith("E0007",
         """class Test {


### PR DESCRIPTION
## Summary
- `SemanticErrorCodeCoverageSpec` asserts a positive trigger for every reachable `SemanticError` code, but `E0006` (`AMBIGUOUS_METHOD`) was one of the remaining gaps — the only existing references to it (`SamOverloadDisambiguationSpec`, `ExecutorSubmitSamSpec`) are regression tests confirming it does *not* fire for specific SAM-overload cases, not a test that it correctly fires and renders.
- Added a minimal case: two unrelated-type static overloads (`foo(x: A)` / `foo(x: B)`) called with `null`, which `MethodResolution` finds equally applicable and equally specific to both, so `MethodLookupSupport.tryFindMethod` reports `AMBIGUOUS_METHOD`.

## Test plan
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.SemanticErrorCodeCoverageSpec"` — 46/46 passed (new E0006 case included)
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2908 tests, 0 failed, 1 canceled (unrelated `sbt dist` packaging integration test, cancels itself in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5mZoFfNzdbSCPCnAKhUmF)_