### PR TITLE
fix: ICE (operand-stack underflow) when explicit return used in every ADT-enum select branch

### DIFF
--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -11,8 +11,8 @@
 | # | 次元 | 測定方法 | 現在値（2026-07-27） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
 | 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2848 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
-| 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 73 / 73 compile | すべてコンパイル、rot なし |
-| 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 16（Blackjack、BrokenLogDemo、BudgetTracker、GradeBook、Inventory、LibraryCatalog、LibrarySystem、MiniRpg、OrderReport、PayrollReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager、ToolDemo、TournamentTracker） | ≥ 5 |
+| 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 74 / 74 compile | すべてコンパイル、rot なし |
+| 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 17（Blackjack、BrokenLogDemo、BudgetTracker、GradeBook、GraphSearch、Inventory、LibraryCatalog、LibrarySystem、MiniRpg、OrderReport、PayrollReport、ShapeProcessor、StatsApp、TextAnalyzer、TodoManager、ToolDemo、TournamentTracker） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |
 | 5 | 既知の使い勝手バグ | 実装済みだが到達不能/壊れた機能として未解決のもの | 0 | 0 |
 | 6 | ドキュメントの対等性 | `docs/guide` と `docs/ja/guide` の数 + すべてのコードブロックがコンパイル可能 | 15 / 15 | 対等性 + すべてのブロックを検証 |

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -14,8 +14,8 @@ had already drifted after the effect-table / tool-capability / tool-contracts wo
 | # | Dimension | How to measure | Current (2026-07-27) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
 | 1 | Test suite | `sbt -batch -Duser.language=en test` | 2848 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
-| 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 73 / 73 compile | all compile, no rot |
-| 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 16 (Blackjack, BrokenLogDemo, BudgetTracker, GradeBook, Inventory, LibraryCatalog, LibrarySystem, MiniRpg, OrderReport, PayrollReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager, ToolDemo, TournamentTracker) | ≥ 5 |
+| 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 74 / 74 compile | all compile, no rot |
+| 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 17 (Blackjack, BrokenLogDemo, BudgetTracker, GradeBook, GraphSearch, Inventory, LibraryCatalog, LibrarySystem, MiniRpg, OrderReport, PayrollReport, ShapeProcessor, StatsApp, TextAnalyzer, TodoManager, ToolDemo, TournamentTracker) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |
 | 5 | Known usability bugs | implemented-but-unreachable / broken features still open | 0 | 0 |
 | 6 | Docs parity | `docs/guide` vs `docs/ja/guide` count + every code block compiles | 15 / 15 | parity + all blocks verified |

