### PR TITLE
docs(error-codes): add missing E0030-E0035 sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0030`
+  (type is not generic), `E0031` (type argument arity mismatch), `E0033` (method is not
+  generic), `E0034` (method type argument arity mismatch), and `E0035` (erased JVM
+  signature collision) only in the end-of-file summary table.** Added the missing
+  `### E0030`–`### E0035` sections (skipping `E0032`, which has a live report site but
+  no in-process trigger under the current grammar — see the note in
+  `SemanticErrorCodeCoverageSpec`) to both language references, using the existing
+  `SemanticErrorCodeCoverageSpec` cases as the basis for the examples, and added a new
+  `E0030` coverage case (previously untested).
 - **`docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0025`
   (duplicate constructor), `E0026` (duplicate generated method), `E0027` (type not
   boxable), `E0028` (lvalue required), and `E0029` (duplicate type parameter) only in

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -98,6 +98,87 @@ public:
 
 修正方法: 変数・フィールド・配列要素に代入してください。
 
+### `E0030` — 型はジェネリックではない
+
+型引数を取らない型に対して型引数が渡されました。
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val x: String[Int] = null   // E0030: String は型引数を取らない
+    return 0
+  }
+}
+```
+
+修正方法: 型引数を外してください（`String[Int]` ではなく `String`）。
+
+### `E0031` — 型引数の個数が一致しない
+
+ジェネリック型に渡された型引数の個数が誤っています。
+
+```onion
+class Box[T] { public: def this {} }
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val b = new Box[String, String]()   // E0031: Box は1個であり2個ではない
+    return 0
+  }
+}
+```
+
+このエラーは、`val b: Box[String, String]? = null` のように nullable な型注釈の
+中に個数不一致が書かれた場合にも発生します。
+
+### `E0033` — メソッドはジェネリックではない
+
+型引数を取らないメソッドの呼び出しに型引数が渡されました。
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int { return "abc".length[String]() }   // E0033
+}
+```
+
+修正方法: 呼び出しから型引数を外してください（`"abc".length()`）。
+
+### `E0034` — メソッド型引数の個数が一致しない
+
+ジェネリックメソッド呼び出しに渡された明示的な型引数の個数が誤っています。
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val l = java.util.Collections::emptyList[String, String]()   // E0034: 1個であり2個ではない
+    return 0
+  }
+}
+```
+
+### `E0035` — erasure 後の JVM シグネチャが衝突している
+
+Onion の型システムでは異なる2つのオーバーロードが、同じ JVM メソッド記述子に
+erasure されてしまう場合があります（ジェネリクスは erasure ベースであり、
+`List[String]` と `List[Integer]` はバイトコードレベルでは区別できません）。
+その結果、クラスファイルは両方を保持できません。
+
+```onion
+class C {
+public:
+  def this {}
+  def f(x: java.util.List[String]): Int = 1
+  def f(x: java.util.List[Integer]): Int = 2   // E0035: どちらも f(List)I に erasure される
+}
+```
+
+修正方法: オーバーロードの erasure 後シグネチャを変える（引数の個数を変える、
+同じクラスに erasure されない引数型にするなど）か、内部で分岐する1つの
+メソッドに統合してください。
+
 ## 名前解決エラー
 
 ### `E0002` — 変数が見つからない

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -98,6 +98,87 @@ public:
 
 Fix: assign to a variable, field, or array element instead.
 
+### `E0030` — Type is not generic
+
+Type arguments were supplied for a type that takes none.
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val x: String[Int] = null   // E0030: String takes no type arguments
+    return 0
+  }
+}
+```
+
+Fix: drop the type arguments (`String`, not `String[Int]`).
+
+### `E0031` — Type argument arity mismatch
+
+A generic type was applied with the wrong number of type arguments.
+
+```onion
+class Box[T] { public: def this {} }
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val b = new Box[String, String]()   // E0031: Box takes 1, not 2
+    return 0
+  }
+}
+```
+
+This also fires when the mismatch is written inside a nullable type
+annotation, e.g. `val b: Box[String, String]? = null`.
+
+### `E0033` — Method is not generic
+
+Type arguments were supplied at a call site for a method that takes none.
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int { return "abc".length[String]() }   // E0033
+}
+```
+
+Fix: drop the type arguments from the call (`"abc".length()`).
+
+### `E0034` — Method type argument arity mismatch
+
+A generic method call supplied the wrong number of explicit type arguments.
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val l = java.util.Collections::emptyList[String, String]()   // E0034: expects 1, not 2
+    return 0
+  }
+}
+```
+
+### `E0035` — Erased JVM signature collision
+
+Two overloads have parameter types that differ in Onion's type system but erase
+to the same JVM method descriptor (generics are erasure-based, so `List[String]`
+and `List[Integer]` are indistinguishable at the bytecode level), so the class
+file cannot carry both.
+
+```onion
+class C {
+public:
+  def this {}
+  def f(x: java.util.List[String]): Int = 1
+  def f(x: java.util.List[Integer]): Int = 2   // E0035: both erase to f(List)I
+}
+```
+
+Fix: give the overloads different erased signatures (e.g. different arity, or
+a parameter type that doesn't erase to the same class), or merge them into one
+method that dispatches internally.
+
 ## Resolution errors
 
 ### `E0002` — Variable not found

--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -362,6 +362,17 @@ class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
   }
 
   describe("generics") {
+    it("E0030 type is not generic") {
+      failsWith("E0030",
+        """class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: String[Int] = null
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
     it("E0031 type argument arity mismatch") {
       failsWith("E0031",
         """class Box[T] { public: def this {} }


### PR DESCRIPTION
## Summary
- `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0030` (type is not generic), `E0031` (type argument arity mismatch), `E0033` (method is not generic), `E0034` (method type argument arity mismatch), and `E0035` (erased JVM signature collision) only in the end-of-file summary table, unlike their neighbors which have full prose sections.
- Added the missing `### E0030`–`### E0035` sections to both language references, using the existing `SemanticErrorCodeCoverageSpec` cases as the basis for the examples (verified against actual compiler output).
- Added a new `E0030` coverage case to `SemanticErrorCodeCoverageSpec` (previously untested — confirmed with a manual repro before writing the test).
- `E0032` (type argument must be a reference type) is intentionally skipped: it has a live report site but no in-process trigger under the current grammar, per the existing note at the top of `SemanticErrorCodeCoverageSpec`.
- Noted the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.SemanticErrorCodeCoverageSpec'` — 47/47 passed, including the new E0030 case.
- [x] `sbt -Duser.language=en test` — full suite: 448 suites, 3179 tests succeeded, 0 failed, 1 pre-existing environment-gated cancellation (`ProjectDistributionSpec`, unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sma92nrYfL4sb3211EPPpx)_