### PR TITLE
refactor(typing): drop non-local return in StringInterpolationTyping

### DIFF
--- a/src/main/scala/onion/compiler/typing/StringInterpolationTyping.scala
+++ b/src/main/scala/onion/compiler/typing/StringInterpolationTyping.scala
@@ -1,5 +1,8 @@
 package onion.compiler.typing
 
+import scala.util.boundary
+import scala.util.boundary.break
+
 import onion.compiler.*
 import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
@@ -11,9 +14,9 @@ final class StringInterpolationTyping(
   private val body: TypingBodyPass
 ) {
 
-  def typeStringInterpolation(node: AST.StringInterpolation, context: LocalContext): Option[Term] = {
+  def typeStringInterpolation(node: AST.StringInterpolation, context: LocalContext): Option[Term] = boundary {
     val typedExprs = node.expressions.map(e => typed(e, context).getOrElse(null))
-    if (typedExprs.contains(null)) return None
+    if (typedExprs.contains(null)) break(None)
 
     val stringType = bodyContext.load("java.lang.String")
     val sbType = bodyContext.load("java.lang.StringBuilder")
@@ -21,7 +24,7 @@ final class StringInterpolationTyping(
     val constructors = sbType.findConstructor(Array[Term]())
     if (constructors.isEmpty) {
       bodyContext.report(CONSTRUCTOR_NOT_FOUND, node, sbType, Array[Type](), sbType.constructors)
-      return None
+      break(None)
     }
     val noArgConstructor = constructors(0)
 
@@ -60,7 +63,7 @@ final class StringInterpolationTyping(
               }
             case other =>
               bodyContext.report(INCOMPATIBLE_TYPE, node, bodyContext.rootClass, other)
-              return None
+              break(None)
           }
         }
       }
@@ -69,7 +72,7 @@ final class StringInterpolationTyping(
     val toStringMethods = sbType.findMethod("toString", Array[Term]())
     if (toStringMethods.isEmpty) {
       bodyContext.report(METHOD_NOT_FOUND, node, sbType, "toString", Array[Type]())
-      return None
+      break(None)
     }
     Some(new Call(result, toStringMethods(0), Array[Term]()))
   }


### PR DESCRIPTION
## Summary
- `typeStringInterpolation` used four `return None` early exits, which Scala 3 warns are non-local returns (implemented via an exception under the hood) — deprecated in favor of `boundary`/`break`.
- Wrapped the method body in `boundary { ... }` and swapped each `return None` for `break(None)`. Control flow is unchanged: fail fast on an untyped sub-expression, a missing StringBuilder constructor/append/toString method, or an incompatible interpolated type.
- Continues the same cleanup already applied to `OperatorTyping.tryOperatorMethod` (#593).

## Test plan
- [x] `sbt compile` — no warnings for this file (was 1 non-local-return warning before)
- [x] `SBT_OPTS="-Xmx6G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3176 succeeded, 0 failed, 1 canceled, all green

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014XAd9bcCprg9mMZPzeZcid)_