### PR TITLE
docs(changelog): move ConferenceSchedule.on entry back to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`run/ConferenceSchedule.on`, a 451-line conference schedule management sample.**
+  Exercises a data-carrying enum (`Verdict` with `Approved`/`Rejected`/`Pending`,
+  dispatched via `select case is`), a plain enum (`Track`), an interface
+  (`Summarizable`) implemented by two records, records with methods and `conforms`
+  (`Speaker`, `Session`, `Proposal`), a generic `Box[T]` class with a `map[U]`
+  method, extension methods on `Int` (`hourStr`) and `String` (`padRight`,
+  `truncate`), collection pipelines (`filter`/`map`/`fold`/`sortedBy`/`groupBy`/
+  `partition`/`zip`/`flatten`/`distinct`/`any`/`count`), `foreach (k, v)` on
+  `Map`, nullable types with null guards, a tail-recursive prefix search, a
+  `while` loop, `try`/`catch`, and `string interpolation` throughout.
+
 ## [0.10.29] - 2026-08-10
 
 ### Added
@@ -153,16 +166,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `select`/type-pattern dispatch over `ReadStatus`, `foreach` over an
   inclusive range and over `Map` entries, nullable return types, recursion,
   and `try`/`catch`.
-- **`run/ConferenceSchedule.on`, a 451-line conference schedule management sample.**
-  Exercises a data-carrying enum (`Verdict` with `Approved`/`Rejected`/`Pending`,
-  dispatched via `select case is`), a plain enum (`Track`), an interface
-  (`Summarizable`) implemented by two records, records with methods and `conforms`
-  (`Speaker`, `Session`, `Proposal`), a generic `Box[T]` class with a `map[U]`
-  method, extension methods on `Int` (`hourStr`) and `String` (`padRight`,
-  `truncate`), collection pipelines (`filter`/`map`/`fold`/`sortedBy`/`groupBy`/
-  `partition`/`zip`/`flatten`/`distinct`/`any`/`count`), `foreach (k, v)` on
-  `Map`, nullable types with null guards, a tail-recursive prefix search, a
-  `while` loop, `try`/`catch`, and `string interpolation` throughout.
 - **`run/GameOfLife.on`, a 422-line Conway's Game of Life simulation.** Exercises
   a homogeneous enum (`CellState`) and a data-carrying enum (`PatternKind`) with
   a `select`-based label method, records with methods (`Cell.distanceTo`/`label`,


### PR DESCRIPTION
## Summary

PR #650 was branched before `v0.10.29` was tagged. When it merged into `develop` (after the tag cut), its CHANGELOG entry for `run/ConferenceSchedule.on` landed positionally inside the already-released `## [0.10.29]` section instead of `## [Unreleased]`, because the diff applied at the line offset from before the release-cut commit inserted a new header above it. This PR moves that entry to `[Unreleased]` so the changelog accurately reflects what `v0.10.29` actually contained.

## Why draft

The full test suite (`sbt -Duser.language=en test`) could not be verified green in this session — two consecutive runs (with `-Xmx4G` and `-Xmx8G` heap) stalled without producing a final summary, in the same region of the suite (around `SmartCastSpec`/`ToolCapabilitySpec`) each time, and had to be killed. Per this repo's release protocol, changes are never merged without a real green test run, so this is left as a draft for the next session to verify and merge (or to investigate the stall further — it may be worth a closer look since it reproduced twice at a similar point in the suite, though this docs-only change could not have caused it).

This change touches only `CHANGELOG.md`, no compiler code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XR8F8u257rgNN3wyQNuwVu)_