### PR TITLE
docs(ja): complete Yaml Module parity in stdlib.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`docs/ja/reference/stdlib.md`'s Yaml Module section collapsed the English section's
+  four subsections (`Yaml::parse`, `Yaml::stringify`, the round-trip guarantee, and
+  `derive!(Yaml)` usage) into a single short paragraph, dropping the round-trip
+  guarantee statement and the `derive!(Yaml)` code examples (`ServerConfig`,
+  `derive!(Json, Yaml)`) entirely.** Restored the missing subsections and examples, and
+  added `StdlibDocYamlModuleParitySpec` (same subheading-count approach as
+  `StdlibDocFutureModuleParitySpec`, plus a direct check for the `derive!(Yaml)` example)
+  so this can't silently drift again.
+
 - **`docs/ja/reference/stdlib.md`'s Maps Module and Sets Module sections were missing
   several members that `docs/reference/stdlib.md` documents** — Maps: `newMap`,
   `getOrDefault`, `filterKeys`, `filterValues`, `toList`, `forEach`, `merge`; Sets:

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -886,16 +886,79 @@ Json::getStringOr(obj, "name", "anon")  // "anon"
 
 ## Yaml モジュール
 
-YAML（flat block mapping のサブセット）のパースとシリアライズ。中間表現は Json と共通です。
+flat block mapping ドキュメント限定の YAML パースとシリアライズ（`onion.Yaml`）。
+Json と同じ中間表現を共有しており（scalar は同じ Java 型にマップされる）、
+`derive!(Yaml)` は `derive!(Json)` とまったく同じ `toMap` / `fromMap` の土台の上に
+構築されています。
 
-### Yaml::parse / Yaml::stringify
+対象範囲: flat block mapping のみ（ネストした map、シーケンス、アンカーは非対応）。
+
+### Yaml::parse
+
+YAML の flat block-mapping 文字列を `LinkedHashMap` にパースします:
 
 ```onion
-val obj = Yaml::parse("name: ko\nage: 3")    // Object（実体は Map）
-val text = Yaml::stringify(obj)               // "name: ko\nage: 3\n"
+val data = Yaml::parse("name: Alice\nage: 30\n")
+// data は LinkedHashMap；scalar の型推論は Json::parse と同じ
 ```
 
-scalar の型推論は Json と一致します（`3`→Long、`3.5`→Double、`true`→Boolean、`null`→null）。自分が出力した範囲を読み戻せる round-trip サブセットで、`record ... derive!(Yaml)` の土台になっています。`:` や前後の空白を含むキーは `key: value` の区切りと衝突しないよう自動的にダブルクォートされます(値側の quoting ルールと同じ)。
+scalar の型推論規則（Json と同一）:
+- `""` または `null` → `null`
+- `true` / `false` → `Boolean`
+- 整数リテラル（`-?\d+` にマッチ）→ `Long`
+- 浮動小数点パターンや `.`/`e`/`E` を含む数値 → `Double`
+- クォートされた `"..."` → `String`（エスケープ解除のみ、それ以上の変換なし）
+- それ以外 → `String`
+
+不正な入力に対しては `Yaml.YamlParseException` を投げます。`derive!(Yaml)` の
+`fromYaml` はこれを捕捉して代わりに `null` を返します。
+
+### Yaml::stringify
+
+`Map`（または scalar）を YAML の flat block-mapping 文字列にシリアライズします:
+
+```onion
+val m = ["name": "Alice", "age": 30L]
+val yaml = Yaml::stringify(m)
+// "name: Alice\nage: 30\n"
+```
+
+パースし直したときに誤読される可能性のある文字列値（`:`、`#`、改行を含む、または
+数値・真偽値に見えるもの）は自動的にダブルクォートされます。数値と真偽値はそのまま
+出力されます。Map の**キー**も同じ規則でクォートされます — `:` や前後の空白を含む
+キーは `key: value` の区切りと衝突しないようダブルクォートされます。
+
+### round-trip の保証
+
+`Yaml::parse` が生成した任意の `Map` について、`Yaml::parse(Yaml::stringify(m))` は
+等しい map を返します。同様に、`derive!(Yaml)` を付けたレコードでは、scalar 成分の
+みを持つすべての値について `fromYaml(toYaml(v)) == v` が成り立ちます。
+
+### `derive!(Yaml)` の利用
+
+`derive!(Yaml)` は scalar 成分のみを持つ任意のレコードに対して `fromYaml` と
+`toYaml` を合成します。
+
+```onion
+record ServerConfig(host: String, port: Int, debug: Boolean) derive!(Yaml)
+
+val cfg = new ServerConfig("localhost", 8080, false)
+val yaml = ServerConfig::toYaml(cfg)
+// "host: localhost\nport: 8080\ndebug: false\n"
+
+val cfg2 = ServerConfig::fromYaml(yaml)   // ServerConfig? — パース/変換失敗時は null
+```
+
+`derive!(Json, Yaml)` も有効です。両フォーマットは内部の `toMap` / `fromMap` を
+共有するため、重複はありません:
+
+```onion
+record User(name: String, age: Int) derive!(Json, Yaml)
+
+val u = new User("ko", 3)
+val viaJson = User::fromJson(User::toJson(u))   // == u
+val viaYaml = User::fromYaml(User::toYaml(u))  // == u
+```
 
 ## Config モジュール
 

