### PR TITLE
test(stdlib): add execution coverage for Stats::sum static form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   case in `OriginSpec.scala`. Added a case covering the normal span and one
   covering the `Math.max(1, span)` clamp for a non-positive span.
 
+- **Execution coverage for the generic static `onion.Stats::sum`.** It was
+  implemented and documented in `docs/reference/stdlib.md` as the first
+  example in the Stats module section, but unlike `sumInt`/`sumLong` and the
+  other aggregates, never invoked directly by a `shell.run` test case in
+  `HashCodecStatsSpec.scala` (only reached transitively through
+  `xs.sum()`). Added a case to `HashCodecStatsSpec`.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/HashCodecStatsSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HashCodecStatsSpec.scala
@@ -70,6 +70,14 @@ class HashCodecStatsSpec extends AbstractShellSpec {
         Shell.Success(125)) // 100 + 25
     }
 
+    it("sums a List[Int] in double precision via the generic static form") {
+      runStr(
+        "import { onion.Stats }",
+        "val xs: List[Int] = [10, 20, 30, 40]\n" +
+        "return Double::toString(Stats::sum(xs))",
+        Shell.Success("100.0"))
+    }
+
     it("min, max and median in double precision") {
       runStr(
         "import { onion.Stats }",


### PR DESCRIPTION
## Summary
- `Stats::sum(nums)` is implemented (`src/main/java/onion/Stats.java`) and documented as the very first example in the Stats module section of `docs/reference/stdlib.md`, but unlike `sumInt`/`sumLong` and the other aggregates it was never invoked directly by a `shell.run` test case in `HashCodecStatsSpec.scala` — only reached transitively through `xs.sum()`.
- Adds a direct `Stats::sum` case to `HashCodecStatsSpec.scala` and a matching `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *HashCodecStatsSpec'` — 12/12 passing, new case included
- [x] `sbt -Duser.language=en test` — full suite green: 2987 succeeded, 0 failed, 1 canceled (pre-existing), exit code 0


---
_Generated by [Claude Code](https://claude.ai/code/session_012YH4GXAtRdshaFDRTiii1U)_