### PR TITLE
refactor(typing): drop non-local return in InstanceMethodCallSupport

### DIFF
--- a/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
@@ -8,6 +8,8 @@ import onion.compiler.typing.session.TypingBodyContext
 import java.util.{TreeSet => JTreeSet}
 
 import scala.jdk.CollectionConverters.*
+import scala.util.boundary
+import scala.util.boundary.break
 
 import ArgumentHelpers.hasNamedArguments
 
@@ -151,55 +153,57 @@ private[compiler] final class InstanceMethodCallSupport(
         }
       case _ => return None
     }
-    val components = definition.recordComponents.getOrElse(return None)
+    boundary[Option[Term]] {
+      val components = definition.recordComponents.getOrElse(break(None))
 
-    val named = scala.collection.mutable.LinkedHashMap[String, AST.Expression]()
-    node.args.foreach {
-      case AST.NamedArgument(_, name, value) => named(name) = value
-      case _ => return None // positional args mixed in: use the regular path
-    }
-    for (name <- named.keys if !components.exists(_._1 == name)) {
-      calls.reportMethodNotFound(node, targetType, s"copy(${name} = ...)", Array[Type]())
-      return Some(null).filter(_ != null) // reported; abort typing
-    }
-
-    val classSubst = TypeSubstitution.classSubstitution(targetType)
-    val fullParams = new Array[Term](components.length)
-    var i = 0
-    while (i < components.length) {
-      val (cname, ctype) = components(i)
-      val expectedType = TypeSubstitution.substituteType(ctype, classSubst, scala.collection.immutable.Map.empty, defaultToBound = true)
-      named.get(cname) match {
-        case Some(expr) =>
-          calls.typed(expr, context, expectedType) match {
-            case Some(term) =>
-              // Box primitives against reference-typed components so the
-              // raw signature (copy(A, B)) still matches: copy(second = 42)
-              fullParams(i) =
-                if (!expectedType.isBasicType && term.isBasicType) onion.compiler.toolbox.Boxing.boxing(bodyContext.table, term)
-                else term
-            case None => return Some(null).filter(_ != null)
-          }
-        case None =>
-          targetType.findMethod(cname, Array[Term]()) match {
-            case Array(getter, _*) =>
-              // Specialize the component type for applied records so the
-              // kept value of first() on Pair[String, Integer] is a String
-              val call = new Call(target, getter, Array[Term]())
-              fullParams(i) = TypeSubst.withCast(call, TypeSubst.withClassOnly(getter.returnType, targetType))
-            case _ => return None
-          }
+      val named = scala.collection.mutable.LinkedHashMap[String, AST.Expression]()
+      node.args.foreach {
+        case AST.NamedArgument(_, name, value) => named(name) = value
+        case _ => break(None) // positional args mixed in: use the regular path
       }
-      i += 1
-    }
+      for (name <- named.keys if !components.exists(_._1 == name)) {
+        calls.reportMethodNotFound(node, targetType, s"copy(${name} = ...)", Array[Type]())
+        break(None) // reported; abort typing
+      }
 
-    targetType.findMethod("copy", fullParams) match {
-      case Array(method, _*) =>
-        calls.buildResolvedCall(node, method, fullParams, node.typeArgs, classSubst, null)(
-          expectedArgs => calls.processParamsWithExpected(node, fullParams, expectedArgs),
-          finalParams => new Call(target, method, finalParams)
-        )
-      case _ => None
+      val classSubst = TypeSubstitution.classSubstitution(targetType)
+      val fullParams = new Array[Term](components.length)
+      var i = 0
+      while (i < components.length) {
+        val (cname, ctype) = components(i)
+        val expectedType = TypeSubstitution.substituteType(ctype, classSubst, scala.collection.immutable.Map.empty, defaultToBound = true)
+        named.get(cname) match {
+          case Some(expr) =>
+            calls.typed(expr, context, expectedType) match {
+              case Some(term) =>
+                // Box primitives against reference-typed components so the
+                // raw signature (copy(A, B)) still matches: copy(second = 42)
+                fullParams(i) =
+                  if (!expectedType.isBasicType && term.isBasicType) onion.compiler.toolbox.Boxing.boxing(bodyContext.table, term)
+                  else term
+              case None => break(None)
+            }
+          case None =>
+            targetType.findMethod(cname, Array[Term]()) match {
+              case Array(getter, _*) =>
+                // Specialize the component type for applied records so the
+                // kept value of first() on Pair[String, Integer] is a String
+                val call = new Call(target, getter, Array[Term]())
+                fullParams(i) = TypeSubst.withCast(call, TypeSubst.withClassOnly(getter.returnType, targetType))
+              case _ => break(None)
+            }
+        }
+        i += 1
+      }
+
+      targetType.findMethod("copy", fullParams) match {
+        case Array(method, _*) =>
+          calls.buildResolvedCall(node, method, fullParams, node.typeArgs, classSubst, null)(
+            expectedArgs => calls.processParamsWithExpected(node, fullParams, expectedArgs),
+            finalParams => new Call(target, method, finalParams)
+          )
+        case _ => None
+      }
     }
   }
 

--- a/src/test/scala/onion/compiler/tools/RecordCopySpec.scala
+++ b/src/test/scala/onion/compiler/tools/RecordCopySpec.scala
@@ -1,12 +1,21 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * Tests for issue #130: record copy with named arguments (partial copy),
  * zero-arg clone, and the original positional form.
  */
 class RecordCopySpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
 
   describe("record copy") {
     it("supports partial copy with named arguments") {
@@ -44,6 +53,42 @@ class RecordCopySpec extends AbstractShellSpec {
         Array()
       )
       assert(Shell.Success("2,10,5") == result)
+    }
+
+    it("reports E0005 for an unknown named component instead of crashing") {
+      val results = errors(
+        """
+          |record Point(x: Int, y: Int)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): void {
+          |    val p = new Point(1, 2)
+          |    val q = p.copy(z = 9)
+          |  }
+          |}
+          |""".stripMargin
+      )
+      val codes = results.map(_._1)
+      assert(codes.contains(Some("E0005")))
+    }
+
+    it("falls back to the regular call path when positional and named args are mixed") {
+      val result = shell.run(
+        """
+          |record Point(x: Int, y: Int)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val p = new Point(1, 2)
+          |    val q = p.copy(5, y = 9)
+          |    return q.x() + "," + q.y()
+          |  }
+          |}
+          |""".stripMargin,
+        "MixedArgsCopy.on",
+        Array()
+      )
+      assert(Shell.Failure(-1) == result)
     }
   }
 }


