### PR TITLE
test(stdlib): add execution coverage for Result::ofNullable/Result::trying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already-completed futures holding the same value so the winner is
   deterministic regardless of which completes first.
 
+- **Execution coverage for `onion.Result::ofNullable` and `Result::trying`.**
+  Both were implemented and documented in `docs/reference/stdlib.md` right
+  next to `Result::ok`/`Result::err`, but unlike those, never invoked by a
+  `shell.run` test case in `OptionResultEnrichedSpec.scala`. Added a case
+  covering `ofNullable`'s non-null/null branches and `trying`'s
+  success/throw branches.
+
 ## [0.10.14] - 2026-07-31
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OptionResultEnrichedSpec.scala
@@ -112,5 +112,16 @@ class OptionResultEnrichedSpec extends AbstractShellSpec {
         "return a + b + c + fv + gv",
         Shell.Success(11))
     }
+
+    it("ofNullable and trying wrap nullable values and throwing operations") {
+      run(
+        "val a: Result[String, String] = Result::ofNullable(\"v\", \"boom\")\n" +
+        "val b: Result[String, String] = Result::ofNullable(null, \"boom\")\n" +
+        "val c: Result[String, Throwable] = Result::trying(() -> \"ok\")\n" +
+        "val d: Result[String, Throwable] = Result::trying(() -> { throw new RuntimeException(\"bad\") })\n" +
+        "return a.getOrElse(\"X\") + \"|\" + a.isOk() + \"|\" + b.getError() + \"|\" + b.isErr() + \"|\" + " +
+        "c.getOrElse(\"X\") + \"|\" + c.isOk() + \"|\" + d.getError().getMessage() + \"|\" + d.isErr()",
+        Shell.Success("v|true|boom|true|ok|true|bad|true"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `Result::ofNullable` and `Result::trying` were implemented and documented in `docs/reference/stdlib.md` right next to `Result::ok`/`Result::err`, but unlike those, were never invoked by a `shell.run` test case in `OptionResultEnrichedSpec.scala`.
- Added one case covering `ofNullable`'s non-null/null branches and `trying`'s success/throw branches.
- Noted the change in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.OptionResultEnrichedSpec'` — 9/9 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3015 succeeded, 0 failed, 1 canceled (pre-existing, unrelated)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AS96PBFAv8imFjUqPAbRgA)_