### PR TITLE
docs(ja): complete Future Module parity in stdlib.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a future stdlib call added only to the English guide fails the build
   instead of silently widening the gap again.
 
+- **`docs/ja/reference/stdlib.md`'s "Future Module" section trailed off partway
+  through**, missing the "Error Handling", "Status Queries", "Combining
+  Futures", and "Conversions" subsections entirely, plus the `asyncThrowing`,
+  `filter`/`bind`, and `onComplete` calls documented within its existing
+  subsections. Translated the missing content and added
+  `StdlibDocFutureModuleParitySpec` so a future addition to the English
+  section fails the build instead of silently widening the gap again.
+
 ## [0.10.13] - 2026-07-30
 
 ### Fixed

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -615,6 +615,11 @@ val fail: Future[Int] = Future::failed(new RuntimeException("error"))
 // バックグラウンドスレッドで非同期実行
 val async: Future[String] = Future::async(() -> { return compute(); })
 
+// 例外処理付きの非同期実行
+val safe: Future[Int] = Future::asyncThrowing(() -> {
+  return riskyOperation();
+})
+
 // 遅延
 val delayed: Future[Void] = Future::delay(1000L)  // 1秒
 ```
@@ -629,6 +634,27 @@ f.map((x: Int) -> { return x * 2; })  // Future[Int] = 20
 
 // 非同期操作をチェイン
 f.flatMap((x: Int) -> { return Future::successful(x + 1); })
+
+// フィルタ（述語が false なら失敗）
+f.filter((x: Int) -> { return x > 0; })
+
+// flatMap の別名（do記法が使用）
+f.bind((x: Int) -> { return Future::successful(x); })
+```
+
+### エラーハンドリング
+
+```onion
+val f: Future[Int] = Future::failed(new RuntimeException("oops"))
+
+// 値で回復
+f.recover((e: Throwable) -> { return 0; })
+
+// 別の Future で回復
+f.recoverWith((e: Throwable) -> { return Future::successful(42); })
+
+// エラーを変換
+f.mapError((e: Throwable) -> { return new CustomException(e); })
 ```
 
 ### コールバック
@@ -638,6 +664,10 @@ val f: Future[String] = Future::async(() -> { return "result"; })
 
 f.onSuccess((value: String) -> { IO::println(value); })
 f.onFailure((error: Throwable) -> { IO::println(error); })
+f.onComplete(
+  (value: String) -> { IO::println("ok: " + value); },
+  (error: Throwable) -> { IO::println("err: " + error); }
+)
 ```
 
 ### ブロッキング操作
@@ -648,6 +678,48 @@ val f: Future[Int] = Future::successful(42)
 f.await()              // ブロックして結果を取得（失敗時は例外）
 f.awaitTimeout(5000L)  // タイムアウト付きでブロック（ミリ秒）
 f.getOrElse(0)         // 結果を取得、失敗時はデフォルト値
+```
+
+### ステータス照会
+
+```onion
+f.isCompleted()  // 完了していれば true（成功・失敗いずれも）
+f.isSuccess()    // 成功で完了していれば true
+f.isFailure()    // エラーで完了していれば true
+```
+
+これらは**非ブロッキング**です——future の*現在の*状態を報告するだけなので、まだ実行中の
+future は `isSuccess()` と `isFailure()` の両方が `false` を返します。結果を待ちたい場合は、
+`isFailure()` をポーリングするのではなく `await()`/`getOrElse()`（あるいは
+`onSuccess`/`onFailure`/`recover`）を使ってください。
+
+### Futureの結合
+
+```onion
+val f1: Future[Int] = Future::successful(1)
+val f2: Future[Int] = Future::successful(2)
+
+// タプルのような配列へまとめる
+f1.zip(f2)  // Future[List[Object]] = [1, 2]
+
+// レース: 先に完了した方が勝つ
+f1.race(f2)
+
+// すべての完了を待つ
+Future::all(f1, f2, f3)  // Future[List[Object]] = [1, 2, 3]
+
+// 最初に完了したもの
+Future::first(f1, f2, f3)
+```
+
+### 変換
+
+```onion
+val f: Future[Int] = Future::successful(42)
+
+f.toOption()   // Option[Int] - Some(42) または None（ブロックする）
+f.toResult()   // Result[Int, Throwable]（ブロックする）
+f.underlying() // 相互運用のための Java CompletableFuture
 ```
 
 ### Do記法サポート

--- a/src/test/scala/onion/compiler/tools/StdlibDocFutureModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocFutureModuleParitySpec.scala
@@ -1,0 +1,32 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Future Module" section of docs/reference/stdlib.md
+ * against its Japanese translation in docs/ja/reference/stdlib.md, which
+ * trailed off partway through the section (`StdlibDocDriftSpec` can't catch
+ * this: it only checks that documented `Class::method` calls exist
+ * somewhere, not that a section is complete).
+ */
+class StdlibDocFutureModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def subheadingsUnder(doc: String, heading: String): Seq[String] = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).filter(_.trim.startsWith("### "))
+  }
+
+  it("has the same number of Future Module subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/reference/stdlib.md"), "## Future Module")
+    val ja = subheadingsUnder(read("docs/ja/reference/stdlib.md"), "## Future モジュール")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Future Module section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/reference/stdlib.md has ${en.size} Future Module subsections but " +
+      s"docs/ja/reference/stdlib.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/ja/reference/stdlib.md`'s "Future Module" section trailed off partway through the English version: it was missing the "Error Handling", "Status Queries", "Combining Futures", and "Conversions" subsections entirely, plus the `asyncThrowing`, `filter`/`bind`, and `onComplete` calls within its existing subsections.
- Translated the missing content to bring it to full parity with `docs/reference/stdlib.md`.
- Added `StdlibDocFutureModuleParitySpec` (mirrors the existing `StdlibDocMathAndFunctionInterfacesParitySpec` pattern) so a future English-only addition to this section fails the build instead of silently widening the gap again.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2912 tests, 0 failed, 1 canceled, all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmK4gSnhGHcv7NfVyTjEsJ)_