### PR TITLE
test(stdlib): add execution coverage for Option::of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Option::of`.** It was implemented and
+  documented in `docs/reference/stdlib.md` right next to `Option::some`/
+  `Option::none`, but unlike those, never invoked by a `shell.run` test case
+  in `OptionResultEnrichedSpec.scala`. Added a case covering both the
+  non-null wrap and the null-collapses-to-`none` behavior that distinguishes
+  it from `Option::some`.
+
 - **Execution coverage for `onion.Result::mapError`.** It was implemented
   and documented in `docs/reference/stdlib.md` right next to `map`/`flatMap`/
   `fold`/`recover`, but unlike those, never invoked by a `shell.run` test

--- a/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
@@ -56,6 +56,16 @@ class OptionResultEnrichedSpec extends AbstractShellSpec {
         "return some.toList().size() + non.toList().size()",
         Shell.Success(1))
     }
+
+    it("of wraps a non-null value and collapses null to none") {
+      runInt(
+        "val present: Option[Int] = Option::of(42)\n" +
+        "val absent: Option[Int] = Option::of(null)\n" +
+        "val a = present.isDefined()\n" +
+        "val b = absent.isDefined()\n" +
+        "return present.getOrElse(-1) + absent.getOrElse(-1) + (if a { 100 } else { 0 }) + (if b { 100 } else { 0 })",
+        Shell.Success(141))
+    }
   }
 
   describe("enriched Result") {


### PR DESCRIPTION
## Summary
- `Option::of(value)` was implemented and documented in `docs/reference/stdlib.md` right next to `Option::some`/`Option::none`, but unlike those, was never invoked by a `shell.run` test case anywhere in the suite.
- Adds a case to `OptionResultEnrichedSpec.scala` covering both behaviors: `Option::of` wraps a non-null value like `Option::some`, but collapses a null argument to `none` (unlike `Option::some`, which would report `isDefined() == true` with a null payload).
- Notes the addition in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3012 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated distribution test unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A3uX6K6MKqGVFUJrGdqrgB)_