### PR TITLE
test(stdlib): add execution coverage for Option::orNull/Result::orNull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ConfigSpec.scala`. Added two cases per method (value found / falls back to
   default).
 
+- **Execution coverage for `onion.Option::orNull` and `onion.Result::orNull`.**
+  Both were implemented and documented in `docs/reference/stdlib.md` right
+  next to `getOrElse`/`orElseGet`, and even name-checked in
+  `OptionResultEnrichedSpec`'s own doc comment as covered, but unlike their
+  siblings, never actually invoked by a `shell.run` test case. Extended the
+  existing "orElseGet, orNull and orElse" (Option) and "orElseGet, exists and
+  toList" (Result) cases to also assert `.orNull()` on both the
+  present/`Ok` and absent/`Err` sides.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
@@ -31,8 +31,12 @@ class OptionResultEnrichedSpec extends AbstractShellSpec {
         "val a = some.orElseGet(() -> -1)\n" +
         "val b = non.orElseGet(() -> -1)\n" +
         "val c = non.orElse(some).getOrElse(0)\n" +
-        "return a + b + c",
-        Shell.Success(83))
+        "val d = some.orNull()\n" +
+        "val e = non.orNull()\n" +
+        "val dv = d ?: -1\n" +
+        "val ev = e ?: -1\n" +
+        "return a + b + c + dv + ev",
+        Shell.Success(124))
     }
 
     it("contains, exists and fold inspect the value") {
@@ -81,8 +85,12 @@ class OptionResultEnrichedSpec extends AbstractShellSpec {
         "val a = er.orElseGet(() -> -99)\n" +
         "val b = if ok.exists((v: Int) -> v > 5) { 100 } else { 0 }\n" +
         "val c = ok.toList().size() + er.toList().size()\n" +
-        "return a + b + c",
-        Shell.Success(2))
+        "val f = ok.orNull()\n" +
+        "val g = er.orNull()\n" +
+        "val fv = f ?: -1\n" +
+        "val gv = g ?: -1\n" +
+        "return a + b + c + fv + gv",
+        Shell.Success(11))
     }
   }
 }


### PR DESCRIPTION
## Summary
- `Option::orNull` and `Result::orNull` were implemented and documented in `docs/reference/stdlib.md` right next to `getOrElse`/`orElseGet`, and even name-checked in `OptionResultEnrichedSpec`'s own doc comment as covered, but unlike their siblings were never actually invoked by a `shell.run` test case.
- Extended the existing "orElseGet, orNull and orElse" (Option) and "orElseGet, exists and toList" (Result) test cases to assert `.orNull()` on both the present/`Ok` and absent/`Err` sides.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *OptionResultEnrichedSpec'` — 6/6 passed
- [x] `sbt -Duser.language=en test` (full suite) — 2998 succeeded, 0 failed, 1 canceled (pre-existing/unrelated), 0 ignored


---
_Generated by [Claude Code](https://claude.ai/code/session_019RZMmAZbYAEPNecRq2ymR6)_