### PR TITLE
docs(ja): complete scripting guide parity

### DIFF
--- a/docs/ja/guide/scripting.md
+++ b/docs/ja/guide/scripting.md
@@ -1,6 +1,73 @@
 # スクリプティング
 
-Onion は bash を超えたスクリプトを書くための機能を備えています。
+Onion は bash では手に負えなくなったシェルスクリプトを置き換えるために作られています。
+このページではスクリプティング用の機能を一通り紹介します。
+
+## スクリプトの実行
+
+```bash
+onion script.on arg1 arg2     # メモリ上でコンパイルして実行
+onion --watch script.on       # 保存のたびに再実行
+onion repl                    # 対話的な REPL
+```
+
+スクリプトは shebang を使えます。
+
+```onion
+#!/usr/bin/env onion
+println("hello")
+```
+
+トップレベルの文は上から順に実行され、`args` にコマンドライン引数が入ります。
+コンパイルエラーが起きると非ゼロの終了ステータスで終了します。
+
+## コマンドライン引数
+
+```onion
+val opts = Args::parse(args)
+
+if opts.flag("verbose") { ... }          // --verbose または -v
+val out = opts.option("output", "a.txt") // --output=x または --output x
+val n = opts.intOption("count", 1)       // デフォルト付きの数値
+val files = opts.positional()            // それ以外すべて
+```
+
+## 外部コマンドの実行
+
+```onion
+val branch = Proc::run("git", "branch", "--show-current")  // 標準出力を取得、失敗時は例外
+
+val r = Proc::capture("sh", "-c", "ls missing")            // 例外を投げない
+if r.failed() { println(r.stderr()) }
+
+val code = Proc::exec("make", "build")                     // コンソールを継承、終了コードを返す
+```
+
+`Proc::runIn(dir, ...)` は作業ディレクトリを指定できるバリアントです。
+
+## ファイルと glob
+
+```onion
+val text = Files::readText("config.txt")
+Files::writeText("out.txt", text.toUpperCase())
+
+foreach f: String in Files::glob(".", "*.on") {
+  println(f)
+}
+Files::glob("src", "**/*.java")    // 再帰的に検索
+```
+
+## JSON と HTTP
+
+```onion
+val body = Http::get("https://api.github.com/repos/onion-lang/onion")
+val v = Json::value(body)
+println(v["name"].asString() + " stars=" + v["stargazers_count"].asInt())
+```
+
+`Json::value` はナビゲート可能な値を返します。オブジェクトや配列を添字アクセスした上で、
+`asString` / `asInt` / `asDouble` / `asBoolean` で変換します。存在しないパスは例外ではなく
+`isNull()` で判定できます。
 
 ## スキームプレフィックス付きリテラル
 
@@ -89,6 +156,22 @@ def main(name: String, count: Int = 3, loud: Boolean = false): void { ... }
 ```
 
 フラグは `--name value` と `--name=value` の両形式を受け付けます。`--help`（または `-h`）で生成された usage を表示して終了します。
+
+## まとめて使う
+
+```onion
+#!/usr/bin/env onion
+record Hit(ip: String, method: String, path: String, status: Int)
+  from re"(\S+) (\w+) (\S+) (\d+)"
+
+def main(log: String, minStatus: Int = 500): void {
+  Hit::parseAll(file(log).text())
+    .filter { h => h.status() >= minStatus }
+    .groupBy { h => h.path() }
+    .mapValues { xs => xs.size }
+    |> println
+}
+```
 
 ## 次のステップ
 

--- a/src/test/scala/onion/compiler/tools/ScriptingDocParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/ScriptingDocParitySpec.scala
@@ -1,0 +1,30 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for docs/guide/scripting.md against its Japanese translation,
+ * docs/ja/guide/scripting.md, which was missing the "Running Scripts",
+ * "Command-Line Arguments", "Running External Commands", "Files and Globs",
+ * "JSON and HTTP", and "Putting It Together" sections entirely — only the
+ * back half of the English page (from "Scheme-Prefixed Literals" onward) had
+ * ever been translated.
+ */
+class ScriptingDocParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def apiTokens(doc: String): Set[String] =
+    """(Args|Proc|Files|Http|Json)::\w+""".r.findAllMatchIn(doc).map(_.group(0)).toSet
+
+  it("mentions the same stdlib API calls as the English scripting guide") {
+    val en = apiTokens(read("docs/guide/scripting.md"))
+    val ja = apiTokens(read("docs/ja/guide/scripting.md"))
+    assert(en.nonEmpty, "docs/guide/scripting.md listed no Args/Proc/Files/Http/Json calls — the scan has rotted")
+    val missing = en -- ja
+    assert(missing.isEmpty,
+      s"docs/ja/guide/scripting.md is missing ${missing.size} stdlib call(s) present in English: " +
+      missing.toSeq.sorted.mkString(", "))
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/ja/guide/scripting.md` only translated the back half of `docs/guide/scripting.md` (from "Scheme-Prefixed Literals" onward) — the "Running Scripts", "Command-Line Arguments", "Running External Commands", "Files and Globs", and "JSON and HTTP" sections at the top, and the "Putting It Together" section at the end, were missing entirely.
- Translated the missing sections so the Japanese guide now has the same 13-heading structure as the English one.
- Added `ScriptingDocParitySpec` — a drift guard asserting the Japanese doc mentions the same `Args::`/`Proc::`/`Files::`/`Http::`/`Json::` stdlib calls as the English guide, so a future addition to the English page fails the build instead of silently widening the gap again.

## Test plan
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.ScriptingDocParitySpec"` — passes
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2910 succeeded, 0 failed, 1 canceled (pre-existing, unrelated), all suites green

---
_Generated by [Claude Code](https://claude.ai/code/session_012AQXYbJkXGAhgdNhue9Ljm)_