### PR TITLE
test: cap MutationFuzzSpec total compilations to stop it OOMing

### DIFF
--- a/src/test/scala/onion/compiler/tools/MutationFuzzSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MutationFuzzSpec.scala
@@ -17,11 +17,19 @@ import scala.util.Random
  *
  * The seed is fixed so this is an ordinary regression test, not a flaky one.
  * Bump MUTATIONS_PER_SEED or change the seed locally to hunt for new crashes.
+ *
+ * Total compiler instantiations are capped at MAX_TOTAL_MUTATIONS regardless
+ * of how many seed programs exist in run/: each new example added there
+ * (encouraged elsewhere) would otherwise multiply this test's heap usage
+ * without bound, which previously OOM'd under the prescribed -Xmx4G once
+ * run/ grew past ~130 files (8280 compilations). Growing the corpus now
+ * scales down the effective per-seed mutation count instead.
  */
 class MutationFuzzSpec extends AnyFunSpec {
 
   private val SEED = sys.props.get("onion.fuzz.seed").map(_.toLong).getOrElse(20260610L)
   private val MUTATIONS_PER_SEED = sys.props.get("onion.fuzz.mutations").map(_.toInt).getOrElse(60)
+  private val MAX_TOTAL_MUTATIONS = sys.props.get("onion.fuzz.maxTotal").map(_.toInt).getOrElse(3000)
 
   private def newConfig: CompilerConfig =
     CompilerConfig(Seq("."), null, "UTF-8", "", 10)
@@ -80,11 +88,14 @@ class MutationFuzzSpec extends AnyFunSpec {
       .map(_.toSeq.filter(_.getName.endsWith(".on")).sortBy(_.getName)).getOrElse(Seq.empty)
     assert(seeds.nonEmpty, "no seed programs found in run/")
 
+    val mutationsPerSeed =
+      math.max(1, math.min(MUTATIONS_PER_SEED, MAX_TOTAL_MUTATIONS / seeds.size))
+
     val outDir = new File("/tmp/onion-fuzz")
     val crashers = scala.collection.mutable.Buffer[(String, String)]()
     for (seed <- seeds) {
       val original = scala.io.Source.fromFile(seed, "UTF-8").mkString
-      for (i <- 0 until MUTATIONS_PER_SEED) {
+      for (i <- 0 until mutationsPerSeed) {
         var mutated = original
         val mutations = 1 + rng.nextInt(3)
         for (_ <- 0 until mutations) mutated = mutate(mutated, rng)


### PR DESCRIPTION
## Summary
- `MutationFuzzSpec` compiles `MUTATIONS_PER_SEED` (60) mutants per `run/*.on` seed file. The `run/` corpus has grown to 138 files, so this is now 8,280 fresh `OnionCompiler` instantiations in a single test — which OOMs under the prescribed `-Xmx4G` (reproduced twice on a clean checkout, independent of any other diff).
- This was discovered blocking PR #684 (draft due to this OOM); that PR has since merged with only its own change, so this fix is split out as its own PR targeting the current `develop` HEAD.

## Fix
`MutationFuzzSpec` now caps its total compilations at `MAX_TOTAL_MUTATIONS` (default 3000, tunable via `-Donion.fuzz.maxTotal`) and scales the effective per-seed mutation count down as the corpus grows, so adding more `run/` examples (an explicitly encouraged kind of contribution) no longer makes this test's memory footprint unbounded.

## Test plan
- [x] `testOnly onion.compiler.tools.MutationFuzzSpec` under `-Xmx4G` — previously OOM'd (confirmed reproduced), now passes in ~50s
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` (matching this repo's actual CI heap setting in `.github/workflows/scala.yml` — the `-Xmx4G` figure in the release playbook is stale relative to CI) — **green**: 3349 tests, 456 suites, 0 failed, 0 aborted, 1 intentionally-gated smoke test canceled (`ProjectDistributionSpec`, requires `-Donion.dist.path`, also unset in CI)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197Dqg1ANS6G5L4SWmPw8qe)_