### PR TITLE
docs(ja): translate missing CSV/Regex sections in examples/basic.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`docs/ja/examples/basic.md` was missing the "CSV Processing" and "Regex Log
+  Parsing" sections** present in the English `docs/examples/basic.md`.
+  Translated the missing sections and added `BasicExamplesDocParitySpec` so a
+  future stdlib call added only to the English doc fails the build instead of
+  silently widening the gap again.
+
 - **`docs/ja/guide/collections.md`'s "Map Iteration" section had an untranslated
   intro sentence and was missing the `[String, Integer]` generic type arguments
   on `Map.Entry`** that the English version's example uses, under-demonstrating

--- a/docs/ja/examples/basic.md
+++ b/docs/ja/examples/basic.md
@@ -224,6 +224,95 @@ Division: 3
 Modulo: 1
 ```
 
+## CSV処理
+
+CSVデータをパースして簡単な集計を行う:
+
+**ファイル: `CsvProcessor.on`**
+```onion
+import {
+  java.lang.Integer as JInt;
+}
+
+class CsvProcessor {
+public:
+  static def main(args: String[]): String {
+    val input = "name,score\nAlice,85\nBob,92\nCharlie,78\nDiana,95\n"
+    val rows = Csv::parseWithHeader(input)
+
+    var total: Int = 0
+    var count: Int = 0
+    for var i: Int = 0; i < rows.size(); i = i + 1 {
+      val row = rows.get(i)
+      val scoreText = row.get("score")
+      if (scoreText != null) {
+        total = total + JInt::parseInt(scoreText)
+        count = count + 1
+      }
+    }
+
+    var average: Int = 0
+    if (count > 0) {
+      average = total / count
+    }
+    return "Processed " + count.toString() + " rows, average score = " + average.toString()
+  }
+}
+```
+
+**トピック:**
+- `Csv::parseWithHeader` によるCSVパース
+- `List<Map<String, String>>` の反復
+- `JInt::parseInt` による文字列から整数への変換
+- null安全なフィールドアクセス
+
+## 正規表現によるログ解析
+
+正規表現でテキストから数値を抽出する:
+
+**ファイル: `RegexLogParser.on`**
+```onion
+import {
+  java.lang.Integer as JInt;
+}
+
+class RegexLogParser {
+public:
+  static def main(args: String[]): String {
+    val logs = Colls::mutableListOf(
+      "[INFO] request took 45ms",
+      "[WARN] request took 120ms",
+      "[INFO] request took 30ms"
+    )
+
+    val pattern = "\\d+ms"
+    var total: Int = 0
+    var count: Int = 0
+
+    for var i: Int = 0; i < logs.size(); i = i + 1 {
+      val line = logs.get(i)
+      val match = Regex::findFirst(line, pattern)
+      if (match.length() > 0) {
+        val msText = match.substring(0, match.length() - 2)
+        total = total + JInt::parseInt(msText)
+        count = count + 1
+      }
+    }
+
+    var average: Int = 0
+    if (count > 0) {
+      average = total / count
+    }
+    return "Average response time: " + average.toString() + "ms"
+  }
+}
+```
+
+**トピック:**
+- パターンマッチングのための `Regex::findFirst`
+- `substring` による文字列のスライス
+- リストの値の集計
+
 ## 次のステップ
 
 - [オブジェクト指向の例](oop.md) - オブジェクト指向プログラム

--- a/src/test/scala/onion/compiler/tools/BasicExamplesDocParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/BasicExamplesDocParitySpec.scala
@@ -1,0 +1,27 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for docs/examples/basic.md against its Japanese translation,
+ * docs/ja/examples/basic.md, which was missing the "CSV Processing" and
+ * "Regex Log Parsing" sections entirely.
+ */
+class BasicExamplesDocParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def apiTokens(doc: String): Set[String] =
+    """(Csv|Regex|JInt)::\w+""".r.findAllMatchIn(doc).map(_.group(0)).toSet
+
+  it("mentions the same stdlib API calls as the English basic examples doc") {
+    val en = apiTokens(read("docs/examples/basic.md"))
+    val ja = apiTokens(read("docs/ja/examples/basic.md"))
+    assert(en.nonEmpty, "docs/examples/basic.md listed no Csv/Regex/JInt calls — the scan has rotted")
+    val missing = en -- ja
+    assert(missing.isEmpty,
+      s"docs/ja/examples/basic.md is missing ${missing.size} stdlib call(s) present in English: " +
+      missing.toSeq.sorted.mkString(", "))
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/ja/examples/basic.md` predated the "CSV Processing" and "Regex Log Parsing" sections in the English `docs/examples/basic.md`, leaving the translation silently incomplete
- Translated both missing sections
- Added `BasicExamplesDocParitySpec` as a drift guard so a future stdlib call added only to the English doc fails the build instead of silently widening the gap again

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.BasicExamplesDocParitySpec'` — red before the fix, green after
- [x] `sbt -Duser.language=en test` — full suite green (2911 succeeded, 1 canceled, 0 failed)

---
_Generated by [Claude Code](https://claude.ai/code/session_016rLiwHT3mKAszdbbZhuAcG)_