### PR TITLE
test: cover 5 more previously-untested run/ console samples

### DIFF
--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -449,5 +449,25 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs BookClub.on") {
       assert(Shell.Success(null) == runSample("run/BookClub.on"))
     }
+
+    it("runs BugTracker.on") {
+      assert(Shell.Success(null) == runSample("run/BugTracker.on"))
+    }
+
+    it("runs CarRentalFleet.on") {
+      assert(Shell.Success(null) == runSample("run/CarRentalFleet.on"))
+    }
+
+    it("runs CinemaBooking.on") {
+      assert(Shell.Success(null) == runSample("run/CinemaBooking.on"))
+    }
+
+    it("runs CipherSuite.on") {
+      assert(Shell.Success(null) == runSample("run/CipherSuite.on"))
+    }
+
+    it("runs ConferenceSchedule.on") {
+      assert(Shell.Success(null) == runSample("run/ConferenceSchedule.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `RunSamplesSpec` still left roughly 45 of the `run/*.on` example programs unexercised by any test.
- Adds coverage for `BugTracker.on`, `CarRentalFleet.on`, `CinemaBooking.on`, `CipherSuite.on`, and `ConferenceSchedule.on` — all of which run standalone (no stdin, no CLI args, no GUI) and return `Shell.Success(null)` after printing their reports.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3339 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated smoke test unrelated to this change), 0 ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ut4zDHwUcr6zCe3asMEDF)_