### PR TITLE
docs(stdlib): document Json builder helpers and Value accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Documented `Json::object()`/`Json::array()` and `Value.isNull()`/`Value.size()`/
+  `Value.raw()` in the English Json Module reference (`docs/reference/stdlib.md`),
+  and added the missing `Json::array()`/`Value.raw()` mentions to the Japanese
+  reference (`docs/ja/reference/stdlib.md`).** These `onion.Json` builder helpers
+  and `Value` accessors existed in code but were absent (or partially absent) from
+  the docs in both languages, making them undiscoverable without reading the
+  Java source.
+
 ## [0.10.30] - 2026-08-11
 
 ### Documentation

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -872,6 +872,7 @@ val age = Json::getInt(obj, "age")                     // 3
 val m = Json::object()                                  // 空の Map
 m.put("x", 1)
 val text = Json::stringify(m)                           // {"x":1}
+val a = Json::array()                                   // 空の List（JSON 配列値の構築に使う）
 ```
 
 `getString` / `getInt` / `getLong` / `getDouble` / `getFloat` / `getBoolean` / `getShort` / `getByte` でキーから型別に取得します（見つからない・型不一致のときは null）。
@@ -897,7 +898,7 @@ v["users"][0]["name"].asString()
 
 キーが存在しない・添字が範囲外のときは null を保持する `Value` を返すので、途中の欠損があっても例外にはなりません
 （末尾で `asString()` 等を呼ぶと `null` になります）。`isNull()` で null かどうか、`size()` で配列・オブジェクトの
-要素数を調べられます。
+要素数（それ以外は `0`）を調べられ、`raw()` で内部表現（`Map`/`List`/scalar/`null`）を直接取り出せます。
 
 ## Yaml モジュール
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -996,12 +996,19 @@ Files::withExtension("report.txt", "md")   // "report.md"
 
 ## Json Module
 
-JSON parsing and serialization (`onion.Json`):
+JSON parsing and serialization (`onion.Json`). The intermediate representation is
+plain Java `Map`/`List`/scalars (`String`/`Long`/`Double`/`Boolean`/`null`):
 
 ```onion
 val obj = Json::parse("{\"name\": \"kota\"}")
 Json::getString(obj, "name")           // typed accessors: getInt/getDouble/getBoolean
 Json::stringify(obj) / Json::stringifyPretty(obj)
+
+// Building a value to stringify
+val m = Json::object()                 // empty Map
+m.put("x", 1)
+Json::stringify(m)                     // {"x":1}
+val a = Json::array()                  // empty List, for JSON array values
 
 // Navigable wrapper: index with [] and convert with as-methods
 val v = Json::value(jsonText)
@@ -1019,6 +1026,12 @@ val obj = Json::parse("{}")
 Json::getIntOr(obj, "missing", 42)     // 42, no NPE
 Json::getStringOr(obj, "name", "anon") // "anon"
 ```
+
+A missing key or out-of-range index on the `Json::value` wrapper yields a null-holding
+`Value` instead of throwing, so a chain like `v["users"][99]["name"]` stays safe until you
+convert it — `asString()`/`asInt()`/etc. return `null`/`0`/`false` at the end of the chain.
+`Value` also has `isNull()` (was the underlying value `null`?), `size()` (element count for
+an array/object Value, `0` otherwise), and `raw()` (the underlying `Map`/`List`/scalar/`null`).
 
 ## Yaml Module
 


### PR DESCRIPTION
## Summary
- `Json::object()` / `Json::array()` and `Value.isNull()` / `Value.size()` / `Value.raw()` exist in `onion.Json` (`src/main/java/onion/Json.java`) but were missing, or only partially present, from the "Json Module" section of the stdlib reference in both languages.
- English reference (`docs/reference/stdlib.md`) gets the full set of additions: `Json::object()`/`Json::array()` builder examples plus a paragraph on `Value.isNull()`/`size()`/`raw()`.
- Japanese reference (`docs/ja/reference/stdlib.md`) already documented `Json::object()`/`isNull()`/`size()`; this adds the two it was still missing (`Json::array()`, `Value.raw()`) so both languages now cover the same API surface.
- Added a `[Unreleased]` CHANGELOG entry.

Docs-only change, no code changes.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3324 tests, 0 failed, 1 canceled (`ProjectDistributionSpec`'s opt-in smoke test, which self-cancels unless `-Donion.dist.path` is set — unrelated to this change), 0 ignored. All tests passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QPRGivSJ1MTNwtdM6v5JGT)_