### PR TITLE
test(stdlib): execution coverage for Csv::stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Csv::stringify`.** It was implemented and
+  documented (the direct inverse of `Csv::parse`) but, unlike its sibling
+  `stringifyWithHeader`, never invoked by a `shell.run` test case in
+  `CsvEnrichedSpec`. Added a round-trip case and a comma-quoting case.
+
 - **Execution coverage for 8 `onion.Json` accessor methods that were
   documented in `docs/reference/stdlib.md` but never invoked by a
   `shell.run` test case.** `getLong`, `getFloat`, `getShort`, `getByte`

--- a/src/test/scala/onion/compiler/tools/CsvEnrichedSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CsvEnrichedSpec.scala
@@ -38,6 +38,23 @@ class CsvEnrichedSpec extends AbstractShellSpec {
         Shell.Success(3))
     }
 
+    it("stringify closes the parse round-trip") {
+      runStr(
+        "val rows = Csv::parse(\"name,age\\nAlice,30\\nBob,25\")\n" +
+        "val out = Csv::stringify(rows)\n" +
+        "val back = Csv::parse(out)\n" +
+        "return back.get(2).get(0) + \":\" + back.get(2).get(1)",
+        Shell.Success("Bob:25"))
+    }
+
+    it("stringify quotes fields with commas") {
+      runStr(
+        "val rows = Csv::parse(\"a,b\\n\\\"x,y\\\",z\")\n" +
+        "val out = Csv::stringify(rows)\n" +
+        "return Csv::parse(out).get(1).get(0)",
+        Shell.Success("x,y"))
+    }
+
     it("stringifyWithHeader closes the parseWithHeader round-trip") {
       runStr(
         "val recs = Csv::parseWithHeader(\"name,age\\nAlice,30\\nBob,25\")\n" +


### PR DESCRIPTION
## Summary
- `onion.Csv::stringify` was implemented and documented (the direct inverse of `Csv::parse`) but, unlike its sibling `stringifyWithHeader`, was never invoked by a `shell.run` test case in `CsvEnrichedSpec`.
- Adds a round-trip case and a comma-quoting case for `Csv::stringify`, mirroring the existing `stringifyWithHeader` coverage pattern.
- Notes the addition in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *CsvEnrichedSpec'` — 6/6 passed
- [x] `sbt -Duser.language=en test` — full suite: 2969 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PUcj4qvQxEmCQnCm5u21ne)_