### PR TITLE
refactor(typing): remove unreachable ArrayType branches in generic unify

### DIFF
--- a/src/main/scala/onion/compiler/typing/GenericMethodTypeArguments.scala
+++ b/src/main/scala/onion/compiler/typing/GenericMethodTypeArguments.scala
@@ -226,12 +226,6 @@ private[typing] object GenericMethodTypeArguments {
                 case Some(view) => unifyWithApplied(view)
                 case None =>
             case _ =>
-        case aft: ArrayType =>
-          actual match {
-            case aat: ArrayType if aft.dimension == aat.dimension =>
-              unify(aft.component, aat.component, position)
-            case _ =>
-          }
         case _ =>
     }
 
@@ -447,12 +441,6 @@ private[typing] object GenericMethodTypeArguments {
                 case Some(view) => unifyWithApplied(view)
                 case None =>
             case _ =>
-        case aft: ArrayType =>
-          actual match {
-            case aat: ArrayType if aft.dimension == aat.dimension =>
-              unify(aft.component, aat.component, position)
-            case _ =>
-          }
         case _ =>
     }
 

--- a/src/test/scala/onion/compiler/tools/GenericArrayTypeInferenceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/GenericArrayTypeInferenceSpec.scala
@@ -1,0 +1,79 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+class GenericArrayTypeInferenceSpec extends AbstractShellSpec {
+  describe("Generic type parameter inference over array-typed arguments") {
+    it("infers T from a 1D T[] argument") {
+      val result = shell.run(
+        """
+          |class Util {
+          |public:
+          |  static def first[T](arr: T[]): T {
+          |    return arr[0];
+          |  }
+          |
+          |  static def main(args: String[]): Int {
+          |    var arr: String[] = new String[3];
+          |    arr[0] = "seven";
+          |    var r: String = Util::first(arr);
+          |    if (r == "seven") { return 1; }
+          |    return 0;
+          |  }
+          |}
+        """.stripMargin,
+        "GenericArray1D.on",
+        Array()
+      )
+      assert(Shell.Success(1) == result)
+    }
+
+    it("infers T from a 2D T[][] argument") {
+      val result = shell.run(
+        """
+          |class Util {
+          |public:
+          |  static def first[T](arr: T[][]): T {
+          |    return arr[0][0];
+          |  }
+          |
+          |  static def main(args: String[]): Int {
+          |    var arr: String[][] = new String[3][4];
+          |    arr[0][0] = "forty-two";
+          |    var r: String = Util::first(arr);
+          |    if (r == "forty-two") { return 1; }
+          |    return 0;
+          |  }
+          |}
+        """.stripMargin,
+        "GenericArray2D.on",
+        Array()
+      )
+      assert(Shell.Success(1) == result)
+    }
+
+    it("infers T from a 3D T[][][] argument") {
+      val result = shell.run(
+        """
+          |class Util {
+          |public:
+          |  static def first[T](arr: T[][][]): T {
+          |    return arr[0][0][0];
+          |  }
+          |
+          |  static def main(args: String[]): Int {
+          |    var arr: String[][][] = new String[2][3][4];
+          |    arr[0][0][0] = "ninety-nine";
+          |    var r: String = Util::first(arr);
+          |    if (r == "ninety-nine") { return 1; }
+          |    return 0;
+          |  }
+          |}
+        """.stripMargin,
+        "GenericArray3D.on",
+        Array()
+      )
+      assert(Shell.Success(1) == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `GenericMethodTypeArguments.infer` and `.inferWithoutDefaults` each had a `case aft: ArrayType` branch positioned after an earlier `case af: TypedAST.ArrayType` branch that already matches every `ArrayType` value. The later branch could never execute, and the Scala 3 compiler flagged it as an unreachable match case (E030) at every build.
- Removed both dead branches. No behavior change — the reachable branch already unifies array component types correctly (recursing through `ArrayType.base` handles arbitrary array dimensions).
- Added `GenericArrayTypeInferenceSpec.scala`, a regression test exercising generic type-parameter inference over 1D/2D/3D array-typed method parameters (`T[]`, `T[][]`, `T[][][]`), to lock in this behavior.

## Test plan
- [x] `sbt -Duser.language=en test` — full suite green: 3153 succeeded, 0 failed, 1 canceled (pre-existing environment-conditional dist-packaging test, unrelated to this change)
- [x] Clean `sbt compile` confirms both E030 unreachable-case warnings are gone
- [x] New `GenericArrayTypeInferenceSpec` passes (3/3)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_013rRfNrShJXkFQnCtwfyMeC)_