### PR TITLE
test(stdlib): execution coverage for 8 untested Json accessor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for 8 `onion.Json` accessor methods that were
+  documented in `docs/reference/stdlib.md` but never invoked by a
+  `shell.run` test case.** `getLong`, `getFloat`, `getShort`, `getByte`
+  (the boxed, null-on-missing accessors) and `getLongOr`, `getDoubleOr`,
+  `getFloatOr`, `getBooleanOr` (the defaulted variants) had no coverage,
+  unlike their siblings `getInt`/`getDouble`/`getBoolean`/`getIntOr`/
+  `getStringOr`. Added `JsonAccessorCoverageSpec` with one case per method.
+
 - **Execution coverage for `onion.Stats::variance` and `onion.Stats::sumLong`.**
   Both members were implemented and documented but, unlike every other
   `Stats` method, never invoked by a `shell.run` test case in

--- a/src/test/scala/onion/compiler/tools/JsonAccessorCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JsonAccessorCoverageSpec.scala
@@ -1,0 +1,155 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * Execution coverage for `onion.Json` accessors that are documented in
+ * docs/reference/stdlib.md (the `getString`/`getInt`/`getLong`/`getDouble`/
+ * `getFloat`/`getBoolean`/`getShort`/`getByte` family and their `*Or`
+ * defaulted counterparts) but, unlike `getInt`/`getDouble`/`getBoolean`/
+ * `getIntOr`/`getStringOr`, were never invoked by a `shell.run` test case:
+ * `getLong`, `getFloat`, `getShort`, `getByte`, `getLongOr`, `getDoubleOr`,
+ * `getFloatOr`, `getBooleanOr`.
+ */
+class JsonAccessorCoverageSpec extends AbstractShellSpec {
+
+  it("getLong() converts a number to Long") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Long {
+        |    val obj = Json::parse("{\"count\": 42}")
+        |    val count: Long = Json::getLong(obj, "count")
+        |    return count
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success(42L) == result)
+  }
+
+  it("getFloat() converts a number to Float") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Float {
+        |    val obj = Json::parse("{\"pi\": 3.5}")
+        |    val pi: Float = Json::getFloat(obj, "pi")
+        |    return pi
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success(3.5f) == result)
+  }
+
+  it("getShort() converts a number to Short") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val obj = Json::parse("{\"n\": 100}")
+        |    val n: Short = Json::getShort(obj, "n")
+        |    return n as Int
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success(100) == result)
+  }
+
+  it("getByte() converts a number to Byte") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val obj = Json::parse("{\"n\": 7}")
+        |    val n: Byte = Json::getByte(obj, "n")
+        |    return n as Int
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success(7) == result)
+  }
+
+  it("getLongOr() returns the value when present and the default when missing") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): String {
+        |    val obj = Json::parse("{\"n\": 5}")
+        |    return Long::toString(Json::getLongOr(obj, "n", 99L)) + "|" + Long::toString(Json::getLongOr(obj, "missing", 99L))
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success("5|99") == result)
+  }
+
+  it("getDoubleOr() returns the value when present and the default when missing") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): String {
+        |    val obj = Json::parse("{\"pi\": 3.5}")
+        |    return Double::toString(Json::getDoubleOr(obj, "pi", 0.0)) + "|" + Double::toString(Json::getDoubleOr(obj, "missing", 1.5))
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success("3.5|1.5") == result)
+  }
+
+  it("getFloatOr() returns the value when present and the default when missing") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): String {
+        |    val obj = Json::parse("{\"pi\": 2.5}")
+        |    return Float::toString(Json::getFloatOr(obj, "pi", 0.0f)) + "|" + Float::toString(Json::getFloatOr(obj, "missing", 1.5f))
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success("2.5|1.5") == result)
+  }
+
+  it("getBooleanOr() returns the value when present and the default when missing") {
+    val result = shell.run(
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): String {
+        |    val obj = Json::parse("{\"active\": true}")
+        |    return Boolean::toString(Json::getBooleanOr(obj, "active", false)) + "|" + Boolean::toString(Json::getBooleanOr(obj, "missing", false))
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success("true|false") == result)
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Json::getLong`/`getFloat`/`getShort`/`getByte` (boxed, null-on-missing accessors) and `getLongOr`/`getDoubleOr`/`getFloatOr`/`getBooleanOr` (defaulted variants) are documented in `docs/reference/stdlib.md` but, unlike their siblings `getInt`/`getDouble`/`getBoolean`/`getIntOr`/`getStringOr`, were never invoked by a `shell.run` test case.
- Added `JsonAccessorCoverageSpec` with one execution-coverage case per method.
- Added a matching `[Unreleased]` entry to `CHANGELOG.md`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.JsonAccessorCoverageSpec'` — 8/8 passed
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2967 succeeded, 0 failed, 1 canceled (pre-existing, unrelated packaging smoke test)

---
_Generated by [Claude Code](https://claude.ai/code/session_0136aP8sXBBKTYZSmGZgNWp6)_