### PR TITLE
docs(stdlib): document undocumented onion.Timing methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `Value` accessors existed in code but were absent (or partially absent) from
   the docs in both languages, making them undiscoverable without reading the
   Java source.
+- **Documented `Timing::elapsedMillis`, `Timing::formatMillis`,
+  `Timing::measureVoid`, and `Timing::sleepNanos` in the Timing Module section
+  of both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.** These
+  `onion.Timing` public static methods existed in code but were absent from the
+  docs in both languages, making them undiscoverable without reading the Java
+  source. Added a drift-guard spec (`StdlibDocTimingModuleParitySpec`) so
+  future additions to `Timing`'s public API get caught the same way.
 
 ## [0.10.30] - 2026-08-11
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -670,8 +670,9 @@ val startMillis: Long = Timing::millis()   // 壁時計 (System.currentTimeMilli
 ```onion
 val start: Long = Timing::nanos()
 // ... 何らかの処理 ...
-val elapsedNs: Long = Timing::elapsedNanos(start)    // ナノ秒での経過時間
-val elapsedMs: Double = Timing::elapsedMs(start)     // ミリ秒での経過時間
+val elapsedNs: Long = Timing::elapsedNanos(start)      // ナノ秒での経過時間
+val elapsedMs: Double = Timing::elapsedMs(start)       // ミリ秒での経過時間（サブミリ秒精度のdouble）
+val elapsedMillis: Long = Timing::elapsedMillis(start) // Timing::millis()起点のミリ秒での経過時間
 ```
 
 ### 時間のフォーマット
@@ -680,12 +681,17 @@ val elapsedMs: Double = Timing::elapsedMs(start)     // ミリ秒での経過時
 val nanos: Long = 1234567890L
 val formatted: String = Timing::formatNanos(nanos)   // "1.23s"
 // 出力形式: "123ns", "45.67μs", "12.34ms", "1.23s"
+
+val millis: Long = 125000L
+val formattedMs: String = Timing::formatMillis(millis)  // "2m5s"
+// 出力形式: "500ms", "1.23s", "2m30s"
 ```
 
 ### スリープ
 
 ```onion
-Timing::sleep(1000L)  // 1000ミリ秒スリープ
+Timing::sleep(1000L)        // 1000ミリ秒スリープ
+Timing::sleepNanos(500000L) // 500,000ナノ秒スリープ
 ```
 
 ### 関数実行時間の計測
@@ -694,6 +700,12 @@ Timing::sleep(1000L)  // 1000ミリ秒スリープ
 // 実行時間を計測して表示し、結果を返す
 val result: Int = Timing::measure(() -> { return expensiveOperation(); })
 // 出力: "Elapsed: 123.45ms"
+
+// 戻り値のない関数版
+Timing::measureVoid(() -> { expensiveOperation(); })
+// 出力: "Elapsed: 123.45ms"
+Timing::measureVoid("task", () -> { expensiveOperation(); })
+// 出力: "task: 123.45ms"
 
 // 表示なしで実行時間（ナノ秒）を取得
 val timeNanos: Long = Timing::time(() -> { return expensiveOperation(); })

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -898,8 +898,9 @@ val startMillis: Long = Timing::millis()   // Wall clock (System.currentTimeMill
 ```onion
 val start: Long = Timing::nanos()
 // ... some operation ...
-val elapsedNs: Long = Timing::elapsedNanos(start)    // Elapsed in nanoseconds
-val elapsedMs: Double = Timing::elapsedMs(start)     // Elapsed in milliseconds
+val elapsedNs: Long = Timing::elapsedNanos(start)      // Elapsed in nanoseconds
+val elapsedMs: Double = Timing::elapsedMs(start)       // Elapsed in milliseconds (double, sub-ms precision)
+val elapsedMillis: Long = Timing::elapsedMillis(start) // Elapsed in milliseconds since a Timing::millis() start
 ```
 
 ### Formatting Time
@@ -908,12 +909,17 @@ val elapsedMs: Double = Timing::elapsedMs(start)     // Elapsed in milliseconds
 val nanos: Long = 1234567890L
 val formatted: String = Timing::formatNanos(nanos)   // "1.23s"
 // Output formats: "123ns", "45.67μs", "12.34ms", "1.23s"
+
+val millis: Long = 125000L
+val formattedMs: String = Timing::formatMillis(millis)  // "2m5s"
+// Output formats: "500ms", "1.23s", "2m30s"
 ```
 
 ### Sleep
 
 ```onion
-Timing::sleep(1000L)  // Sleep for 1000 milliseconds
+Timing::sleep(1000L)        // Sleep for 1000 milliseconds
+Timing::sleepNanos(500000L) // Sleep for 500,000 nanoseconds
 ```
 
 ### Measuring Function Execution
@@ -922,6 +928,12 @@ Timing::sleep(1000L)  // Sleep for 1000 milliseconds
 // Measure and print execution time, return result
 val result: Int = Timing::measure(() -> { return expensiveOperation(); })
 // Prints: "Elapsed: 123.45ms"
+
+// Same, but for a function that returns nothing
+Timing::measureVoid(() -> { expensiveOperation(); })
+// Prints: "Elapsed: 123.45ms"
+Timing::measureVoid("task", () -> { expensiveOperation(); })
+// Prints: "task: 123.45ms"
 
 // Get execution time in nanoseconds without printing
 val timeNanos: Long = Timing::time(() -> { return expensiveOperation(); })

--- a/src/test/scala/onion/compiler/tools/StdlibDocTimingModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocTimingModuleParitySpec.scala
@@ -1,0 +1,44 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Timing Module" section of docs/reference/stdlib.md (and its
+ * Japanese translation) against `onion.Timing`'s public API. Several public static
+ * methods on the class (see src/main/java/onion/Timing.java) were never mentioned
+ * in either reference, making them undiscoverable without reading the Java source.
+ */
+class StdlibDocTimingModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def sectionUnder(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+  }
+
+  private val methods = Seq(
+    "elapsedMillis", "formatMillis", "measureVoid", "sleepNanos"
+  )
+
+  it("mentions every public onion.Timing method in the English Timing Module section") {
+    val en = sectionUnder(read("docs/reference/stdlib.md"), "## Timing Module")
+    methods.foreach { name =>
+      assert(en.contains(s"Timing::$name"),
+        s"docs/reference/stdlib.md's Timing Module section doesn't mention Timing::$name, " +
+        "a public onion.Timing method")
+    }
+  }
+
+  it("mentions every public onion.Timing method in the Japanese Timing Module section") {
+    val ja = sectionUnder(read("docs/ja/reference/stdlib.md"), "## Timing モジュール")
+    methods.foreach { name =>
+      assert(ja.contains(s"Timing::$name"),
+        s"docs/ja/reference/stdlib.md's Timing モジュール section doesn't mention Timing::$name, " +
+        "a public onion.Timing method")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `Timing::elapsedMillis`, `Timing::formatMillis`, `Timing::measureVoid`, and `Timing::sleepNanos` existed in `onion.Timing` but were absent from the Timing Module section of both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, making them undiscoverable without reading the Java source.
- Added `StdlibDocTimingModuleParitySpec`, a drift-guard test (same pattern as the existing Strings/Json accessor parity specs) so future additions to `Timing`'s public API get caught the same way.
- Added a `[Unreleased]` CHANGELOG entry.

## Test plan
- [x] `StdlibDocTimingModuleParitySpec` fails before the doc changes, passes after (verified locally)
- [x] Full suite (`SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test`, English locale): 3360 succeeded, 0 failed, 1 canceled (pre-existing environment-dependent `ProjectDistributionSpec` case, unrelated to this change)