### PR TITLE
test(extensions): cover nested-generic type args in extension collision fix

### DIFF
--- a/src/test/scala/onion/compiler/tools/ExtensionGenericParamNameSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ExtensionGenericParamNameSpec.scala
@@ -89,5 +89,47 @@ class ExtensionGenericParamNameSpec extends AbstractShellSpec {
       )
       assert(Shell.Success("6") == result)
     }
+
+    it("can define extension List[List[Int]] alongside extension List[List[String]] (nested type args)") {
+      val result = shell.run(
+        """
+          |extension List[List[Int]] {
+          |  def sumAll(): Int {
+          |    var total: Int = 0
+          |    foreach inner: List in this {
+          |      foreach v: Int in inner {
+          |        total = total + v
+          |      }
+          |    }
+          |    return total
+          |  }
+          |}
+          |
+          |extension List[List[String]] {
+          |  def joinAll(): String {
+          |    var s: String = ""
+          |    foreach inner: List in this {
+          |      foreach v: String in inner {
+          |        s = s + v
+          |      }
+          |    }
+          |    return s
+          |  }
+          |}
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val nums: List[List[Int]] = [[1, 2], [3, 4]]
+          |    val words: List[List[String]] = [["a", "b"], ["c"]]
+          |    return "" + nums.sumAll() + "/" + words.joinAll()
+          |  }
+          |}
+          |""".stripMargin,
+        "ExtNestedGenericParam.on",
+        Array()
+      )
+      assert(Shell.Success("10/abc") == result)
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `ExtensionGenericParamNameSpec` covered the E0008 extension-container-naming
  fix (`extension List[Int]` vs `extension List[String]`) only for single-level
  type arguments (`List[Int]`/`List[String]`, `Map[String, Int]`/`Map[String, String]`).
- Nested type arguments (`extension List[List[Int]]` vs `extension List[List[String]]`)
  were untested. Manually verified via `runScript` that the existing fix in
  `TypingHeaderPass` already handles this correctly (no code change needed) — this
  PR only adds the regression test to lock the behavior in.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly *ExtensionGenericParamNameSpec'` — 3/3 pass
- [x] `SBT_OPTS="-Xmx10g -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3429 tests, 0 failed, 1 canceled (gated dist smoke test)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjm5JzX8Za2D6T4Ttv51xv)_