### PR TITLE
fix(docs): restore 13 missing Strings::* entries in ja stdlib.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`docs/ja/reference/stdlib.md`'s Strings Module section was missing 13 of the 29
+  documented `Strings::*` members** (`split`, `join`, `upper`, `lower`, `trim`, `replace`,
+  `replaceRegex`, `startsWith`, `endsWith`, `contains`, `padLeft`, `padRight`, `repeat`) —
+  the first code block was dropped during translation, leaving only the case/inspection
+  and null-safe-parsing examples. Restored it in the same grouping as the English
+  reference, and added `StdlibDocStringsModuleParitySpec` to guard against this drifting
+  again (the existing subheading-based parity specs don't cover this section, since it
+  has no `###` subheadings to count).
+
 - **`docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` listed `E0058`
   (label not found), `E0059` (invalid regex literal), `E0060` (regex capture group /
   binding count mismatch), `E0061` (record component type unsupported by `from

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -935,7 +935,18 @@ Config::getWithEnvOverride(config, "database.host", "DB_HOST", "localhost")
 
 ## Strings モジュール
 
-文字列ユーティリティ（`onion.Strings`、自動 import）。分割・結合・大文字小文字変換・パディングに加え：
+文字列ユーティリティ（`onion.Strings`、自動 import）：
+
+```onion
+Strings::split("a,b,c", ",")          // List[String] ["a","b","c"]
+Strings::join(parts, "-")             // 配列・List どちらも可
+Strings::upper(s) / Strings::lower(s) / Strings::trim(s)
+Strings::replace(s, "a", "b") / Strings::replaceRegex(s, "[0-9]+", "#")
+Strings::startsWith(s, p) / Strings::endsWith(s, p) / Strings::contains(s, sub)
+Strings::padLeft(s, 8, '0') / Strings::padRight(s, 8, ' ') / Strings::repeat(s, 3)
+```
+
+大文字小文字と検査のヘルパー：
 
 ```onion
 Strings::capitalize("hello")             // "Hello"

--- a/src/test/scala/onion/compiler/tools/StdlibDocStringsModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocStringsModuleParitySpec.scala
@@ -1,0 +1,39 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Strings Module" section of docs/reference/stdlib.md against its
+ * Japanese translation in docs/ja/reference/stdlib.md, which dropped the first two code
+ * blocks (split/join/case/padding and startsWith/endsWith/contains/isEmpty/isBlank/
+ * substring/indexOf/lastIndexOf/lines/reverse) during translation. The section has no
+ * `###` subheadings, so `StdlibDocFutureModuleParitySpec`'s subheading-count approach
+ * does not apply here — this compares the set of documented `Strings::method` names
+ * instead.
+ */
+class StdlibDocStringsModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def stringsMethodsUnder(doc: String, heading: String): Set[String] = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    val section = lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+    """\bStrings::([a-zA-Z][A-Za-z0-9_]*)""".r
+      .findAllMatchIn(section)
+      .map(_.group(1))
+      .toSet
+  }
+
+  it("documents the same Strings::* members in English and Japanese") {
+    val en = stringsMethodsUnder(read("docs/reference/stdlib.md"), "## Strings Module")
+    val ja = stringsMethodsUnder(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Strings Module section documented no Strings::* members")
+    assert(en == ja,
+      s"docs/reference/stdlib.md documents ${en.size} Strings::* members but " +
+      s"docs/ja/reference/stdlib.md documents ${ja.size} — missing in Japanese: " +
+      s"${(en -- ja).toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/ja/reference/stdlib.md`'s Strings Module section documented only 16 of the 29 `Strings::*` members that `docs/reference/stdlib.md` documents — the first code block (`split`, `join`, `upper`, `lower`, `trim`, `replace`, `replaceRegex`, `startsWith`, `endsWith`, `contains`, `padLeft`, `padRight`, `repeat`) was dropped entirely during translation.
- Restored the missing block, grouped the same way as the English reference.
- Added `StdlibDocStringsModuleParitySpec` so this can't silently drift again — the existing subheading-count parity specs (`StdlibDocFutureModuleParitySpec`, `StdlibDocWrapperAndCommonJavaClassesParitySpec`) don't cover this section since it has no `###` subheadings to count; this one instead diffs the set of documented `Strings::method` names between the English and Japanese sections.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] New spec fails before the doc fix (confirmed red — reported the 13 missing names) and passes after
- [x] `StdlibDocDriftSpec` still passes (no member names invented)
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3185 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R97tXinGC2obG5hMM26xcZ)_