### PR TITLE
fix(docs): restore missing Maps::*/Sets::* entries in ja stdlib.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`docs/ja/reference/stdlib.md`'s Maps Module and Sets Module sections were missing
+  several members that `docs/reference/stdlib.md` documents** — Maps: `newMap`,
+  `getOrDefault`, `filterKeys`, `filterValues`, `toList`, `forEach`, `merge`; Sets:
+  `newSet`, `containsAll`, `forEach`. Restored the missing entries and added
+  `StdlibDocMapsSetsModuleParitySpec` (same approach as `StdlibDocStringsModuleParitySpec`)
+  so this can't silently drift again.
+
 - **`docs/ja/reference/stdlib.md`'s Strings Module section was missing 13 of the 29
   documented `Strings::*` members** (`split`, `join`, `upper`, `lower`, `trim`, `replace`,
   `replaceRegex`, `startsWith`, `endsWith`, `contains`, `padLeft`, `padRight`, `repeat`) —

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -970,14 +970,20 @@ Strings::toIntOr("nope", 0)              // 0
 Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持（`LinkedHashMap`）。
 
 ```onion
+val m: Map[String, Int] = Maps::newMap()
+Maps::getOrDefault(m, "a", 0)                 // あればその値、無ければデフォルト
 Maps::getOrElse(m, "x", () -> compute())      // 遅延デフォルト
 Maps::keys(m) / Maps::values(m)               // 順序を保ったリスト
 Maps::mapValues(m, (v: Int) -> v * 2) / Maps::mapKeys(m, (k: String) -> k.toUpperCase())
+Maps::filterValues(m, (v: Int) -> v > 0) / Maps::filterKeys(m, (k: String) -> k.startsWith("a"))
 Maps::filter(m, (k: String, v: Int) -> v > 0) // キー+値の述語
 Maps::invert(m)                               // キーと値を入れ替え
+Maps::toList(m, (k: String, v: Int) -> k + "=" + v)  // エントリ -> List
+Maps::forEach(m, (k: String, v: Int) -> println(k))
 Maps::count(m, p) / Maps::anyEntry(m, p) / Maps::allEntries(m, p)
 Maps::groupBy(items, keyOf)                   // Map[K, List]
 Maps::countBy(items, keyOf)                   // 頻度 Map[K, Integer]
+val merged = Maps::merge(a, b)                // 衝突時は b が優先
 Maps::mergeWith(a, b, (x: Int, y: Int) -> x + y)  // 衝突を結合
 Maps::update(m, "a", (v: Int) -> v + 1)       // 関数的更新
 ```
@@ -987,11 +993,13 @@ Maps::update(m, "a", (v: Int) -> v + 1)       // 関数的更新
 Set ユーティリティ（`onion.Sets`）。結果 Set は挿入順を保持し、集合演算は null 安全。
 
 ```onion
-Sets::of(1, 2, 3) / Sets::fromList([1, 1, 2]) / Sets::toList(a)
+Sets::of(1, 2, 3) / Sets::newSet[Int]() / Sets::fromList([1, 1, 2]) / Sets::toList(a)
 Sets::union(a, b) / Sets::intersection(a, b) / Sets::difference(a, b)
 Sets::symmetricDifference(a, b)               // どちらか一方だけに含まれる
+Sets::containsAll(a, b)                       // a が b の要素をすべて含む
 Sets::isSubsetOf(a, b) / Sets::isSupersetOf(a, b) / Sets::isDisjoint(a, b)
 Sets::map(a, f) / Sets::filter(a, p) / Sets::find(a, p)
+Sets::forEach(a, (x: Int) -> println(x))
 Sets::count(a, p) / Sets::any(a, p) / Sets::all(a, p)
 ```
 

--- a/src/test/scala/onion/compiler/tools/StdlibDocMapsSetsModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocMapsSetsModuleParitySpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Maps Module" and "Sets Module" sections of docs/reference/stdlib.md
+ * against their Japanese translations in docs/ja/reference/stdlib.md. Both Japanese sections
+ * dropped several members during translation (Maps: newMap, getOrDefault, filterKeys,
+ * filterValues, toList, forEach, merge; Sets: newSet, containsAll, forEach). Neither section
+ * uses `###` subheadings in the Japanese doc, so `StdlibDocFutureModuleParitySpec`'s
+ * subheading-count approach does not apply here — this compares the set of documented
+ * `Maps::method` / `Sets::method` names instead, the same approach as
+ * `StdlibDocStringsModuleParitySpec`.
+ */
+class StdlibDocMapsSetsModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def methodsUnder(doc: String, heading: String, className: String): Set[String] = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    val section = lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+    s"""\\b$className::([a-zA-Z][A-Za-z0-9_]*)""".r
+      .findAllMatchIn(section)
+      .map(_.group(1))
+      .toSet
+  }
+
+  it("documents the same Maps::* members in English and Japanese") {
+    val en = methodsUnder(read("docs/reference/stdlib.md"), "## Maps Module", "Maps")
+    val ja = methodsUnder(read("docs/ja/reference/stdlib.md"), "## Maps モジュール", "Maps")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Maps Module section documented no Maps::* members")
+    assert(en == ja,
+      s"docs/reference/stdlib.md documents ${en.size} Maps::* members but " +
+      s"docs/ja/reference/stdlib.md documents ${ja.size} — missing in Japanese: " +
+      s"${(en -- ja).toSeq.sorted.mkString(", ")}")
+  }
+
+  it("documents the same Sets::* members in English and Japanese") {
+    val en = methodsUnder(read("docs/reference/stdlib.md"), "## Sets Module", "Sets")
+    val ja = methodsUnder(read("docs/ja/reference/stdlib.md"), "## Sets モジュール", "Sets")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Sets Module section documented no Sets::* members")
+    assert(en == ja,
+      s"docs/reference/stdlib.md documents ${en.size} Sets::* members but " +
+      s"docs/ja/reference/stdlib.md documents ${ja.size} — missing in Japanese: " +
+      s"${(en -- ja).toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/ja/reference/stdlib.md`'s Maps Module section documented only 14 of the 21 `Maps::*` members that `docs/reference/stdlib.md` documents — missing `newMap`, `getOrDefault`, `filterKeys`, `filterValues`, `toList`, `forEach`, and `merge`.
- Its Sets Module section documented only 16 of the 19 `Sets::*` members — missing `newSet`, `containsAll`, and `forEach`.
- Restored the missing entries (translated comments included), grouped consistently with the existing style of each section.
- Added `StdlibDocMapsSetsModuleParitySpec` so this can't silently drift again — the existing subheading-count parity specs (`StdlibDocFutureModuleParitySpec`, `StdlibDocWrapperAndCommonJavaClassesParitySpec`) don't cover these sections since they have no `###` subheadings to count; this one instead diffs the set of documented `Maps::method` / `Sets::method` names between the English and Japanese sections, the same approach `StdlibDocStringsModuleParitySpec` uses for the Strings module.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] New spec fails before the doc fix (confirmed red — reported the missing names) and passes after
- [x] `StdlibDocDriftSpec` still passes (no member names invented)
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3187 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RgJ2ULbSeMxRxWJRsT3CC)_