--- a/run/GraphSearch.on
+++ b/run/GraphSearch.on
@@ -1,0 +1,186 @@
+import {
+  java.util.*
+}
+
+// Weighted directed graph with BFS, DFS, and Dijkstra's shortest path.
+// Demonstrates: ADT enums, explicit return in select branches, Map/List
+// operations, and formatted output.
+
+// A search result: either a found path with total cost, or unreachable.
+enum SearchResult {
+  case Found(path: List[String], cost: Int)
+  case Unreachable
+public:
+  def describe(): String = select this {
+    case f is Found: return "cost=" + f.cost() + " path=" + f.path()
+    case u is Unreachable: return "unreachable"
+  }
+  def isFound(): Boolean = select this {
+    case f is Found: return true
+    case u is Unreachable: return false
+  }
+}
+
+// A simple weighted graph backed by an adjacency list.
+// Each adjacency entry is stored as "neighbor:weight" strings.
+class WeightedGraph {
+  val adjacency: Map[String, List[String]]
+public:
+  def this {
+    adjacency = [:]
+  }
+
+  def addEdge(from: String, to: String, weight: Int): void {
+    if adjacency.get(from) == null { adjacency.put(from, []) }
+    if adjacency.get(to)   == null { adjacency.put(to, []) }
+    adjacency.get(from) << (to + ":" + weight)
+  }
+
+  def neighbors(node: String): List[String] {
+    val n: List[String] = adjacency.get(node)
+    if n == null { return [] }
+    return n
+  }
+
+  // Breadth-first search — returns shortest hop-count path (unweighted).
+  def bfs(start: String, goal: String): SearchResult {
+    if adjacency.get(start) == null { return new Unreachable() }
+    val visited: Map[String, Boolean] = [:]
+    val queue: LinkedList[String] = new LinkedList[String]()
+    val prev: Map[String, String] = [:]
+    queue.add(start)
+    visited.put(start, true)
+    while !queue.isEmpty() {
+      val cur: String = queue.poll()
+      if cur == goal { return new Found(buildPath(prev, start, goal), 0) }
+      foreach edge: String in neighbors(cur) {
+        val nb: String = edgeNode(edge)
+        if visited.get(nb) == null {
+          visited.put(nb, true)
+          prev.put(nb, cur)
+          queue.add(nb)
+        }
+      }
+    }
+    return new Unreachable()
+  }
+
+  // Depth-first search — returns any path to the goal.
+  def dfs(start: String, goal: String): SearchResult {
+    if adjacency.get(start) == null { return new Unreachable() }
+    val visited: Map[String, Boolean] = [:]
+    val path: List[String] = []
+    if dfsVisit(start, goal, visited, path) { return new Found(path, 0) }
+    return new Unreachable()
+  }
+
+  def dfsVisit(node: String, goal: String, visited: Map[String, Boolean], path: List[String]): Boolean {
+    if visited.get(node) != null { return false }
+    visited.put(node, true)
+    path << node
+    if node == goal { return true }
+    foreach edge: String in neighbors(node) {
+      val nb: String = edgeNode(edge)
+      if dfsVisit(nb, goal, visited, path) { return true }
+    }
+    path.remove(path.size - 1)
+    return false
+  }
+
+  // Dijkstra's algorithm — returns the least-cost path and its total weight.
+  // Uses a simple O(V^2) scan instead of a priority queue for clarity.
+  def dijkstra(start: String, goal: String): SearchResult {
+    if adjacency.get(start) == null { return new Unreachable() }
+    val dist: Map[String, Int] = [:]
+    val prev: Map[String, String] = [:]
+    val settled: Map[String, Boolean] = [:]
+    dist.put(start, 0)
+    // Collect all nodes we have distances for and find the minimum each round.
+    var found: Boolean = false
+    while !found {
+      // Pick the unsettled node with the smallest tentative distance.
+      var u: String? = null
+      var best: Int = Integer::MAX_VALUE
+      foreach entry: Map.Entry in dist.entrySet() {
+        val node: String = (entry.getKey() as String)
+        val d: Int = (entry.getValue() as Int)
+        if settled.get(node) == null && d < best {
+          best = d
+          u = node
+        }
+      }
+      if u == null { break }
+      val cur: String = u!!
+      settled.put(cur, true)
+      if cur == goal { found = true; break }
+      foreach edge: String in neighbors(cur) {
+        val nb: String = edgeNode(edge)
+        val wt: Int = edgeWeight(edge)
+        val alt: Int = (dist.get(cur) as Int) + wt
+        val dNb = dist.get(nb)
+        if dNb == null || alt < (dNb as Int) {
+          dist.put(nb, alt)
+          prev.put(nb, cur)
+        }
+      }
+    }
+    if !found { return new Unreachable() }
+    return new Found(buildPath(prev, start, goal), (dist.get(goal) as Int))
+  }
+
+  // Build a path list by following the prev-map backward from goal to start.
+  def buildPath(prev: Map[String, String], start: String, goal: String): List[String] {
+    val path: List[String] = []
+    var cur: String = goal
+    while cur != null {
+      path.add(0, cur)
+      if cur == start { break }
+      cur = prev.get(cur)
+    }
+    return path
+  }
+
+  // Extract the neighbor node from an "node:weight" edge string.
+  def edgeNode(edge: String): String {
+    return edge.substring(0, edge.lastIndexOf(":"))
+  }
+
+  // Extract the weight from an "node:weight" edge string.
+  def edgeWeight(edge: String): Int {
+    return Integer::parseInt(edge.substring(edge.lastIndexOf(":") + 1))
+  }
+}
+
+// Build a sample graph: A->B(4), A->C(2), C->B(1), B->D(5), C->D(8), B->E(6), D->E(2)
+val g: WeightedGraph = new WeightedGraph()
+g.addEdge("A", "B", 4)
+g.addEdge("A", "C", 2)
+g.addEdge("C", "B", 1)
+g.addEdge("B", "D", 5)
+g.addEdge("C", "D", 8)
+g.addEdge("B", "E", 6)
+g.addEdge("D", "E", 2)
+
+IO::println("=== BFS A -> E ===")
+IO::println(g.bfs("A", "E").describe())
+
+IO::println("=== DFS A -> E ===")
+IO::println(g.dfs("A", "E").describe())
+
+IO::println("=== Dijkstra A -> E ===")
+IO::println(g.dijkstra("A", "E").describe())
+
+IO::println("=== Dijkstra A -> D ===")
+IO::println(g.dijkstra("A", "D").describe())
+
+IO::println("=== Unreachable: E -> A ===")
+IO::println(g.dijkstra("E", "A").describe())
+
+IO::println("=== BFS: unknown start ===")
+IO::println(g.bfs("Z", "A").describe())
+
+// Verify SearchResult methods work
+val res1: SearchResult = g.dijkstra("A", "E")
+val res2: SearchResult = g.dijkstra("E", "A")
+IO::println("A->E isFound: " + res1.isFound())
+IO::println("E->A isFound: " + res2.isFound())

