### PR TITLE
test(stdlib): add execution coverage for Result::mapError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Result::mapError`.** It was implemented
+  and documented in `docs/reference/stdlib.md` right next to `map`/`flatMap`/
+  `fold`/`recover`, but unlike those, never invoked by a `shell.run` test
+  case in `OptionResultEnrichedSpec.scala`. Added a case covering the `Err`
+  transform and the `Ok` passthrough.
+
 - **Execution coverage for `JInteger`/`JLong`/`JDouble`/`JBoolean` static
   methods.** `JInteger::parseInt`, `JInteger::MAX_VALUE`/`MIN_VALUE`,
   `JLong::parseLong`, `JLong::toString`, `JDouble::parseDouble`,

--- a/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
@@ -78,6 +78,16 @@ class OptionResultEnrichedSpec extends AbstractShellSpec {
         Shell.Success(11))
     }
 
+    it("mapError transforms an Err and passes through an Ok") {
+      run(
+        "val ok: Result[Int, String] = Result::ok(10)\n" +
+        "val er: Result[Int, String] = Result::err(\"boom\")\n" +
+        "val a = ok.mapError((e: String) -> e.toUpperCase())\n" +
+        "val b = er.mapError((e: String) -> e.toUpperCase())\n" +
+        "return a.getOrElse(-1) + \"|\" + a.isOk() + \"|\" + b.getError() + \"|\" + b.isErr()",
+        Shell.Success("10|true|BOOM|true"))
+    }
+
     it("orElseGet, exists and toList work on Ok/Err") {
       runInt(
         "val ok: Result[Int, String] = Result::ok(10)\n" +


### PR DESCRIPTION
## Summary
- `Result::mapError` was implemented and documented in `docs/reference/stdlib.md` right next to `map`/`flatMap`/`fold`/`recover`, but unlike those, was never invoked by a `shell.run` test case anywhere in the suite (`OptionResultEnrichedSpec.scala` covers the rest of the enriched Result API).
- Added one case exercising both branches: `Err.mapError` transforms the error, `Ok.mapError` passes the value through unchanged.
- Noted in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.OptionResultEnrichedSpec'` — green
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3011 succeeded, 0 failed, 1 canceled

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016qoTp4ngQjTr9waxr5Uc7M)_