### PR TITLE
fix: nullable method-call target reports E0070, not generic E0041

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Calling `.method()` (not `?.method()`) on a nullable class-typed value
+  (e.g. `x: Box?`) reported the generic, unhelpful `E0041`
+  ("type Box? is not a valid method call target.") instead of the dedicated
+  null-safety diagnostic `E0070`, which points at `?.` / `?:` / `!!` / a null
+  check.** Field access on the same nullable value already reported `E0070`;
+  `MethodTargetTypingSupport`'s method-call path just never had a
+  `NullableType` case to route through it.
+
 ## [0.10.35] - 2026-08-14
 
 ### Added

--- a/src/main/scala/onion/compiler/typing/MethodTargetTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodTargetTypingSupport.scala
@@ -24,6 +24,9 @@ private[compiler] final class MethodTargetTypingSupport(private val bodyContext:
       case tv: TypeVariableType if tv.nullability == Nullability.Nullable =>
         bodyContext.report(TYPE_PARAMETER_MAY_BE_NULL, node, tv.displayName)
         None
+      case nullable: NullableType =>
+        bodyContext.report(NULLABLE_MEMBER_ACCESS, node, nullable.displayName)
+        None
       case targetType: ObjectType =>
         Some(ResolvedMethodTarget(target, targetType))
       case basicType: BasicType =>

--- a/src/test/scala/onion/compiler/tools/NullableMemberAccessSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NullableMemberAccessSpec.scala
@@ -62,4 +62,72 @@ class NullableMemberAccessSpec extends AbstractShellSpec {
     )
     assert(Shell.Success(3) == result)
   }
+
+  it("rejects direct method call on a nullable class-typed value") {
+    val result = shell.run(
+      """
+        |class Box {
+        |  val value: Int
+        |public:
+        |  def this(v: Int) { value = v }
+        |  def get: Int = value
+        |}
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val b: Box? = new Box(1)
+        |    return b.get()
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Failure(-1) == result)
+  }
+
+  it("reports E0070, not the generic E0041 fallback, for a direct method call on a nullable value") {
+    val codes = errorCodes(
+      """
+        |class Box {
+        |  val value: Int
+        |public:
+        |  def this(v: Int) { value = v }
+        |  def get: Int = value
+        |}
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val b: Box? = new Box(1)
+        |    return b.get()
+        |  }
+        |}
+        |""".stripMargin
+    )
+    assert(codes.contains("E0070"), s"expected E0070 in $codes")
+    assert(!codes.contains("E0041"), s"must not fall back to the generic E0041 message: $codes")
+  }
+
+  it("accepts safe method call on a nullable value") {
+    val result = shell.run(
+      """
+        |class Box {
+        |  val value: Int
+        |public:
+        |  def this(v: Int) { value = v }
+        |  def get: Int = value
+        |}
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val b: Box? = new Box(1)
+        |    return b?.get() ?: 0
+        |  }
+        |}
+      """.stripMargin,
+      "None",
+      Array()
+    )
+    assert(Shell.Success(1) == result)
+  }
 }


### PR DESCRIPTION
## Summary

- `x.method()` where `x: Box?` (a nullable class-typed value, not a generic
  type parameter) fell through `MethodTargetTypingSupport.normalizeMethodCallTarget`
  to the generic `E0041` (`INVALID_METHOD_CALL_TARGET`, *"type Box? is not a
  valid method call target."*), which gives the caller no guidance on what to
  do about it.
- Field access on the same nullable value (`x.field`) already reports the
  dedicated `E0070` (`NULLABLE_MEMBER_ACCESS`), which points at `?.` / `?:` /
  `!!` / a null check — `normalizeMethodCallTarget` just never had a
  `NullableType` case to route through it, only a `TypeVariableType` (bare
  `[T]`) nullable case did. This adds the missing case, matching the existing
  `normalizeSafeMethodCallTarget` / `MemberSelectionResolutionSupport`
  handling for field access.
- Added `docs/CHANGELOG.md` entry (user-visible diagnostic change) and three
  new cases to `NullableMemberAccessSpec` covering the method-call path
  (reject direct call, reject-with-E0070-not-E0041, accept safe `?.` call).

## Test plan

- [x] `sbt -Duser.language=en 'testOnly *NullableMemberAccessSpec'` — 6/6 pass
- [x] `sbt -Duser.language=en 'testOnly *InvalidMethodCallTargetSpec *FlowSensitiveVarNarrowingSpec'` — no regressions (these cover other `E0041` call sites: indexing, construction, assignment — untouched by this change)
- [x] Full suite: `sbt -Duser.language=en test` — 3462 succeeded, 0 failed, 1 canceled (pre-existing `ProjectDistributionSpec` sandbox-environment skip, unrelated file)

---
Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rp3ZybVkeZZdCwDrYT3WSi)_