### PR TITLE
docs(ja): fix broken cross-doc anchor links in GENERICS_DESIGN.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sortedBy` collection pipelines; `foreach` map destructuring; `while`
   loops; string interpolation; and `select`/`is` pattern matching.
 
+### Fixed
+
+- **`docs/ja/GENERICS_DESIGN.md` linked to two anchors that MkDocs could
+  never generate.** Its cross-references to `reference/specification.md#ジェネリクス`
+  and `guide/classes-and-objects.md#ジェネリッククラス` relied on MkDocs
+  slugifying Japanese heading text, but the slugifier can't build a stable
+  slug from it and falls back to positional ids (`#_6`, `#_9`) instead —
+  confirmed broken via `mkdocs build --strict`. The two target headings now
+  carry explicit `attr_list` ids (`#generics`, `#generic-classes`, mirroring
+  the English page's slugs) and the links point at those.
+
 ## [0.10.34] - 2026-08-14
 
 ### Fixed

--- a/docs/ja/GENERICS_DESIGN.md
+++ b/docs/ja/GENERICS_DESIGN.md
@@ -3,8 +3,8 @@
 ステータス: **出荷済み。** 以下のチェックポイントはすべて完了している: クラス/メソッドへの型パラメータ、
 `[T extends Bound]` による上限境界、括弧による型適用、ブリッジメソッドを伴う消去ベースのコード生成、
 一般的なジェネリック呼び出しに対する型推論。現在の構文と意味論については
-[docs/reference/specification.md](reference/specification.md#ジェネリクス)と
-[docs/guide/classes-and-objects.md](guide/classes-and-objects.md#ジェネリッククラス)を、
+[docs/reference/specification.md](reference/specification.md#generics)と
+[docs/guide/classes-and-objects.md](guide/classes-and-objects.md#generic-classes)を、
 意図的にスコープ外としている点（消去ベース、不変、実行時型情報なし）については CLAUDE.md の
 「Known Limitations」を参照。このページは元の段階的計画の歴史的記録として残している。
 

--- a/docs/ja/guide/classes-and-objects.md
+++ b/docs/ja/guide/classes-and-objects.md
@@ -221,7 +221,7 @@ def describe(o: Opt[String]): String = select o {
 なります。定数形式の enum は型パラメータを取れません（`java.lang.Enum` になり、
 JVM がジェネリックな enum を許さないためです）。
 
-## ジェネリッククラス
+## ジェネリッククラス {: #generic-classes }
 
 クラスは `[]` で型パラメータを取れます。型パラメータは本体で通常の型として使えます：
 

--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -87,7 +87,7 @@ val         var         when        while
 - `null` リテラルを non-null 型に代入すると警告（W0012）
 - `Object` はあらゆる nullable 値を受け入れる（Scala の `Any` のようなトップ型）
 
-### ジェネリクス
+### ジェネリクス {: #generics }
 
 `[]` 構文の消去ベースジェネリクス: `class Box[T]`、`def first[T](xs: List[T]): T`、
 `record Pair[A, B](first: A, second: B)`。ワイルドカード `?`、`? extends T`、


### PR DESCRIPTION
## Summary
- `docs/ja/GENERICS_DESIGN.md` linked to `reference/specification.md#ジェネリクス` and `guide/classes-and-objects.md#ジェネリッククラス`, but MkDocs' default slugifier can't turn Japanese heading text into a stable slug and falls back to positional ids (`#_6`, `#_9`) instead. `mkdocs build --strict` confirmed both anchors were unresolved — this pair was the only Japanese-text cross-doc anchor link anywhere in `docs/ja/`.
- Gave the two target headings explicit `attr_list` ids (`#generics`, `#generic-classes`, mirroring the English page's slugs) and pointed the links at those instead, so the anchors stay stable across future heading edits instead of relying on fragile positional fallback ids.
- Added a one-line CHANGELOG entry under `[Unreleased] / Fixed`.

## Test plan
- [x] `pip install mkdocs-material mkdocs-glightbox && mkdocs build --strict` — no more "does not contain an anchor" warnings for these two links.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — `Total number of tests run: 3459`, `Tests: succeeded 3459, failed 0, canceled 1, ignored 0` (the one cancellation is a pre-existing, environment-dependent "unpacked distribution" test unrelated to this change), `All tests passed.`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014QYhs3gc1RrAEB9YYQRfwE

---
_Generated by [Claude Code](https://claude.ai/code/session_014QYhs3gc1RrAEB9YYQRfwE)_