### PR TITLE
test: cover 5 more previously-untested run/ console samples

### DIFF
--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -429,5 +429,25 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs CensusAnalyzer.on") {
       assert(Shell.Success(null) == runSample("run/CensusAnalyzer.on"))
     }
+
+    it("runs AirlineReservation.on") {
+      assert(Shell.Success(null) == runSample("run/AirlineReservation.on"))
+    }
+
+    it("runs AuctionHouse.on") {
+      assert(Shell.Success(null) == runSample("run/AuctionHouse.on"))
+    }
+
+    it("runs BankSystem.on") {
+      assert(Shell.Success(null) == runSample("run/BankSystem.on"))
+    }
+
+    it("runs Blackjack.on") {
+      assert(Shell.Success(null) == runSample("run/Blackjack.on"))
+    }
+
+    it("runs BookClub.on") {
+      assert(Shell.Success(null) == runSample("run/BookClub.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `RunSamplesSpec` still left roughly a third of `run/*.on` unexercised
- Add coverage for `AirlineReservation`, `AuctionHouse`, `BankSystem`, `Blackjack`, and `BookClub`, which all run standalone (no stdin, no CLI args) and return `Shell.Success(null)` after printing their reports

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3334 succeeded, 0 failed, 1 canceled (pre-existing opt-in `ProjectDistributionSpec` smoke test gated behind `-Donion.dist.path`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi36WmBK9Dmy3vfzvgfwa4)_