### PR TITLE
test(stdlib): add execution coverage for JInteger/JLong/JDouble/JBoolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `JInteger`/`JLong`/`JDouble`/`JBoolean` static
+  methods.** `JInteger::parseInt`, `JInteger::MAX_VALUE`/`MIN_VALUE`,
+  `JLong::parseLong`, `JLong::toString`, `JDouble::parseDouble`,
+  `JDouble::toString`, `JBoolean::parseBoolean`, and `JBoolean::toString`
+  were all implemented and documented in `docs/reference/stdlib.md`'s
+  Wrapper Classes section, but — unlike `JInteger::toString`, which is
+  exercised incidentally by unrelated specs — none were ever invoked
+  directly by a `shell.run` test case anywhere in the suite. Added
+  `WrapperClassesSpec` with one case per method.
+
 - **Execution coverage for `onion.Config::get`.** It was implemented and
   documented in `docs/reference/stdlib.md` right next to the typed accessors
   (`getString`/`getInt`/`getLong`/`getDouble`/`getBoolean`) that all delegate

--- a/src/test/scala/onion/compiler/tools/WrapperClassesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/WrapperClassesSpec.scala
@@ -1,0 +1,150 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+class WrapperClassesSpec extends AbstractShellSpec {
+  describe("JInteger") {
+    it("parses a string into an Int") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val i: Int = JInteger::parseInt("42");
+          |    return "" + i;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("42") == result)
+    }
+
+    it("exposes MAX_VALUE and MIN_VALUE") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val max: Int = JInteger::MAX_VALUE;
+          |    val min: Int = JInteger::MIN_VALUE;
+          |    return max + "," + min;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("2147483647,-2147483648") == result)
+    }
+  }
+
+  describe("JLong") {
+    it("parses a string into a Long") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val l: Long = JLong::parseLong("1234567890");
+          |    return "" + l;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("1234567890") == result)
+    }
+
+    it("converts a Long to a String") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val s: String = JLong::toString(1234567890L);
+          |    return s;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("1234567890") == result)
+    }
+  }
+
+  describe("JDouble") {
+    it("parses a string into a Double") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val d: Double = JDouble::parseDouble("3.14");
+          |    return "" + d;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("3.14") == result)
+    }
+
+    it("converts a Double to a String") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val s: String = JDouble::toString(3.14);
+          |    return s;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("3.14") == result)
+    }
+  }
+
+  describe("JBoolean") {
+    it("parses a string into a Boolean") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val b: Boolean = JBoolean::parseBoolean("true");
+          |    return "" + b;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("true") == result)
+    }
+
+    it("converts a Boolean to a String") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val s: String = JBoolean::toString(true);
+          |    return s;
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("true") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `JInteger::parseInt`, `JInteger::MAX_VALUE`/`MIN_VALUE`, `JLong::parseLong`, `JLong::toString`, `JDouble::parseDouble`, `JDouble::toString`, `JBoolean::parseBoolean`, and `JBoolean::toString` were all implemented and documented in `docs/reference/stdlib.md`'s Wrapper Classes section, but none were ever invoked directly by a `shell.run` test case anywhere in the suite (confirmed via a full-repo grep for each symbol against `src/test/scala` and `src/test/run`).
- Added `WrapperClassesSpec` with one case per method.
- Noted the addition in `CHANGELOG.md`'s `[Unreleased]` section, following the existing execution-coverage entries.

## Test plan
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.WrapperClassesSpec"` — 8/8 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3010 succeeded, 0 failed, 1 canceled (pre-existing `ProjectDistributionSpec` smoke test gated on `-Donion.dist.path`, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_019bCk9eUPgxwD3CTnvGegpA)_