### PR TITLE
refactor(typing): drop non-local return in ConstructionTyping

### DIFF
--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -6,6 +6,9 @@ import onion.compiler.TypedAST.*
 import onion.compiler.toolbox.Boxing
 import onion.compiler.typing.session.TypingBodyContext
 
+import scala.util.boundary
+import scala.util.boundary.break
+
 final class ConstructionTyping(
   private val typing: Typing,
   private val bodyContext: TypingBodyContext,
@@ -223,56 +226,58 @@ final class ConstructionTyping(
     if (hasNamedArguments(node.args)) return None
 
     bareGenericTarget(node).flatMap { raw =>
-      // Probe-type the arguments: a genuine error here is reported once by the
-      // real resolution path below, not twice by this speculative pass.
-      val args = typing.withSuppressedReporting(typedTerms(node.args.toArray, context))
-      if (args == null || args.exists(_ == null)) return None
+      boundary[Option[ClassType]] {
+        // Probe-type the arguments: a genuine error here is reported once by the
+        // real resolution path below, not twice by this speculative pass.
+        val args = typing.withSuppressedReporting(typedTerms(node.args.toArray, context))
+        if (args == null || args.exists(_ == null)) break(None)
 
-      val typeParams = raw.typeParameters
-      val candidates = raw.constructors.collect {
-        case cd: ConstructorDefinition
-          if cd.getArgs.length == args.length ||
-            (cd.argumentsWithDefaults != null && args.length < cd.argumentsWithDefaults.length && args.length >= cd.minArguments) => cd
-      }
-      if (candidates.isEmpty) return None
-
-      val solutions: List[List[Type]] = candidates.toList.flatMap { candidate =>
-        val synthetic = new MethodDefinition(
-          node.location,
-          candidate.modifier,
-          raw,
-          "<init>",
-          candidate.getArgs.take(args.length),
-          raw,
-          null,
-          typeParams
-        )
-        val bindings = typing.withSuppressedReporting {
-          GenericMethodTypeArguments.inferWithoutDefaults(
-            typing, node, synthetic, args, scala.collection.immutable.Map.empty)
+        val typeParams = raw.typeParameters
+        val candidates = raw.constructors.collect {
+          case cd: ConstructorDefinition
+            if cd.getArgs.length == args.length ||
+              (cd.argumentsWithDefaults != null && args.length < cd.argumentsWithDefaults.length && args.length >= cd.minArguments) => cd
         }
-        // Every class type parameter must be pinned by an argument; a partially
-        // inferred type would otherwise silently default the rest to their bound.
-        if (typeParams.forall(tp => bindings.contains(tp.name)))
-          Some(typeParams.map(tp => bindings(tp.name)).toList)
-        else None
-      }.distinct
+        if (candidates.isEmpty) break(None)
 
-      solutions match {
-        case only :: Nil => Some(AppliedClassType(raw, only))
-        case _ => None
+        val solutions: List[List[Type]] = candidates.toList.flatMap { candidate =>
+          val synthetic = new MethodDefinition(
+            node.location,
+            candidate.modifier,
+            raw,
+            "<init>",
+            candidate.getArgs.take(args.length),
+            raw,
+            null,
+            typeParams
+          )
+          val bindings = typing.withSuppressedReporting {
+            GenericMethodTypeArguments.inferWithoutDefaults(
+              typing, node, synthetic, args, scala.collection.immutable.Map.empty)
+          }
+          // Every class type parameter must be pinned by an argument; a partially
+          // inferred type would otherwise silently default the rest to their bound.
+          if (typeParams.forall(tp => bindings.contains(tp.name)))
+            Some(typeParams.map(tp => bindings(tp.name)).toList)
+          else None
+        }.distinct
+
+        solutions match {
+          case only :: Nil => Some(AppliedClassType(raw, only))
+          case _ => None
+        }
       }
     }
   }
 
-  def typeNewObject(node: AST.NewObject, context: LocalContext, expected: Type = null): Option[Term] = {
+  def typeNewObject(node: AST.NewObject, context: LocalContext, expected: Type = null): Option[Term] = boundary {
     val typeRef = diamondType(node, expected).orElse(diamondTypeFromArguments(node, context)).getOrElse {
       typing.mapFromDeclared(node.typeRef) match {
         case Some(ct: ClassType) => ct
         case Some(other) =>
           bodyContext.report(INCOMPATIBLE_TYPE, node, bodyContext.rootClass, other)
-          return None
-        case None => return None
+          break(None)
+        case None => break(None)
       }
     }
 
@@ -283,12 +288,12 @@ final class ConstructionTyping(
     }
     if (Modifier.isAbstract(classToCheck.modifier)) {
       bodyContext.report(ABSTRACT_CLASS_INSTANTIATION, node, typeRef)
-      return None
+      break(None)
     }
 
     // Check for named arguments
     if (hasNamedArguments(node.args)) {
-      return typeNewObjectWithNamedArgs(node, typeRef, context)
+      break(typeNewObjectWithNamedArgs(node, typeRef, context))
     }
 
     // A lambda argument can't take its final type until its target type (the
@@ -302,14 +307,14 @@ final class ConstructionTyping(
     }.toSet
     if (untypedClosureIndices.nonEmpty) {
       resolveConstructorForClosures(node, typeRef, context, untypedClosureIndices) match {
-        case Some(term) => return Some(term)
+        case Some(term) => break(Some(term))
         case None => // ambiguous/unresolved: fall through to the eager path, which reports E0052 / constructor-not-found
       }
     }
 
     // Existing positional argument handling
     val parameters0 = typedTerms(node.args.toArray, context)
-    if (parameters0 == null) return None
+    if (parameters0 == null) break(None)
 
     val constructors0 = typeRef.findConstructor(parameters0)
     // Exact matching is substitution-blind (an applied Pair[String, Integer]
@@ -335,7 +340,7 @@ final class ConstructionTyping(
     }
     if (!substitutionValid) {
       bodyContext.report(CONSTRUCTOR_NOT_FOUND, node, typeRef, types(parameters), typeRef.constructors)
-      return None
+      break(None)
     }
     if (constructors.length == 0) {
       // Default-parameter fallback: a constructor with defaults accepts
@@ -347,7 +352,7 @@ final class ConstructionTyping(
             parameters0.length >= cd.minArguments
         case _ => false
       }
-      if (defaultsCandidate) return typeNewObjectWithNamedArgs(node, typeRef, context)
+      if (defaultsCandidate) break(typeNewObjectWithNamedArgs(node, typeRef, context))
       bodyContext.report(CONSTRUCTOR_NOT_FOUND, node, typeRef, types(parameters), typeRef.constructors)
       None
     } else if (constructors.length > 1) {
@@ -470,7 +475,7 @@ final class ConstructionTyping(
     typeRef: ClassType,
     context: LocalContext,
     closureIndices: Set[Int]
-  ): Option[Term] = {
+  ): Option[Term] = boundary {
     val args = node.args.toArray
     val classSubst = TypeSubstitution.classSubstitution(typeRef)
     def substitutedArgs(c: ConstructorRef): Array[Type] =
@@ -480,7 +485,7 @@ final class ConstructionTyping(
     for (i <- args.indices if !closureIndices.contains(i)) {
       typed(args(i), context) match {
         case Some(t) => prelim(i) = t
-        case None => return None
+        case None => break(None)
       }
     }
 
@@ -494,7 +499,7 @@ final class ConstructionTyping(
             TypeRelations.isAssignableWithBoxing(formals(i), prelim(i).`type`, bodyContext.table)
         }
     }
-    if (candidates.length != 1) return None
+    if (candidates.length != 1) break(None)
 
     val ctor = candidates(0)
     val formals = substitutedArgs(ctor)
@@ -503,7 +508,7 @@ final class ConstructionTyping(
       if (closureIndices.contains(i)) {
         typed(args(i), context, formals(i)) match {
           case Some(t) => finalParams(i) = t
-          case None => return None
+          case None => break(None)
         }
       } else {
         val p = prelim(i)


### PR DESCRIPTION
## Summary
- `diamondTypeFromArguments()`, `typeNewObject()`, and `resolveConstructorForClosures()` in `ConstructionTyping.scala` used `return` from inside closures (the `flatMap` probe, the `getOrElse` fallback, and the `for`-loops over closure arguments) — Scala 3 non-local returns, flagged at compile time as deprecated in favor of `boundary`/`break`.
- Rewrote the closure-embedded early exits with `boundary`/`break`, following the same pattern already used in `StringInterpolationTyping` and `InstanceMethodCallSupport`.
- No behavior change — pure internal refactor to eliminate the compiler warnings.

## Test plan
- [x] `sbt compile` — no warnings for `ConstructionTyping.scala`
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3178 succeeded, 0 failed, 1 pre-existing environment-conditional cancellation (unrelated distribution-packaging spec)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gr9TvriKEgAuQ4xz7Vq1yh)_