### PR TITLE
docs(ja): document Json::value navigable wrapper in stdlib.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`docs/ja/reference/stdlib.md`'s Json Module section never mentioned `Json::value`,
+  the navigable JSON wrapper (`Value`, indexable with `[]` and read with
+  `asString`/`asInt`/`asLong`/`asDouble`/`asBoolean`/`isNull`/`size`) that
+  `docs/reference/stdlib.md` documents.** Added the missing subsection and example to
+  the Japanese page, and added `StdlibDocJsonModuleParitySpec` (same approach as
+  `StdlibDocYamlModuleParitySpec`) so this can't silently drift again.
+
 - **`docs/tools/compiler.md` and `docs/tools/script-runner.md` (and their `docs/ja`
   translations) had no section for the real `-super <super class>` and `--verbose`
   flags, and the `compiler.md` pair was additionally missing `--effects`** — all three

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -884,6 +884,21 @@ Json::getIntOr(obj, "missing", 42)      // 42（NPE にならない）
 Json::getStringOr(obj, "name", "anon")  // "anon"
 ```
 
+### Json::value（ナビゲート可能なラッパー）
+
+`Json::value(text)` は `[]` でインデックスアクセスできるラッパー値を返します。オブジェクトのキーには文字列、
+配列の要素には整数でアクセスでき、値の取り出しには `asString()` / `asInt()` / `asLong()` / `asDouble()` /
+`asBoolean()` を使います:
+
+```onion
+val v = Json::value(jsonText)
+v["users"][0]["name"].asString()
+```
+
+キーが存在しない・添字が範囲外のときは null を保持する `Value` を返すので、途中の欠損があっても例外にはなりません
+（末尾で `asString()` 等を呼ぶと `null` になります）。`isNull()` で null かどうか、`size()` で配列・オブジェクトの
+要素数を調べられます。
+
 ## Yaml モジュール
 
 flat block mapping ドキュメント限定の YAML パースとシリアライズ（`onion.Yaml`）。

--- a/src/test/scala/onion/compiler/tools/StdlibDocJsonModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocJsonModuleParitySpec.scala
@@ -1,0 +1,37 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Json Module" section of docs/reference/stdlib.md against its
+ * Japanese translation in docs/ja/reference/stdlib.md. The English section documents
+ * the navigable `Json::value(text)` wrapper (`Value`, indexable with `[]` and read
+ * with `asString`/`asInt`/.../`asBoolean`), but the Japanese section never mentions
+ * it, leaving `Json::value` and its `[]`/`as*` API undiscoverable in Japanese.
+ */
+class StdlibDocJsonModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def sectionUnder(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+  }
+
+  it("mentions the Json::value navigable wrapper in the Japanese Json Module section") {
+    val ja = sectionUnder(read("docs/ja/reference/stdlib.md"), "## Json モジュール")
+    assert(ja.contains("Json::value"),
+      "docs/ja/reference/stdlib.md's Json Module section doesn't mention Json::value, " +
+      "the navigable JSON wrapper documented in the English reference")
+  }
+
+  it("shows the [] indexing and as* accessor usage in the Japanese Json Module section") {
+    val ja = sectionUnder(read("docs/ja/reference/stdlib.md"), "## Json モジュール")
+    assert(ja.contains("asString()"),
+      "docs/ja/reference/stdlib.md's Json Module section is missing the Value.asString() " +
+      "example that the English reference shows for Json::value")
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/ja/reference/stdlib.md`'s Json Module section never mentioned `Json::value`, the navigable JSON wrapper (`Value`, indexable with `[]` and read with `asString`/`asInt`/`asLong`/`asDouble`/`asBoolean`/`isNull`/`size`) that `docs/reference/stdlib.md` documents.
- Added the missing subsection and example to the Japanese page, and added `StdlibDocJsonModuleParitySpec` (same approach as `StdlibDocYamlModuleParitySpec`) so this can't silently drift again.
- Noted the change in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `StdlibDocJsonModuleParitySpec` confirmed red before the docs fix, green after
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3201 tests, 0 failed, 1 canceled, all green

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6AKpc6Mk3uCgSoQ7Ybe99)_