### PR TITLE
docs(changelog): note the CensusAnalyzer.on sample addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closures capturing outer `val`s, recursion (`halveDepth`), `foreach` over
   list/map-entry/range, `while`, `try`/`catch`, and the two-step
   `(val as Int) as Double` numeric cast pattern.
-  110 total corpus programs.
+- **`run/CensusAnalyzer.on`, a 468-line population data parsing and reporting
+  sample.** Combines features under-represented elsewhere in the corpus:
+  `from re"..."` pattern-attached record parsing (`Person`), `do[List]`
+  list-comprehension cross-tabulation, the `|>` pipeline operator, an ADT
+  `case`-enum (`AgeGroup`) alongside a homogeneous enum with methods
+  (`IncomeBracket`), a wrapper record with computed properties (`PersonExt`),
+  extension methods on `Int`/`Double`, `foreach (k, v)` over `Map`, and
+  `record example {}` build-time parse round-trip assertions.
+  111 total corpus programs.
 
 ### Documentation
 


### PR DESCRIPTION
## Summary

PR #628 added `run/CensusAnalyzer.on` (468-line population data sample) but did not add a `CHANGELOG.md` entry under `[Unreleased]`. This adds the missing entry, matching the style of the other sample entries already present, and bumps the corpus count note to 111.

---
_Generated by [Claude Code](https://claude.ai/code/session_018YTULwXAaKzHcw4F8KY5cr)_