### PR TITLE
docs(changelog): add Inventory.on entry to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`run/Inventory.on`, a 279-line shop inventory manager sample.** Adds a
+  large end-to-end program to the corpus (16th at ≥100 lines), combining
+  data-carrying ADT enums (`Category` and `TxKind`, four cases each),
+  records with compiler-verified `example` clauses (`Item`, `Transaction`,
+  `StockAlert`), extension methods on `String` and `Double`, `select` with
+  type-pattern exhaustiveness, a nullable `Item?` lookup, collection
+  pipelines (`filter`/`map`/`groupBy`/`sortedBy`/`find`), `foreach (k, v)`
+  map iteration, closures, string interpolation, and graceful
+  exception-free failure returns.
+
 ## [0.10.16] - 2026-08-01
 
 ### Added


### PR DESCRIPTION
## Summary

- PR #544 added `run/Inventory.on` (279-line shop inventory manager sample) but merged without a `CHANGELOG.md` entry.
- Back-fills the `[Unreleased]` section so it reflects what has actually shipped past v0.10.16, matching the style used for the other corpus-addition entries (TournamentTracker, PayrollReport, etc.).

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` (docs-only change; full suite run for verification per repo policy)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4Rcppt1Y7DUhhFfMaanS5)_