### PR TITLE
test(stdlib): add execution coverage for Proc::captureIn/execIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Proc::captureIn` and `Proc::execIn`.** Both
+  were implemented and documented in `docs/reference/stdlib.md` right next to
+  `runIn`, but unlike `runIn`, never invoked by a `shell.run` test case in
+  `ProcSpec.scala`. Added one case each, exercising the working-directory
+  behavior via the process's own exit status/stderr.
+
 - **Execution coverage for `onion.Json::stringifyPretty`.** It was implemented
   and documented in `docs/reference/stdlib.md` right next to `Json::stringify`,
   but unlike `stringify`, never invoked by a `shell.run` test case in

--- a/src/test/scala/onion/compiler/tools/ProcSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ProcSpec.scala
@@ -95,5 +95,38 @@ class ProcSpec extends AbstractShellSpec {
       )
       assert(Shell.Success("/tmp") == result)
     }
+
+    it("captures status, stdout and stderr from a given working directory") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val r = Proc::captureIn("/tmp", "sh", "-c", "pwd 1>&2; exit 5")
+          |    return r.status() + ":" + r.stderr().strip()
+          |  }
+          |}
+          |""".stripMargin,
+        "ProcCaptureIn.on",
+        Array()
+      )
+      assert(Shell.Success("5:/tmp") == result)
+    }
+
+    it("returns the exit status from exec in a given working directory") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return Proc::execIn("/tmp", "sh", "-c", "[ \"$(pwd)\" = \"/tmp\" ]")
+          |  }
+          |}
+          |""".stripMargin,
+        "ProcExecIn.on",
+        Array()
+      )
+      assert(Shell.Success(0) == result)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `Proc::captureIn` and `Proc::execIn` were implemented and documented in `docs/reference/stdlib.md` right next to `runIn`, but unlike `runIn`, were never invoked by a `shell.run` test case in `ProcSpec.scala`.
- Added one case each, exercising the working-directory behavior via the process's own exit status/stderr.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.ProcSpec'` — 7/7 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green (2993 passed, 0 failed, 1 canceled)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh5cBz19S7UEFrXB94jvJ9)_