### PR TITLE
test: cover 5 more previously-untested run/ console samples

### DIFF
--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -409,5 +409,25 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs GraphAlgorithms.on") {
       assert(Shell.Success(null) == runSample("run/GraphAlgorithms.on"))
     }
+
+    it("runs GradeBook.on") {
+      assert(Shell.Success(null) == runSample("run/GradeBook.on"))
+    }
+
+    it("runs GraphSearch.on") {
+      assert(Shell.Success(null) == runSample("run/GraphSearch.on"))
+    }
+
+    it("runs InventoryReport.on") {
+      assert(Shell.Success(null) == runSample("run/InventoryReport.on"))
+    }
+
+    it("runs BudgetTracker.on") {
+      assert(Shell.Success(null) == runSample("run/BudgetTracker.on"))
+    }
+
+    it("runs CensusAnalyzer.on") {
+      assert(Shell.Success(null) == runSample("run/CensusAnalyzer.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary

`RunSamplesSpec` exercised roughly half of the `run/*.on` example programs (about 55 of 138 were never actually run by the test suite, only present as documentation samples). This adds coverage for 5 more, following the pattern from #677:

- `GradeBook.on`
- `GraphSearch.on`
- `InventoryReport.on`
- `BudgetTracker.on`
- `CensusAnalyzer.on`

All five are standalone console programs (no stdin, no CLI args) and were verified via `sbt runScript` to complete successfully, returning `Shell.Success(null)` after printing their reports.

## Test plan

- [x] `sbt -Duser.language=en test` — full suite green (3329 succeeded, 0 failed, 1 pre-existing unrelated canceled test in `ProjectDistributionSpec`)
- [x] Each new sample manually run via `sbt runScript run/<Name>.on` to confirm output and exit behavior before writing the assertion

---
Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_017p3udUsST8UdbovDBGfntK)_