### PR TITLE
docs(changelog): add CodeContest.on entry to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Rankable`); classes with mutable state; extension methods on `Int`,
   `Double`, `String`; collection pipelines including `zip` and
   `partition`; and `select`/type-pattern dispatch.
+- **`run/CodeContest.on`, a 543-line ICPC-style competitive programming
+  contest simulator.** Data-carrying enum (`Language`), plain enum
+  (`Verdict`), ADT case-enum (`ContestPhase`); records with `example`
+  clauses (`Problem`, `Submission`) and a generic record (`Ranked[T]`);
+  a class/interface pair (`Contest`, `Contestant conforms Scorable`);
+  `do[Option]` and `do[List]` monadic notation; collection pipelines
+  (`map`/`filter`/`fold`/`groupBy`/`sortedBy`/`distinct`/`find`); and
+  the `|>` pipeline operator.
 
 ## [0.10.34] - 2026-08-14
 


### PR DESCRIPTION
## Summary

- PR #730 added `run/CodeContest.on` (a 543-line ICPC-style competitive programming contest simulator) but did not add a `CHANGELOG.md` entry.
- This adds the missing `[Unreleased]` entry, following the same format as the other recent `run/` sample additions (GenericLeaderboard, GeneticSequencer, KaraokeNight, etc).

## Test results

```
[info] Total number of tests run: 3453
[info] Tests: succeeded 3453, failed 0, canceled 1, ignored 0, pending 0
[info] All tests passed.
```
(`sbt -Duser.language=en test`, English locale, per `docs/quality-bar.md`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdWkYCHJicaHmHcYKgbYWE)_