### PR TITLE
test: cover 5 previously-untested run/ console samples

### DIFF
--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -389,5 +389,25 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs PropertyManager.on") {
       assert(Shell.Success(null) == runSample("run/PropertyManager.on"))
     }
+
+    it("runs BankLedger.on") {
+      assert(Shell.Success(null) == runSample("run/BankLedger.on"))
+    }
+
+    it("runs Inventory.on") {
+      assert(Shell.Success(null) == runSample("run/Inventory.on"))
+    }
+
+    it("runs MathParser.on") {
+      assert(Shell.Success(null) == runSample("run/MathParser.on"))
+    }
+
+    it("runs TicTacToe.on") {
+      assert(Shell.Success(null) == runSample("run/TicTacToe.on"))
+    }
+
+    it("runs GraphAlgorithms.on") {
+      assert(Shell.Success(null) == runSample("run/GraphAlgorithms.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `RunSamplesSpec` exercised 77 of the 138 example programs under `run/`, leaving 61 samples with no regression coverage.
- Add coverage for 5 console-only samples with no GUI/stdin dependencies: `BankLedger.on`, `Inventory.on`, `MathParser.on`, `TicTacToe.on`, `GraphAlgorithms.on`.
- Each was run against `Shell` to confirm it executes successfully today, and the assertion pins the actual observed result (`Shell.Success(null)` for all five, since each ends on a `void`-returning `IO::println` call).

## Test plan
- [x] `SBT_OPTS="-Xmx10g -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3324 succeeded, 0 failed, 1 canceled (pre-existing opt-in distribution smoke test gated behind `-Donion.dist.path`, unrelated to this change), 0 ignored.

---

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01J42duB8GaPUQHZ4hJWHPqM)_