### PR TITLE
test: cover 5 more previously-untested run/ console samples

### DIFF
--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -469,5 +469,25 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs ConferenceSchedule.on") {
       assert(Shell.Success(null) == runSample("run/ConferenceSchedule.on"))
     }
+
+    it("runs ConwayLife.on") {
+      assert(Shell.Success(null) == runSample("run/ConwayLife.on"))
+    }
+
+    it("runs CourseRegistration.on") {
+      assert(Shell.Success(null) == runSample("run/CourseRegistration.on"))
+    }
+
+    it("runs DoctorScheduler.on") {
+      assert(Shell.Success(null) == runSample("run/DoctorScheduler.on"))
+    }
+
+    it("runs EspressoShop.on") {
+      assert(Shell.Success(null) == runSample("run/EspressoShop.on"))
+    }
+
+    it("runs EventTicketing.on") {
+      assert(Shell.Success(null) == runSample("run/EventTicketing.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `RunSamplesSpec` still left about 40 `run/*.on` files unexercised
- Adds coverage for `ConwayLife`, `CourseRegistration`, `DoctorScheduler`, `EspressoShop`, and `EventTicketing`, which all run standalone (no stdin, no CLI args, no GUI) and return `Shell.Success(null)` after printing their reports
- Continuation of the ongoing `run/` sample coverage sweep (see #677, #680, #681, #682)

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — 102 tests, all succeeded
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3344 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`, unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01LD4C5z7xBPoLgKehXmXy9z)_