### PR TITLE
test(stdlib): add execution coverage for Iterables::exists/forAll/listOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Iterables::exists`, `forAll`, and `listOf`.**
+  All three were implemented and documented in `docs/reference/stdlib.md`
+  right next to `map`/`filter`/`foldl`/`sort`, but unlike those, never
+  invoked by a `shell.run` test case in `IterablesSpec.scala`. Added cases
+  covering `exists`/`forAll` in both the matching and non-matching case, and
+  `listOf`'s varargs construction.
+
 - **Execution coverage for `onion.Proc::captureIn` and `Proc::execIn`.** Both
   were implemented and documented in `docs/reference/stdlib.md` right next to
   `runIn`, but unlike `runIn`, never invoked by a `shell.run` test case in

--- a/src/test/scala/onion/compiler/tools/IterablesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IterablesSpec.scala
@@ -86,5 +86,95 @@ class IterablesSpec extends AbstractShellSpec {
       )
       assert(Shell.Success("[1, 1, 2, 3, 4, 5, 6, 9]") == result)
     }
+
+    it("exists returns true when a predicate matches at least one element") {
+      val result = shell.run(
+        """
+          |import { onion.Iterables }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Boolean {
+          |    val xs = Colls::listOf(1, 3, 4, 7)
+          |    return Iterables::exists(xs, (x: Int) -> x % 2 == 0)
+          |  }
+          |}
+          |""".stripMargin,
+        "IterablesExists.on",
+        Array()
+      )
+      assert(Shell.Success(true) == result)
+    }
+
+    it("exists returns false when no element matches the predicate") {
+      val result = shell.run(
+        """
+          |import { onion.Iterables }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Boolean {
+          |    val xs = Colls::listOf(1, 3, 5, 7)
+          |    return Iterables::exists(xs, (x: Int) -> x % 2 == 0)
+          |  }
+          |}
+          |""".stripMargin,
+        "IterablesExistsFalse.on",
+        Array()
+      )
+      assert(Shell.Success(false) == result)
+    }
+
+    it("forAll returns true when every element matches the predicate") {
+      val result = shell.run(
+        """
+          |import { onion.Iterables }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Boolean {
+          |    val xs = Colls::listOf(2, 4, 6, 8)
+          |    return Iterables::forAll(xs, (x: Int) -> x % 2 == 0)
+          |  }
+          |}
+          |""".stripMargin,
+        "IterablesForAll.on",
+        Array()
+      )
+      assert(Shell.Success(true) == result)
+    }
+
+    it("forAll returns false when one element fails the predicate") {
+      val result = shell.run(
+        """
+          |import { onion.Iterables }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Boolean {
+          |    val xs = Colls::listOf(2, 4, 5, 8)
+          |    return Iterables::forAll(xs, (x: Int) -> x % 2 == 0)
+          |  }
+          |}
+          |""".stripMargin,
+        "IterablesForAllFalse.on",
+        Array()
+      )
+      assert(Shell.Success(false) == result)
+    }
+
+    it("listOf builds a list from varargs") {
+      val result = shell.run(
+        """
+          |import { onion.Iterables }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val xs = Iterables::listOf(3, 1, 4, 1, 5)
+          |    return xs.toString()
+          |  }
+          |}
+          |""".stripMargin,
+        "IterablesListOf.on",
+        Array()
+      )
+      assert(Shell.Success("[3, 1, 4, 1, 5]") == result)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `Iterables::exists`, `Iterables::forAll`, and `Iterables::listOf` are implemented and documented in `docs/reference/stdlib.md` right next to `map`/`filter`/`foldl`/`sort`, but unlike those, were never invoked by a `shell.run` test case in `IterablesSpec.scala`.
- Added 5 new cases to `IterablesSpec.scala`: `exists` (matching + non-matching), `forAll` (all-match + one-fails), and `listOf` (varargs construction).
- Noted the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.IterablesSpec'` — 8/8 passed (3 existing + 5 new)
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 2998 succeeded, 0 failed, 1 canceled (pre-existing, opt-in `ProjectDistributionSpec` smoke test gated on `-Donion.dist.path`, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_016nhNzbvQtuARjf4RSiVXE8)_