### PR TITLE
refactor(typing): drop dead-code branch in BlockElementLowering.isMapType

### DIFF
--- a/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
+++ b/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
@@ -633,10 +633,7 @@ final class BlockElementLowering(
 
   /** True when the value is a java.util.Map (which has no iterator()). */
   private def isMapType(tp: Type): Boolean =
-    bodyContext.load("java.util.Map") match {
-      case mapType: ObjectType => TypeRules.isSuperType(mapType, tp)
-      case _ => false
-    }
+    TypeRules.isSuperType(bodyContext.load("java.util.Map"), tp)
 
   private def indexref(bind: ClosureLocalBinding, value: Term): Term =
     new RefArray(new RefLocal(bind), value)


### PR DESCRIPTION
## Summary
- `sbt compile` emitted an `[E121] Unreachable case except for null` warning in `BlockElementLowering.isMapType` (`src/main/scala/onion/compiler/typing/BlockElementLowering.scala:638`).
- `bodyContext.load(name)` returns a non-nullable `ClassType`, which always `extends ObjectType`, so the `case _: ObjectType => ... case _ => false` match's wildcard branch was dead code.
- Simplified to call `TypeRules.isSuperType` directly on the loaded type. No behavior change.

## Test plan
- [x] `sbt compile` — warning is gone, clean build
- [x] `sbt -Duser.language=en 'testOnly *ForeachSpec'` — passes (covers `foreach (k, v) in Map` / map destructuring, the caller of `isMapType`)
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green: 3324 succeeded, 0 failed, 1 canceled (pre-existing, opt-in `ProjectDistributionSpec` smoke test gated behind `-Donion.dist.path`, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_011tMgnxiXeJj9CmLq46sqrS)_