### PR TITLE
test(verification): assert E0064/E0065/E0074 error codes explicitly in LawExampleSpec

### DIFF
--- a/src/test/scala/onion/compiler/tools/LawExampleSpec.scala
+++ b/src/test/scala/onion/compiler/tools/LawExampleSpec.scala
@@ -1,14 +1,28 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * B3: `law` / `example` clauses on a record are executed by the compiler at build time
  * (LawCheckPhase). `example { e }` must evaluate true; `law name(p: T) { e }` must hold for
  * every generated sample of p. A false example or a falsified law fails compilation —
- * the spec asserts Shell.Success (compiled + ran) vs Shell.Failure (compile error).
+ * the spec asserts Shell.Success (compiled + ran) vs Shell.Failure (compile error), and for
+ * the error-code-bearing cases also asserts the specific E0064/E0065/E0074 diagnostic code
+ * (LawCheckPhase), since a bare Shell.Failure doesn't distinguish these from an unrelated
+ * compile error.
  */
 class LawExampleSpec extends AbstractShellSpec {
+  private def errorCodes(program: String): Seq[Option[String]] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val inputs = Seq(new StreamInputSource(() => new StringReader(program), "LawExample.on"))
+    new OnionCompiler(config).compile(inputs) match {
+      case CompilationOutcome.Failure(errs) => errs.map(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
   describe("law / example compile-time checks") {
     it("compiles and runs when law and example hold") {
       val result = shell.run(
@@ -43,6 +57,19 @@ class LawExampleSpec extends AbstractShellSpec {
       assert(result.isInstanceOf[Shell.Failure])
     }
 
+    it("reports E0065 for a false example") {
+      val codes = errorCodes(
+        """
+          |record R(x: Int)
+          |  example { new R(1).x() == 2 }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin)
+      assert(codes.contains(Some("E0065")), s"expected E0065, got: $codes")
+    }
+
     it("fails compilation on a falsified law (counterexample x != y)") {
       val result = shell.run(
         """
@@ -57,6 +84,32 @@ class LawExampleSpec extends AbstractShellSpec {
         Array()
       )
       assert(result.isInstanceOf[Shell.Failure])
+    }
+
+    it("reports E0064 for a falsified law (counterexample x != y)") {
+      val codes = errorCodes(
+        """
+          |record Pt(x: Int, y: Int)
+          |  law wrong(p: Pt) { p.x() == p.y() }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin)
+      assert(codes.contains(Some("E0064")), s"expected E0064, got: $codes")
+    }
+
+    it("reports E0074 for a law parameter type that cannot be sample-generated") {
+      val codes = errorCodes(
+        """
+          |record Dummy(v: Int)
+          |  law bad(r: Runnable) { r != null }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "ok" }
+          |}
+          |""".stripMargin)
+      assert(codes.contains(Some("E0074")), s"expected E0074, got: $codes")
     }
 
     it("fails compilation on a falsified scalar-arg law (generator produces negatives)") {


### PR DESCRIPTION
## Summary
- `LawExampleSpec`'s false-example/falsified-law tests previously only asserted `Shell.Failure`, which doesn't distinguish `LawCheckPhase`'s diagnostics (E0064/E0065) from any other unrelated compile error.
- Added direct `OnionCompiler.compile` assertions on the specific error codes (matching the pattern used in `MissingReturnSpec`/`SealedExhaustivenessSpec`), and added the first coverage at all for **E0074** (a law parameter type — e.g. `Runnable` — that `ArgGenerator` cannot sample-generate).

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.LawExampleSpec'` — 9/9 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2917 passed, 0 failed (1 canceled, pre-existing opt-in distribution smoke test unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01XuNouSWhcQi8FDJfGVA6VY)_