### PR TITLE
Refactor OperatorTyping.tryOperatorMethod to drop non-local return

### DIFF
--- a/src/main/scala/onion/compiler/typing/OperatorTyping.scala
+++ b/src/main/scala/onion/compiler/typing/OperatorTyping.scala
@@ -298,26 +298,26 @@ final class OperatorTyping(
   private val operatorMethodNames: Map[String, String] =
     Map("+" -> "plus", "-" -> "minus", "*" -> "times", "/" -> "div", "%" -> "rem")
 
-  def tryOperatorMethod(node: AST.Node, symbol: String, left: Term, right: Term): Option[Term] = {
-    val methodName = operatorMethodNames.getOrElse(symbol, return None)
-    left.`type` match {
-      case targetType: ObjectType if right.`type`.isObjectType || right.`type`.isBasicType =>
-        val params = Array(right)
-        tryFindMethod(node, targetType, methodName, params) match {
-          case Right(method) =>
-            val classSubst = TypeSubstitution.classSubstitution(targetType)
-            val resultType = TypeSubstitution.substituteType(method.returnType, classSubst, scala.collection.immutable.Map.empty, defaultToBound = true)
-            Some(TypeSubst.withCast(new Call(left, method, params), resultType))
-          case Left(_) =>
-            // No member `plus`/`minus`/... — consult extension methods so an
-            // operator defined via an `extension` block resolves (records have no
-            // body block, so extensions are the only way to overload their
-            // operators). None here lets the caller fall back to string concat.
-            body.tryExtensionOperatorMethod(node, methodName, left, targetType, right, null)
-        }
-      case _ => None
+  def tryOperatorMethod(node: AST.Node, symbol: String, left: Term, right: Term): Option[Term] =
+    operatorMethodNames.get(symbol).flatMap { methodName =>
+      left.`type` match {
+        case targetType: ObjectType if right.`type`.isObjectType || right.`type`.isBasicType =>
+          val params = Array(right)
+          tryFindMethod(node, targetType, methodName, params) match {
+            case Right(method) =>
+              val classSubst = TypeSubstitution.classSubstitution(targetType)
+              val resultType = TypeSubstitution.substituteType(method.returnType, classSubst, scala.collection.immutable.Map.empty, defaultToBound = true)
+              Some(TypeSubst.withCast(new Call(left, method, params), resultType))
+            case Left(_) =>
+              // No member `plus`/`minus`/... — consult extension methods so an
+              // operator defined via an `extension` block resolves (records have no
+              // body block, so extensions are the only way to overload their
+              // operators). None here lets the caller fall back to string concat.
+              body.tryExtensionOperatorMethod(node, methodName, left, targetType, right, null)
+          }
+        case _ => None
+      }
     }
-  }
 
   def typeLogicalBinary(node: AST.BinaryExpression, kind: BinaryKind, context: LocalContext): Option[Term] = {
     val ops = processLogicalExpression(node, context)


### PR DESCRIPTION
## Summary
- `tryOperatorMethod` in `src/main/scala/onion/compiler/typing/OperatorTyping.scala` used `operatorMethodNames.getOrElse(symbol, return None)`, which the Scala 3.3.7 compiler flags with "Non local returns are no longer supported; use `boundary` and `boundary.break` in `scala.util` instead."
- The method's body already returns `Option[Term]` on every branch, so the lookup is rewritten as `operatorMethodNames.get(symbol).flatMap { methodName => ... }` — a behavior-preserving change that removes the warning without touching any call site or logic branch.

## Test plan
- [x] `sbt -Duser.language=en compile` — no more warning for this file
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3172 succeeded, 0 failed, 1 canceled, all green (includes `OperatorOverloadSpec`, `OperatorExtensionMethodSpec`, `RecordMethodsSpec`, which exercise this code path)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XkgocLTmhtEyk8gWV5s5JL)_