### PR TITLE
test(stdlib): add execution coverage for Strings::replaceRegex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Execution coverage for `onion.Strings::replaceRegex`.** It was implemented
+  and documented in `docs/reference/stdlib.md` right next to `Strings::replace`,
+  but unlike `replace`, never invoked by a `shell.run` test case in
+  `StringsSpec.scala`. Added one case.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/StringsSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsSpec.scala
@@ -111,6 +111,23 @@ class StringsSpec extends AbstractShellSpec {
         assert(Shell.Success("hello onion") == result)
       }
 
+      it("replaces substring matching a regex") {
+        val result = shell.run(
+          """
+            |import { onion.Strings; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    return Strings::replaceRegex("a1b22c333", "[0-9]+", "#");
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("a#b#c#") == result)
+      }
+
       it("reverses string") {
         val result = shell.run(
           """


### PR DESCRIPTION
## Summary
- `onion.Strings::replaceRegex` was implemented and documented in `docs/reference/stdlib.md` right next to `Strings::replace`, but unlike `replace`, it was never invoked by a `shell.run` test case in `StringsSpec.scala`.
- Added one test case exercising `Strings::replaceRegex("a1b22c333", "[0-9]+", "#")` → `"a#b#c#"`.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.StringsSpec'` — new test passes
- [x] `sbt -Duser.language=en test` — full suite green (2978 succeeded, 0 failed, 1 canceled — the pre-existing, environment-dependent distribution-packaging journey test, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKPSFfheJhpn2VFZj9MnZz)_