### PR DESCRIPTION
## Summary
- `tryRecordCopy()` in `InstanceMethodCallSupport.scala` used `return` from inside `foreach`/for-comprehension closures — a Scala 3 non-local return, flagged as a deprecated-pattern compiler warning (`sbt compile` currently emits several of these across the typing package; this addresses the ones in this file).
- Rewrote the closure-embedded early exits with `boundary`/`break`, following the pattern already established in `StringInterpolationTyping.scala` (#596). No behavior change intended.
- Added two `RecordCopySpec` cases exercising the refactored paths directly: an unknown named component (`E0005`) and positional+named args mixed (falls back to the regular call path, still fails cleanly rather than crashing).

## Verification status
- `sbt -Duser.language=en compile`: clean, the 3 non-local-return warnings for this file are gone.
- Targeted suite (`RecordCopySpec`, `GenericRecordSpec`, `RecordMethodsSpec`, `RecordSpec` — 25 tests): all green.
- Full `sbt -Duser.language=en test`: **started but did not finish within this session** — the run stalled in heavy GC thrashing (>95% time in GC against the prescribed `-Xmx4G`) partway through `MutationFuzzSpec`, with no forward progress for several minutes despite the process staying alive. This looks like environment resource pressure rather than a regression from this change (the stall point is unrelated code), but per project policy this PR is left as **draft** until a clean full-suite run confirms green.

## Test plan
- [ ] Full `sbt -Duser.language=en test` run to completion, green
- [x] Targeted record-copy specs green
- [x] Compile clean, target warnings gone

---
_Generated by [Claude Code](https://claude.ai/code/session_01QptrpJ6sJps1SXJHS5ok1c)_