### PR TITLE
docs(error-codes): add full E0084/E0085 sections (en/ja)

### DIFF
--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -298,6 +298,46 @@ try {
 より具体的な型を先に書くよう並べ替えるか、到達不能な節を削除してください。1つの
 multi-catch 節（`catch e: A | B`）の候補同士は互いにチェックされません。
 
+## extension メソッドエラー
+
+### `E0084` — extension メソッドの重複
+
+同じ `extension` ブロック内に、同じ名前・同じパラメータ型を持つメソッドが2つ宣言され
+ています。チェックせずに放置すると、生成されるコンテナクラスが同一の JVM シグネチャを
+持つメソッドを2つ持つことになり、コンパイル時ではなくクラスをロードした瞬間に初めて
+（`ClassFormatError` が内部エラー I0000 として現れる形で）失敗します。
+
+```onion
+extension Double {
+  def pct(): String = "" + self
+  def pct(): String = "" + self   // E0084: duplicated extension method pct() on Double
+}
+```
+
+対処: 重複を削除するかリネームしてください。名前は同じでもパラメータ型が異なる
+extension メソッド同士は影響を受けません — 通常のオーバーロードです。
+
+## 宣言エラー
+
+### `E0085` — 本体のない static メソッド
+
+`static` と宣言されたメソッドに本体（`{ ... }` も `= expr` も）がありません。文法上
+本体のないメソッドは abstract/interface 的な宣言として受理されますが、`static` と
+abstract は矛盾します — static メソッドはオーバーライドできないため、abstract にも
+なり得ません。もしクラスファイルを生成すれば `ACC_STATIC` と `ACC_ABSTRACT` の両方が
+必要になり、これは JVM が拒否します。
+
+```onion
+class LineFilter {
+public:
+  static def main(args: String[]): void
+  // E0085: static method main must have a body
+}
+```
+
+対処: 本体を追加するか、`static` を外して通常の abstract インスタンスメソッドとして
+宣言してください。
+
 ## パターンマッチングエラー
 
 ### `E0042` — 網羅性のないパターンマッチング

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -300,6 +300,46 @@ Reorder so the more specific type comes first, or remove the unreachable clause.
 alternatives of a single multi-catch clause (`catch e: A | B`) are not checked against
 each other.
 
+## Extension method errors
+
+### `E0084` — Duplicate extension method
+
+Two methods with the same name and parameter types are declared in the same
+`extension` block. Left unchecked, the generated container class would carry two
+methods with an identical JVM signature, which only fails once something loads the
+class (a `ClassFormatError`, surfaced as an internal I0000 error) rather than at
+compile time.
+
+```onion
+extension Double {
+  def pct(): String = "" + self
+  def pct(): String = "" + self   // E0084: duplicated extension method pct() on Double
+}
+```
+
+Fix: remove or rename the duplicate. Two extension methods with the same name but
+different parameter types are unaffected — that's ordinary overloading.
+
+## Declaration errors
+
+### `E0085` — Static method with no body
+
+A method declared `static` has no body (no `{ ... }` and no `= expr`). The grammar
+also accepts a bodyless method as an abstract/interface-style declaration, but `static`
+and abstract are contradictory — a static method cannot be overridden, so it cannot be
+abstract either. Generating a class file for one would need both `ACC_STATIC` and
+`ACC_ABSTRACT`, which the JVM rejects.
+
+```onion
+class LineFilter {
+public:
+  static def main(args: String[]): void
+  // E0085: static method main must have a body
+}
+```
+
+Fix: add a body, or drop `static` to declare an ordinary abstract instance method.
+
 ## Pattern-matching errors
 
 ### `E0042` — Non-exhaustive pattern match


### PR DESCRIPTION
## Summary
- `E0084` (duplicate extension method) and `E0085` (static method with no body) were only listed in the end-of-file summary table of `docs/reference/error-codes.md` / `docs/ja/reference/error-codes.md`, unlike every other error code which also gets a prose `### E00xx` section with an example and fix.
- Adds those two sections in both the English and Japanese references, mirroring the style/structure of the existing `E0083` write-up, sourced from the actual message templates (`errorMessage.properties`) and the existing regression tests (`DuplicateExtensionMethodSpec`, `StaticMethodWithoutBodySpec`).
- Docs-only change; no compiler behavior changes.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.ErrorCodeDocCoverageSpec'` — green
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green: 3176 succeeded, 0 failed, 1 canceled, exit code 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRHdT2UBzCNv9xVNAXKuUs)_