### PR TITLE
test(stdlib): add execution coverage for Config::get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Config::get`.** It was implemented and
+  documented in `docs/reference/stdlib.md` right next to the typed accessors
+  (`getString`/`getInt`/`getLong`/`getDouble`/`getBoolean`) that all delegate
+  to it, but unlike those, never invoked directly by a `shell.run` test case
+  in `ConfigSpec.scala`. Added three cases: an existing dot-notation path, a
+  missing path returning `null`, and a numeric path segment indexing into an
+  array.
+
 - **Execution coverage for `onion.Iterables::exists`, `forAll`, and `listOf`.**
   All three were implemented and documented in `docs/reference/stdlib.md`
   right next to `map`/`filter`/`foldl`/`sort`, but unlike those, never

--- a/src/test/scala/onion/compiler/tools/ConfigSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ConfigSpec.scala
@@ -42,6 +42,65 @@ class ConfigSpec extends AbstractShellSpec {
       }
     }
 
+    describe("raw get") {
+      it("returns the raw value at an existing path") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"database\": {\"host\": \"localhost\"}}";
+            |    val config = Config::parseJson(json);
+            |    val value = Config::get(config, "database.host");
+            |    return value.toString();
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("localhost") == result)
+      }
+
+      it("returns null for a missing path") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"a\": 1}";
+            |    val config = Config::parseJson(json);
+            |    val value = Config::get(config, "missing.path");
+            |    return "" + (value == null);
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("true") == result)
+      }
+
+      it("indexes into an array by numeric path segment") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"items\": [\"first\", \"second\"]}";
+            |    val config = Config::parseJson(json);
+            |    val value = Config::get(config, "items.0");
+            |    return value.toString();
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("first") == result)
+      }
+    }
+
     describe("default values") {
       it("returns default value when path not found") {
         val result = shell.run(


### PR DESCRIPTION
## Summary
- `onion.Config::get` is the raw dot-notation accessor that `getString`/`getInt`/`getLong`/`getDouble`/`getBoolean` all delegate to, and it's documented in `docs/reference/stdlib.md`, but unlike its typed siblings it was never invoked directly by a `shell.run` test case in `ConfigSpec.scala`.
- Added three cases to `ConfigSpec.scala`: an existing dot-notation path, a missing path returning `null`, and a numeric path segment indexing into an array.
- Noted the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3001 succeeded, 0 failed, 1 canceled (pre-existing, network-dependent `sbt dist` packaging test, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UUhsDCghfgm6vXvnDsBVFe)_