### PR TITLE
test(stdlib): add execution coverage for Json::stringifyPretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Json::stringifyPretty`.** It was implemented
+  and documented in `docs/reference/stdlib.md` right next to `Json::stringify`,
+  but unlike `stringify`, never invoked by a `shell.run` test case in
+  `JsonSpec.scala`. Added two cases covering object indentation and a nested
+  array inside an object.
+
 - **Execution coverage for `onion.Strings::replaceRegex`.** It was implemented
   and documented in `docs/reference/stdlib.md` right next to `Strings::replace`,
   but unlike `replace`, never invoked by a `shell.run` test case in

--- a/src/test/scala/onion/compiler/tools/JsonSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JsonSpec.scala
@@ -479,6 +479,51 @@ class JsonSpec extends AbstractShellSpec {
       }
     }
 
+    describe("stringifyPretty()") {
+      it("pretty-prints an object with indentation") {
+        val result = shell.run(
+          """
+            |import { onion.Json; java.util.Map; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val obj: Map[String, Object] = Json::object()
+            |    obj.put("name", "John")
+            |    obj.put("age", new Integer(30))
+            |    return Json::stringifyPretty(obj)
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("{\n  \"name\": \"John\",\n  \"age\": 30\n}") == result)
+      }
+
+      it("pretty-prints a nested array inside an object") {
+        val result = shell.run(
+          """
+            |import { onion.Json; java.util.Map; java.util.List; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val arr: List[Object] = Json::array()
+            |    arr.add(new Integer(2))
+            |    arr.add(new Integer(3))
+            |    val obj: Map[String, Object] = Json::object()
+            |    obj.put("a", new Integer(1))
+            |    obj.put("b", arr)
+            |    return Json::stringifyPretty(obj)
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("{\n  \"a\": 1,\n  \"b\": [\n    2,\n    3\n  ]\n}") == result)
+      }
+    }
+
     describe("round-trip parse and stringify") {
       it("round-trips simple object") {
         val result = shell.run(


### PR DESCRIPTION
## Summary
- `Json::stringifyPretty` is implemented and documented in `docs/reference/stdlib.md` right next to `Json::stringify`, but unlike `stringify` was never invoked by a `shell.run` test case in `JsonSpec.scala`.
- Added two cases: pretty-printing an object with indentation, and a nested array inside an object.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.JsonSpec'` — 40/40 pass
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` (full suite, English locale) — 2986/2986 pass, 1 canceled (environment-gated distribution smoke test, unrelated)


---
_Generated by [Claude Code](https://claude.ai/code/session_011atGidLQNDmG2cVQbrc7cv)_