### PR TITLE
refactor(typing): drop non-local return in TypingBodyPass

### DIFF
--- a/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
@@ -159,41 +159,40 @@ final class TypingBodyPass(private val typing: Typing, private val unitContext: 
       unitContext.currentDefinition = definition
       typing.find(definition.name).foreach(unitContext.currentMapper = _)
       val stringType = typing.loadRequired("java.lang.String")
-      val ctorOpt = definition.constructors.headOption
-      if (ctorOpt.isEmpty) return
-      val ctor = ctorOpt.get
-      val paramTypes = ctor.getArgs.drop(2)
-      val enumContext = new LocalContext
-      enumContext.setStatic(true)
-      val statements = scala.collection.mutable.Buffer[ActionStatement]()
-      node.constants.zipWithIndex.foreach { case (constant, ordinal) =>
-        if (constant.args.length != paramTypes.length) {
-          typing.report(
-            SemanticError.CONSTRUCTOR_NOT_FOUND, constant, definition,
-            constant.args.map(_ => bodyContext.rootClass: Type).toArray, definition.constructors
-          )
-        } else {
-          val typedArgs = constant.args.zip(paramTypes).map { case (argExpr, expected) =>
-            typed(argExpr, enumContext, expected).map { term =>
-              assignabilitySupport.processAssignable(argExpr, expected, term)
-            }.orNull
-          }
-          if (typedArgs.forall(_ != null)) {
-            val field = definition.field(constant.name)
-            val callArgs: Array[Term] =
-              Array[Term](new StringValue(constant.name, stringType), new IntValue(constant.location, ordinal)) ++ typedArgs
-            val init = new NewObject(ctor, callArgs)
-            statements += new ExpressionActionStatement(new SetStaticField(constant.location, definition, field, init))
+      definition.constructors.headOption.foreach { ctor =>
+        val paramTypes = ctor.getArgs.drop(2)
+        val enumContext = new LocalContext
+        enumContext.setStatic(true)
+        val statements = scala.collection.mutable.Buffer[ActionStatement]()
+        node.constants.zipWithIndex.foreach { case (constant, ordinal) =>
+          if (constant.args.length != paramTypes.length) {
+            typing.report(
+              SemanticError.CONSTRUCTOR_NOT_FOUND, constant, definition,
+              constant.args.map(_ => bodyContext.rootClass: Type).toArray, definition.constructors
+            )
+          } else {
+            val typedArgs = constant.args.zip(paramTypes).map { case (argExpr, expected) =>
+              typed(argExpr, enumContext, expected).map { term =>
+                assignabilitySupport.processAssignable(argExpr, expected, term)
+              }.orNull
+            }
+            if (typedArgs.forall(_ != null)) {
+              val field = definition.field(constant.name)
+              val callArgs: Array[Term] =
+                Array[Term](new StringValue(constant.name, stringType), new IntValue(constant.location, ordinal)) ++ typedArgs
+              val init = new NewObject(ctor, callArgs)
+              statements += new ExpressionActionStatement(new SetStaticField(constant.location, definition, field, init))
+            }
           }
         }
-      }
-      definition.setStaticInitializers(statements.toArray)
+        definition.setStaticInitializers(statements.toArray)
 
-      // Type the bodies of user-defined members
-      for (section <- node.sections; member <- section.members) {
-        member match {
-          case m: AST.MethodDeclaration => processMethodDeclaration(m)
-          case _ => // enum bodies currently support methods only
+        // Type the bodies of user-defined members
+        for (section <- node.sections; member <- section.members) {
+          member match {
+            case m: AST.MethodDeclaration => processMethodDeclaration(m)
+            case _ => // enum bodies currently support methods only
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- `processEnumDeclaration()` used `if (ctorOpt.isEmpty) return` from inside the `kernelNodeOf(...).foreach` closure — a Scala 3 non-local return, flagged as deprecated at compile time in favor of `boundary`/`break`.
- Restructured as `definition.constructors.headOption.foreach { ctor => ... }`, so the constructor-body-typing and static-initializer logic simply doesn't run when there is no constructor — same early-exit semantics, no explicit `return`.
- No behavior change. Continues the same cleanup pattern already applied to `ConstructionTyping`, `InstanceMethodCallSupport`, `StringInterpolationTyping`, and `OperatorTyping`.

## Test plan
- [x] `sbt compile` — the non-local-return warning for this file is gone.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3178 succeeded, 0 failed, 1 canceled (pre-existing environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change).

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnJk859fg7VSF1YVQhwk1K)_