### PR TITLE
docs(tools): document --Wno warning codes (W0001-W0015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Documented all 15 `--Wno` warning codes (`W0001`–`W0015`) in a new
+  reference table in `docs/tools/compiler.md` and `docs/ja/tools/compiler.md`.**
+  The `--Wno <codes>` option showed a single example (`W0001,unused-parameter`)
+  but never enumerated the warning categories, their codes, or their
+  `--Wno` name aliases defined in `WarningCategory` (`Warning.scala`) —
+  unlike `E0xxx` error codes, which get a full guarded reference page. Added
+  a drift-guard spec (`WarningCodeDocCoverageSpec`), mirroring
+  `ErrorCodeDocCoverageSpec`, so future warning categories get caught the
+  same way.
+
 ### Added
 
 - **`run/RestaurantOrders.on`, a 327-line restaurant order management sample.**

--- a/docs/ja/tools/compiler.md
+++ b/docs/ja/tools/compiler.md
@@ -122,6 +122,26 @@ onionc --warn error MyProgram.on
 onionc --Wno W0001,unused-parameter MyProgram.on
 ```
 
+各コードは `W####` 形式、または以下に示す `--Wno` 用の名前のどちらでも指定できます。
+
+| コード | 名前 | 説明 |
+|------|------|--------------|
+| `W0001` | `unused-variable` | 未使用の変数 |
+| `W0002` | `unused-import` | 未使用の import |
+| `W0003` | `unreachable-code` | 到達不能コード |
+| `W0004` | `deprecated`, `deprecated-feature` | 非推奨の機能 |
+| `W0005` | `shadowed-variable` | 変数のシャドーイング |
+| `W0006` | `unused-parameter` | 未使用の引数 |
+| `W0007` | `empty-block` | 空のブロック |
+| `W0008` | `redundant-cast` | 冗長なキャスト |
+| `W0009` | `possible-null-deref`, `null-deref` | null 参照の可能性 |
+| `W0010` | `unnecessary-conversion` | 不要な型変換 |
+| `W0011` | `unchecked-cast` | 未検査キャスト |
+| `W0012` | `null-to-non-nullable` | 非 null 型への null 代入 |
+| `W0013` | `suspicious-interpolation` | 疑わしい文字列補間構文 |
+| `W0014` | `discarded-toplevel` | main が定義されているためトップレベル文が無視された |
+| `W0015` | `platform-unboxing` | ボックス化されたプラットフォーム値が非 null プリミティブへ暗黙的にアンボックスされた |
+
 ### `--no-check-laws`
 
 レコードの `law` / `example` 句を実行しません。

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -122,6 +122,26 @@ Suppress specific warning categories by code or name.
 onionc --Wno W0001,unused-parameter MyProgram.on
 ```
 
+Every code accepts either its `W####` form or the `--Wno` name shown below:
+
+| Code | Name | Description |
+|------|------|--------------|
+| `W0001` | `unused-variable` | Unused variable |
+| `W0002` | `unused-import` | Unused import |
+| `W0003` | `unreachable-code` | Unreachable code |
+| `W0004` | `deprecated`, `deprecated-feature` | Deprecated feature |
+| `W0005` | `shadowed-variable` | Shadowed variable |
+| `W0006` | `unused-parameter` | Unused parameter |
+| `W0007` | `empty-block` | Empty block |
+| `W0008` | `redundant-cast` | Redundant cast |
+| `W0009` | `possible-null-deref`, `null-deref` | Possible null dereference |
+| `W0010` | `unnecessary-conversion` | Unnecessary type conversion |
+| `W0011` | `unchecked-cast` | Unchecked cast |
+| `W0012` | `null-to-non-nullable` | Null assigned to non-nullable type |
+| `W0013` | `suspicious-interpolation` | Suspicious string interpolation syntax |
+| `W0014` | `discarded-toplevel` | Top-level statements ignored because a main is defined |
+| `W0015` | `platform-unboxing` | Boxed platform value implicitly unboxed to a non-null primitive |
+
 ### `--no-check-laws`
 
 Do not execute a record's `law` / `example` clauses.

--- a/src/test/scala/onion/compiler/tools/WarningCodeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/WarningCodeDocCoverageSpec.scala
@@ -1,0 +1,43 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the warning-code reference, mirroring ErrorCodeDocCoverageSpec.
+ *
+ * `E0xxx` error codes get a full reference table in docs/reference/error-codes.md,
+ * guarded against drift. `W0xxx` warning codes (`WarningCategory` in Warning.scala,
+ * surfaced via `--Wno`) had no such table and no guard. This is that tie.
+ */
+class WarningCodeDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private lazy val declared: Set[String] =
+    """extends WarningCategory\("(W\d+)"""".r
+      .findAllMatchIn(read("src/main/scala/onion/compiler/Warning.scala"))
+      .map(_.group(1))
+      .toSet
+
+  private def check(path: String): Unit = {
+    val doc = read(path)
+    assert(declared.nonEmpty, "no WarningCategory cases found — the scan has rotted")
+    val missing = declared.filterNot(doc.contains).toSeq.sorted
+    assert(missing.isEmpty, s"$path does not mention: ${missing.mkString(", ")}")
+
+    // The reverse: a documented code that no longer exists sends readers looking for
+    // a warning they can never see.
+    val documented = """`(W\d{4})`""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+    val stale = (documented -- declared).toSeq.sorted
+    assert(stale.isEmpty, s"$path documents codes that no longer exist: ${stale.mkString(", ")}")
+  }
+
+  it("the English compiler tool reference mentions every declared warning code, and no retired one") {
+    check("docs/tools/compiler.md")
+  }
+
+  it("the Japanese compiler tool reference mentions every declared warning code, and no retired one") {
+    check("docs/ja/tools/compiler.md")
+  }
+}


### PR DESCRIPTION
## Summary
- `--Wno <codes>` showed a single example (`W0001,unused-parameter`) but never enumerated the 15 warning categories, their codes, or their `--Wno` name aliases defined in `WarningCategory` (`Warning.scala`) — unlike `E0xxx` error codes, which get a full guarded reference table in `docs/reference/error-codes.md`.
- Adds a reference table for all `W0001`–`W0015` codes to `docs/tools/compiler.md` and `docs/ja/tools/compiler.md`.
- Adds `WarningCodeDocCoverageSpec`, mirroring `ErrorCodeDocCoverageSpec`, so future warning categories can't drift from the docs undetected.

## Test plan
- [x] `WarningCodeDocCoverageSpec` written first and confirmed red (missing codes) before the doc changes, then green after.
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3404 succeeded, 0 failed, 1 pre-existing unrelated cancellation (`ProjectDistributionSpec`'s dist-journey test).

---
_Generated by [Claude Code](https://claude.ai/code/session_012n4cGvJsUEkCz7SEX5F7cS)_