### PR TITLE
test(stdlib): add execution coverage for Files::list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   but unlike `replace`, never invoked by a `shell.run` test case in
   `StringsSpec.scala`. Added one case.
 
+- **Execution coverage for `onion.Files::list`.** It was implemented and
+  documented in `docs/reference/stdlib.md` right next to `Files::glob`, but
+  unlike `glob`, never invoked by a `shell.run` test case anywhere in the
+  suite. Added `FilesListSpec` with one case.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/FilesListSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FilesListSpec.scala
@@ -1,0 +1,33 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `Files::list` is implemented and documented in docs/reference/stdlib.md
+ * right next to `Files::glob`, but unlike `glob`, was never invoked by a
+ * `shell.run` test case anywhere in the suite. Added one.
+ */
+class FilesListSpec extends AbstractShellSpec {
+  it("lists directory entries as a sorted List of names") {
+    val dir = System.getProperty("java.io.tmpdir") + "/onion-files-list-test"
+    val result = shell.run(
+      s"""
+        |class Test {
+        |public:
+        |  static def main(args: String[]): String {
+        |    new java.io.File("$dir").mkdirs()
+        |    Files::writeText("$dir/b.txt", "y")
+        |    Files::writeText("$dir/a.txt", "x")
+        |    val found = Files::list("$dir")
+        |    Files::delete("$dir/a.txt")
+        |    Files::delete("$dir/b.txt")
+        |    return found.toString()
+        |  }
+        |}
+        |""".stripMargin,
+      "FilesListBasic.on",
+      Array()
+    )
+    assert(Shell.Success("[a.txt, b.txt]") == result)
+  }
+}


### PR DESCRIPTION
## Summary
- `Files::list` is implemented (`src/main/java/onion/Files.java`) and documented in `docs/reference/stdlib.md` right next to `Files::glob`, but unlike `glob` it was never invoked by a `shell.run` test case anywhere in the suite.
- Added `FilesListSpec` with one case that creates a temp directory, writes two files into it, calls `Files::list`, and asserts the sorted name list is returned.
- Noted the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.FilesListSpec'` — new test passes
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite: 2979 succeeded, 0 failed, 1 pre-existing canceled (unrelated distribution-packaging integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017JBAppPcBNdazShPDdELWC)_