### PR TITLE
test(stdlib): add execution coverage for Config::getLong/getWithEnvOverride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `HashCodecStatsSpec.scala` (only reached transitively through
   `xs.sum()`). Added a case to `HashCodecStatsSpec`.
 
+- **Execution coverage for `onion.Config::getLong` and
+  `Config::getWithEnvOverride`.** Both were implemented and documented in
+  `docs/reference/stdlib.md` right next to `getInt`/`getDouble`/`getBoolean`
+  and `getEnv`, but unlike those, never invoked by a `shell.run` test case in
+  `ConfigSpec.scala`. Added two cases per method (value found / falls back to
+  default).
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/ConfigSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ConfigSpec.scala
@@ -175,6 +175,44 @@ class ConfigSpec extends AbstractShellSpec {
         assert(Shell.Success("3000") == result)
       }
 
+      it("gets long values with getLong") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"maxConnections\": 4294967296}";
+            |    val config = Config::parseJson(json);
+            |    val maxConnections = Config::getLong(config, "maxConnections", 10L);
+            |    return "" + maxConnections;
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("4294967296") == result)
+      }
+
+      it("returns default long for non-numeric value") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"maxConnections\": \"invalid\"}";
+            |    val config = Config::parseJson(json);
+            |    val maxConnections = Config::getLong(config, "maxConnections", 10L);
+            |    return "" + maxConnections;
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("10") == result)
+      }
+
       it("gets double values with getDouble") {
         val result = shell.run(
           """
@@ -251,6 +289,44 @@ class ConfigSpec extends AbstractShellSpec {
           Array()
         )
         assert(Shell.Success("has_path") == result)
+      }
+
+      it("prefers env var over config value with getWithEnvOverride") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"database\": {\"host\": \"localhost\"}}";
+            |    val config = Config::parseJson(json);
+            |    return Config::getWithEnvOverride(config, "database.host", "PATH", "fallback");
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(result.isInstanceOf[Shell.Success])
+        val Shell.Success(value) = result: @unchecked
+        assert(value != "localhost")
+      }
+
+      it("falls back to config value when env var not set with getWithEnvOverride") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"database\": {\"host\": \"localhost\"}}";
+            |    val config = Config::parseJson(json);
+            |    return Config::getWithEnvOverride(config, "database.host", "NONEXISTENT_VAR_12345", "fallback");
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("localhost") == result)
       }
     }
 


### PR DESCRIPTION
## Summary
- `Config::getLong` and `Config::getWithEnvOverride` were implemented and documented in `docs/reference/stdlib.md` right next to `getInt`/`getDouble`/`getBoolean` and `getEnv`, but unlike those, never invoked by a `shell.run` test case in `ConfigSpec.scala`.
- Added two cases per method (value found / falls back to default) to `ConfigSpec.scala`.
- Noted the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *ConfigSpec'` — 19/19 passed
- [x] `sbt -Duser.language=en test` — 2991 succeeded, 0 failed, 1 canceled (pre-existing, environment-dependent distribution-packaging test, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_013kkpq6xU1BUsD657WRMdZ3)_