### PR TITLE
fix(records): skip synthetic toString/equals/hashCode/copy when user overrides them

### DIFF
--- a/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
@@ -216,38 +216,53 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
       ctor.setArgumentsWithDefaults(methodArgs)
       definition_.add(ctor)
 
+      // Collect method names declared in user-provided body sections so we can
+      // skip generating a synthetic where the user has supplied an override.
+      val userDefinedMethodNames: Set[String] =
+        node.sections.flatMap(_.members).collect {
+          case m: AST.MethodDeclaration => m.name
+        }.toSet
+
       // Generate equals(Object): Boolean method
-      val equalsModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
-      val equalsMethod = new MethodDefinition(
-        node.location, equalsModifier, definition_, "equals",
-        Array(rootClass), BasicType.BOOLEAN, null
-      )
-      definition_.add(equalsMethod)
+      if (!userDefinedMethodNames.contains("equals")) {
+        val equalsModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
+        val equalsMethod = new MethodDefinition(
+          node.location, equalsModifier, definition_, "equals",
+          Array(rootClass), BasicType.BOOLEAN, null
+        )
+        definition_.add(equalsMethod)
+      }
 
       // Generate hashCode(): Int method
-      val hashCodeModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
-      val hashCodeMethod = new MethodDefinition(
-        node.location, hashCodeModifier, definition_, "hashCode",
-        Array.empty, BasicType.INT, null
-      )
-      definition_.add(hashCodeMethod)
+      if (!userDefinedMethodNames.contains("hashCode")) {
+        val hashCodeModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
+        val hashCodeMethod = new MethodDefinition(
+          node.location, hashCodeModifier, definition_, "hashCode",
+          Array.empty, BasicType.INT, null
+        )
+        definition_.add(hashCodeMethod)
+      }
 
       // Generate toString(): String method
-      val toStringModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
       val stringType = loadRequired("java.lang.String")
-      val toStringMethod = new MethodDefinition(
-        node.location, toStringModifier, definition_, "toString",
-        Array.empty, stringType, null
-      )
-      definition_.add(toStringMethod)
+      if (!userDefinedMethodNames.contains("toString")) {
+        val toStringModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
+        val toStringMethod = new MethodDefinition(
+          node.location, toStringModifier, definition_, "toString",
+          Array.empty, stringType, null
+        )
+        definition_.add(toStringMethod)
+      }
 
       // Generate copy(components...): ThisType method
-      val copyModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
-      val copyMethod = new MethodDefinition(
-        node.location, copyModifier, definition_, "copy",
-        argTypes, definition_, null
-      )
-      definition_.add(copyMethod)
+      if (!userDefinedMethodNames.contains("copy")) {
+        val copyModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
+        val copyMethod = new MethodDefinition(
+          node.location, copyModifier, definition_, "copy",
+          argTypes, definition_, null
+        )
+        definition_.add(copyMethod)
+      }
 
       // Pattern-attached records (`record ... from re"..."`): validate that every
       // component type can be derived from a captured String, then register the

--- a/src/test/scala/onion/compiler/tools/RecordOverrideToStringSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RecordOverrideToStringSpec.scala
@@ -1,0 +1,115 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+class RecordOverrideToStringSpec extends AbstractShellSpec {
+  describe("Record with user-defined toString/equals/hashCode in body") {
+    it("can override toString without duplicate-method crash") {
+      val result = shell.run(
+        """
+          |record Point(x: Int, y: Int) {
+          |public:
+          |  override def toString(): String = "Point(" + x() + ", " + y() + ")"
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): String {
+          |    return new Point(3, 4).toString()
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("Point(3, 4)") == result)
+    }
+
+    it("can override equals without duplicate-method crash") {
+      val result = shell.run(
+        """
+          |record Box(value: Int) {
+          |public:
+          |  override def equals(o: Object): Boolean {
+          |    if o == null { return false }
+          |    if !(o is Box) { return false }
+          |    return (o as Box).value() == value()
+          |  }
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val b1: Box = new Box(42)
+          |    val b2: Box = new Box(42)
+          |    val b3: Box = new Box(7)
+          |    return "" + b1.equals(b2) + "," + b1.equals(b3)
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("true,false") == result)
+    }
+
+    it("synthetic toString is still generated when body has no override") {
+      val result = shell.run(
+        """
+          |record Tag(name: String) { }
+          |class Main {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val t: String = new Tag("hello").toString()
+          |    return if t != null { "ok" } else { "null" }
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("ok") == result)
+    }
+
+    it("can define both toString and a custom method in the body") {
+      val result = shell.run(
+        """
+          |record Vec2(x: Double, y: Double) {
+          |public:
+          |  override def toString(): String = "(" + x() + "," + y() + ")"
+          |  def length(): Double = Math::sqrt(x() * x() + y() * y())
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val v: Vec2 = new Vec2(3.0d, 4.0d)
+          |    return v.toString() + " len=" + v.length()
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("(3.0,4.0) len=5.0") == result)
+    }
+
+    it("can override hashCode without duplicate-method crash") {
+      val result = shell.run(
+        """
+          |record Named(name: String) {
+          |public:
+          |  override def hashCode(): Int = name().hashCode() * 31
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val n: Named = new Named("test")
+          |    return if n.hashCode() != 0 { "ok" } else { "zero" }
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("ok") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Bug**: A record that declares `override def toString()` (or `equals`/`hashCode`/`copy`) in its body caused an I0000 internal compiler error — "Duplicate method name" — because the auto-generated synthetic method AND the user's override were both registered on the same `ClassDefinition`, producing invalid bytecode.
- **Root cause**: `TypingOutlinePass.processRecordDeclaration` unconditionally added synthetic `MethodDefinition` objects for all four record methods, without checking whether the user had already defined one in the record's `sections`.
- **Fix**: Before emitting each synthetic, collect method names from `node.sections`; skip any synthetic whose name is already present. The user's method (`block != null`, no `SYNTHETIC_RECORD` modifier) then compiles through the normal code-generation path with no duplicate.

## Changes

- `src/main/scala/onion/compiler/typing/TypingOutlinePass.scala`: Guard each of the four synthetic record method emits with a `!userDefinedMethodNames.contains(...)` check.
- `src/test/scala/onion/compiler/tools/RecordOverrideToStringSpec.scala`: 5 new spec cases (RED before fix, GREEN after):
  - override `toString` in record body
  - override `equals` with custom field comparison
  - override `hashCode`
  - synthetic `toString` still generated when body has no override (regression guard)
  - override `toString` combined with an additional custom method

## Verified output (5 of 5 tests pass)

```
Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

Broader regression run (106 tests across ExtensionMethodSpec, RecordSpec, AdtEnumSpec, CompilationFailureSpec, HelloWorldSpec, FactorialSpec, StringInterpolationSpec, ImportSpec, BreakContinueSpec, SampleCorpusSpec, CollectionPipelineSpec, NullableTypeSpec, and more): all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X56hrEnzYnu1EP1y7yiCkM)_