### PR TITLE
test: close the "Default static imports" describe block before the next one

### DIFF
--- a/src/test/scala/onion/compiler/tools/DefaultStaticImportSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DefaultStaticImportSpec.scala
@@ -66,7 +66,8 @@ class DefaultStaticImportSpec extends AbstractShellSpec {
       )
       assert(Shell.Success(4.0) == result)
     }
-  
+  }
+
   describe("the narrowed default set (#360): an effectful line looks effectful") {
     it("no longer resolves bare calls into Files, Http, DateTime or System") {
       for (call <- Seq(
@@ -138,5 +139,4 @@ class DefaultStaticImportSpec extends AbstractShellSpec {
       assert(Shell.Success("ok") == r, r.toString)
     }
   }
-}
 }


### PR DESCRIPTION
## Summary
- `DefaultStaticImportSpec` never closed its first top-level `describe("Default static imports")` block, so the second one (`describe("the narrowed default set (#360)...")`) ended up nested inside it instead of being a sibling — the convention every other spec in this package follows (e.g. `ArrayInvarianceSpec`, `AdtEnumSpec`).
- Braces were still balanced, so this compiled and ran fine, but scalac flagged the resulting indentation mismatch on every test compile:
  ```
  [warn] DefaultStaticImportSpec.scala:70:2
  [warn] 70 |  describe("the narrowed default set (#360): an effectful line looks effectful") {
  [warn]    |  ^
  [warn]    |  Line is indented too far to the left, or a `}` is missing
  ```
- Fix: close the first `describe` block right after its last `it`, making the second `describe` a sibling. No test names/assertions changed in substance beyond ScalaTest's nesting-derived display name.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *DefaultStaticImportSpec'` — 9/9 pass, no compiler warning
- [x] `sbt -Duser.language=en test` (full suite, default `-Xmx10g` from `.jvmopts`) — 3471 succeeded, 0 failed, 1 canceled (expected, dist smoke test), matches baseline on `develop`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuCsAr21fUgSUeKVwxREma)_