### PR TITLE
test(verification): assert E0013/E0014 error codes explicitly

### DIFF
--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -218,6 +218,35 @@ class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
     }
   }
 
+  describe("member accessibility") {
+    it("E0013 private static method called from another class") {
+      failsWith("E0013",
+        """class C {
+          |private:
+          |  static def s(): Int = 1
+          |}
+          |def main(args: String[]): void { IO::println(C::s()) }
+          |""".stripMargin)
+    }
+    it("E0014 writing a non-public field from outside its class") {
+      failsWith("E0014",
+        """class Plain {
+          |  var value: String
+          |public:
+          |  def this(v: String) { value = v }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val p = new Plain("orig")
+          |    p.value = "changed"
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+    }
+  }
+
   describe("inheritance and interfaces") {
     it("E0018 illegal inheritance (extending a final class)") {
       failsWith("E0018",


### PR DESCRIPTION
## Summary
- `METHOD_NOT_ACCESSIBLE` (E0013) and `FIELD_NOT_ACCESSIBLE` (E0014) are both documented in `docs/reference/error-codes.md` with concrete repros, and are already exercised by `StaticMethodAccessSpec`/`FieldWriteAccessSpec` — but neither test asserts the literal error code, only the generic `Shell.Failure(-1)`.
- Adds two direct code-asserting cases to `SemanticErrorCodeCoverageSpec`, matching the existing per-code coverage pattern (#499, #483).
- No implementation change — pure test-coverage addition.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green: 3203 succeeded, 0 failed, 1 canceled (pre-existing, unrelated), 0 ignored.
- [x] Confirmed both new cases (`E0013 private static method called from another class`, `E0014 writing a non-public field from outside its class`) ran and passed in the log.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLg8qxrqpHLmMHMdX266CX)_