### PR TITLE
test(stdlib): add execution coverage for Http::put/Http::delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Http::put`/`Http::delete`.** Both were
+  implemented and documented in `docs/reference/stdlib.md`'s Http "Other
+  Methods" section, but unlike `get`/`post`, never invoked by a `shell.run`
+  test case in `HttpSpec.scala`. Added cases against a local echo server
+  covering `put`'s body passthrough, `put`'s null-body-becomes-empty
+  behavior, and `delete`'s method/empty-body request.
+
 - **Execution coverage for `onion.Future::all`/`Future::first`.** Both were
   implemented and documented in `docs/reference/stdlib.md`'s "Combining
   Futures" section right next to `zip`/`race`, but unlike those, never

--- a/src/test/scala/onion/compiler/tools/HttpSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HttpSpec.scala
@@ -1,8 +1,32 @@
 package onion.compiler.tools
 
 import onion.tools.Shell
+import com.sun.net.httpserver.{HttpServer, HttpExchange, HttpHandler}
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
 
 class HttpSpec extends AbstractShellSpec {
+
+  private def withEchoServer()(test: (String, () => (String, String)) => Unit): Unit = {
+    var seenMethod = ""
+    var seenBody = ""
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/", new HttpHandler {
+      override def handle(exchange: HttpExchange): Unit = {
+        seenMethod = exchange.getRequestMethod
+        seenBody = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+        val bytes = s"$seenMethod:$seenBody".getBytes(StandardCharsets.UTF_8)
+        exchange.sendResponseHeaders(200, bytes.length)
+        val os = exchange.getResponseBody
+        try os.write(bytes) finally os.close()
+      }
+    })
+    server.start()
+    try {
+      test(s"http://127.0.0.1:${server.getAddress.getPort}/", () => (seenMethod, seenBody))
+    } finally server.stop(0)
+  }
+
   describe("Http library") {
     describe("URL encoding/decoding") {
       it("encodes URL parameters") {
@@ -166,6 +190,68 @@ class HttpSpec extends AbstractShellSpec {
           Array()
         )
         assert(Shell.Success("https://example.com") == result)
+      }
+    }
+
+    describe("PUT and DELETE requests") {
+      it("sends a PUT request with a body") {
+        withEchoServer() { (url, seen) =>
+          val result = shell.run(
+            s"""
+               |import { onion.Http; }
+               |class Test {
+               |public:
+               |  static def main(args: String[]): String {
+               |    return Http::put("$url", "updated content");
+               |  }
+               |}
+               |""".stripMargin,
+            "None",
+            Array()
+          )
+          assert(Shell.Success("PUT:updated content") == result)
+          assert(("PUT", "updated content") == seen())
+        }
+      }
+
+      it("sends a PUT request with a null body as empty") {
+        withEchoServer() { (url, seen) =>
+          val result = shell.run(
+            s"""
+               |import { onion.Http; }
+               |class Test {
+               |public:
+               |  static def main(args: String[]): String {
+               |    return Http::put("$url", null);
+               |  }
+               |}
+               |""".stripMargin,
+            "None",
+            Array()
+          )
+          assert(Shell.Success("PUT:") == result)
+          assert(("PUT", "") == seen())
+        }
+      }
+
+      it("sends a DELETE request") {
+        withEchoServer() { (url, seen) =>
+          val result = shell.run(
+            s"""
+               |import { onion.Http; }
+               |class Test {
+               |public:
+               |  static def main(args: String[]): String {
+               |    return Http::delete("$url");
+               |  }
+               |}
+               |""".stripMargin,
+            "None",
+            Array()
+          )
+          assert(Shell.Success("DELETE:") == result)
+          assert(("DELETE", "") == seen())
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- `Http::put` and `Http::delete` were implemented and documented in `docs/reference/stdlib.md`'s Http "Other Methods" section, right next to `get`/`post`, but unlike those, were never invoked by a `shell.run` test case anywhere in the suite.
- Added a local echo-server helper (`withEchoServer`) to `HttpSpec.scala` and three new cases: `put`'s request-body passthrough, `put`'s null-body-becomes-empty behavior, and `delete`'s method/empty-body request.
- Updated `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *HttpSpec'` — 14/14 passed (3 new)
- [x] `sbt -Duser.language=en test` — full suite green, 3018/3018 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew8gDZRGw6sbNt86GMPig7)_