### PR TITLE
test(stdlib): add execution coverage for Origin::hasColumn/inSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `HashCodecStatsSpec.scala` (only reached transitively through
   `xs.sum()`). Added a case to `HashCodecStatsSpec`.
 
+- **Execution coverage for `onion.Origin::hasColumn` and `Origin::inSource`.**
+  Both were implemented and documented in `docs/reference/stdlib.md` right
+  next to `onLine` (`inSource` in the same subsection, `hasColumn` in the
+  module's intro example), but unlike `onLine`, never invoked by a
+  `shell.run` test case in `OriginSpec.scala`. Added a case for
+  `hasColumn()` distinguishing `at()` from `atLine()`, and a case for
+  `inSource()` retargeting an Origin's source while keeping line/column.
+
 - **Execution coverage for `onion.Config::getLong` and
   `Config::getWithEnvOverride`.** Both were implemented and documented in
   `docs/reference/stdlib.md` right next to `getInt`/`getDouble`/`getBoolean`

--- a/src/test/scala/onion/compiler/tools/OriginSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OriginSpec.scala
@@ -126,5 +126,34 @@ class OriginSpec extends AbstractShellSpec {
           |""".stripMargin, "None", Array())
       assert(Shell.Success("log.txt:40:3") == result)
     }
+
+    it("knows whether a column is present, as opposed to only a line") {
+      val result = shell.run(
+        """import { onion.Origin; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    return Origin::at("x.on", 1, 3).hasColumn() + "|" + Origin::atLine("x.on", 1).hasColumn()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("true|false") == result)
+    }
+
+    it("retargets to a different source via inSource(), keeping line, column and span") {
+      // A sub-parse may only learn which document it came from after the fact (e.g. an
+      // included file); inSource() moves an already-built Origin without re-deriving it.
+      val result = shell.run(
+        """import { onion.Origin; }
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val o = Origin::at("a.on", 3, 8).inSource("b.on")
+          |    return o.source() + "|" + o.line() + "|" + o.column()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("b.on|3|8") == result)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `Origin::hasColumn` and `Origin::inSource` are implemented (`src/main/java/onion/Origin.java`) and documented (`docs/reference/stdlib.md`, right next to `onLine`), but neither was ever invoked by a `shell.run` test case in `OriginSpec.scala`.
- Added one case for `hasColumn()` (distinguishing `at()` from `atLine()`) and one for `inSource()` (retargeting an Origin's source while keeping line/column), following the existing spec's pattern.
- Added a matching `[Unreleased]` entry to `CHANGELOG.md`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *OriginSpec'` — 10/10 passing
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3020 succeeded, 0 failed, 1 canceled (network-dependent test that self-skips without egress, unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp8egKxgJ4kYm8HPzig4Xz)_