### PR TITLE
docs(changelog): add Unreleased entry for run/SpaceMission.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`run/SpaceMission.on`, a 324-line space mission planner sample.** Exercises
+  records with body methods (`Planet`, `Spacecraft.wetMass`/`massRatio`,
+  `MissionLog`), a plain enum (`MissionStatus`), a data-carrying enum
+  (`MissionOutcome`), an ADT case-enum (`MissionEvent` with 4 cases), a class
+  with mutable state (`MissionController`), collection pipelines (`filter`,
+  `map`, `fold`, `groupBy`, `sortedBy`, `find`), exhaustive `select` over the
+  ADT cases, nullable lookups (`findPlanet(): Planet?`), closures, string
+  interpolation, recursion (Newton's method for orbital period), `foreach`
+  over a range, `while`, `try`/`catch`, and `foreach (k, v) in map`.
 - **`run/KingdomSim.on`, a 550-line medieval kingdom simulation sample.**
   Exercises operator overloading (`plus`/`times`/`minus` on a `Resource`
   record), `do[List]` comprehension for trade-pair generation, multiple


### PR DESCRIPTION
## Summary

PR #657 added `run/SpaceMission.on` (324-line space mission planner sample) but
did not record it in `CHANGELOG.md`. This adds the missing `[Unreleased]` entry,
matching the style of the other sample entries already there.

## Test plan

Docs-only change; no code paths affected. Full test suite already verified
green (3279 pass / 0 fail / 1 cancelled) as part of landing #657.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRhmgSubpBQzEmcvw2AsP7)_