### PR TITLE
docs: fix onion CLI --help drift for --effects, --stacktrace, --watch

### DIFF
--- a/docs/ja/tools/script-runner.md
+++ b/docs/ja/tools/script-runner.md
@@ -108,6 +108,30 @@ onion --no-check-laws MyScript.on
 onion --law-samples 500 MyScript.on
 ```
 
+### `--effects`
+
+コンパイルされた各メソッドの推論済みエフェクト集合（`read write net exec env clock rand console unknown`。空はpureを意味する）を標準エラー出力に表示します。
+
+```bash
+onion --effects MyScript.on
+```
+
+### `--stacktrace`
+
+未捕捉のランタイムエラーについて、整形された診断レポートの代わりに生のJVMスタックトレースを表示します。
+
+```bash
+onion --stacktrace MyScript.on
+```
+
+### `--watch`
+
+スクリプトを実行した後、ファイルが変更されるたびに自動的に再実行します。コンパイルエラーやランタイム例外が発生してもウォッチループは止まりません。Ctrl-Cで停止します。
+
+```bash
+onion --watch MyScript.on
+```
+
 ## プログラム引数
 
 ソースファイルの後ろに指定した引数は、プログラムに渡されます。

--- a/docs/tools/script-runner.md
+++ b/docs/tools/script-runner.md
@@ -109,6 +109,30 @@ produced its counterexample.
 onion --law-samples 500 MyScript.on
 ```
 
+### `--effects`
+
+Print each compiled method's inferred effect set (`read write net exec env clock rand console unknown`; empty means pure) to stderr.
+
+```bash
+onion --effects MyScript.on
+```
+
+### `--stacktrace`
+
+Print the raw JVM trace for an uncaught runtime error instead of the rendered diagnostic report.
+
+```bash
+onion --stacktrace MyScript.on
+```
+
+### `--watch`
+
+Run the script, then re-run it automatically whenever its file changes. Compile errors and runtime exceptions are printed without stopping the watch loop; press Ctrl-C to stop.
+
+```bash
+onion --watch MyScript.on
+```
+
 ## Program Arguments
 
 Arguments after the source file(s) are passed to your program:

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -269,6 +269,9 @@ class ScriptRunner {
          |  --no-check-laws             Do not execute record `law`/`example` clauses
          |  --law-seed <n>              RNG seed for law sample generation
          |  --law-samples <n>           Number of samples generated per law parameter
+         |  --effects                   Print each method's inferred effect set to stderr
+         |  --stacktrace                Print the raw JVM trace for an uncaught runtime error
+         |  --watch                     Re-run the script whenever its file changes
          |  -h, --help                  Show this help message
          |  -v, --version               Show version information
          |

--- a/src/test/scala/onion/tools/OnionCliSpec.scala
+++ b/src/test/scala/onion/tools/OnionCliSpec.scala
@@ -318,6 +318,11 @@ class OnionCliSpec extends AnyFunSuite with Matchers:
     watchExit shouldBe 0
     stdout.toString(StandardCharsets.UTF_8) should include("Usage: onion [options] <source_file>")
     stdout.toString(StandardCharsets.UTF_8) should include(s"Onion Script Runner version ${ScriptRunner.VERSION}")
+    // These three runner options are recognized by runMain/run (see ScriptRunner.scala)
+    // but had silently drifted out of printUsage's help text.
+    stdout.toString(StandardCharsets.UTF_8) should include("--effects")
+    stdout.toString(StandardCharsets.UTF_8) should include("--stacktrace")
+    stdout.toString(StandardCharsets.UTF_8) should include("--watch")
 
   test("ScriptRunner runMain reports a script's exception instead of rethrowing it"):
     val source = Files.createTempFile("onion-cli-throws", ".on")


### PR DESCRIPTION
## Summary
- `ScriptRunner.runMain`/`run` already parse and honor `--effects`, `--stacktrace`, and `--watch`, but `printUsage()` never listed them, so `onion --help` silently omitted three working flags.
- Adds the three flags to the CLI help text, documents them in `docs/tools/script-runner.md` and `docs/ja/tools/script-runner.md`, and extends the existing `OnionCliSpec` help-text assertion so this can't silently regress again.
- No behavior change — pure text/doc addition.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.tools.OnionCliSpec'` — 16/16 passed
- [x] Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3064 succeeded, 0 failed, 1 canceled (environment-gated distribution smoke test, expected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RawXb9sEC5XZBa5VodeqsV)_