### PR TITLE
test(stdlib): add execution coverage for Future::race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   toList" (Result) cases to also assert `.orNull()` on both the
   present/`Ok` and absent/`Err` sides.
 
+- **Execution coverage for `onion.Future::race`.** It was implemented and
+  documented in `docs/reference/stdlib.md` under "Combining Futures", but
+  unlike `zip`, never invoked by a `shell.run` test case in `FutureSpec.scala`
+  — the file had no "combining futures" block at all. Added one, racing two
+  already-completed futures holding the same value so the winner is
+  deterministic regardless of which completes first.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/FutureSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FutureSpec.scala
@@ -599,5 +599,27 @@ class FutureSpec extends AbstractShellSpec {
         assert(result == Shell.Success("hi there"))
       }
     }
+
+    describe("combining futures") {
+      it("race returns the value shared by both completed futures") {
+        val result = shell.run(
+          """
+            |import { onion.Future; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int {
+            |    val f1 = Future::successful[Int](42);
+            |    val f2 = Future::successful[Int](42);
+            |    val raced = f1.race(f2);
+            |    return raced.await()
+            |  }
+            |}
+          """.stripMargin,
+          "None",
+          Array()
+        )
+        assert(result == Shell.Success(42))
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `onion.Future::race` is implemented (`Future.java:325`) and documented in `docs/reference/stdlib.md` under "Combining Futures" right next to `zip`, but unlike `zip` it was never invoked by a `shell.run` test case — `FutureSpec.scala` had no "combining futures" describe block at all.
- Added a `combining futures` block with one case that races two already-completed futures holding the same value, so the winner is deterministic regardless of which completes first.
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *FutureSpec'` — 31/31 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite: 3002 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BqECNonhZiyWddgqm4Wb2v)_