### PR TITLE
test(stdlib): add execution coverage for Config::loadJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Execution coverage for `onion.Config::loadJson`.** It was implemented and
+  documented in `docs/reference/stdlib.md` as the canonical entry point for
+  loading a config file, but unlike `parseJson` and the accessors, never
+  invoked by a `shell.run` test case in `ConfigSpec.scala` (only reached by
+  an effect-table metadata assertion, never actually executed). Added a case
+  covering the read-file-then-parse round trip and a case covering the
+  missing-file error path.
+
 - **Execution coverage for `onion.Http::put`/`Http::delete`.** Both were
   implemented and documented in `docs/reference/stdlib.md`'s Http "Other
   Methods" section, but unlike `get`/`post`, never invoked by a `shell.run`

--- a/src/test/scala/onion/compiler/tools/ConfigSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ConfigSpec.scala
@@ -389,6 +389,50 @@ class ConfigSpec extends AbstractShellSpec {
       }
     }
 
+    describe("loadJson") {
+      it("reads and parses a JSON file from disk") {
+        val path = System.getProperty("java.io.tmpdir") + "/onion-config-loadjson-test.json"
+        val result = shell.run(
+          s"""
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    Files::writeText("$path", "{\\"database\\": {\\"host\\": \\"localhost\\", \\"port\\": 5432}}");
+            |    val config = Config::loadJson("$path");
+            |    Files::delete("$path");
+            |    return Config::getString(config, "database.host", "default") + ":" + Config::getInt(config, "database.port", 0);
+            |  }
+            |}
+            |""".stripMargin,
+          "ConfigLoadJsonBasic.on",
+          Array()
+        )
+        assert(Shell.Success("localhost:5432") == result)
+      }
+
+      it("propagates an error for a missing file") {
+        val path = System.getProperty("java.io.tmpdir") + "/onion-config-loadjson-missing.json"
+        val result = shell.run(
+          s"""
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    try {
+            |      Config::loadJson("$path");
+            |      return "no_error";
+            |    } catch e: Exception {
+            |      return "error";
+            |    }
+            |  }
+            |}
+            |""".stripMargin,
+          "ConfigLoadJsonMissing.on",
+          Array()
+        )
+        assert(Shell.Success("error") == result)
+      }
+    }
+
     describe("hasPath") {
       it("returns true for existing path") {
         val result = shell.run(


### PR DESCRIPTION
## Summary
- `Config::loadJson` is implemented and documented in `docs/reference/stdlib.md` as the canonical entry point for loading a config file, but unlike `parseJson` and the typed accessors, it was never invoked by a `shell.run` test case anywhere in the suite — only referenced by an effect-table metadata assertion (`EffectTableSpec`), which never actually executes it.
- Added two cases to `ConfigSpec.scala`: a read-file-then-parse round trip (write JSON via `Files::writeText`, load it via `Config::loadJson`, read nested values back out) and a missing-file case confirming the `IOException` surfaces as a catchable exception.
- Added a matching `[Unreleased]` entry to `CHANGELOG.md`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *ConfigSpec'` — 24/24 pass, including the 2 new cases
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3031 succeeded, 0 failed, 1 canceled (expected: dist smoke test gated behind `-Donion.dist.path`)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01We2Looq46w47xuQHmCx7nX)_