### PR TITLE
fix: name the mistake when a trailing lambda's params are parenthesized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Writing `{ (k, v) => ... }` for a trailing lambda produced a bare
+  "Encountered `{`, but expecting..." token dump**, with no indication that
+  the actual mistake was the parentheses. Trailing lambdas (`m.filter { k, v
+  => ... }`) never take parenthesized parameters — that syntax is reserved
+  for the non-trailing `(k, v) -> ...` form — and it's an easy slip since
+  both forms are documented side by side. The parser now recognizes this
+  specific shape and names the fix directly: "Hint: a trailing lambda's
+  parameters aren't parenthesized — write `{ k, v => ... }`, not `{ (k, v)
+  => ... }`."
+
 ### Added
 
 - **`run/PlaylistManager.on`, a 502-line music playlist manager sample.** Adds a

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -89,6 +89,7 @@ error.semantic.lawClassNotLoadable={0} declares law/example clauses but its clas
 error.semantic.shapeFormatUnknown=unknown shape format `{0}`. Supported formats: {1}. For an inline pattern write `shape name = re"..."`.
 error.parsing.hint.old_extends=Hint: a superclass is named with `extends`, not `:` — write `class A extends B`.
 error.parsing.hint.old_conforms=Hint: interfaces are named with `conforms`, not `<:` — write `class A conforms I` (and `class A extends B conforms I`).
+error.parsing.hint.trailing_lambda_parens=Hint: a trailing lambda''s parameters aren''t parenthesized — write `'{' {0} => ... '}'`, not `'{' ({0}) => ... '}'`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -89,6 +89,7 @@ error.semantic.lawClassNotLoadable={0} は law/example 句を持ちますが、�
 error.semantic.shapeFormatUnknown=未知の shape フォーマット `{0}` です。サポートしているフォーマット: {1}。インラインのパターンを書く場合は `shape name = re"..."` としてください。
 error.parsing.hint.old_extends=ヒント: 親クラスは `:` ではなく `extends` で指定します — `class A extends B` と書いてください。
 error.parsing.hint.old_conforms=ヒント: インターフェースは `<:` ではなく `conforms` で指定します — `class A conforms I`（親クラスと併用する場合は `class A extends B conforms I`）と書いてください。
+error.parsing.hint.trailing_lambda_parens=ヒント: 末尾ラムダの引数は丸かっこで囲みません — `'{' ({0}) => ... '}'` ではなく `'{' {0} => ... '}'` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -52,7 +52,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * every other line keeps its original line number. On any other line `#!` is
    * left for the lexer to reject rather than being silently skipped (issue #262).
    */
-  private def stripShebang(reader: Reader): Reader = {
+  private def stripShebang(reader: Reader): String = {
     val sb = new StringBuilder
     val buf = new Array[Char](4096)
     try {
@@ -60,12 +60,10 @@ class Parsing(config: CompilerConfig) extends AnyRef
       while (n != -1) { sb.appendAll(buf, 0, n); n = reader.read(buf) }
     } finally reader.close()
     val text = sb.toString
-    val stripped =
-      if (text.startsWith("#!")) {
-        val nl = text.indexOf('\n')
-        if (nl < 0) "" else text.substring(nl)
-      } else text
-    new StringReader(stripped)
+    if (text.startsWith("#!")) {
+      val nl = text.indexOf('\n')
+      if (nl < 0) "" else text.substring(nl)
+    } else text
   }
 
   private def parseFile(
@@ -74,7 +72,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
     problems: ArrayBuffer[CompileError]
   ): Unit = {
     try {
-      val reader = stripShebang(source.openReader())
+      val sourceText = stripShebang(source.openReader())
+      val reader = new StringReader(sourceText)
       val parser = new JJOnionParser(reader)
 
       // Enable error recovery mode to collect multiple errors
@@ -85,7 +84,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
 
         // Check for collected errors during parsing
         if (parser.hasErrors()) {
-          collectParseErrors(parser, source.name, problems)
+          collectParseErrors(parser, source.name, sourceText, problems)
         }
 
         // Only add the unit if we got a valid result
@@ -96,10 +95,10 @@ class Parsing(config: CompilerConfig) extends AnyRef
         case e: ParseException =>
           // First, add any collected errors
           if (parser.hasErrors()) {
-            collectParseErrors(parser, source.name, problems)
+            collectParseErrors(parser, source.name, sourceText, problems)
           }
           // Then add the final error that stopped parsing
-          addParseException(e, source.name, problems)
+          addParseException(e, source.name, sourceText, problems)
       } finally {
         reader.close()
       }
@@ -115,6 +114,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private def collectParseErrors(
     parser: JJOnionParser,
     fileName: String,
+    sourceText: String,
     problems: ArrayBuffer[CompileError]
   ): Unit = {
     val errors = parser.getCollectedErrors()
@@ -123,7 +123,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
       problems += CompileError(
         fileName,
         new Location(error.line, error.column),
-        syntaxErrorMessage(error.found, error.expected)
+        syntaxErrorMessage(error.found, error.expected, contextAt(sourceText, error.line, error.column))
       )
     }
   }
@@ -134,6 +134,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private def addParseException(
     e: ParseException,
     fileName: String,
+    sourceText: String,
     problems: ArrayBuffer[CompileError]
   ): Unit = {
     // Message-only ParseExceptions (e.g. from string-interpolation splitting)
@@ -146,9 +147,25 @@ class Parsing(config: CompilerConfig) extends AnyRef
       problems += CompileError(
         fileName,
         new Location(error.beginLine, error.beginColumn),
-        syntaxErrorMessage(error.image, expected)
+        syntaxErrorMessage(error.image, expected, contextAt(sourceText, error.beginLine, error.beginColumn))
       )
     }
+  }
+
+  /**
+   * The source text starting at a 1-based (line, column), for hints that need
+   * to look past the offending token (bounded so a pathological file can't
+   * make the regex match slow).
+   */
+  private def contextAt(sourceText: String, line: Int, column: Int): String = {
+    var offset = 0
+    var currentLine = 1
+    while (currentLine < line && offset >= 0 && offset < sourceText.length) {
+      val nl = sourceText.indexOf('\n', offset)
+      if (nl < 0) offset = sourceText.length else { offset = nl + 1; currentLine += 1 }
+    }
+    val start = math.min(sourceText.length, offset + column - 1)
+    sourceText.substring(start, math.min(sourceText.length, start + 200))
   }
 
   /**
@@ -162,21 +179,28 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * (complete strings lex as a single STRING token); report it as such
    * instead of listing unrelated expected tokens.
    */
-  private def syntaxErrorMessage(found: String, expected: String): String = {
+  private def syntaxErrorMessage(found: String, expected: String, context: String = ""): String = {
     // At EOF the expected-token list is a large, unhelpful dump; report the real
     // problem (an unclosed block/paren) instead.
     if (found == null || found.isEmpty) return Message("error.parsing.unexpected_eof")
     val base =
       if (found == "\"") Message("error.parsing.unterminated_string")
       else Message("error.parsing.syntax_error", displayTokenImage(found), expected)
-    val hint = commonSyntaxHint(found, expected)
+    val hint = commonSyntaxHint(found, expected, context)
     if (hint.isEmpty) base else base + " " + hint
   }
 
   /**
+   * A trailing lambda's parameter list is never parenthesized (`{ k, v => ... }`,
+   * unlike the non-trailing `(k, v) -> ...` form), so `{ (k, v) => ... }` fails
+   * right at the `{` with an unhelpful expected-token dump.
+   */
+  private val ParenthesizedTrailingLambdaHead = """\A\{\s*\(([^()]*)\)\s*=>""".r
+
+  /**
    * Add friendly hints for common syntax mistakes.
    */
-  private def commonSyntaxHint(found: String, expected: String): String = found match {
+  private def commonSyntaxHint(found: String, expected: String, context: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
     case "<:" =>
@@ -187,6 +211,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
       "Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`."
     case "else" =>
       "Hint: `else` must follow an `if` block. Onion does not support `if` as an expression; use `if (cond) { ... } else { ... }`."
+    case "{" if ParenthesizedTrailingLambdaHead.findFirstMatchIn(context).isDefined =>
+      val params = ParenthesizedTrailingLambdaHead.findFirstMatchIn(context).get.group(1).trim
+      Message("error.parsing.hint.trailing_lambda_parens", params)
     case _ if expected.contains("{") && !Set(";", "<EOL>", "<EOF>").exists(expected.contains) =>
       "Hint: a block `{ ... }` is expected here."
     case _ =>

--- a/src/test/scala/onion/compiler/tools/TrailingLambdaParenHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TrailingLambdaParenHintSpec.scala
@@ -1,0 +1,70 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A trailing lambda's parameter list is never parenthesized (`{ k, v => ... }`,
+ * not `{ (k, v) => ... }`) — that's valid only for the non-trailing `(x) -> body`
+ * form. Writing parens in the trailing-block form is a common slip since both
+ * forms are documented side by side; the parser should name the mistake instead
+ * of just dumping the raw expected-token list at the `{`.
+ */
+class TrailingLambdaParenHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("trailing lambda with parenthesized params") {
+    it("hints at the unparenthesized form for a two-arg lambda") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val m: Map[String, Int] = ["a": 1]
+          |    val r = m.filter { (k, v) => v > 0 }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("k, v =>"), s"expected a hint naming the unparenthesized form, got: $msgs")
+    }
+
+    it("hints at the unparenthesized form for a single-arg lambda") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs = [1, 2, 3]
+          |    val r = xs.map { (x) => x * 2 }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("x =>"), s"expected a hint naming the unparenthesized form, got: $msgs")
+    }
+
+    it("does not add the hint for an unrelated unexpected brace") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1 {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("=>"), s"did not expect the lambda hint here, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `m.filter { (k, v) => v > 0 }` (or any trailing lambda written with
  parenthesized params) failed with a bare `Encountered "{", but
  expecting <EOF>, <EOL>, ";", "("` token dump — no indication that the
  parentheses were the actual problem.
