### PR TITLE
test(stdlib): execution coverage for onion.DateTime's untested 10 members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   methods had a `shell.run` case. Added one per method, following the
   existing pattern.
 
+- **Execution coverage for 10 `onion.DateTime` members that were never run
+  through the compiler/shell.** `addHours`/`addMinutes`/`addSeconds`,
+  `diff`/`diffSeconds`, `dayOfYear`, `startOfDay`/`endOfDay`, and both
+  `nowString` overloads had no `shell.run` case across `DateTimeSpec`,
+  `DateTimeParseSpec`, or `DateTimeExtraSpec` — `DateTimeExtraSpec`'s
+  docstring even claimed to cover `diffSeconds` without actually calling it.
+  Added `DateTimeCoverageSpec` with one case per method, using fixed
+  timestamps for determinism.
+
 ### Fixed
 
 - **A `val (a, b) = expr` destructuring declaration as the trailing element of

--- a/src/test/scala/onion/compiler/tools/DateTimeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DateTimeCoverageSpec.scala
@@ -1,0 +1,118 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * Execution coverage for onion.DateTime members that DateTimeSpec,
+ * DateTimeParseSpec, and DateTimeExtraSpec never exercised: addHours,
+ * addMinutes, addSeconds, diff, diffSeconds, dayOfYear, startOfDay,
+ * endOfDay, and both nowString overloads. Uses fixed timestamps (via
+ * DateTime::of) so the assertions are stable, following the same pattern
+ * as DateTimeExtraSpec.
+ */
+class DateTimeCoverageSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Boolean): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(Shell.Success(expect) == shell.run(src, "DateTimeCoverageBool.on", Array()))
+  }
+
+  describe("DateTime arithmetic helpers") {
+    it("addHours adds hours to a timestamp") {
+      runBool(
+        "val t = DateTime::of(2024, 3, 15, 10, 0, 0)\n" +
+        "val expected = DateTime::of(2024, 3, 15, 14, 0, 0)\n" +
+        "return DateTime::addHours(t, 4) == expected",
+        true
+      )
+    }
+
+    it("addMinutes adds minutes to a timestamp") {
+      runBool(
+        "val t = DateTime::of(2024, 3, 15, 10, 0, 0)\n" +
+        "val expected = DateTime::of(2024, 3, 15, 11, 30, 0)\n" +
+        "return DateTime::addMinutes(t, 90) == expected",
+        true
+      )
+    }
+
+    it("addSeconds adds seconds to a timestamp") {
+      runBool(
+        "val t = DateTime::of(2024, 3, 15, 10, 0, 0)\n" +
+        "val expected = DateTime::of(2024, 3, 15, 10, 2, 5)\n" +
+        "return DateTime::addSeconds(t, 125) == expected",
+        true
+      )
+    }
+  }
+
+  describe("DateTime comparison helpers") {
+    it("diff returns the millisecond difference between two timestamps") {
+      runBool(
+        "val t1 = DateTime::of(2024, 3, 15, 10, 0, 5)\n" +
+        "val t2 = DateTime::of(2024, 3, 15, 10, 0, 0)\n" +
+        "return DateTime::diff(t1, t2) == 5000L",
+        true
+      )
+    }
+
+    it("diffSeconds returns the whole-second difference between two timestamps") {
+      runBool(
+        "val t1 = DateTime::of(2024, 3, 15, 10, 1, 30)\n" +
+        "val t2 = DateTime::of(2024, 3, 15, 10, 0, 0)\n" +
+        "return DateTime::diffSeconds(t1, t2) == 90L",
+        true
+      )
+    }
+  }
+
+  describe("DateTime component helper") {
+    it("dayOfYear returns the day-of-year ordinal") {
+      runBool(
+        // 2024 is a leap year: Jan(31) + Feb(29) + 15 = 75
+        "val t = DateTime::of(2024, 3, 15, 12, 0, 0)\n" +
+        "return DateTime::dayOfYear(t) == 75",
+        true
+      )
+    }
+  }
+
+  describe("DateTime day-boundary helpers") {
+    it("startOfDay returns midnight for the given day") {
+      runBool(
+        "val t = DateTime::of(2024, 3, 15, 14, 37, 21)\n" +
+        "val expected = DateTime::of(2024, 3, 15, 0, 0, 0)\n" +
+        "return DateTime::startOfDay(t) == expected",
+        true
+      )
+    }
+
+    it("endOfDay returns 23:59:59 for the given day") {
+      runBool(
+        "val t = DateTime::of(2024, 3, 15, 14, 37, 21)\n" +
+        "val end = DateTime::endOfDay(t)\n" +
+        "return DateTime::hour(end) == 23 && DateTime::minute(end) == 59 && DateTime::second(end) == 59",
+        true
+      )
+    }
+  }
+
+  describe("DateTime current-time string formatting") {
+    it("nowString returns a non-empty ISO-formatted string") {
+      runBool(
+        "val s = DateTime::nowString()\n" +
+        "return s.length > 0 && s.indexOf(\"T\") >= 0",
+        true
+      )
+    }
+
+    it("nowString(pattern) formats the current time with a custom pattern") {
+      runBool(
+        "val s = DateTime::nowString(\"yyyy\")\n" +
+        "return s == (DateTime::year(DateTime::now())).toString()",
+        true
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `DateTimeSpec`/`DateTimeParseSpec`/`DateTimeExtraSpec` together exercised only 21 of `onion.DateTime`'s 31 public static methods.
- `addHours`/`addMinutes`/`addSeconds`, `diff`/`diffSeconds`, `dayOfYear`, `startOfDay`/`endOfDay`, and both `nowString` overloads had never been run through the compiler/shell.
- `DateTimeExtraSpec`'s docstring even claimed `diffSeconds` coverage without the test body ever calling it.
- Adds `DateTimeCoverageSpec` with one `shell.run` case per method, using fixed timestamps (via `DateTime::of`) for determinism — same pattern as the recently-merged `onion.OnionMath` coverage addition (#502).

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.DateTimeCoverageSpec'` — 10/10 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite, 2954 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test)


---
_Generated by [Claude Code](https://claude.ai/code/session_015nZtcCv3xXhh7LGyeNiTW5)_