### PR TITLE
docs(changelog): note the OnionMath execution coverage addition (#502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Execution coverage for the 20 `onion.OnionMath` members `MathSpec` never
+  exercised.** `asin`/`acos`/`atan`/`atan2`, `sinh`/`cosh`/`tanh`, `log10`/
+  `cbrt`, `absFloat`/`absLong`, `minLong`/`maxLong`, `roundFloat`, `signum`/
+  `signumFloat`, `toRadians`/`toDegrees`, `clampInt`, and `hypot` had never
+  been run through the compiler/shell — only 18 of the module's 39 public
+  methods had a `shell.run` case. Added one per method, following the
+  existing pattern.
+
 ### Fixed
 
 - **A `val (a, b) = expr` destructuring declaration as the trailing element of


### PR DESCRIPTION
## Summary
- #502 (merged) added execution coverage for 20 previously-untested `onion.OnionMath` members but didn't include a `CHANGELOG.md` entry. This adds one under `[Unreleased] / Added`, matching the existing "Execution coverage for ..." entry style used throughout the file.

## Test plan
- [x] Docs-only change; no compiler/test code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RryaTYYBqdEvRyrpQC5fRQ)_