### PR TITLE
docs(stdlib): document undocumented onion.IO methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   docs in both languages, making them undiscoverable without reading the Java
   source. Added a drift-guard spec (`StdlibDocTimingModuleParitySpec`) so
   future additions to `Timing`'s public API get caught the same way.
+- **Documented 21 undocumented `onion.IO` methods
+  (`readLine`, `readAll`, `printf`, `format`, `eprint`, `eprintln`, `eprintf`,
+  `readInt`, `readLong`, `readDouble`, `readBoolean`, `tryReadInt`,
+  `tryReadDouble`, `tryReadLong`, `readLines`, `eachLine`, `printLines`,
+  `printAll`, `flush`, `newline`, `clear`) in the IO Module section of both
+  `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.** These public
+  static methods existed in code but were absent from the docs in both
+  languages, making them undiscoverable without reading the Java source. Added
+  a drift-guard spec (`StdlibDocIOAccessorParitySpec`) so future additions to
+  `IO`'s public API get caught the same way.
 
 ## [0.10.30] - 2026-08-11
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -55,6 +55,78 @@ val name: String = IO::readln("名前は？ ")
 IO::println("こんにちは、" + name)
 ```
 
+### IO::readLine
+
+標準入力から1行読み取り、入力の終端では `null` を返す。プロンプトなしの
+`IO::readln()` はこのメソッドの別名：
+
+```onion
+val line: String? = IO::readLine()
+```
+
+### IO::readAll
+
+残りの標準入力全体を1つの文字列として読み取り：
+
+```onion
+val everything: String = IO::readAll()
+```
+
+### フォーマット出力
+
+```onion
+IO::printf("%s is %d\n", "age", 30)
+val s: String = IO::format("%.2f", 3.14159)
+```
+
+### エラー出力（stderr）
+
+```onion
+IO::eprint("warning: ")
+IO::eprintln("disk almost full")
+IO::eprintf("failed after %d retries\n", 3)
+```
+
+### 型安全な入力
+
+1行を指定の型として読み取ってパースし、不正な入力なら例外を投げる。各メソッドには
+先にプロンプトを表示するオーバーロードがある：
+
+```onion
+val age: Int = IO::readInt("Age: ")
+val price: Long = IO::readLong("Price: ")
+val ratio: Double = IO::readDouble("Ratio: ")
+val ok: Boolean = IO::readBoolean("Continue? ")  // true/yes/1、false/no/0 を受け付け
+```
+
+### 安全な入力
+
+上記の型安全な読み取りと同様だが、不正な入力や入力終端では例外を投げず
+`null` を返す：
+
+```onion
+val n: Int? = IO::tryReadInt("N: ")
+val d: Double? = IO::tryReadDouble("D: ")
+val l: Long? = IO::tryReadLong("L: ")
+```
+
+### 行単位の入出力
+
+```onion
+val lines: List = IO::readLines()          // 入力の終端まで読み取り
+IO::eachLine { line => IO::println(line) } // 残りの各行にコールバックを適用
+IO::printLines(["a", "b", "c"])            // 1項目1行で出力
+IO::printAll("a", "b", "c")                // printLines の可変長引数版
+```
+
+### ユーティリティ
+
+```onion
+IO::flush()    // 標準出力をフラッシュ
+IO::newline()  // 空行を出力
+IO::clear()    // ターミナル画面をクリア（ANSIエスケープコード）
+```
+
 ## Math モジュール
 
 Javaの`Math`クラス経由の数学演算。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -55,6 +55,78 @@ val name: String = IO::readln("What's your name? ")
 IO::println("Hello, " + name)
 ```
 
+### IO::readLine
+
+Read a line from standard input, or `null` at end of input. `IO::readln()` (no
+prompt) is an alias for this:
+
+```onion
+val line: String? = IO::readLine()
+```
+
+### IO::readAll
+
+Read all remaining standard input as a single string:
+
+```onion
+val everything: String = IO::readAll()
+```
+
+### Formatted Output
+
+```onion
+IO::printf("%s is %d\n", "age", 30)
+val s: String = IO::format("%.2f", 3.14159)
+```
+
+### Error Output (stderr)
+
+```onion
+IO::eprint("warning: ")
+IO::eprintln("disk almost full")
+IO::eprintf("failed after %d retries\n", 3)
+```
+
+### Type-Safe Input
+
+Read and parse a line as a specific type, throwing on invalid input; each has
+an overload that prints a prompt first:
+
+```onion
+val age: Int = IO::readInt("Age: ")
+val price: Long = IO::readLong("Price: ")
+val ratio: Double = IO::readDouble("Ratio: ")
+val ok: Boolean = IO::readBoolean("Continue? ")  // accepts true/yes/1, false/no/0
+```
+
+### Safe Input
+
+Like the type-safe readers above, but return `null` instead of throwing on
+invalid input or end of stream:
+
+```onion
+val n: Int? = IO::tryReadInt("N: ")
+val d: Double? = IO::tryReadDouble("D: ")
+val l: Long? = IO::tryReadLong("L: ")
+```
+
+### Line-Oriented I/O
+
+```onion
+val lines: List = IO::readLines()          // reads until end of input
+IO::eachLine { line => IO::println(line) } // applies a callback to each remaining line
+IO::printLines(["a", "b", "c"])            // one item per line
+IO::printAll("a", "b", "c")                // varargs form of printLines
+```
+
+### Utility
+
+```onion
+IO::flush()    // flushes standard output
+IO::newline()  // prints a blank line
+IO::clear()    // clears the terminal screen (ANSI escape codes)
+```
+
 ## System Module
 
 Access to system-level operations via Java's `System` class.

--- a/src/test/scala/onion/compiler/tools/StdlibDocIOAccessorParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocIOAccessorParitySpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "IO Module" section of docs/reference/stdlib.md (and its
+ * Japanese translation) against `onion.IO`'s public API. Several public static
+ * methods on the class (see src/main/java/onion/IO.java) were never mentioned
+ * in either reference, making them undiscoverable without reading the Java source.
+ */
+class StdlibDocIOAccessorParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def sectionUnder(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+  }
+
+  private val methods = Seq(
+    "readLine", "readAll", "printf", "format", "eprint", "eprintln", "eprintf",
+    "readInt", "readLong", "readDouble", "readBoolean",
+    "tryReadInt", "tryReadDouble", "tryReadLong",
+    "readLines", "eachLine", "printLines", "printAll", "flush", "newline", "clear"
+  )
+
+  it("mentions every public onion.IO method in the English IO Module section") {
+    val en = sectionUnder(read("docs/reference/stdlib.md"), "## IO Module")
+    methods.foreach { name =>
+      assert(en.contains(s"IO::$name"),
+        s"docs/reference/stdlib.md's IO Module section doesn't mention IO::$name, " +
+        "a public onion.IO method")
+    }
+  }
+
+  it("mentions every public onion.IO method in the Japanese IO Module section") {
+    val ja = sectionUnder(read("docs/ja/reference/stdlib.md"), "## IO モジュール")
+    methods.foreach { name =>
+      assert(ja.contains(s"IO::$name"),
+        s"docs/ja/reference/stdlib.md's IO モジュール section doesn't mention IO::$name, " +
+        "a public onion.IO method")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Documents 21 public `onion.IO` static methods (`readLine`, `readAll`, `printf`, `format`, `eprint`, `eprintln`, `eprintf`, `readInt`, `readLong`, `readDouble`, `readBoolean`, `tryReadInt`, `tryReadDouble`, `tryReadLong`, `readLines`, `eachLine`, `printLines`, `printAll`, `flush`, `newline`, `clear`) that existed in code but were absent from the IO Module section of `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, making them undiscoverable without reading the Java source.
- Adds `StdlibDocIOAccessorParitySpec` as a drift guard for this section, mirroring the existing `StdlibDocStringsAccessorParitySpec` / `StdlibDocJsonAccessorParitySpec` / `StdlibDocTimingModuleParitySpec` pattern.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly *StdlibDocIOAccessorParitySpec *StdlibDocStringsAccessorParitySpec *StdlibDocJsonAccessorParitySpec *StdlibDocTimingModuleParitySpec'` — 8/8 green locally.
- [ ] Full `sbt -Duser.language=en test` — **could not be confirmed locally.** Two consecutive attempts in this sandbox died in a GC-thrashing `OutOfMemoryError` spiral partway through the suite (both times immediately after `FutureSpec`'s "combining futures" tests), under the exact `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m"` heap budget prescribed for this repo. `FutureSpec` run in isolation passes cleanly (33/33) in ~1.5s, so this looks like cumulative heap pressure across the full suite hitting the 4G ceiling rather than anything caused by this docs-only change. Opening as draft per policy until CI (which may have more headroom) confirms green, or until this is otherwise investigated.

Marking as draft until CI confirms the full suite is green in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRodzpfVxeqXXT9gF1UGDL)_