### PR TITLE
docs(changelog): add missing entry for BudgetTracker.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`run/BudgetTracker.on`, a 308-line personal finance tracker sample.** Adds
+  a large end-to-end program to the corpus (13th at ≥100 lines), combining an
+  ADT case-enum (`TransactionKind` with `Income`/`Expense` cases) matched via
+  `select`/type patterns, a homogeneous enum (`Month`) with methods, three
+  records with methods (`Transaction`, `Category`, `MonthSummary`), a class
+  with a `List[Transaction]` field, collection pipelines (`groupBy`/
+  `sortedBy`/`filter`/`map`/`fold`/`partition`/`reverse`/`take`/`distinct`),
+  `foreach (k, v)` map iteration, nullable-map-lookup null guards, and a
+  tail-recursive compound-interest helper in one coherent scenario.
+
 - **`run/LibraryCatalog.on`, a 329-line library management sample.** Adds a
   large end-to-end program to the corpus (12th at ≥100 lines), combining
   interfaces (`Lendable`, `Describable`) with `conforms`, class inheritance


### PR DESCRIPTION
## Summary

- PR #539 added `run/BudgetTracker.on` (a 308-line personal finance tracker sample) but did not append a corresponding `[Unreleased]` entry to `CHANGELOG.md`, unlike the other large-sample additions in the corpus (e.g. `LibraryCatalog.on`, `LibrarySystem.on`).
- Adds the missing entry, matching the style/detail level of the existing entries.

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3044 tests, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJgvdvsopWoo6qNLYHNqmV)_