### PR TITLE
docs(error-codes): add missing E0036-E0041 sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0036`
+  (cannot assign to val), `E0037` (unimplemented abstract method), `E0038` (cannot
+  instantiate abstract class), `E0039` (cannot override a final method), `E0040` (cannot
+  call method on primitive type), and `E0041` (invalid method call target) only in the
+  end-of-file summary table.** Added the missing `### E0036`–`### E0041` sections to both
+  language references. `E0041` (`INVALID_METHOD_CALL_TARGET`) had no regression test at
+  all; added `InvalidMethodCallTargetSpec` covering the "indexing a nullable class-typed
+  value" trigger site.
 - **`docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0030`
   (type is not generic), `E0031` (type argument arity mismatch), `E0033` (method is not
   generic), `E0034` (method type argument arity mismatch), and `E0035` (erased JVM

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -98,6 +98,26 @@ public:
 
 修正方法: 変数・フィールド・配列要素に代入してください。
 
+### `E0036` — val に代入できない
+
+`val` で宣言された束縛 ― ローカル変数、またはコンストラクタの外から書き込まれた
+インスタンスフィールド ― に、初回の代入のあとで再代入（あるいはインクリメント・
+デクリメント）が行われました。
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val x: Int = 1
+    x = 2   // E0036: x は val であり var ではない
+    return x
+  }
+}
+```
+
+修正方法: 値を変更する必要があるなら `var` として宣言してください。インスタンスの
+`val` フィールドはコンストラクタ内で一度だけ代入するようにしてください。
+
 ### `E0030` — 型はジェネリックではない
 
 型引数を取らない型に対して型引数が渡されました。
@@ -421,6 +441,105 @@ public:
 
 対処: フィールド／対象をインタフェース型で宣言するか、委譲が本当に不要であれば
 `forward` を取り除いてください。
+
+### `E0037` — 抽象メソッドが実装されていない
+
+クラスが `conforms` したインタフェース（または `extends` した抽象クラス）が宣言する
+抽象メソッドの実装を提供しておらず、かつそのクラス自身も `abstract` として宣言され
+ていません。
+
+```onion
+interface I { def m(): Int }
+class A conforms I {   // E0037: A は m() を実装するか abstract 宣言が必要
+public:
+  def this {}
+}
+```
+
+対処: 不足しているメソッドを実装するか、クラスを `abstract` として宣言してください。
+
+### `E0038` — 抽象クラスをインスタンス化できない
+
+`new` 式が `abstract` として宣言されたクラスを対象にしています。そのクラス自身が
+抽象メソッドを宣言しているかどうかは問いません。
+
+```onion
+abstract class Shape {
+public:
+  abstract def area(): Int
+}
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val s: Shape = new Shape();   // E0038: Shape は abstract
+    return 0
+  }
+}
+```
+
+対処: 代わりに具象サブクラスをインスタンス化してください。
+
+### `E0039` — final メソッドをオーバーライドできない
+
+`override` を付けたメソッドが、スーパークラスで `final` として宣言されたメソッドを
+対象にしています。
+
+```onion
+class A {
+public:
+  def this {}
+  final def m(): Int = 1
+}
+class B extends A {
+public:
+  def this {}
+  override def m(): Int = 2   // E0039: A.m は final
+}
+```
+
+対処: `override` を取り除くか、オーバーライドが本当に必要であればスーパークラス側の
+`final` を外してください。
+
+### `E0040` — プリミティブ型に対するメソッド呼び出し
+
+メソッド呼び出しの対象式が `void` 型を持っています。典型的には、何も返さない
+呼び出しの結果に対して直接メソッドを連鎖させた場合に発生します。
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    IO::println("a").toString()   // E0040: println は void を返す
+    return 0
+  }
+}
+```
+
+対処: 2つの呼び出しを別々の文に分けてください。
+
+### `E0041` — 不正なメソッド呼び出しターゲット
+
+メソッド呼び出し（または `[...]` によるインデックスアクセス）の対象式の型が、
+呼び出し可能なレシーバーとして使えません。たとえば `null` 除去前の nullable な
+クラス型の値（`T?`）や、具体的な上限を持たないワイルドカード型などです。
+
+```onion
+class Box {
+public:
+  def this {}
+}
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val b: Box? = null;
+    val v = b[0];   // E0041: Box? はメソッド呼び出しのターゲットとして不正
+    return 0
+  }
+}
+```
+
+対処: まず `null` を除外してください（`if b != null { ... }`、`b ?: default`、
+`b?.method()` / `b?[...]` など）。レシーバーが確定した非 null 型を持つようにします。
 
 ### `E0073` — Map は直接反復できない
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -98,6 +98,26 @@ public:
 
 Fix: assign to a variable, field, or array element instead.
 
