### PR TITLE
docs(changelog): record ICE fix for return-in-every-select-branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Internal compiler error (operand-stack underflow) when an ADT-enum method
+  body used an explicit `return` in every branch of a `select this`
+  expression**, e.g. `def describe(): String = select this { case f is Found:
+  return "found"; case n is None: return "none" }`. The typed AST collapses
+  such a select into a `StatementTerm(BottomType)` once every branch already
+  transfers control via an inner `Return`; codegen then emitted dead
+  unboxing/return bytecode on an empty operand stack, which the JVM verifier
+  rejected as `[I0000]`. Fixed in `AssignabilitySupport.processAssignable`
+  and `ControlFlowEmitter.emitReturn` to recognize a bottom-typed
+  `StatementTerm` and skip the redundant instructions.
+
 ### Added
 
 - **`run/Inventory.on`, a 279-line shop inventory manager sample.** Adds a


### PR DESCRIPTION
## Summary
- PR #547 fixed a real crash (`[I0000] Internal compiler error in LawCheck: Operand stack underflow` when an ADT-enum method used explicit `return` in every branch of a `select this` expression) but did not add a `CHANGELOG.md` entry, even though it's a user-visible bug fix.
- This backfills a `### Fixed` entry under `[Unreleased]` describing the crash and the fix, per the CHANGELOG-maintenance convention used by this repo.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3058 succeeded, 0 failed, 1 canceled (known distribution smoke test gated behind a flag), 0 ignored.

Docs-only change (CHANGELOG.md), no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwsWe7XjLFErbTJuEfRiYW)_