### PR TITLE
docs(quality-bar): re-measure row 1 test count (2848 -> 3096)

### DIFF
--- a/docs/ja/quality-bar.md
+++ b/docs/ja/quality-bar.md
@@ -8,9 +8,9 @@
 いましたが実際は 2644、ガイドは 14/14 に対し 15/15（`docs/guide/tools.md` が #357 で追加）、
 診断コードは 77 に対し 80（capability boundary が追加した `E0077`–`E0079`）でした。
 
-| # | 次元 | 測定方法 | 現在値（2026-07-27） | 合格閾値 |
+| # | 次元 | 測定方法 | 現在値（2026-08-02） | 合格閾値 |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 2848 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | テストスイート | `sbt -batch -Duser.language=en test` | 3096 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | サンプルの健全性 | `SampleCompilesSpec` / `SampleProgramsSpec`（どちらも `run/*.on` 全件をコンパイル） | 84 / 84 compile | すべてコンパイル、rot なし |
 | 3 | 大規模プログラム | 100行以上の `run/*.on` をそのまま end-to-end で実行できる数 | 27（AuctionHouse、BankLedger、BankSystem、Blackjack、BrokenLogDemo、BudgetTracker、FitnessTracker、GradeBook、GraphSearch、HotelReservation、Inventory、LibraryCatalog、LibrarySystem、MiniRpg、OrderReport、PayrollReport、PlaylistManager、RecipeManager、ShapeProcessor、ShoppingCart、StatsApp、StockPortfolio、TaskPlanner、TextAnalyzer、TodoManager、ToolDemo、TournamentTracker） | ≥ 5 |
 | 4 | 機能網羅性 | 下記のチェックリストが大規模サンプル内で実証されている | 完了 | すべての項目 ✓ |

--- a/docs/quality-bar.md
+++ b/docs/quality-bar.md
@@ -11,9 +11,9 @@ had already drifted after the effect-table / tool-capability / tool-contracts wo
 15/15 (`docs/guide/tools.md` shipped with #357), and 77 diagnostic codes against 80
 (`E0077`–`E0079` added by the capability boundary).
 
-| # | Dimension | How to measure | Current (2026-07-27) | Pass threshold |
+| # | Dimension | How to measure | Current (2026-08-02) | Pass threshold |
 |---|-----------|----------------|----------------------|----------------|
-| 1 | Test suite | `sbt -batch -Duser.language=en test` | 2848 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
+| 1 | Test suite | `sbt -batch -Duser.language=en test` | 3096 pass / 0 fail / 1 cancelled | 0 failed, 0 skipped |
 | 2 | Sample health | `SampleCompilesSpec` / `SampleProgramsSpec` (both compile every `run/*.on`) | 84 / 84 compile | all compile, no rot |
 | 3 | Large programs | count of `run/*.on` ≥ 100 lines that run end-to-end as-is | 27 (AuctionHouse, BankLedger, BankSystem, Blackjack, BrokenLogDemo, BudgetTracker, FitnessTracker, GradeBook, GraphSearch, HotelReservation, Inventory, LibraryCatalog, LibrarySystem, MiniRpg, OrderReport, PayrollReport, PlaylistManager, RecipeManager, ShapeProcessor, ShoppingCart, StatsApp, StockPortfolio, TaskPlanner, TextAnalyzer, TodoManager, ToolDemo, TournamentTracker) | ≥ 5 |
 | 4 | Feature coverage | checklist below demonstrated inside the large samples | complete | every item ✓ |


### PR DESCRIPTION
## Summary
- `docs/quality-bar.md` row 1 (test suite count) was still recording `2848 pass / 0 fail / 1 cancelled` from the 2026-07-26 baseline. `QualityBarSpec` only sanity-checks that figure against a wide 2700–4000 band, so it can drift silently without failing the build — unlike rows 2/3/6/7, which are exactly enforced and already matched reality.
- A full `sbt -Duser.language=en test` run today reports **3096 pass / 0 fail / 1 cancelled**. Updated both `docs/quality-bar.md` and `docs/ja/quality-bar.md` with the re-measured count and today's date, keeping the two language copies in sync (also checked by `QualityBarSpec`).

## Test plan
- [x] `sbt -J-Xmx8G -Duser.language=en test` — 3096 succeeded, 0 failed, 1 canceled, all green (includes `QualityBarSpec`, which checks EN/JA parity and the row-1 plausibility band).

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBWZegPbTpPkKvuA9aekwU)_