### PR TITLE
test(stdlib): add execution coverage for Files::readBytes/writeBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unlike `glob`, never invoked by a `shell.run` test case anywhere in the
   suite. Added `FilesListSpec` with one case.
 
+- **Execution coverage for `onion.Files::readBytes` / `Files::writeBytes`.**
+  Both were implemented and documented in `docs/reference/stdlib.md` right
+  next to `readText`/`writeText`, but unlike those, never invoked by a
+  `shell.run` test case anywhere in the suite. Added `FilesBytesSpec` with a
+  round-trip case.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/FilesBytesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FilesBytesSpec.scala
@@ -1,0 +1,40 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `Files::readBytes` and `Files::writeBytes` are implemented and documented
+ * in docs/reference/stdlib.md right next to the other `Files` methods, but
+ * unlike `readText`/`writeText`, never invoked by a `shell.run` test case
+ * anywhere in the suite. Added a round-trip case.
+ */
+class FilesBytesSpec extends AbstractShellSpec {
+  it("writes bytes to a file and reads them back") {
+    val path = System.getProperty("java.io.tmpdir") + "/onion-files-bytes-test.bin"
+    val result = shell.run(
+      s"""
+        |class Test {
+        |public:
+        |  static def main(args: String[]): String {
+        |    val data: Byte[] = new Byte[3]
+        |    data[0] = (72 as Byte)
+        |    data[1] = (73 as Byte)
+        |    data[2] = (33 as Byte)
+        |    Files::writeBytes("$path", data)
+        |    val read: Byte[] = Files::readBytes("$path")
+        |    Files::delete("$path")
+        |    val sb = new StringBuilder()
+        |    foreach b: Byte in read {
+        |      sb.append(b as Int)
+        |      sb.append(",")
+        |    }
+        |    return sb.toString()
+        |  }
+        |}
+        |""".stripMargin,
+      "FilesBytesBasic.on",
+      Array()
+    )
+    assert(Shell.Success("72,73,33,") == result)
+  }
+}


### PR DESCRIPTION
## Summary
- `Files::readBytes` and `Files::writeBytes` were implemented and documented in `docs/reference/stdlib.md` right next to `readText`/`writeText`, but unlike those, were never invoked by a `shell.run` test case anywhere in the suite.
- Added `FilesBytesSpec` with a round-trip write/read case.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.FilesBytesSpec'` — passes
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green (2980 succeeded, 0 failed, 1 pre-existing environment-gated cancellation unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz9n8g7dTc5JoPyHakrd9H)_