### PR TITLE
docs(stdlib): document onion.OnionMath, the undocumented 41-member numeric module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`onion.OnionMath` — a genuine, default-imported stdlib module with 41 public
+  members (`sin`/`cos`/`tan`, hyperbolic trig, `clamp`/`clampInt`, `hypot`,
+  bounded `randomInt`, ...) — had no documentation in `docs/reference/stdlib.md`
+  or `docs/ja/reference/stdlib.md`,** unlike every other stdlib module. Added an
+  "OnionMath Module" section to both files (mirroring the existing "Math
+  Module" style) and a row in "Modules at a glance", plus
+  `OnionMathDocCoverageSpec` so a future addition to `onion.OnionMath` fails
+  the build instead of silently staying undocumented.
+
 - **`docs/ja/examples/basic.md` was missing the "CSV Processing" and "Regex Log
   Parsing" sections** present in the English `docs/examples/basic.md`.
   Translated the missing sections and added `BasicExamplesDocParitySpec` so a

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -9,7 +9,7 @@ Onionの標準ライブラリは、一般的な機能のための組み込みモ
 | **I/O・システム** | `IO`（コンソール）, `Files`（ファイル・パス）, `System`, `Proc`（サブプロセス）, `Args`（CLI）, `Http`（HTTPクライアント） |
 | **コレクション** | `Colls`（リスト: map/filter/fold, chunked/windowed, sumBy/maxBy）, `Iterables`, `Maps`, `Sets` |
 | **テキスト** | `Strings`（大小文字・分割・パディング・パース）, `Text`（wrap/indent/table）, `Regex` |
-| **数値** | `Math`, `Stats`（sum/average/median/stddev）, `Format`（桁区切り・bytes・duration） |
+| **数値** | `Math`, `OnionMath`（双曲線関数, `clamp`, `hypot`, 範囲付き`randomInt`）, `Stats`（sum/average/median/stddev）, `Format`（桁区切り・bytes・duration） |
 | **データ形式** | `Json`, `Yaml`, `Csv`, `Config`（ドット記法での設定値アクセス） |
 | **エンコード** | `Codec`（base64/hex/url）, `Hash`（md5/sha256/…） |
 | **関数型** | `Option`, `Result`, `Future`, `Outcome`・`Defect`（外部データの読み取り） |
@@ -127,6 +127,130 @@ val tangent: Double = Math::tan(Math::PI / 4) // 1.0
 ```onion
 val pi: Double = Math::PI       // 3.14159...
 val e: Double = Math::E         // 2.71828...
+```
+
+## OnionMath モジュール
+
+JDKの`Math`とは別の`onion.*`数値モジュールで、双曲線関数、安全な丸め・クランプ、範囲付きの
+乱数整数を提供します。標準ライブラリの他のモジュールと同様デフォルトでインポートされるため、
+明示的なインポートは不要です。
+
+### OnionMath::sin / OnionMath::cos / OnionMath::tan / OnionMath::asin / OnionMath::acos / OnionMath::atan / OnionMath::atan2
+
+三角関数と逆三角関数（ラジアン）：
+
+```onion
+val sine: Double = OnionMath::sin(OnionMath::PI / 2)     // 1.0
+val angle: Double = OnionMath::atan2(1.0, 1.0)           // pi/4
+```
+
+### OnionMath::sinh / OnionMath::cosh / OnionMath::tanh
+
+双曲線関数：
+
+```onion
+val h: Double = OnionMath::sinh(1.0)
+```
+
+### OnionMath::exp / OnionMath::log / OnionMath::log10
+
+指数関数と対数関数：
+
+```onion
+val e2: Double = OnionMath::exp(1.0)     // e
+val l: Double = OnionMath::log(OnionMath::E)   // 1.0
+val l10: Double = OnionMath::log10(100.0)      // 2.0
+```
+
+### OnionMath::pow / OnionMath::sqrt / OnionMath::cbrt
+
+累乗と平方根・立方根：
+
+```onion
+val cube: Double = OnionMath::pow(2.0, 3.0)  // 8.0
+val root: Double = OnionMath::sqrt(16.0)     // 4.0
+val croot: Double = OnionMath::cbrt(27.0)    // 3.0
+```
+
+### OnionMath::abs / OnionMath::absFloat / OnionMath::absInt / OnionMath::absLong
+
+プリミティブ型ごとの絶対値：
+
+```onion
+val a1: Double = OnionMath::abs(-3.14)
+val a2: Int = OnionMath::absInt(-10)      // 10
+val a3: Long = OnionMath::absLong(-10L)   // 10
+```
+
+### OnionMath::min / OnionMath::minInt / OnionMath::minLong / OnionMath::max / OnionMath::maxInt / OnionMath::maxLong
+
+プリミティブ型ごとの最小値・最大値：
+
+```onion
+val lo: Int = OnionMath::minInt(10, 20)   // 10
+val hi: Int = OnionMath::maxInt(10, 20)   // 20
+```
+
+### OnionMath::floor / OnionMath::ceil / OnionMath::round / OnionMath::roundFloat
+
+丸め処理：
+
+```onion
+val f: Double = OnionMath::floor(3.7)     // 3.0
+val c: Double = OnionMath::ceil(3.2)      // 4.0
+val r: Long = OnionMath::round(3.5)       // 4
+val rf: Int = OnionMath::roundFloat(3.5f) // 4
+```
+
+### OnionMath::random / OnionMath::randomInt
+
+乱数生成。`Math::random`と異なり、`randomInt`は範囲を直接指定でき、エフェクトチェッカーに
+よって`Rand`エフェクトとして追跡されます：
+
+```onion
+val r: Double = OnionMath::random()          // [0.0, 1.0)
+val n: Int = OnionMath::randomInt(1, 10)     // [1, 10]（両端含む）
+```
+
+### OnionMath::signum / OnionMath::signumFloat
+
+数値の符号（`-1.0`、`0.0`、または`1.0`）：
+
+```onion
+val s: Double = OnionMath::signum(-5.0)   // -1.0
+```
+
+### OnionMath::toRadians / OnionMath::toDegrees
+
+角度単位の変換：
+
+```onion
+val rad: Double = OnionMath::toRadians(180.0)  // pi
+val deg: Double = OnionMath::toDegrees(OnionMath::PI)  // 180.0
+```
+
+### OnionMath::clamp / OnionMath::clampInt
+
+値を範囲内に収める：
+
+```onion
+val c1: Double = OnionMath::clamp(15.0, 0.0, 10.0)  // 10.0
+val c2: Int = OnionMath::clampInt(-5, 0, 10)        // 0
+```
+
+### OnionMath::hypot
+
+オーバーフロー・アンダーフローを避けた斜辺の長さ：
+
+```onion
+val h: Double = OnionMath::hypot(3.0, 4.0)  // 5.0
+```
+
+### OnionMath Constants
+
+```onion
+val pi: Double = OnionMath::PI  // 3.14159...
+val e: Double = OnionMath::E    // 2.71828...
 ```
 
 ## Origin

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -9,7 +9,7 @@ Onion's standard library consists of built-in modules and interfaces for common 
 | **I/O & system** | `IO` (console), `Files` (files + paths), `System`, `Proc` (subprocesses), `Args` (CLI), `Http` (HTTP client) |
 | **Collections** | `Colls` (lists: map/filter/fold, chunked/windowed, sumBy/maxBy), `Iterables`, `Maps`, `Sets` |
 | **Text** | `Strings` (case, split, pad, parse), `Text` (wrap/indent/table), `Regex` |
-| **Numbers** | `Math`, `Stats` (sum/average/median/stddev), `Format` (grouping, bytes, durations) |
+| **Numbers** | `Math`, `OnionMath` (hyperbolic trig, `clamp`, `hypot`, bounded `randomInt`), `Stats` (sum/average/median/stddev), `Format` (grouping, bytes, durations) |
 | **Data formats** | `Json`, `Yaml`, `Csv`, `Config` (dot-notation config access) |
 | **Encoding** | `Codec` (base64/hex/url), `Hash` (md5/sha256/…) |
 | **Functional** | `Option`, `Result`, `Future`, `Outcome` + `Defect` (reading external data) |
@@ -183,6 +183,130 @@ val tangent: Double = Math::tan(Math::PI / 4) // 1.0
 ```onion
 val pi: Double = Math::PI       // 3.14159...
 val e: Double = Math::E         // 2.71828...
+```
+
+## OnionMath Module
+
+An `onion.*` numeric module, distinct from the JDK's `Math`, covering hyperbolic
+trig, safe rounding/clamping, and a bounded random integer. It is default-imported
+like the rest of the standard library, so no explicit import is needed.
+
+### OnionMath::sin / OnionMath::cos / OnionMath::tan / OnionMath::asin / OnionMath::acos / OnionMath::atan / OnionMath::atan2
+
+Trigonometric and inverse trigonometric functions (radians):
+
+```onion
+val sine: Double = OnionMath::sin(OnionMath::PI / 2)     // 1.0
+val angle: Double = OnionMath::atan2(1.0, 1.0)           // pi/4
+```
+
+### OnionMath::sinh / OnionMath::cosh / OnionMath::tanh
+
+Hyperbolic trigonometric functions:
+
+```onion
+val h: Double = OnionMath::sinh(1.0)
+```
+
+### OnionMath::exp / OnionMath::log / OnionMath::log10
+
+Exponential and logarithms:
+
+```onion
+val e2: Double = OnionMath::exp(1.0)     // e
+val l: Double = OnionMath::log(OnionMath::E)   // 1.0
+val l10: Double = OnionMath::log10(100.0)      // 2.0
+```
+
+### OnionMath::pow / OnionMath::sqrt / OnionMath::cbrt
+
+Powers and roots:
+
+```onion
+val cube: Double = OnionMath::pow(2.0, 3.0)  // 8.0
+val root: Double = OnionMath::sqrt(16.0)     // 4.0
+val croot: Double = OnionMath::cbrt(27.0)    // 3.0
+```
+
+### OnionMath::abs / OnionMath::absFloat / OnionMath::absInt / OnionMath::absLong
+
+Absolute value, by primitive type:
+
+```onion
+val a1: Double = OnionMath::abs(-3.14)
+val a2: Int = OnionMath::absInt(-10)      // 10
+val a3: Long = OnionMath::absLong(-10L)   // 10
+```
+
+### OnionMath::min / OnionMath::minInt / OnionMath::minLong / OnionMath::max / OnionMath::maxInt / OnionMath::maxLong
+
+Minimum and maximum, by primitive type:
+
+```onion
+val lo: Int = OnionMath::minInt(10, 20)   // 10
+val hi: Int = OnionMath::maxInt(10, 20)   // 20
+```
+
+### OnionMath::floor / OnionMath::ceil / OnionMath::round / OnionMath::roundFloat
+
+Rounding functions:
+
+```onion
+val f: Double = OnionMath::floor(3.7)     // 3.0
+val c: Double = OnionMath::ceil(3.2)      // 4.0
+val r: Long = OnionMath::round(3.5)       // 4
+val rf: Int = OnionMath::roundFloat(3.5f) // 4
+```
+
+### OnionMath::random / OnionMath::randomInt
+
+Random number generation. Unlike `Math::random`, `randomInt` takes bounds directly
+and is tracked by the effect checker as a `Rand` effect:
+
+```onion
+val r: Double = OnionMath::random()          // [0.0, 1.0)
+val n: Int = OnionMath::randomInt(1, 10)     // [1, 10], inclusive
+```
+
+### OnionMath::signum / OnionMath::signumFloat
+
+Sign of a number (`-1.0`, `0.0`, or `1.0`):
+
+```onion
+val s: Double = OnionMath::signum(-5.0)   // -1.0
+```
+
+### OnionMath::toRadians / OnionMath::toDegrees
+
+Angle unit conversion:
+
+```onion
+val rad: Double = OnionMath::toRadians(180.0)  // pi
+val deg: Double = OnionMath::toDegrees(OnionMath::PI)  // 180.0
+```
+
+### OnionMath::clamp / OnionMath::clampInt
+
+Constrain a value to a range:
+
+```onion
+val c1: Double = OnionMath::clamp(15.0, 0.0, 10.0)  // 10.0
+val c2: Int = OnionMath::clampInt(-5, 0, 10)        // 0
+```
+
+### OnionMath::hypot
+
+Hypotenuse without intermediate overflow/underflow:
+
+```onion
+val h: Double = OnionMath::hypot(3.0, 4.0)  // 5.0
+```
+
+### OnionMath Constants
+
+```onion
+val pi: Double = OnionMath::PI  // 3.14159...
+val e: Double = OnionMath::E    // 2.71828...
 ```
 
 ## Origin

--- a/src/test/scala/onion/compiler/tools/OnionMathDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OnionMathDocCoverageSpec.scala
@@ -1,0 +1,60 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `OnionMath` module docs.
+ *
+ * `onion.OnionMath` is a genuine, default-imported stdlib module (`OnionMath::sin`,
+ * `OnionMath::clamp`, `OnionMath::hypot`, ...) with its own effect tracking
+ * (docs/reference/effects.md lists it as effectful), but it has never had a section in
+ * docs/reference/stdlib.md or docs/ja/reference/stdlib.md — every public member is
+ * checked here against both files so a future addition to onion.OnionMath fails the
+ * build instead of silently staying undocumented.
+ */
+class OnionMathDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """OnionMath::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.OnionMath]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    val fieldNames = c.getFields
+      .filter(f => java.lang.reflect.Modifier.isStatic(f.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    (methodNames ++ fieldNames).toSet
+  }
+
+  it("actual onion.OnionMath exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.OnionMath found no static members — the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.OnionMath member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing OnionMath:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.OnionMath member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing OnionMath:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions OnionMath in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("OnionMath"),
+      "docs/reference/stdlib.md's overview table should mention OnionMath")
+    assert(read("docs/ja/reference/stdlib.md").contains("OnionMath"),
+      "docs/ja/reference/stdlib.md's overview table should mention OnionMath")
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.OnionMath` is a genuine, default-imported stdlib module (`OnionMath::sin`, `clamp`/`clampInt`, `hypot`, hyperbolic trig, bounded `randomInt`, ...) with 41 public members, full test coverage (`MathSpec`, `EffectTableSpec`), and its own effect tracking — but it had zero mentions in `docs/reference/stdlib.md` or `docs/ja/reference/stdlib.md`, unlike every other stdlib module.
- Adds an "OnionMath Module" section to both files (en + ja, mirroring the existing "Math Module" style) and a row in "Modules at a glance".
- Adds `OnionMathDocCoverageSpec` (TDD: written first, confirmed red against the undocumented module, then made green by the doc additions) — a reflection-based guard, mirroring `AssertStdlibDocSpec`, that fails the build if a future `onion.OnionMath` member ships without a matching doc entry.
- Adds a `CHANGELOG.md` entry.

## Test plan

- [x] `OnionMathDocCoverageSpec` written first, confirmed failing (red) before the doc changes
- [x] `OnionMathDocCoverageSpec` passes after the doc additions (green)
- [x] `StdlibDocDriftSpec` passes (no incorrectly-named members introduced)
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 2921 tests, 0 failures

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud3pd8dcJ9avi3z68GXAyh)_