### PR TITLE
fix(adt-enum): dispatch shared-body toString/equals/hashCode overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   found.`) so a single error reads "1 error is found." while multiple errors
   keep the plural wording. The Japanese bundle was unaffected (Japanese does
   not pluralize).
+- **An ADT case-enum's shared-body `override def toString`/`equals`/`hashCode`
+  is no longer silently ignored on every case.** `enum Shape { case Circle(...)
+  public: override def toString(): String = ... }` desugars the shared body to
+  a sealed-interface default method and each `case` to a bodyless
+  `record X(...) conforms Shape`; `TypingOutlinePass` generated each case's
+  synthetic toString/equals/hashCode whenever the record's OWN body had no
+  override, with no way to see the interface's default, so the shared
+  override compiled cleanly but was never actually called (a class's own
+  method — even a mechanical, auto-generated one — always wins over an
+  inherited interface default for these three names). A record whose
+  conforms-to interface already supplies a concrete default now gets a real
+  forwarding method (`INVOKESPECIAL` back to the interface) instead of the
+  field-based synthetic.
 
 ## [0.10.21] - 2026-08-03
 

--- a/src/main/scala/onion/compiler/Modifier.scala
+++ b/src/main/scala/onion/compiler/Modifier.scala
@@ -27,6 +27,7 @@ object Modifier {
   final val SEALED = 2048
   final val ENUM = 4096
   final val SYNTHETIC_RECORD = 8192  // Auto-generated record methods
+  final val SYNTHETIC_INTERFACE_FORWARD = 16384  // Forwards to a superinterface's default method
 
   def check(modifier: Int, bitFlag: Int): Boolean = {
      (modifier & bitFlag) != 0
@@ -86,6 +87,10 @@ object Modifier {
 
   def isSyntheticRecord(modifier: Int): Boolean = {
      check(modifier, SYNTHETIC_RECORD)
+  }
+
+  def isSyntheticInterfaceForward(modifier: Int): Boolean = {
+     check(modifier, SYNTHETIC_INTERFACE_FORWARD)
   }
 
 }

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -328,10 +328,16 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
     // Synthetic getter for records: non-abstract, no block, no args, has return type, and NOT static
     val isSyntheticGetter = node.block == null && !Modifier.isAbstract(node.modifier) &&
                             node.arguments.isEmpty && node.returnType != BasicType.VOID && !isStatic &&
-                            !Modifier.isSyntheticRecord(node.modifier)
+                            !Modifier.isSyntheticRecord(node.modifier) &&
+                            !Modifier.isSyntheticInterfaceForward(node.modifier)
 
     // Check for synthetic record methods (equals, hashCode, toString, copy)
     val isSyntheticRecord = Modifier.isSyntheticRecord(node.modifier)
+
+    // A record's equals/hashCode/toString that a conforms-to interface already
+    // supplies as a default method (see TypingOutlinePass.processRecordDeclaration):
+    // forwards to that default via INVOKESPECIAL instead of the field-based logic.
+    val isSyntheticInterfaceForward = Modifier.isSyntheticInterfaceForward(node.modifier)
 
     // Synthetic enum helpers: values() and valueOf(String) have no block
     val enumClassDef = node.classType match
@@ -357,12 +363,17 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
             case "copy"     => emitRecordCopy(gen, className, components)
             case _ => // Unknown synthetic record method, no-op
         case _ => // Not a record, no-op
+    else if isSyntheticInterfaceForward then
+      findInterfaceDefaultOwner(node.classType, node.name, node.arguments.length) match
+        case Some(owner) => emitInterfaceForward(gen, node, owner, argTypes, returnType)
+        case None => // Resolved earlier in TypingOutlinePass; absence here would be a compiler bug
+      end match
     else if isSyntheticGetter then
       // Synthetic getter for records: return this.fieldName
       gen.loadThis()
       gen.getField(AsmUtil.objectType(className), node.name, returnType)
 
-    if !isSyntheticGetter && !isSyntheticRecord && !isEnumHelper then
+    if !isSyntheticGetter && !isSyntheticRecord && !isEnumHelper && !isSyntheticInterfaceForward then
       val needsDefault = node.block == null || !hasReturn(node.block.statements)
       MethodEmitter.ensureReturn(gen, returnType, !needsDefault)
     else
@@ -388,6 +399,36 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
         })
       case _ => false
     }
+
+  /**
+   * Finds the superinterface that declares a concrete (non-abstract) method
+   * of the given name/arity — the target of a `SYNTHETIC_INTERFACE_FORWARD`
+   * method (see TypingOutlinePass.processRecordDeclaration). Mirrors the
+   * lookup made there when the modifier was assigned, so this should always
+   * find a match; `None` only on a compiler bug.
+   */
+  private def findInterfaceDefaultOwner(classType: TypedAST.ClassType, name: String, arity: Int): Option[TypedAST.ClassType] =
+    classType.interfaces.find(_.methods(name).exists(m => !Modifier.isAbstract(m.modifier) && m.arguments.length == arity))
+
+  /**
+   * Emits `this.<name>(args...)` as a super call to `owner`'s default method
+   * (`INVOKESPECIAL owner.name(desc)` with the interface flag) — the bytecode
+   * `Owner.super.name(...)` would produce. A class's own method always wins
+   * over an inherited interface default for the same signature, so this
+   * class-level method exists solely to redirect back to the interface body
+   * instead of reimplementing it.
+   */
+  private def emitInterfaceForward(
+    gen: GeneratorAdapter,
+    node: MethodDefinition,
+    owner: TypedAST.ClassType,
+    argTypes: Array[AsmType],
+    returnType: AsmType
+  ): Unit =
+    val desc = AsmType.getMethodDescriptor(returnType, argTypes*)
+    gen.loadThis()
+    argTypes.indices.foreach(gen.loadArg)
+    gen.visitMethodInsn(Opcodes.INVOKESPECIAL, AsmUtil.internalName(owner.name), node.name, desc, true)
 
   // =====================================================
   // Synthetic Record Methods: equals, hashCode, toString, copy

--- a/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
@@ -223,9 +223,30 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
           case m: AST.MethodDeclaration => m.name
         }.toSet
 
+      // A record whose declared super interface already supplies a concrete
+      // (default) method of the same name/arity needs a REAL forwarding method
+      // here, not a plain skip: java.lang.Object already provides concrete
+      // equals/hashCode/toString, and per the JVM's method-resolution rules a
+      // class's inherited-from-Object implementation always wins over an
+      // interface default of the same signature unless the class declares its
+      // own override. So without a class-level method the interface default is
+      // unreachable no matter what. Emitting `Modifier.SYNTHETIC_INTERFACE_FORWARD`
+      // (block == null, handled in AsmCodeGeneration by an INVOKESPECIAL back to
+      // the interface's default) gives the class its own override while keeping
+      // the interface's body as the single source of behavior. This is what makes
+      // an ADT case-enum's shared-body `override def toString`/`equals`/`hashCode`
+      // (desugared to a sealed-interface default method, with each `case`
+      // becoming a bodyless `record ... conforms Enum`) actually take effect for
+      // every case, instead of every case silently keeping the field-based
+      // synthetic (which shadowed it) or Object's identity-based one (which a
+      // bare skip fell back to).
+      def hasDefaultInterfaceMethod(name: String, arity: Int): Boolean =
+        interfaces.exists(_.methods(name).exists(m => !Modifier.isAbstract(m.modifier) && m.arguments.length == arity))
+
       // Generate equals(Object): Boolean method
       if (!userDefinedMethodNames.contains("equals")) {
-        val equalsModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
+        val equalsModifier = Modifier.PUBLIC |
+          (if (hasDefaultInterfaceMethod("equals", 1)) Modifier.SYNTHETIC_INTERFACE_FORWARD else Modifier.SYNTHETIC_RECORD)
         val equalsMethod = new MethodDefinition(
           node.location, equalsModifier, definition_, "equals",
           Array(rootClass), BasicType.BOOLEAN, null
@@ -235,7 +256,8 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
 
       // Generate hashCode(): Int method
       if (!userDefinedMethodNames.contains("hashCode")) {
-        val hashCodeModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
+        val hashCodeModifier = Modifier.PUBLIC |
+          (if (hasDefaultInterfaceMethod("hashCode", 0)) Modifier.SYNTHETIC_INTERFACE_FORWARD else Modifier.SYNTHETIC_RECORD)
         val hashCodeMethod = new MethodDefinition(
           node.location, hashCodeModifier, definition_, "hashCode",
           Array.empty, BasicType.INT, null
@@ -246,7 +268,8 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
       // Generate toString(): String method
       val stringType = loadRequired("java.lang.String")
       if (!userDefinedMethodNames.contains("toString")) {
-        val toStringModifier = Modifier.PUBLIC | Modifier.SYNTHETIC_RECORD
+        val toStringModifier = Modifier.PUBLIC |
+          (if (hasDefaultInterfaceMethod("toString", 0)) Modifier.SYNTHETIC_INTERFACE_FORWARD else Modifier.SYNTHETIC_RECORD)
         val toStringMethod = new MethodDefinition(
           node.location, toStringModifier, definition_, "toString",
           Array.empty, stringType, null

--- a/src/test/scala/onion/compiler/tools/AdtEnumSpec.scala
+++ b/src/test/scala/onion/compiler/tools/AdtEnumSpec.scala
@@ -183,6 +183,63 @@ class AdtEnumSpec extends AbstractShellSpec {
       assert(Shell.Success("found 4|none") == r)
     }
 
+    it("dispatches a shared-body `override def toString` from every case (not the per-case synthetic)") {
+      // Regression: desugarAdtEnum turns the shared body into a sealed-interface
+      // default method and each `case` into a bare `record X(...) conforms Shape`
+      // with no body. TypingOutlinePass.processRecordDeclaration only skips
+      // generating a record's synthetic toString/equals/hashCode/copy when the
+      // RECORD's OWN sections declare an override — it had no way to see the
+      // interface's default method, so every case record still got its own
+      // synthetic toString, which (a class's own method always wins over an
+      // inherited interface default) silently shadowed the user's override.
+      val r = shell.run(
+        """
+          |enum Shape {
+          |  case Circle(radius: Double)
+          |  case Square(side: Double)
+          |public:
+          |  override def toString(): String = select this {
+          |    case c is Circle: "Circle(" + c.radius() + ")"
+          |    case s is Square: "Square(" + s.side() + ")"
+          |  }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val c: Shape = new Circle(2.0)
+          |    val s: Shape = new Square(3.0)
+          |    return c.toString() + "|" + s.toString()
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("Circle(2.0)|Square(3.0)") == r)
+    }
+
+    it("dispatches a shared-body `override def equals` from every case") {
+      val r = shell.run(
+        """
+          |enum Box {
+          |  case Full(value: Int)
+          |  case Empty
+          |public:
+          |  override def equals(o: Object): Boolean {
+          |    if o == null { return false }
+          |    if !(o is Box) { return false }
+          |    return true
+          |  }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val a: Box = new Full(1)
+          |    val b: Box = new Empty()
+          |    return "" + a.equals(b)
+          |  }
+          |}
+          |""".stripMargin, "None", Array())
+      assert(Shell.Success("true") == r)
+    }
+
     it("allows explicit return of a Boolean in every branch (primitive return via StatementTerm)") {
       val r = shell.run(
         """


### PR DESCRIPTION
## Summary

- An ADT case-enum's shared `public:` body desugars (Rewriting phase) to a sealed interface with default methods, and each `case` desugars to a bodyless `record X(...) conforms Enum`. `TypingOutlinePass.processRecordDeclaration` always generated a per-case synthetic `toString`/`equals`/`hashCode` unless the **record's own** body declared an override — it had no way to see the interface's default, so an `override def toString` written in the shared enum body compiled cleanly but was silently ignored on every case (a class's own method, even a mechanical auto-generated one, always wins over an inherited interface default for these three names — this holds regardless of Onion, it's plain JVM/Java method-resolution behavior).
- A record whose `conforms`-to interface already supplies a concrete default for one of these three names now gets a real forwarding method (new `Modifier.SYNTHETIC_INTERFACE_FORWARD`, emitted in `AsmCodeGeneration` as `INVOKESPECIAL <interface>.<name>`) instead of the field-based synthetic. A bare skip doesn't work here: `java.lang.Object` always provides concrete `equals`/`hashCode`/`toString`, so without *some* class-level method the interface default stays unreachable and calls silently fall back to `Object`'s identity-based behavior instead.
- Added two regression tests to `AdtEnumSpec` (shared-body `toString` and `equals` overrides now dispatch correctly across cases) — confirmed both fail without the fix and pass with it.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.AdtEnumSpec'` — 10/10 pass (new tests confirmed red before the fix, green after)
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RecordOverrideToStringSpec onion.compiler.tools.JsonAccessorCoverageSpec onion.compiler.tools.DuplicateExtensionMethodSpec'` — no regressions in adjacent record/extension behavior
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3174 passed, 0 failed, 1 canceled (`ProjectDistributionSpec`'s dist-archive smoke test, which is gated behind a system property not set in normal `sbt test` runs — unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBVywR2D1izwG6hT1QRg6j)_