### PR TITLE
test(stdlib): execution coverage for Sets::newSet, containsAll, forEach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Sets::newSet`, `Sets::containsAll`, and
+  `Sets::forEach`.** All three were implemented and documented in
+  `docs/reference/stdlib.md`, but unlike every other `Sets` method, never
+  invoked by a `shell.run` test case (`isSubsetOf`/`isSupersetOf` exercise
+  `containsAll` only transitively, not as a direct call). Added one case per
+  method to `SetsEnrichedSpec`.
+
 - **Execution coverage for `onion.Csv::stringify`.** It was implemented and
   documented (the direct inverse of `Csv::parse`) but, unlike its sibling
   `stringifyWithHeader`, never invoked by a `shell.run` test case in

--- a/src/test/scala/onion/compiler/tools/SetsEnrichedSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsEnrichedSpec.scala
@@ -3,10 +3,11 @@ package onion.compiler.tools
 import onion.tools.Shell
 
 /**
- * Tests for the practical Set operations added to `onion.Sets`: fromList/toList,
- * symmetricDifference, isSubsetOf/isSupersetOf/isDisjoint, map, filter, forEach,
- * count, any, all, and find. Null-safety of union/intersection/difference is
- * exercised indirectly via the composed operations.
+ * Tests for the practical Set operations added to `onion.Sets`: newSet,
+ * fromList/toList, symmetricDifference, containsAll, isSubsetOf/isSupersetOf/
+ * isDisjoint, map, filter, forEach, count, any, all, and find. Null-safety of
+ * union/intersection/difference is exercised indirectly via the composed
+ * operations.
  */
 class SetsEnrichedSpec extends AbstractShellSpec {
 
@@ -65,6 +66,35 @@ class SetsEnrichedSpec extends AbstractShellSpec {
         "val f = Sets::find(a, (x: Int) -> x > 2)\n" +
         "return if f != null { f!! as Int } else { -1 }",
         Shell.Success(3))
+    }
+
+    it("newSet creates an empty, mutable set") {
+      run(
+        "val s = Sets::newSet[Int]()\n" +
+        "val before = s.size()\n" +
+        "s.add(1)\n" +
+        "s.add(2)\n" +
+        "s.add(1)\n" +
+        "return before * 100 + s.size()",
+        Shell.Success(2))
+    }
+
+    it("containsAll answers whether every element of subset is in container") {
+      run(
+        "val a = Sets::of(1, 2, 3, 4)\n" +
+        "val yes = if Sets::containsAll(a, Sets::of(2, 3)) { 1 } else { 0 }\n" +
+        "val no = if Sets::containsAll(a, Sets::of(3, 9)) { 10 } else { 0 }\n" +
+        "return yes + no",
+        Shell.Success(1))
+    }
+
+    it("forEach applies the action to every element in iteration order") {
+      run(
+        "val a = Sets::of(1, 2, 3)\n" +
+        "var total = 0\n" +
+        "Sets::forEach(a, (x: Int) -> { total = total + x })\n" +
+        "return total",
+        Shell.Success(6))
     }
   }
 }


### PR DESCRIPTION
## Summary
- `onion.Sets::newSet`, `Sets::containsAll`, and `Sets::forEach` are implemented and documented in `docs/reference/stdlib.md`, but unlike every other `Sets` method, were never invoked by a `shell.run` test case (`isSubsetOf`/`isSupersetOf` only exercise `containsAll` transitively through their own implementation).
- Added one test case per method to `SetsEnrichedSpec`, following its existing style.
- Noted the addition in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.SetsEnrichedSpec"` — 9/9 passed (3 new)
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green: 2972 succeeded, 0 failed, 1 canceled (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QyTzKn2fr84fgenwmDeYAn)_