### PR TITLE
docs(error-codes): add missing E0004 prose section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0004`
+  (field not found) only in the end-of-file summary table, unlike its neighbors `E0003`
+  and `E0005`, which both have a full prose section.** Added the missing `### E0004`
+  section to both language references, using the existing `SemanticErrorCodeCoverageSpec`
+  case as the basis for the example.
+
 ## [0.10.23] - 2026-08-05
 
 ### Fixed

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -81,6 +81,20 @@ println(usrName)   // E0002、userName を提案
 val xs = new ArrayLst[String]()   // E0003、ArrayList を提案
 ```
 
+### `E0004` — フィールドが見つからない
+
+対象の型にその名前のフィールドが存在しません。スペルとフィールドの可視性を確認してください。
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val s = "a".noSuchField   // E0004
+    return 0
+  }
+}
+```
+
 ### `E0005` — メソッドが見つからない
 
 呼び出しに一致するメソッドがありません。同じ名前のメソッドが存在するが引数の型が異なる場合、コンパイラは利用可能なシグネチャを一覧表示します。

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -81,6 +81,20 @@ A type name could not be resolved.  Check spelling and imports.
 val xs = new ArrayLst[String]()   // E0003, suggests ArrayList
 ```
 
+### `E0004` — Field not found
+
+No field with that name exists on the target type.  Check spelling and field visibility.
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val s = "a".noSuchField   // E0004
+    return 0
+  }
+}
+```
+
 ### `E0005` — Method not found
 
 No method matches the call.  If a method with the same name exists but the argument types differ, the compiler lists the available signatures.


### PR DESCRIPTION
## Summary
- `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0004` (field not found) only in the end-of-file summary table, unlike its immediate neighbors `E0003` and `E0005`, which both have a full prose section (heading, explanation, example).
- Added the missing `### E0004` section to both language references, mirroring the style of the surrounding sections, using the existing `SemanticErrorCodeCoverageSpec` case (`"a".noSuchField`) as the basis for the example.
- Added a `CHANGELOG.md` entry under `[Unreleased] / Documentation`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3178 tests passed, 0 failed, 1 canceled, across 448 suites.
- [x] Docs-only change (new headings/prose, no links or nav changes), so no mkdocs strict-build risk.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QdcdBjyCtFDRkB1hfpkVDZ)_