### PR TITLE
test(stdlib): add execution coverage for Http::post / Http::postJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   covering `ofNullable`'s non-null/null branches and `trying`'s
   success/throw branches.
 
+- **Execution coverage for `onion.Http::post` and `Http::postJson`.** Both
+  were implemented and documented in `docs/reference/stdlib.md`'s Http "POST
+  Requests" subsection, but unlike `put`/`delete`, never invoked by a
+  `shell.run` test case in `HttpSpec.scala`. Added cases against the local
+  echo server covering `post`'s body passthrough, `post`'s null-body-becomes-
+  empty behavior, `postJson`'s body passthrough, and `postJson`'s
+  null-body-becomes-`"{}"` behavior.
+
 - **`run/LibrarySystem.on`, a 374-line library management sample.** Adds a
   large end-to-end program to the corpus (10th at ≥100 lines), combining a
   plain enum matched via `select`, four records, a class with mutable `List`

--- a/src/test/scala/onion/compiler/tools/HttpSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HttpSpec.scala
@@ -255,6 +255,88 @@ class HttpSpec extends AbstractShellSpec {
       }
     }
 
+    describe("POST requests") {
+      it("sends a POST request with a body") {
+        withEchoServer() { (url, seen) =>
+          val result = shell.run(
+            s"""
+               |import { onion.Http; }
+               |class Test {
+               |public:
+               |  static def main(args: String[]): String {
+               |    return Http::post("$url", "new content");
+               |  }
+               |}
+               |""".stripMargin,
+            "None",
+            Array()
+          )
+          assert(Shell.Success("POST:new content") == result)
+          assert(("POST", "new content") == seen())
+        }
+      }
+
+      it("sends a POST request with a null body as empty") {
+        withEchoServer() { (url, seen) =>
+          val result = shell.run(
+            s"""
+               |import { onion.Http; }
+               |class Test {
+               |public:
+               |  static def main(args: String[]): String {
+               |    return Http::post("$url", null);
+               |  }
+               |}
+               |""".stripMargin,
+            "None",
+            Array()
+          )
+          assert(Shell.Success("POST:") == result)
+          assert(("POST", "") == seen())
+        }
+      }
+
+      it("sends a POST request with a JSON body") {
+        withEchoServer() { (url, seen) =>
+          val result = shell.run(
+            s"""
+               |import { onion.Http; }
+               |class Test {
+               |public:
+               |  static def main(args: String[]): String {
+               |    return Http::postJson("$url", "{\\"a\\":1}");
+               |  }
+               |}
+               |""".stripMargin,
+            "None",
+            Array()
+          )
+          assert(Shell.Success("POST:{\"a\":1}") == result)
+          assert(("POST", "{\"a\":1}") == seen())
+        }
+      }
+
+      it("sends a POST request with a null JSON body defaulting to an empty object") {
+        withEchoServer() { (url, seen) =>
+          val result = shell.run(
+            s"""
+               |import { onion.Http; }
+               |class Test {
+               |public:
+               |  static def main(args: String[]): String {
+               |    return Http::postJson("$url", null);
+               |  }
+               |}
+               |""".stripMargin,
+            "None",
+            Array()
+          )
+          assert(Shell.Success("POST:{}") == result)
+          assert(("POST", "{}") == seen())
+        }
+      }
+    }
+
     describe("null handling") {
       it("handles null URL in encodeUrl") {
         val result = shell.run(


### PR DESCRIPTION
## Summary
- `Http::post` and `Http::postJson` were implemented and documented in `docs/reference/stdlib.md`'s Http "POST Requests" subsection, but unlike `put`/`delete`, neither was ever invoked by a `shell.run` test case in `HttpSpec.scala`.
- Adds 4 cases against the existing local echo server helper: `post`'s body passthrough, `post`'s null-body-becomes-empty behavior, `postJson`'s body passthrough, and `postJson`'s null-body-becomes-`"{}"` behavior.
- CHANGELOG `[Unreleased]` updated.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.HttpSpec'` — 18/18 green (4 new)
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite 3041/3041 green (1 canceled, pre-existing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GftSogzQ62MHTQV2n8z1KJ)_