### PR TITLE
test(stdlib): add execution coverage for Maps::filterKeys and Maps::forEach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Maps::filterKeys` and `Maps::forEach`.**
+  Both were implemented and documented in `docs/reference/stdlib.md`, but
+  unlike every other `Maps` method, never invoked by a `shell.run` test
+  case — `MapsEnrichedSpec`'s own docstring claimed to cover `forEach`
+  without actually calling it, and `filterKeys` wasn't mentioned at all.
+  Added one case per method to `MapsEnrichedSpec`.
+
 - **Execution coverage for `onion.Sets::newSet`, `Sets::containsAll`, and
   `Sets::forEach`.** All three were implemented and documented in
   `docs/reference/stdlib.md`, but unlike every other `Sets` method, never

--- a/src/test/scala/onion/compiler/tools/MapsEnrichedSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapsEnrichedSpec.scala
@@ -4,8 +4,8 @@ import onion.tools.Shell
 
 /**
  * Tests for the practical Map operations added to `onion.Maps`: keys/values,
- * mapKeys, filter/count/anyEntry/allEntries (key+value predicates), forEach,
- * toList, invert, groupBy, countBy, update, mergeWith, and getOrElse.
+ * mapKeys, filter/filterKeys/count/anyEntry/allEntries (key+value predicates),
+ * forEach, toList, invert, groupBy, countBy, update, mergeWith, and getOrElse.
  */
 class MapsEnrichedSpec extends AbstractShellSpec {
 
@@ -37,6 +37,22 @@ class MapsEnrichedSpec extends AbstractShellSpec {
         "val m: Map[String, Int] = [\"a\": 1, \"b\": 20, \"c\": 3]\n" +
         "return Maps::filter(m, (k: String, v: Int) -> v >= 10).size()",
         Shell.Success(1))
+    }
+
+    it("filterKeys keeps entries whose key matches a predicate") {
+      run(
+        "val m: Map[String, Int] = [\"apple\": 1, \"banana\": 2, \"avocado\": 3]\n" +
+        "return Maps::filterKeys(m, (k: String) -> k.startsWith(\"a\")).size()",
+        Shell.Success(2))
+    }
+
+    it("forEach visits every key/value pair") {
+      run(
+        "val m: Map[String, Int] = [\"a\": 1, \"b\": 2, \"c\": 3]\n" +
+        "var total = 0\n" +
+        "Maps::forEach(m, (k: String, v: Int) -> { total = total + v })\n" +
+        "return total",
+        Shell.Success(6))
     }
 
     it("count/anyEntry/allEntries take key+value predicates") {


### PR DESCRIPTION
## Summary
- `onion.Maps::filterKeys` and `Maps::forEach` are implemented and documented in `docs/reference/stdlib.md`, but unlike every other `Maps` method were never invoked by a `shell.run` test case (`MapsEnrichedSpec`'s own docstring even claimed to cover `forEach` without actually calling it).
- Added one case per method to `MapsEnrichedSpec`, following the existing pattern in that file.
- Added a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *MapsEnrichedSpec'` — 13/13 pass, including the two new cases
- [x] Full suite: `sbt -Duser.language=en test` — 2977 succeeded, 0 failed, 1 canceled (pre-existing, network-dependent `ProjectDistributionSpec` case, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8zAEY9YZ8S1hqWS2uoqrw)_