- Trailing lambdas never take parenthesized params: `{ k, v => ... }` is
  the only valid trailing form; `(k, v) -> ...` is a separate, non-trailing
  lambda syntax. It's an easy slip since both forms are documented side by
  side (`CLAUDE.md`, `docs/reference/stdlib.md`), and even record-methods on
  `Map` (`m.filter`, `m.mapValues`, ...) accept both trailing-block and
  parenthesized-arrow forms depending on call shape.
- `Parsing.scala` now recognizes the `{ (...) => ` shape right at the
  parse-error site (by peeking at the source text after the offending `{`)
  and suggests the fix directly, in both English and Japanese:
  > Hint: a trailing lambda's parameters aren't parenthesized — write
  > `{ k, v => ... }`, not `{ (k, v) => ... }`.
- No grammar/syntax change — this is diagnostics-only. The set of programs
  that compile is unchanged.

## Test plan

- [x] Added `TrailingLambdaParenHintSpec` (TDD: red before the fix, green
      after) covering a two-arg case, a single-arg case, and a check that
      an unrelated unexpected `{` does not get the new hint.
- [x] `sbt -Duser.language=en test` — 3064 passed, 0 failed, 1 canceled
      (the dist-smoke test, gated behind `-Donion.dist.path`, per existing
      convention).
- [x] Manually verified the improved message via the CLI in both `en` and
      `ja` locales.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F7MyuJzC8pszyGEkitg7LK)_