### PR TITLE
docs(changelog): note the WeatherReport.on sample addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`run/WeatherReport.on`, a 261-line weather data analysis sample.** A new
+  domain not previously covered by the corpus. Exercises a data-carrying enum
+  (`AlertLevel`: `NONE`/`ADVISORY`/`WARNING`/`EMERGENCY`), records with inline
+  methods (`DailyReading`, `WeekSummary`), an interface implemented by a class
+  (`Reportable`/`MonthData`), extension methods on `Double` and `String`,
+  `select` dispatch over enum cases, a recursive moving-average function, and
+  collection-pipeline operations underused elsewhere in the corpus
+  (`reduce`/`partition`/`take`/`drop`/`zip`/`flatten`/`distinct`/`sortedBy`).
+  107 total corpus programs.
+
 ### Documentation
 
 - **`docs/ja/reference/stdlib.md`'s Json Module section never mentioned `Json::value`,


### PR DESCRIPTION
## Summary

- PR #622 added `run/WeatherReport.on` (a 261-line weather data analysis sample) but did not record it in `CHANGELOG.md`'s `[Unreleased]` section, breaking the corpus's usual "every new `run/` sample gets a changelog entry" convention.
- Adds the missing entry, matching the style of other sample-addition entries already in the changelog.

## Test plan

- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3207 succeeded, 0 failed, 1 canceled (pre-existing, environment-conditional `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYRHf1wYpnnEoU5q2aHNR7)_