### PR TITLE
ci(release): bump release workflow test/build heap to -Xmx10G

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,11 +97,11 @@ jobs:
           fi
       - name: Test
         env:
-          SBT_OPTS: "-Xmx6G -XX:+UseG1GC -Xss16m"
+          SBT_OPTS: "-Xmx10G -XX:+UseG1GC -Xss16m"
         run: sbt test
       - name: Build artifacts
         env:
-          SBT_OPTS: "-Xmx6G -XX:+UseG1GC -Xss16m"
+          SBT_OPTS: "-Xmx10G -XX:+UseG1GC -Xss16m"
         run: sbt assembly dist
       - name: Collect artifacts
         run: |


### PR DESCRIPTION
## Summary

`release.yml`'s `Test` and `Build artifacts` steps were still hardcoded at `-Xmx6G`, left behind when the identical `run/*.on` corpus-growth OOM was fixed for the regular `scala.yml` CI workflow (bumped to `-Xmx10G` in `0d788b6b`, PR #661).

This caused the `v0.10.26` release workflow run to OOM and abort during `sbt test`, before ever reaching the release-creation step, leaving an orphaned `v0.10.26` git tag with no corresponding GitHub Release.

## Verification

`SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test`: 3266 succeeded, 0 failed, 1 canceled, exit code 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeGq2xeWyxN1QxtVXWRowW)_