### PR TITLE
test(stdlib): add execution coverage for Future::all/Future::first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Future::all`/`Future::first`.** Both were
+  implemented and documented in `docs/reference/stdlib.md`'s "Combining
+  Futures" section right next to `zip`/`race`, but unlike those, never
+  invoked by a `shell.run` test case in `FutureSpec.scala`. Added cases
+  covering `all`'s in-order result list and `first`'s first-completed value.
+
 - **Execution coverage for `onion.Option::of`.** It was implemented and
   documented in `docs/reference/stdlib.md` right next to `Option::some`/
   `Option::none`, but unlike those, never invoked by a `shell.run` test case

--- a/src/test/scala/onion/compiler/tools/FutureSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FutureSpec.scala
@@ -620,6 +620,47 @@ class FutureSpec extends AbstractShellSpec {
         )
         assert(result == Shell.Success(42))
       }
+
+      it("all combines multiple futures into a List of results in order") {
+        val result = shell.run(
+          """
+            |import { onion.Future; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val f1 = Future::successful[Int](1);
+            |    val f2 = Future::successful[Int](2);
+            |    val f3 = Future::successful[Int](3);
+            |    val combined = Future::all(f1, f2, f3);
+            |    return combined.await().toString()
+            |  }
+            |}
+          """.stripMargin,
+          "None",
+          Array()
+        )
+        assert(result == Shell.Success("[1, 2, 3]"))
+      }
+
+      it("first returns the value shared by both completed futures") {
+        val result = shell.run(
+          """
+            |import { onion.Future; }
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int {
+            |    val f1 = Future::successful[Int](42);
+            |    val f2 = Future::successful[Int](42);
+            |    val firstDone = Future::first(f1, f2);
+            |    return firstDone.await()
+            |  }
+            |}
+          """.stripMargin,
+          "None",
+          Array()
+        )
+        assert(result == Shell.Success(42))
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `onion.Future::all` and `onion.Future::first` were implemented and documented in `docs/reference/stdlib.md`'s "Combining Futures" section right next to `zip`/`race`, but unlike those, never invoked by a `shell.run` test case anywhere in the suite.
- Added two cases to `FutureSpec.scala`'s `combining futures` block: one covering `all`'s in-order result list, one covering `first`'s first-completed value (mirroring the existing `race` test's determinism trick of using equal values on both futures).
- Noted in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *FutureSpec'` — 33/33 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3014/3014 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvE1Re3TAScZEwxstjM9st)_