### PR TITLE
test: cover 5 more previously-untested run/ console samples

### DIFF
--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -509,5 +509,25 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs HuffmanCoding.on") {
       assert(Shell.Success(null) == runSample("run/HuffmanCoding.on"))
     }
+
+    it("runs InventoryManager.on") {
+      assert(Shell.Success(null) == runSample("run/InventoryManager.on"))
+    }
+
+    it("runs JobScheduler.on") {
+      assert(Shell.Success(null) == runSample("run/JobScheduler.on"))
+    }
+
+    it("runs KingdomSim.on") {
+      assert(Shell.Success(null) == runSample("run/KingdomSim.on"))
+    }
+
+    it("runs LibraryCatalog.on") {
+      assert(Shell.Success(null) == runSample("run/LibraryCatalog.on"))
+    }
+
+    it("runs LogAnalytics.on") {
+      assert(Shell.Success(null) == runSample("run/LogAnalytics.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `RunSamplesSpec` coverage for `InventoryManager.on`, `JobScheduler.on`, `KingdomSim.on`, `LibraryCatalog.on`, and `LogAnalytics.on`, continuing the alphabetical batch begun by earlier `test/run-samples-coverage-*-batch` PRs.
- All five are pure console samples (no stdin/GUI dependencies); each asserts `Shell.Success(null)` matching the established pattern for samples with no explicit non-void return.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3356 succeeded, 0 failed, 1 canceled (pre-existing, environment-dependent `ProjectDistributionSpec` distribution smoke test, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwHcdS92UdsAWA9YucQJKV)_