### PR TITLE
test(stdlib): add execution coverage for Origin::spanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unlike those, never invoked by a `shell.run` test case in `RandomSpec.scala`.
   Added one case each.
 
+- **Execution coverage for `onion.Origin::spanning`.** It was implemented and
+  documented in `docs/reference/stdlib.md` right next to `Origin::at` and
+  `Origin::atLine`, but unlike those, never invoked by a `shell.run` test
+  case in `OriginSpec.scala`. Added a case covering the normal span and one
+  covering the `Math.max(1, span)` clamp for a non-positive span.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/OriginSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OriginSpec.scala
@@ -83,6 +83,35 @@ class OriginSpec extends AbstractShellSpec {
       assert(Shell.Success(true) == result)
     }
 
+    it("covers a span of characters via spanning()") {
+      val result = shell.run(
+        """import { onion.Origin; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val o = Origin::spanning("a.on", 3, 8, 4)
+          |    return o.source() + "|" + o.line() + "|" + o.column() + "|" + o.span()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("a.on|3|8|4") == result)
+    }
+
+    it("clamps a non-positive span to at least one character via spanning()") {
+      // Origin.spanning(..., span) takes Math.max(1, span); a parser that computed a
+      // zero-or-negative span (e.g. an empty match) must still get a valid Origin.
+      val result = shell.run(
+        """import { onion.Origin; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return Origin::spanning("a.on", 3, 8, 0).span()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success(1) == result)
+    }
+
     it("shifts to a line within an enclosing text, for per-line parsing") {
       // `S.lines` parses each line separately; each sub-parse reports positions relative
       // to its own line and has to be lifted back into the whole document.


### PR DESCRIPTION
## Summary
- `Origin::spanning` was implemented (`src/main/java/onion/Origin.java`) and documented (`docs/reference/stdlib.md`) right next to `Origin::at` and `Origin::atLine`, but unlike those, was never invoked by a `shell.run` test case in `OriginSpec.scala`.
- Added a case covering the normal span, and a case covering the `Math.max(1, span)` clamp for a non-positive span.
- Noted in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *OriginSpec'` — 8/8 passing
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2984 succeeded, 0 failed, 1 canceled (pre-existing network-gated test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBTGCQVVDbiGVb6H3zyeR8)_