### PR TITLE
test(stdlib): add execution coverage for Rand::nextInt()/nextLong() no-arg overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `shell.run` test case anywhere in the suite. Added `FilesBytesSpec` with a
   round-trip case.
 
+- **Execution coverage for `onion.Rand::nextInt()` / `Rand::nextLong()`
+  (no-arg overloads).** Both were implemented and documented in
+  `docs/reference/stdlib.md` right next to their bounded counterparts, but
+  unlike those, never invoked by a `shell.run` test case in `RandomSpec.scala`.
+  Added one case each.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/RandomSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RandomSpec.scala
@@ -28,6 +28,24 @@ class RandomSpec extends AbstractShellSpec {
         assert(Shell.Success("true") == result)
       }
 
+      it("generates random int without bound") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val a = Rand::nextInt();
+            |    val b = Rand::nextInt();
+            |    return "" + (a != b);
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("true") == result)
+      }
+
       it("generates random int in range with min and max") {
         val result = shell.run(
           """
@@ -261,6 +279,24 @@ class RandomSpec extends AbstractShellSpec {
     }
 
     describe("long random") {
+      it("generates random long without bound") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val a = Rand::nextLong();
+            |    val b = Rand::nextLong();
+            |    return "" + (a != b);
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("true") == result)
+      }
+
       it("generates random long with bound") {
         val result = shell.run(
           """


### PR DESCRIPTION
## Summary
- `Rand::nextInt()` and `Rand::nextLong()` (the zero-argument overloads) are implemented in `src/main/java/onion/Rand.java` and documented in `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`, right next to their bounded counterparts (`nextInt(bound)`, `nextLong(bound)`).
- Unlike the bounded overloads, neither no-arg overload was ever invoked by a `shell.run` test case anywhere in the suite.
- Adds one test case each to `RandomSpec.scala`, following the same pattern as the existing `Strings::replaceRegex` / `Files::list` / `Files::readBytes`/`writeBytes` coverage additions.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *RandomSpec'` — 14/14 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2982 succeeded, 0 failed, 1 canceled (pre-existing environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dke9gnNdmS83kk6wkTbYDr)_