### PR TITLE
fix: use singular wording for "1 error is found." message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The English `error.count` trailer no longer says "1 errors are found."
+  for a single-error compile.** `error.count` in `errorMessage.properties`
+  used a plain `"{0} errors are found."` template regardless of count; it now
+  uses a `MessageFormat` choice format (`1#1 error is found.|1<{0} errors are
+  found.`) so a single error reads "1 error is found." while multiple errors
+  keep the plural wording. The Japanese bundle was unaffected (Japanese does
+  not pluralize).
+
 ## [0.10.21] - 2026-08-03
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -1,4 +1,4 @@
-error.count={0} errors are found.
+error.count={0,choice,1#1 error is found.|1<{0,number,integer} errors are found.}
 error.command.noArgument={0} requires argument.
 error.command.invalidArgument={0} is invalid argument.
 error.command.requireNaturalNumber=value of {0} is required to natural number.

--- a/src/test/scala/onion/compiler/ErrorCountMessageSpec.scala
+++ b/src/test/scala/onion/compiler/ErrorCountMessageSpec.scala
@@ -1,0 +1,22 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * `error.count` is printed as the trailer after a failed compilation
+ * (`DiagnosticRenderer.printErrors`, `Repl`). The English bundle used a bare
+ * `"{0} errors are found."` template regardless of count, which reads as
+ * "1 errors are found." for a single-error compile.
+ */
+class ErrorCountMessageSpec extends AnyFunSpec with Diagrams {
+  it("uses singular wording for a single error in English") {
+    val text = onion.compiler.toolbox.Message("error.count", 1)
+    assert(!text.contains("1 errors"))
+  }
+
+  it("uses plural wording for multiple errors in English") {
+    val text = onion.compiler.toolbox.Message("error.count", 3)
+    assert(text.contains("3 errors"))
+  }
+}


### PR DESCRIPTION
## Summary
- The English `error.count` trailer always read "N errors are found." regardless of count, so a single-error compile printed "1 errors are found."
- Switches `error.count` in `errorMessage.properties` to a `MessageFormat` choice format so a single error reads "1 error is found." while multiple errors keep the plural "N errors are found."
- Japanese bundle (`errorMessage_ja.properties`) is unaffected — Japanese doesn't pluralize.

## Test plan
- [x] Added `ErrorCountMessageSpec` (TDD: confirmed red before the fix, green after)
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 3172 succeeded, 0 failed, 1 canceled (pre-existing, environment-dependent dist-packaging test, unrelated to this change)
- [x] `CHANGELOG.md` updated under `[Unreleased]`

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9uQ4vCgPYRu8cPTPE4guy)_