### PR TITLE
fix(typing): destructuring declaration as a block's trailing expression-position element no longer crashes (I0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `val (a, b) = expr` destructuring declaration as the trailing element of
+  a block used in expression position (e.g. `val x = { val (a, b) = expr }`)
+  crashed the compiler with a raw `MatchError`**, reported as an `[I0000]`
+  internal compiler error instead of a clean diagnostic. `typeBlockExpression`
+  only special-cased `LocalVariableDeclaration` for a block's last element;
+  `DestructuringDeclaration` now follows the same path and reports the same
+  clean type diagnostic a plain `val` declaration gets there. Added a
+  crash-corpus regression (`031-destructuring-last-in-expr-block.on`).
+
 - **`onion.OnionMath` — a genuine, default-imported stdlib module with 41 public
   members (`sin`/`cos`/`tan`, hyperbolic trig, `clamp`/`clampInt`, `hypot`,
   bounded `randomInt`, ...) — had no documentation in `docs/reference/stdlib.md`

--- a/src/main/scala/onion/compiler/typing/ControlExpressionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ControlExpressionTyping.scala
@@ -60,7 +60,7 @@ final class ControlExpressionTyping(
             terms += statementTerm(stmt, BasicType.VOID, element.location)
           } else {
             element match {
-              case _: AST.LocalVariableDeclaration =>
+              case _: AST.LocalVariableDeclaration | _: AST.DestructuringDeclaration =>
                 val stmt = translate(element, context)
                 terms += statementTerm(stmt, BasicType.VOID, element.location)
               case expr: AST.Expression =>

--- a/src/test/resources/crash-corpus/031-destructuring-last-in-expr-block.on
+++ b/src/test/resources/crash-corpus/031-destructuring-last-in-expr-block.on
@@ -1,0 +1,15 @@
+// A destructuring declaration (`val (a, b) = expr`) as the trailing element of
+// a block used in expression position (here, a val initializer) hit an
+// unhandled case in ControlExpressionTyping.typeBlockExpression's last-element
+// match — which only special-cased LocalVariableDeclaration and Expression —
+// raising a raw Scala MatchError as an [I0000] internal compiler error instead
+// of the same clean void-vs-expected-type diagnostic a plain `val` declaration
+// gets in that position.
+record Point(x: Int, y: Int)
+class Test {
+public:
+  static def main(args: String[]): void {
+    val x = { val (a, b) = new Point(1, 2) }
+    IO::println("should not compile")
+  }
+}


### PR DESCRIPTION
## Summary
- `typeBlockExpression`'s last-element match only special-cased `LocalVariableDeclaration` and `Expression`, so a `val (a, b) = expr` destructuring declaration as the trailing element of a block used in expression position (e.g. `val x = { val (a, b) = expr }`) fell through with a raw Scala `MatchError`, surfaced to users as an `[I0000]` internal compiler error rather than a diagnostic.
- `DestructuringDeclaration` now follows the same statement-typing path `LocalVariableDeclaration` already takes there, so it reports the same clean diagnostic (e.g. a void-vs-expected-type error) a plain `val` declaration gets in that position.
- Adds crash-corpus reproducer `src/test/resources/crash-corpus/031-destructuring-last-in-expr-block.on`, picked up automatically by `CompilerCrashRegressionSpec`.
- Notes the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `CompilerCrashRegressionSpec` reproduces `[I0000]` on the new corpus file before the fix, and passes after
- [x] `DestructuringDeclarationSpec` still green
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2922 passed, 0 failed (1 pre-existing environment-dependent cancellation unrelated to this change)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHKZZofHzLNh6YghBWzXDs)_