### PR TITLE
test(stdlib): execution coverage for Stats::variance and Stats::sumLong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Stats::variance` and `onion.Stats::sumLong`.**
+  Both members were implemented and documented but, unlike every other
+  `Stats` method, never invoked by a `shell.run` test case in
+  `HashCodecStatsSpec`. Added one case per method.
+
 - **Execution coverage for the 20 `onion.OnionMath` members `MathSpec` never
   exercised.** `asin`/`acos`/`atan`/`atan2`, `sinh`/`cosh`/`tanh`, `log10`/
   `cbrt`, `absFloat`/`absLong`, `minLong`/`maxLong`, `roundFloat`, `signum`/

--- a/src/test/scala/onion/compiler/tools/HashCodecStatsSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HashCodecStatsSpec.scala
@@ -85,6 +85,21 @@ class HashCodecStatsSpec extends AbstractShellSpec {
         Shell.Success("2.0"))
     }
 
+    it("variance of a known sample") {
+      runStr(
+        "import { onion.Stats }",
+        "return Double::toString(Stats::variance([2, 4, 4, 4, 5, 5, 7, 9]))",
+        Shell.Success("4.0"))
+    }
+
+    it("sums a Long list exactly") {
+      runStr(
+        "import { onion.Stats }",
+        "val xs: List[Long] = [10L, 20L, 30L]\n" +
+        "return Long::toString(Stats::sumLong(xs))",
+        Shell.Success("60"))
+    }
+
     it("works on a Double list too") {
       runStr(
         "import { onion.Stats }",


### PR DESCRIPTION
## Summary
- `onion.Stats::variance` and `onion.Stats::sumLong` are implemented and documented but, unlike every other `Stats` method, were never invoked by a `shell.run` test case in `HashCodecStatsSpec`.
- Added one `shell.run` case per method, following the existing pattern in the "Stats module" describe block.
- Noted the addition in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *HashCodecStatsSpec'` — 11/11 passed (2 new)
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite: 2959/2959 passed, 0 failed, 1 canceled (pre-existing, opt-in dist smoke test unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ7K8mgwWLu2D849zDvEGi)_