### PR TITLE
docs(ja): complete Language Characteristics and Syntax Highlights parity in overview.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `StdlibDocFutureModuleParitySpec` so a future addition to the English
   section fails the build instead of silently widening the gap again.
 
+- **`docs/ja/guide/overview.md` only translated the first three "Language
+  Characteristics" subsections**, missing "JVM Target" and "Java
+  Interoperability" entirely, and never translated the "Syntax Highlights"
+  section (`val`/`var` fields, type annotations, `::` static access, `as`
+  casting, `select` pattern matching) at all. Translated the missing
+  subsections and added `OverviewDocParitySpec` so a future subsection added
+  only in English fails the build instead of silently widening the gap
+  again.
+
 ## [0.10.13] - 2026-07-30
 
 ### Fixed

--- a/docs/ja/guide/overview.md
+++ b/docs/ja/guide/overview.md
@@ -51,7 +51,8 @@ val scores = [95, 87, 91]   // List[Int] と推論される
 - プリミティブ型：`Int`、`Long`、`Double`、`Float`、`Boolean`、`Byte`、`Short`、`Char`
 - 参照型：クラス・インターフェース
 - 配列型：`Type[]`
-- Nullable型：`Type?`
+- Null型：`null` 値の特別な扱い
+- ボトム型：値を返さない式のための `Nothing`
 
 ### オブジェクト指向
 
@@ -93,7 +94,40 @@ def makeCounter(): () -> Int {
 }
 ```
 
-### コンパイルモデル
+### JVMターゲット
+
+Onion は JVM バイトコードに直接コンパイルされます：
+
+- コンパイルされた `.class` ファイルは標準的な JVM クラスです
+- Java のクラスと一緒に JAR にまとめられます
+- JVM の性能特性を引き継ぎます
+- Java エコシステム全体にアクセスできます
+
+### Javaとの相互運用
+
+Java へ直接、シームレスにアクセスできます：
+
+```onion
+import {
+  java.util.ArrayList;
+  java.util.HashMap;
+  javax.swing.JFrame;
+}
+
+val list: ArrayList[String] = new ArrayList[String]()
+val map: HashMap[String, String] = new HashMap[String, String]()
+val window: JFrame = new JFrame("Title")
+```
+
+ポイント：
+- `import { }` で Java のクラスをインポートする
+- `new` で Java のオブジェクトを生成する
+- Java のメソッドを普通に呼び出せる
+- Java のインターフェースを実装できる
+- Java のクラスを継承できる
+- 静的メソッドへのアクセスには `::` を使う
+
+## コンパイルモデル
 
 ```
 ソースファイル (.on)
@@ -111,6 +145,78 @@ def makeCounter(): () -> Int {
 - `onionc` — `.class` ファイルにコンパイル
 - `onion` — インメモリでコンパイルしてすぐ実行
 - `Shell` — インタラクティブREPL
+
+## 構文のハイライト
+
+### `val` / `var` によるフィールド
+
+フィールドは `val`（不変）または `var`（可変）で宣言し、`this.field` でアクセスします：
+
+```onion
+class Counter {
+  var count: Int
+
+  public:
+    def increment {
+      this.count = this.count + 1
+    }
+}
+```
+
+### `:` による型注釈
+
+型はコロンの後に指定します。ローカル宣言は初期化子があれば型を省略できます：
+
+```onion
+val variable: Type = value
+val inferred = value
+def method(param: Type): ReturnType { }
+```
+
+### `::` による静的アクセス
+
+静的メソッド・静的フィールドには `::` を使います：
+
+```onion
+println("Hello")
+Math::random()
+System::out.println("Java style")
+```
+
+デフォルトの静的インポートにより、一部のクラスメンバーは `::` なしで使えます（例えば
+`onion.IO` の `println("Hello")`）。このデフォルトの集合は意図的に狭く、純粋なヘルパー群と
+コンソール用の例外である `onion.IO` だけに絞られています——そのため副作用のある行は見た目にも
+副作用があるとわかります。`Files::readText`、`Http::get`、`DateTime::now`、`System::exit` は
+修飾して書くか、`import { onion.Files::* }`（クラス全体）や `import { java.lang.System::exit }`
+（メンバー1つ）で明示的にインポートする必要があります。一覧は
+`src/main/resources/onion/default-static-imports.txt` にあります。
+
+### `as` による型キャスト
+
+キャスト式には `as` 演算子を使います：
+
+```onion
+val x: Double = 3.14
+val y: Int = (x as Int)  // Int にキャスト
+
+val obj: Object = "string"
+val str: String = (obj as String)  // String にキャスト
+```
+
+### `select` によるパターンマッチング
+
+switch 風のパターンマッチングです：
+
+```onion
+select value {
+  case 1, 2, 3:
+    println("Small")
+  case 4, 5, 6:
+    println("Medium")
+  else:
+    println("Large")
+}
+```
 
 ## Javaとの主な違い
 

--- a/src/test/scala/onion/compiler/tools/OverviewDocParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/OverviewDocParitySpec.scala
@@ -1,0 +1,41 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for docs/guide/overview.md against its Japanese translation,
+ * docs/ja/guide/overview.md, which was missing the "JVM Target" and "Java
+ * Interoperability" subsections of "Language Characteristics" and the entire
+ * "Syntax Highlights" section (five subsections) — only the first three
+ * Language Characteristics subsections had ever been translated.
+ */
+class OverviewDocParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def subheadingsUnder(doc: String, heading: String): Seq[String] = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).filter(_.trim.startsWith("### "))
+  }
+
+  it("has the same number of Language Characteristics subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/guide/overview.md"), "## Language Characteristics")
+    val ja = subheadingsUnder(read("docs/ja/guide/overview.md"), "## 主な特徴")
+    assert(en.nonEmpty, "docs/guide/overview.md's Language Characteristics section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/guide/overview.md has ${en.size} Language Characteristics subsections but " +
+      s"docs/ja/guide/overview.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+
+  it("has the same number of Syntax Highlights subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/guide/overview.md"), "## Syntax Highlights")
+    val ja = subheadingsUnder(read("docs/ja/guide/overview.md"), "## 構文のハイライト")
+    assert(en.nonEmpty, "docs/guide/overview.md's Syntax Highlights section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/guide/overview.md has ${en.size} Syntax Highlights subsections but " +
+      s"docs/ja/guide/overview.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/ja/guide/overview.md` only translated the first three "Language Characteristics" subsections (静的型付き/オブジェクト指向/関数型の要素), missing "JVM Target" and "Java Interoperability" entirely, and never translated the "Syntax Highlights" section (`val`/`var` fields, type annotations, `::` static access, `as` casting, `select` pattern matching) at all — only about half of `docs/guide/overview.md`'s headings existed in the Japanese version.
- Translated the missing subsections, promoted `コンパイルモデル` to an H2 to match the English heading level (it was nested a level too deep), and added a bilingual "Null型"/"ボトム型" bullet pair matching the English "Null type"/"Bottom type" entries.
- Added `OverviewDocParitySpec` (subsection-count drift guard, following the existing `ScriptingDocParitySpec`/`StdlibDocFutureModuleParitySpec` pattern) so a future subsection added only in English fails the build instead of silently widening the gap again.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2914 succeeded, 0 failed, 1 canceled (pre-existing, unrelated)


---
_Generated by [Claude Code](https://claude.ai/code/session_014q1qytKZ5fiM2hKPKWmfHf)_