+### `E0036` — Cannot assign to val
+
+A `val`-declared binding — a local variable, or an instance field written from
+outside its constructor — was reassigned (or incremented/decremented) after
+its initial assignment.
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val x: Int = 1
+    x = 2   // E0036: x is a val, not a var
+    return x
+  }
+}
+```
+
+Fix: declare the binding `var` if it needs to change, or assign an instance
+`val` field only once, from within the constructor.
+
 ### `E0030` — Type is not generic
 
 Type arguments were supplied for a type that takes none.
@@ -422,6 +442,104 @@ public:
 
 Fix: declare the field/target with an interface type, or drop `forward` if
 delegation isn't actually needed.
+
+### `E0037` — Unimplemented abstract method
+
+A class doesn't provide an implementation for an abstract method declared by
+an interface it `conforms` to (or an abstract class it `extends`), and the
+class itself isn't declared `abstract`.
+
+```onion
+interface I { def m(): Int }
+class A conforms I {   // E0037: A must implement m() or be declared abstract
+public:
+  def this {}
+}
+```
+
+Fix: implement the missing method(s), or declare the class `abstract`.
+
+### `E0038` — Cannot instantiate abstract class
+
+A `new` expression targets a class declared `abstract`, whether or not it
+declares any abstract methods of its own.
+
+```onion
+abstract class Shape {
+public:
+  abstract def area(): Int
+}
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val s: Shape = new Shape();   // E0038: Shape is abstract
+    return 0
+  }
+}
+```
+
+Fix: instantiate a concrete subclass instead.
+
+### `E0039` — Cannot override a final method
+
+A method marked `override` targets a method its superclass declared `final`.
+
+```onion
+class A {
+public:
+  def this {}
+  final def m(): Int = 1
+}
+class B extends A {
+public:
+  def this {}
+  override def m(): Int = 2   // E0039: A.m is final
+}
+```
+
+Fix: drop the `override`, or remove `final` from the superclass method if
+overriding was actually intended.
+
+### `E0040` — Cannot call method on primitive type
+
+A method call's target expression has `void` type — typically chaining a call
+directly onto the result of another call that returns nothing.
+
+```onion
+class Test {
+public:
+  static def main(args: String[]): Int {
+    IO::println("a").toString()   // E0040: println returns void
+    return 0
+  }
+}
+```
+
+Fix: split the two calls into separate statements.
+
+### `E0041` — Invalid method call target
+
+A method call (or `[...]` indexing) targets an expression whose type isn't a
+usable receiver — for example a nullable class-typed value (`T?`) that hasn't
+been unwrapped, or a wildcard type with no concrete upper bound.
+
+```onion
+class Box {
+public:
+  def this {}
+}
+class Test {
+public:
+  static def main(args: String[]): Int {
+    val b: Box? = null;
+    val v = b[0];   // E0041: Box? is not a valid method call target
+    return 0
+  }
+}
+```
+
+Fix: exclude `null` first (`if b != null { ... }`, `b ?: default`, or
+`b?.method()`/`b?[...]`) so the receiver has a definite, non-null type.
 
 ### `E0073` — Map cannot be iterated directly
 

--- a/src/test/scala/onion/compiler/tools/InvalidMethodCallTargetSpec.scala
+++ b/src/test/scala/onion/compiler/tools/InvalidMethodCallTargetSpec.scala
@@ -1,0 +1,61 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * E0041 (INVALID_METHOD_CALL_TARGET) is reported from several sites in
+ * MethodTargetTypingSupport/ConstructionTyping/AssignmentTyping, but had no
+ * regression coverage at all before this spec.
+ */
+class InvalidMethodCallTargetSpec extends AbstractShellSpec {
+  private def errors(src: String): Seq[(Option[String], String)] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(e => (e.errorCode, e.message))
+      case _ => Seq.empty
+    }
+  }
+
+  describe("indexing a value whose type isn't a usable receiver") {
+    it("reports E0041 when indexing a nullable class-typed value") {
+      val results = errors(
+        """
+          |class Box {
+          |public:
+          |  def this {}
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val b: Box? = null;
+          |    val v = b[0];
+          |    return 0;
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(results.map(_._1).contains(Some("E0041")))
+    }
+
+    it("does not report E0041 when indexing a non-null class-typed value with a get method") {
+      val results = errors(
+        """
+          |class Box {
+          |public:
+          |  def this {}
+          |  def get(i: Int): Int = i
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val b: Box = new Box();
+          |    return b[0];
+          |  }
+          |}
+          |""".stripMargin
+      )
+      assert(!results.map(_._1).contains(Some("E0041")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0036` (cannot assign to val), `E0037` (unimplemented abstract method), `E0038` (cannot instantiate abstract class), `E0039` (cannot override a final method), `E0040` (cannot call method on primitive type), and `E0041` (invalid method call target) only in the end-of-file summary table. Added the missing prose sections to both language references, following the existing section format (description + `onion` example + fix).
- `E0041` (`INVALID_METHOD_CALL_TARGET`) had no regression test at all despite several report sites in `MethodTargetTypingSupport`/`ConstructionTyping`/`AssignmentTyping`. Added `InvalidMethodCallTargetSpec` covering the nullable class-typed indexing trigger (`val b: Box? = null; b[0]`).
- Noted both additions in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3181 succeeded, 0 failed, 1 canceled (pre-existing, unrelated dist-packaging test), 0 ignored.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_017hG4xP7dMneESZL7L1h3wY)_