### PR TITLE
Document the lossless-shapes/lens API in the stdlib reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented the lossless-shapes/lens API and combinators in the `## Shape`
+  section of `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.**
+  The section covered `parse`, `print`, `canPrint`, and the L1/L2 laws, but
+  never mentioned `isLossless`, `parseLossless`, `printLossless`, `Lossless`,
+  `Residue`, the combinators (`eachLine`, `lines`, `sepBy`, `xmap`,
+  `orElse`), or `Shapes::config`/`Shapes::yaml` — leaving a real,
+  actively-used feature (lossless config editing, see
+  `docs/guide/shapes.md`) undiscoverable from the API reference a user would
+  actually search. Added a drift-guard spec
+  (`StdlibDocShapeModuleParitySpec`) so future additions to the `Shape`/
+  `Lossless` public API get caught the same way.
 - **Documented `Shapes::config` and `Shapes::yaml` in the "When to reach for
   `Shapes` directly" section of `docs/guide/shapes.md` and
   `docs/ja/guide/shapes.md`.** The section only mentioned `Shapes::regex` and

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -462,6 +462,42 @@ L1 のみで、どちらなのかを明言することが「可逆な言語」�
 `"abc,def"` から `Int` を2つ読むと defect は**2件**報告されます。最初の1件ではありません。
 `Outcome` の蓄積する `zip` はそのためにあります。
 
+### Lossless shape と lens
+
+L2 も満たす shape を *lossless* と呼びます——`isLossless()` がそれを伝え、
+`parseLossless(text[, origin])` は素の `T` の代わりに `Lossless[T]` を読みます:値と、
+その周辺すべての `Residue`（コメント、空白、キーの順序、元の値の書き方）です。
+`printLossless(value, residue)` はその residue を通して書き戻します——変更していない
+部分はバイト単位で再現され、意図的に変更した値だけが書き直されます。`Residue` は
+不透明な値で、生成した shape にだけ渡し戻してください。
+
+`Lossless[T]` そのものが lens です:`value()`/`residue()` でペアを読み、
+`withValue(v)` は residue を保ったまま値だけ差し替え、`edit { v => ... }` は更新を
+値にフォーカスします。`render()` がテキストを再構成します:
+
+```onion
+val r   = configShape.parseLossless(file"app.conf".text()).get()
+val out = r.edit { v => v.copy(port = 9090) }.render()
+// diff app.conf out  ->  1行だけ変わる
+```
+
+`Shapes::config` と `Shapes::yaml` は、`shape name = config` / `shape name = yaml` の
+糖衣構文の裏にある lossless shape を、`Shape[T]` の値として直接組み立てます。
+
+### コンビネータ
+
+- `eachLine(text[, origin])` — 1行ごとに `Outcome[T]` を返し、読めた行と読めなかった
+  行の defect の両方を保持します（`Outcome::values`/`Outcome::defects` で分離できます）。
+  ログファイルのように大半の行が読めるケースなど、部分的な結果に意味がある場合は
+  `lines()` よりこちらを使います。
+- `lines()` — 1行1値、全部読めるか失敗するかの `Shape[List[T]]` です。
+- `sepBy(separator)` — リテラルな区切り文字で分割する、全部読めるか失敗するかの
+  `Shape[List[T]]` です。
+- `xmap(forward, backward)` — 同型写像に沿って shape を運びます。`print` が黙って
+  壊れないよう、両方向の関数が必要です。
+- `orElse(other)` — この shape、読めなければ `other`。どちらも読めない場合は両方の
+  defect を報告します。印字はこの shape で行います。
+
 ## 関数インターフェース
 
 ラムダとクロージャのための組み込み関数型。`f.call(args)`の代わりに`f(args)`として呼び出せます。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -522,6 +522,42 @@ the method silently not existing.
 Reading two `Int` components out of `"abc,def"` reports **two** defects, not the first
 one. That is what `Outcome`'s accumulating `zip` is for.
 
+### Lossless shapes and lenses
+
+A shape that also satisfies L2 is *lossless* — `isLossless()` says so, and
+`parseLossless(text[, origin])` reads a `Lossless[T]` instead of a plain `T`: the value
+plus the `Residue` of everything around it (comments, spacing, key order, original
+value spellings). `printLossless(value, residue)` renders back through that residue —
+unchanged parts reproduce byte for byte, and only deliberately changed values re-render.
+`Residue` is opaque; hand it back only to the shape that produced it.
+
+`Lossless[T]` is the lens itself: `value()`/`residue()` read the pair, `withValue(v)`
+swaps the value while keeping the residue, and `edit { v => ... }` focuses an update.
+`render()` reassembles the text:
+
+```onion
+val r   = configShape.parseLossless(file"app.conf".text()).get()
+val out = r.edit { v => v.copy(port = 9090) }.render()
+// diff app.conf out  ->  one changed line
+```
+
+`Shapes::config` and `Shapes::yaml` build the lossless shapes behind `shape name =
+config` / `shape name = yaml` when you want the `Shape[T]` value directly instead of
+the sugar.
+
+### Combinators
+
+- `eachLine(text[, origin])` — one `Outcome[T]` per line, keeping both the lines that
+  read and the defects of the ones that didn't (`Outcome::values`/`Outcome::defects`
+  split them apart). Use this over `lines()` when a partial result is meaningful, as in
+  a log file where most lines parse.
+- `lines()` — a `Shape[List[T]]` reading one value per line, all or nothing.
+- `sepBy(separator)` — a `Shape[List[T]]` split on a literal separator, all or nothing.
+- `xmap(forward, backward)` — transports a shape along an isomorphism; both directions
+  are required so `print` isn't silently destroyed.
+- `orElse(other)` — this shape, or `other` when it doesn't read; reports both shapes'
+  defects when neither does. Prints with this shape.
+
 ## Function Interfaces
 
 Built-in function types for lambdas and closures. You can call them with `f(args)` as a shorthand for `f.call(args)`.

--- a/src/test/scala/onion/compiler/tools/StdlibDocShapeModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocShapeModuleParitySpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the `## Shape` section of docs/reference/stdlib.md (and its Japanese
+ * translation) against `onion.Shape`'s public API. The section covered `parse`,
+ * `print`, `canPrint`, and the L1/L2 laws, but never mentioned the lossless-shapes /
+ * lens API (`isLossless`, `parseLossless`, `printLossless`, `Lossless`, `Residue`), the
+ * combinators (`eachLine`, `lines`, `sepBy`, `xmap`, `orElse`), or the `Shapes::config`
+ * / `Shapes::yaml` factories (see src/main/java/onion/Shape.java, Lossless.java,
+ * Shapes.java) — making a real, actively-used feature undiscoverable from the API
+ * reference doc a user would actually search.
+ */
+class StdlibDocShapeModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def sectionUnder(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+  }
+
+  private val members = Seq(
+    "isLossless", "parseLossless", "printLossless",
+    "eachLine", "sepBy", "xmap", "orElse",
+    "Lossless", "Residue",
+    "Shapes::config", "Shapes::yaml"
+  )
+
+  it("mentions every lossless-shape/lens/combinator member in the English stdlib reference's Shape section") {
+    val en = sectionUnder(read("docs/reference/stdlib.md"), "## Shape")
+    members.foreach { name =>
+      assert(en.contains(name),
+        s"docs/reference/stdlib.md's Shape section doesn't mention $name, " +
+        "a public onion.Shape/Lossless/Shapes member")
+    }
+  }
+
+  it("mentions every lossless-shape/lens/combinator member in the Japanese stdlib reference's Shape section") {
+    val ja = sectionUnder(read("docs/ja/reference/stdlib.md"), "## Shape")
+    members.foreach { name =>
+      assert(ja.contains(name),
+        s"docs/ja/reference/stdlib.md's Shape section doesn't mention $name, " +
+        "a public onion.Shape/Lossless/Shapes member")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- The `## Shape` section of `docs/reference/stdlib.md` (and `docs/ja/reference/stdlib.md`) documented `parse`/`print`/`canPrint` and the L1/L2 laws, but never mentioned the lossless-shapes/lens API (`isLossless`, `parseLossless`, `printLossless`, `Lossless`, `Residue`) or the combinators (`eachLine`, `lines`, `sepBy`, `xmap`, `orElse`), or `Shapes::config`/`Shapes::yaml` — leaving a real, actively-used feature (lossless config editing, already covered in `docs/guide/shapes.md`) undiscoverable from the API reference doc a user would actually search.
- Adds the missing subsections in both English and Japanese.
- Adds a drift-guard spec, `StdlibDocShapeModuleParitySpec`, so future additions to `Shape`/`Lossless`'s public API get caught the same way (mirrors the existing `ShapesGuideDirectApiParitySpec` pattern).
- Adds a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan
- [x] Added `StdlibDocShapeModuleParitySpec` first and confirmed it fails (red) before the doc changes.
- [x] Added the doc sections; confirmed the new spec passes (green).
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` → 3378 passed, 0 failed, 1 canceled (expected dist-path smoke test).

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9mkrNh5weA7Pk3WxAThtd)_