### PR TITLE
ci: cap the test job at 25 minutes instead of GitHub's 6h default

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
     - name: Install sbt
       uses: sbt/setup-sbt@v1


### PR DESCRIPTION
## Summary

Every PR opened since #634 merged (#635 through #660, 20 PRs) has been stuck open, unable to ever report a green check. Root cause, found by inspecting the job logs of several stuck PRs:

- The `pull_request`-triggered "test" run intermittently hits severe GC pressure and an `OutOfMemoryError` partway through the suite (heap capped ~6GB in the affected run vs. the requested `-Xmx10g`), after which the process hangs with zombie background threads instead of exiting.
- With no `timeout-minutes` set on the job, GitHub Actions' default **6-hour** job timeout is what eventually force-cancels it — so the check sits as pending/cancelled for 6 hours on every affected run.
- The identical commit's `push`-triggered run (a separate workflow trigger for the same code) frequently finishes in ~3–4 minutes, so the failure mode reads as intermittent/non-deterministic rather than a hard compile or test failure — easy to miss.

This change adds `timeout-minutes: 25` to the `test` job (normal runs finish in ~3–5 minutes locally and per the successful push-triggered runs observed on recent PRs, so 25 minutes leaves generous headroom without waiting anywhere near 6 hours on a hang). This doesn't fix the underlying GC/OOM flakiness, but it turns a silent multi-hour hang into a fast, visible failure that can actually be seen, diagnosed, and retried — unblocking the current backlog of stuck PRs.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` run locally: 3260 succeeded, 0 failed, 1 pre-existing canceled test (environment-dependent dist-journey test, unrelated to this change), 0 ignored — green.
- [x] Change is a single-line CI config addition (`.github/workflows/scala.yml`), no source changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7PK8rjxnF1wrtUZ7NWJdk)_