### PR TITLE
docs(tools): document -super/--verbose (and --effects for onionc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`docs/tools/compiler.md` and `docs/tools/script-runner.md` (and their `docs/ja`
+  translations) had no section for the real `-super <super class>` and `--verbose`
+  flags, and the `compiler.md` pair was additionally missing `--effects`** — all three
+  work today but were absent from every option reference. Added the missing sections
+  to all four pages and added `CliOptionDocCoverageSpec`, which ties each page to the
+  actual `--help` option list in `CompilerFrontend`/`ScriptRunner` so a future flag
+  added to one and not the other fails the build instead of drifting silently.
+
 ## [0.10.24] - 2026-08-06
 
 ### Documentation

--- a/docs/ja/tools/compiler.md
+++ b/docs/ja/tools/compiler.md
@@ -46,6 +46,24 @@ onionc -d build/classes MyProgram.on
 onionc -maxErrorReport 10 MyProgram.on
 ```
 
+### `-super <super class>`
+
+トップレベルのスクリプトが生成するクラスの親クラスを指定します。明示的なクラス宣言が
+ない場合にのみ意味を持ちます。
+
+```bash
+onionc -super java.lang.Object MyScript.on
+```
+
+### `--verbose`
+
+各コンパイルフェーズ（構文解析、書き換え、型検査、コード生成）の所要時間を実行時に
+表示します。
+
+```bash
+onionc --verbose MyProgram.on
+```
+
 ### `--dump-ast`
 
 構文解析後のASTを標準エラー出力に出力します。構文やパースのデバッグに便利です。
@@ -124,6 +142,14 @@ onionc --no-check-laws MyProgram.on
 ```bash
 onionc --law-samples 500 MyProgram.on
 onionc --law-seed 7 MyProgram.on
+```
+
+### `--effects`
+
+コンパイルされた各メソッドの推論済みエフェクト集合（`read write net exec env clock rand console unknown`。空はpureを意味する）を標準エラー出力に表示します。
+
+```bash
+onionc --effects MyProgram.on
 ```
 
 ## 例

--- a/docs/ja/tools/script-runner.md
+++ b/docs/ja/tools/script-runner.md
@@ -34,6 +34,24 @@ onion -encoding UTF-8 MyScript.on
 onion -maxErrorReport 10 MyScript.on
 ```
 
+### `-super <super class>`
+
+トップレベルのスクリプトが生成するクラスの親クラスを指定します。明示的なクラス宣言が
+ない場合にのみ意味を持ちます。
+
+```bash
+onion -super java.lang.Object MyScript.on
+```
+
+### `--verbose`
+
+スクリプト実行前に、各コンパイルフェーズ（構文解析、書き換え、型検査、コード生成）の
+所要時間を表示します。
+
+```bash
+onion --verbose MyScript.on
+```
+
 ### `--dump-ast`
 
 スクリプト実行前に、構文解析後のASTを標準エラー出力に出力します。

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -46,6 +46,24 @@ Limit the number of compilation errors reported. Useful for large projects with 
 onionc -maxErrorReport 10 MyProgram.on
 ```
 
+### `-super <super class>`
+
+Specify the class a top-level script's synthesized class extends. Only meaningful when
+the source has no explicit class declaration.
+
+```bash
+onionc -super java.lang.Object MyScript.on
+```
+
+### `--verbose`
+
+Show timing for each compilation phase (parsing, rewriting, type checking, code
+generation) as it runs.
+
+```bash
+onionc --verbose MyProgram.on
+```
+
 ### `--dump-ast`
 
 Print the parsed AST to stderr. Useful when debugging syntax and parsing.
@@ -125,6 +143,15 @@ count widens the search for others.
 ```bash
 onionc --law-samples 500 MyProgram.on
 onionc --law-seed 7 MyProgram.on
+```
+
+### `--effects`
+
+Print each compiled method's inferred effect set (`read write net exec env clock rand
+console unknown`; empty means pure) to stderr.
+
+```bash
+onionc --effects MyProgram.on
 ```
 
 ## Examples

--- a/docs/tools/script-runner.md
+++ b/docs/tools/script-runner.md
@@ -34,6 +34,24 @@ Limit the number of compilation errors reported.
 onion -maxErrorReport 10 MyScript.on
 ```
 
+### `-super <super class>`
+
+Specify the class a top-level script's synthesized class extends. Only meaningful when
+the source has no explicit class declaration.
+
+```bash
+onion -super java.lang.Object MyScript.on
+```
+
+### `--verbose`
+
+Show timing for each compilation phase (parsing, rewriting, type checking, code
+generation) before the script runs.
+
+```bash
+onion --verbose MyScript.on
+```
+
 ### `--dump-ast`
 
 Print the parsed AST to stderr before running the script.

--- a/src/test/scala/onion/compiler/tools/CliOptionDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CliOptionDocCoverageSpec.scala
@@ -1,0 +1,60 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard tying `docs/tools/compiler.md` and `docs/tools/script-runner.md` (and
+ * their `docs/ja` translations) to the actual `--help` option lists in
+ * `CompilerFrontend.printUsage` and `ScriptRunner.printUsage`. `-super` and
+ * `--verbose` are real, working flags on both CLIs but had no `### \`<flag>\`` section
+ * on any of the four pages; `--effects` was additionally missing from both
+ * `compiler.md` pages. Nothing tied the option reference to the usage string, so a
+ * flag added to one and not the other could drift silently — this is that tie.
+ */
+class CliOptionDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  // `-h`/`--help` and `-v`/`--version` share one usage line and aren't documented as
+  // standalone `###` sections anywhere; every other flag is expected to have one.
+  private val undocumented = Set("-h", "--help", "-v", "--version")
+
+  private def optionsFrom(usage: String): Set[String] = {
+    val optionsSection = usage.substring(usage.indexOf("Options:"))
+    """\|\s+(-{1,2}[A-Za-z][\w-]*)""".r
+      .findAllMatchIn(optionsSection)
+      .map(_.group(1))
+      .toSet
+      .diff(undocumented)
+  }
+
+  private lazy val compilerOptions: Set[String] =
+    optionsFrom(read("src/main/scala/onion/tools/CompilerFrontend.scala"))
+
+  private lazy val scriptRunnerOptions: Set[String] =
+    optionsFrom(read("src/main/scala/onion/tools/ScriptRunner.scala"))
+
+  private def check(path: String, options: Set[String]): Unit = {
+    assert(options.nonEmpty, s"no options extracted for $path — the scan has rotted")
+    val doc = read(path)
+    val missing = options.filterNot(opt => doc.contains(s"`$opt")).toSeq.sorted
+    assert(missing.isEmpty, s"$path has no section for: ${missing.mkString(", ")}")
+  }
+
+  it("docs/tools/compiler.md documents every onionc option") {
+    check("docs/tools/compiler.md", compilerOptions)
+  }
+
+  it("docs/ja/tools/compiler.md documents every onionc option") {
+    check("docs/ja/tools/compiler.md", compilerOptions)
+  }
+
+  it("docs/tools/script-runner.md documents every onion option") {
+    check("docs/tools/script-runner.md", scriptRunnerOptions)
+  }
+
+  it("docs/ja/tools/script-runner.md documents every onion option") {
+    check("docs/ja/tools/script-runner.md", scriptRunnerOptions)
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/tools/compiler.md` and `docs/tools/script-runner.md` (and their `docs/ja` translations) had no `### `-super <super class>`` or `### `--verbose`` section, even though both flags work on both CLIs today. `compiler.md`'s pair was additionally missing `--effects`, which `script-runner.md` already documented.
- Added the missing sections to all four pages.
- Added `CliOptionDocCoverageSpec`, which extracts the option list from `CompilerFrontend`/`ScriptRunner`'s `printUsage` string and asserts every flag has a `` `<flag>` `` section in the corresponding doc page (en + ja), so a future flag added to one CLI and not the docs fails the build instead of drifting silently.
- Noted the fix in `CHANGELOG.md` under `[Unreleased]`.

## Test plan

- [x] `CliOptionDocCoverageSpec` fails before the doc fix (confirmed red) and passes after (confirmed green)
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3193 succeeded, 0 failed, 1 canceled

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XQBvhL5n62uZ32kDZGTxkd)_