### PR TITLE
test(stdlib): execution coverage for Regex::groupsAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Added `DateTimeCoverageSpec` with one case per method, using fixed
   timestamps for determinism.
 
+- **Execution coverage for `onion.Regex::groupsAll`** (both the `String`
+  pattern and `re"..."`/`Pattern` overloads). It was documented and
+  implemented but, unlike every other `Regex` method, never invoked by a
+  `shell.run` test case. Added multi-match, no-match, and `re"..."` literal
+  cases to `RegexSpec` and `RegexPatternInteropSpec`.
+
 ### Fixed
 
 - **A `val (a, b) = expr` destructuring declaration as the trailing element of

--- a/src/test/scala/onion/compiler/tools/RegexPatternInteropSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RegexPatternInteropSpec.scala
@@ -27,5 +27,9 @@ class RegexPatternInteropSpec extends AbstractShellSpec {
       assert(Shell.Success(true) == shell.run(
         "def main(args: String[]): Boolean { return Regex::matches(\"abc\", \"[a-z]+\") }", "None", Array()))
     }
+    it("groupsAll with a re literal") {
+      assert(Shell.Success(2) == shell.run(
+        "def main(args: String[]): Int { return Regex::groupsAll(\"a1b2\", re\"([a-z])(\\d)\").size }", "None", Array()))
+    }
   }
 }

--- a/src/test/scala/onion/compiler/tools/RegexSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RegexSpec.scala
@@ -144,6 +144,46 @@ class RegexSpec extends AbstractShellSpec {
         )
         assert(Shell.Success("John-25") == result)
       }
+
+      it("extracts capturing groups from every match") {
+        val result = shell.run(
+          """
+            |import { onion.Regex; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val all: List[List[String]] = Regex::groupsAll("a1b2c3", "([a-z])([0-9])");
+            |    var result: String = "";
+            |    foreach g: List[String] in all {
+            |      result = result + g[0] + "=" + g[1] + "+" + g[2] + ";";
+            |    }
+            |    return result;
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("a1=a+1;b2=b+2;c3=c+3;") == result)
+      }
+
+      it("returns an empty list when groupsAll finds no match") {
+        val result = shell.run(
+          """
+            |import { onion.Regex; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int {
+            |    val all: List[List[String]] = Regex::groupsAll("no digits here", "([0-9]+)");
+            |    return all.size;
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success(0) == result)
+      }
     }
 
     describe("replacement") {


### PR DESCRIPTION
## Summary
- `onion.Regex::groupsAll` (both the `String` pattern and `re"..."`/`Pattern` overloads) is documented in `docs/reference/stdlib.md` and implemented in `Regex.java`, but unlike every other `Regex` method it was never exercised by a `shell.run` test case.
- Added multi-match, no-match, and `re"..."` literal coverage to `RegexSpec` and `RegexPatternInteropSpec`, following the existing pattern used for the recent `OnionMath`/`DateTime` coverage additions.
- No production code changes — the tests confirmed existing behavior is correct.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *RegexSpec *RegexPatternInteropSpec'` — 31/31 pass
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2957 succeeded, 0 failed, 1 canceled (pre-existing, unrelated `ProjectDistributionSpec` environment-dependent case)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMeQv83aw8wfPngvr77jrr)_