--- a/src/test/scala/onion/compiler/tools/StdlibDocYamlModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocYamlModuleParitySpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Yaml Module" section of docs/reference/stdlib.md against its
+ * Japanese translation in docs/ja/reference/stdlib.md, which collapsed the English
+ * section's four subsections (`Yaml::parse`, `Yaml::stringify`, round-trip guarantee,
+ * `derive!(Yaml)` usage) into a single short paragraph, dropping the round-trip
+ * guarantee statement and the `derive!(Yaml)` code examples entirely. Same approach
+ * as `StdlibDocFutureModuleParitySpec`.
+ */
+class StdlibDocYamlModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def subheadingsUnder(doc: String, heading: String): Seq[String] = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).filter(_.trim.startsWith("### "))
+  }
+
+  it("has the same number of Yaml Module subsections in English and Japanese") {
+    val en = subheadingsUnder(read("docs/reference/stdlib.md"), "## Yaml Module")
+    val ja = subheadingsUnder(read("docs/ja/reference/stdlib.md"), "## Yaml モジュール")
+    assert(en.nonEmpty, "docs/reference/stdlib.md's Yaml Module section listed no subsections")
+    assert(en.size == ja.size,
+      s"docs/reference/stdlib.md has ${en.size} Yaml Module subsections but " +
+      s"docs/ja/reference/stdlib.md has ${ja.size} — the section is missing or incomplete in Japanese")
+  }
+
+  it("mentions derive!(Yaml) usage in the Japanese Yaml Module section") {
+    val ja = read("docs/ja/reference/stdlib.md")
+    val lines = ja.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == "## Yaml モジュール")
+    assert(start >= 0, "could not find '## Yaml モジュール' heading")
+    val section = lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+    assert(section.contains("derive!(Yaml)"),
+      "docs/ja/reference/stdlib.md's Yaml Module section no longer shows a derive!(Yaml) example")
+    assert(section.contains("ServerConfig") || section.contains("derive!(Json, Yaml)"),
+      "docs/ja/reference/stdlib.md's Yaml Module section is missing the derive!(Yaml) code example")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/ja/reference/stdlib.md`'s Yaml Module section collapsed the English section's four subsections (`Yaml::parse`, `Yaml::stringify`, the round-trip guarantee, and `derive!(Yaml)` usage) into a single short paragraph, dropping the round-trip guarantee statement and both `derive!(Yaml)` code examples (`ServerConfig`, `derive!(Json, Yaml)`) entirely.
- Restored the missing subsections and examples, following the structure of the English section.
- Added `StdlibDocYamlModuleParitySpec` (same subheading-count approach as `StdlibDocFutureModuleParitySpec`, plus a direct check for the `derive!(Yaml)` example) so this can't silently drift again.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] Added `StdlibDocYamlModuleParitySpec`, confirmed it fails (red) against the original ja doc, then passes (green) after the fix.
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3189 succeeded, 0 failed, 1 canceled (pre-existing `ProjectDistributionSpec` environment-conditional cancellation, unrelated to this change), 0 ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4RSxHEhV9QNQKo4mAMsSa)_