### PR TITLE
docs(error-codes): add missing E0011-E0015 sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `E0005`, which both have a full prose section.** Added the missing `### E0004`
   section to both language references, using the existing `SemanticErrorCodeCoverageSpec`
   case as the basis for the example.
+- **`docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0011`
+  (duplicate global variable), `E0012` (duplicate function), `E0013` (method not
+  accessible), `E0014` (field not accessible), and `E0015` (class not accessible) only
+  in the end-of-file summary table.** Added the missing `### E0011`–`### E0015` sections
+  to both language references, using the existing `DuplicateGlobalVariableSpec`,
+  `DuplicateFunctionSpec`, `StaticMethodAccessSpec`, `FieldWriteAccessSpec`, and
+  `ClassAccessibilitySpec` cases as the basis for the examples.
 
 ## [0.10.23] - 2026-08-05
 

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -122,6 +122,85 @@ public:
 対処: 引数をキャストしてオーバーロードを確定させるか（`foo(null as A)`）、
 どちらか一方しか一致しないようにオーバーロードをリネーム・統合してください。
 
+### `E0011` — トップレベルのグローバル変数定義の重複
+
+同じ名前のトップレベル `var`/`val` が2回宣言されています。修飾子付き（`static var x = ...`
+を2回）でも、修飾子なし（ベアなトップレベル `var`/`val` はスクリプトの合成クラスの
+`public static` フィールドに昇格されるため、修飾子付きの形と同様にグローバルです）でも
+該当します。
+
+```onion
+static var x: Int = 1
+static var x: Int = 2   // E0011: x は既に定義されている
+```
+
+### `E0012` — トップレベル関数定義の重複
+
+2つのトップレベル `def` 関数が同じ名前・同じ引数型を持っています。引数型が異なる
+オーバーロードは引き続き許可されます。
+
+```onion
+def foo(x: Int): Int { return x }
+def foo(x: Int): Int { return x + 1 }   // E0012: foo(Int) は既に定義されている
+
+def bar(x: Int): Int { return x }
+def bar(x: String): String { return x }   // OK: 引数型が異なる
+```
+
+### `E0013` — メソッドにアクセスできない
+
+`private`（またはアクセスが不十分な）メソッド・コンストラクタ・静的メソッドが、
+それを参照できないクラスの外部から呼び出されています。
+
+```onion
+class C {
+private:
+  static def s(): Int = 1
+}
+def main(args: String[]): void { IO::println(C::s()) }   // E0013
+```
+
+### `E0014` — フィールドにアクセスできない
+
+非公開フィールドがその宣言クラスの外部から読み書きされています。
+
+```onion
+class Plain {
+  var value: String
+public:
+  def this(v: String) { value = v }
+}
+val p = new Plain("orig")
+p.value = "changed"   // E0014: value は public ではない
+```
+
+### `E0015` — クラスにアクセスできない
+
+静的型が別モジュールで宣言された `internal` クラスである値に対して、メンバーが
+選択されています。可視性はモジュール単位（クラス名の最後のドットより前の接頭辞）
+で決まり、`internal` クラスはそれを宣言したモジュール内からのみアクセスできます。
+
+```onion
+module pkg.a
+internal class Hidden {
+public:
+  var n: Int
+  def this { n = 1 }
+}
+```
+
+```onion
+module pkg.b
+import { pkg.a.Hidden }
+class UseIt {
+public:
+  static def main(args: String[]): Int {
+    val h: Hidden = null
+    return h.n   // E0015: Hidden は pkg.a に internal
+  }
+}
+```
+
 ### `E0021` — コンストラクタが見つからない
 
 引数に一致するコンストラクタがありません。コンパイラは利用可能なコンストラクタを一覧表示します。

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -122,6 +122,86 @@ public:
 Fix: cast the argument to pin the overload (`foo(null as A)`), or rename/merge one
 of the overloads so only one candidate matches.
 
+### `E0011` — Duplicated global variable definition
+
+A top-level `var`/`val` is declared twice with the same name — whether both are
+modifier-qualified (`static var x = ...` twice) or bare (no modifier; a bare
+top-level `var`/`val` is promoted to a `public static` field of the script's
+synthetic class, so it is just as global as the modifier-qualified form).
+
+```onion
+static var x: Int = 1
+static var x: Int = 2   // E0011: x already defined
+```
+
+### `E0012` — Duplicated function definition
+
+Two top-level `def` functions share the same name and the same parameter types.
+Overloading by different parameter types is still allowed.
+
+```onion
+def foo(x: Int): Int { return x }
+def foo(x: Int): Int { return x + 1 }   // E0012: foo(Int) already defined
+
+def bar(x: Int): Int { return x }
+def bar(x: String): String { return x }   // fine: different parameter types
+```
+
+### `E0013` — Method not accessible
+
+A `private` (or otherwise insufficiently visible) method, constructor, or static
+method is called from outside the class that can see it.
+
+```onion
+class C {
+private:
+  static def s(): Int = 1
+}
+def main(args: String[]): void { IO::println(C::s()) }   // E0013
+```
+
+### `E0014` — Field not accessible
+
+A non-public field is read or written from outside its declaring class.
+
+```onion
+class Plain {
+  var value: String
+public:
+  def this(v: String) { value = v }
+}
+val p = new Plain("orig")
+p.value = "changed"   // E0014: value is not public
+```
+
+### `E0015` — Class not accessible
+
+A member is selected on a value whose static type is an `internal` class declared
+in a different module. Accessibility is module-scoped: an `internal` class is
+visible only within the module (the dotted prefix before the class name) that
+declares it.
+
+```onion
+module pkg.a
+internal class Hidden {
+public:
+  var n: Int
+  def this { n = 1 }
+}
+```
+
+```onion
+module pkg.b
+import { pkg.a.Hidden }
+class UseIt {
+public:
+  static def main(args: String[]): Int {
+    val h: Hidden = null
+    return h.n   // E0015: Hidden is internal to pkg.a
+  }
+}
+```
+
 ### `E0021` — Constructor not found
 
 No constructor matches the arguments.  The compiler lists available constructors.


### PR DESCRIPTION
## Summary
- `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0011` (duplicate global variable), `E0012` (duplicate function), `E0013` (method not accessible), `E0014` (field not accessible), and `E0015` (class not accessible) only in the end-of-file summary table, unlike neighboring codes that have full prose sections with examples.
- Added the missing `### E0011`–`### E0015` sections to both language references, using the existing `DuplicateGlobalVariableSpec`, `DuplicateFunctionSpec`, `StaticMethodAccessSpec`, `FieldWriteAccessSpec`, and `ClassAccessibilitySpec` test cases as the basis for the examples.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3178 succeeded, 0 failed, 1 canceled (environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change), 0 ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_017xrRPztcwbpdkvLfQq4hVq)_