--- a/src/main/scala/onion/compiler/backend/asm/ControlFlowEmitter.scala
+++ b/src/main/scala/onion/compiler/backend/asm/ControlFlowEmitter.scala
@@ -155,6 +155,15 @@ final class ControlFlowEmitter(
   def emitReturn(node: Return): Unit =
     if node.term != null then
       visitTerm(node.term)
+      // A StatementTerm with BottomType has already transferred control on every
+      // path (via inner `return`/`throw` nodes). The operand stack is empty after
+      // it and emitting `gen.returnValue()` would place a dead `areturn` on an
+      // empty stack, which the JVM verifier rejects as "Operand stack underflow".
+      // Each inner Return node already runs finallyStack entries on its own path,
+      // so there is nothing left to do here.
+      node.term match
+        case _: StatementTerm if node.term.`type`.isBottomType => return
+        case _ =>
     if finallyStack.nonEmpty then
       // Run enclosing finally blocks before returning; stash the result across them.
       val slot = if node.term != null then storeResultIfNeeded(node.term.`type`) else None

--- a/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
+++ b/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
@@ -47,6 +47,12 @@ private[compiler] final class AssignabilitySupport(
     val retyped = retypeEmptyCollectionLiteral(expected, actual)
     if (retyped ne actual) return processAssignable(node, expected, retyped)
     if (actual.`type`.isBottomType) {
+      // A StatementTerm transfers control (return/throw/break/continue) on every
+      // path and leaves nothing on the operand stack; unboxing it would generate
+      // dead code whose checkcast pops an empty stack (issue #returnInSelect).
+      // Return the term unchanged so emitReturn can recognise it and skip the
+      // redundant gen.returnValue().
+      if (actual.isInstanceOf[StatementTerm]) return actual
       // A bottom-typed value never actually materializes (the expression throws
       // or otherwise never completes), but the bytecode path still has to
       // verify. When it came from an erased generic call -- `f.await()` on a

--- a/src/test/scala/onion/compiler/tools/AdtEnumSpec.scala
+++ b/src/test/scala/onion/compiler/tools/AdtEnumSpec.scala
@@ -117,5 +117,53 @@ class AdtEnumSpec extends AbstractShellSpec {
           |""".stripMargin, "None", Array())
       assert(Shell.Failure(-1) == r)
     }
+
+    it("allows explicit return in every branch of an ADT enum method (no operand-stack underflow)") {
+      val r = shell.run(
+        """
+          |enum R {
+          |  case Found(n: Int)
+          |  case None
+          |public:
+          |  def describe(): String = select this {
+          |    case f is Found: return "found " + f.n()
+          |    case r is None: return "none"
+          |  }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val r1: R = new Found(4)
+          |    val r2: R = new None()
+          |    return r1.describe() + "|" + r2.describe()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("found 4|none") == r)
+    }
+
+    it("allows explicit return of a Boolean in every branch (primitive return via StatementTerm)") {
+      val r = shell.run(
+        """
+          |enum R {
+          |  case Found(n: Int)
+          |  case None
+          |public:
+          |  def isFound(): Boolean = select this {
+          |    case f is Found: return true
+          |    case u is None: return false
+          |  }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val r1: R = new Found(4)
+          |    val r2: R = new None()
+          |    return "" + r1.isFound() + "|" + r2.isFound()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("true|false") == r)
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes a crash that surfaced as `[I0000] Internal compiler error in LawCheck: Operand stack underflow` whenever an ADT-enum method was written with explicit `return` in every branch of a `select this` expression:

```onion
enum R {
  case Found(n: Int)
  case None
public:
  def describe(): String = select this {
    case f is Found: return "found " + f.n()
    case r is None:  return "none"
  }
}
```

### Root cause (two-pronged)

The parser stores `= selectExpr` as `BlockExpression([ReturnExpression(selectExpr)])`.  
After typing, when every branch carries an inner `Return`, the select becomes `StatementTerm(BottomType)`.

1. **`AssignabilitySupport.processAssignable`** — for a primitive return type (e.g. `Boolean`) the `#314` erased-generic path wrapped the `StatementTerm` in `unboxing(AsInstanceOf(...))`, generating a dead `checkcast; invokevirtual booleanValue()` on an empty operand stack.

2. **`ControlFlowEmitter.emitReturn`** — after visiting the `StatementTerm` (whose if-else chain already emits `areturn` on all paths), the code called `gen.returnValue()` unconditionally, producing a second dead `areturn` on an empty stack.

Both paths result in bytecode the JVM verifier rejects.

### Fixes

- `AssignabilitySupport.processAssignable`: short-circuit for `StatementTerm` **before** the primitive-unboxing logic — the term leaves nothing on the stack so no cast or unbox is needed.
- `ControlFlowEmitter.emitReturn`: after visiting a `StatementTerm` with `BottomType`, return early without emitting `gen.returnValue()`.

### Tests added (`AdtEnumSpec`)

- "allows explicit return in every branch of an ADT enum method (no operand-stack underflow)" — `String` return
- "allows explicit return of a Boolean in every branch (primitive return via StatementTerm)" — `Boolean` return

### Corpus

Added `run/GraphSearch.on` (168 lines): weighted directed graph with BFS, DFS, and Dijkstra's shortest path, exercising the now-fixed explicit-return-in-ADT-enum pattern, typed `Map`/`List` collections, nullable types, and non-null assertions (`!!`).

Quality-bar counts updated: 73 → 74 samples, 16 → 17 large programs (EN + JA).

Full suite: **3058 pass / 0 fail / 1 cancelled** (the expected dist smoke test).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7vhzwJ38Gy5f4Q6rodoxZ)_