### PR TITLE
refactor(rewriting): drop non-local return in appendAutoCliCall

### DIFF
--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -480,68 +480,70 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
         "be a scalar parsed from the command line.")))
     }
 
-    toplevels.collectFirst {
+    val restMatch = toplevels.collectFirst {
       case f: AST.FunctionDeclaration if f.name == "main" && !allScalar(f) && restPattern(f) => f
-    }.foreach { f =>
-      val loc = f.location
-      val k = f.args.length - 1
-      val usage = f.args.init.map(a => "<" + a.name + ">").mkString(" ") + " <" + f.args.last.name + ">..."
-      toplevels += AST.StaticMethodCall(
-        loc,
-        AST.TypeNode(loc, AST.ReferenceType("onion.Cli", true), false),
-        "requireArgs",
-        List(AST.Id(loc, "args"), AST.IntegerLiteral(loc, k), AST.StringLiteral(loc, usage))
-      )
-      val argExprs = f.args.zipWithIndex.map { case (a, i) =>
-        if (i < k) convertCliValue(loc, cliKindOf(a.typeRef).get, a.name, AST.Indexing(loc, AST.Id(loc, "args"), AST.IntegerLiteral(loc, i)))
-        else AST.StaticMethodCall(
+    }
+    restMatch match {
+      case Some(f) =>
+        val loc = f.location
+        val k = f.args.length - 1
+        val usage = f.args.init.map(a => "<" + a.name + ">").mkString(" ") + " <" + f.args.last.name + ">..."
+        toplevels += AST.StaticMethodCall(
           loc,
           AST.TypeNode(loc, AST.ReferenceType("onion.Cli", true), false),
-          "rest",
-          List(AST.Id(loc, "args"), AST.IntegerLiteral(loc, k))
+          "requireArgs",
+          List(AST.Id(loc, "args"), AST.IntegerLiteral(loc, k), AST.StringLiteral(loc, usage))
         )
-      }
-      toplevels += AST.UnqualifiedMethodCall(loc, "main", argExprs)
-      return
-    }
+        val argExprs = f.args.zipWithIndex.map { case (a, i) =>
+          if (i < k) convertCliValue(loc, cliKindOf(a.typeRef).get, a.name, AST.Indexing(loc, AST.Id(loc, "args"), AST.IntegerLiteral(loc, i)))
+          else AST.StaticMethodCall(
+            loc,
+            AST.TypeNode(loc, AST.ReferenceType("onion.Cli", true), false),
+            "rest",
+            List(AST.Id(loc, "args"), AST.IntegerLiteral(loc, k))
+          )
+        }
+        toplevels += AST.UnqualifiedMethodCall(loc, "main", argExprs)
 
-    val mainFn = toplevels.collectFirst {
-      case f: AST.FunctionDeclaration if f.name == "main" && allScalar(f) => f
-    }
-    mainFn.foreach { f =>
-      val loc = f.location
-      // Zero-arg main: emit a direct call with no CLI preamble
-      if (f.args.isEmpty) {
-        toplevels += AST.UnqualifiedMethodCall(loc, "main", Nil)
-        return
-      }
-      val cliVar = "__cliArgs"
-      val spec = f.args.map { a =>
-        val kind = cliKindOf(a.typeRef).get
-        if (a.defaultValue == null) a.name
-        else if (kind == "Boolean") a.name + "?"
-        else a.name + "="
-      }.mkString(",")
-      val parseCall = AST.StaticMethodCall(
-        loc,
-        AST.TypeNode(loc, AST.ReferenceType("onion.Cli", true), false),
-        "parse",
-        List(AST.Id(loc, "args"), AST.StringLiteral(loc, spec))
-      )
-      val decl = AST.LocalVariableDeclaration(loc, AST.M_FINAL, cliVar, null, parseCall)
-      val argExprs = f.args.zipWithIndex.map { case (a, i) =>
-        val raw = AST.Indexing(loc, AST.Id(loc, cliVar), AST.IntegerLiteral(loc, i))
-        val converted = convertCliValue(loc, cliKindOf(a.typeRef).get, a.name, raw)
-        if (a.defaultValue == null) converted
-        else AST.IfExpression(
-          loc,
-          AST.Equal(loc, AST.Indexing(loc, AST.Id(loc, cliVar), AST.IntegerLiteral(loc, i)), AST.NullLiteral(loc)),
-          AST.BlockExpression(loc, List(rewriteExpression(a.defaultValue))),
-          AST.BlockExpression(loc, List(converted))
-        )
-      }
-      toplevels += decl
-      toplevels += AST.UnqualifiedMethodCall(loc, "main", argExprs)
+      case None =>
+        val mainFn = toplevels.collectFirst {
+          case f: AST.FunctionDeclaration if f.name == "main" && allScalar(f) => f
+        }
+        mainFn.foreach { f =>
+          val loc = f.location
+          // Zero-arg main: emit a direct call with no CLI preamble
+          if (f.args.isEmpty) {
+            toplevels += AST.UnqualifiedMethodCall(loc, "main", Nil)
+          } else {
+            val cliVar = "__cliArgs"
+            val spec = f.args.map { a =>
+              val kind = cliKindOf(a.typeRef).get
+              if (a.defaultValue == null) a.name
+              else if (kind == "Boolean") a.name + "?"
+              else a.name + "="
+            }.mkString(",")
+            val parseCall = AST.StaticMethodCall(
+              loc,
+              AST.TypeNode(loc, AST.ReferenceType("onion.Cli", true), false),
+              "parse",
+              List(AST.Id(loc, "args"), AST.StringLiteral(loc, spec))
+            )
+            val decl = AST.LocalVariableDeclaration(loc, AST.M_FINAL, cliVar, null, parseCall)
+            val argExprs = f.args.zipWithIndex.map { case (a, i) =>
+              val raw = AST.Indexing(loc, AST.Id(loc, cliVar), AST.IntegerLiteral(loc, i))
+              val converted = convertCliValue(loc, cliKindOf(a.typeRef).get, a.name, raw)
+              if (a.defaultValue == null) converted
+              else AST.IfExpression(
+                loc,
+                AST.Equal(loc, AST.Indexing(loc, AST.Id(loc, cliVar), AST.IntegerLiteral(loc, i)), AST.NullLiteral(loc)),
+                AST.BlockExpression(loc, List(rewriteExpression(a.defaultValue))),
+                AST.BlockExpression(loc, List(converted))
+              )
+            }
+            toplevels += decl
+            toplevels += AST.UnqualifiedMethodCall(loc, "main", argExprs)
+          }
+        }
     }
   }
 


### PR DESCRIPTION
## Summary
- `appendAutoCliCall()` in `Rewriting.scala` used `return` from inside two `.foreach { f => ... }` closures (the rest-collector `main` shape, and the zero-arg `main` shape) — Scala 3 non-local returns, flagged at compile time as deprecated in favor of `boundary`/`break`.
- Restructured the rest-collector branch as a `match` on the collected `Option` (`Some` emits the CLI preamble, `None` falls through to the `allScalar`/`mainFn` handling that follows — the two shapes are mutually exclusive by construction, so this preserves the original short-circuit semantics exactly) and the zero-arg branch as an `if`/`else` instead of an early `return`.
- No behavior change. This mirrors the non-local-return cleanups already landed for `TypingBodyPass`, `ConstructionTyping`, `InstanceMethodCallSupport`, and `StringInterpolationTyping`.

## Test plan
- [x] `sbt -Duser.language=en compile` — no more non-local-return warnings for `Rewriting.scala`
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.AutoCliSpec onion.compiler.tools.ZeroArgMainSpec onion.compiler.tools.ArrayMainAutoCliSpec onion.compiler.tools.MainSignatureSpec onion.compiler.tools.CliParseSpec onion.compiler.tools.CliErrorMessageSpec'` — 18/18 passed, covering both branches (rest-collector, zero-arg/scalar)
- [x] Full suite: `sbt -Duser.language=en test` — 3178 passed, 0 failed, 1 canceled (pre-existing opt-in distribution smoke test, unrelated)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01KUSxsg4k14JdjKyXSfMGya)_