### PR TITLE
docs(changelog): record run/MarkdownConverter.on in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regex `select` patterns, `do[List]` comprehension, collection pipelines
   (`groupBy`/`sortedBy`/`filter`/`map`/`count`/`any`/`partition`),
   `foreach (k, v) in map`, and tail recursion.
+- **`run/MarkdownConverter.on`, a 371-line Markdown-to-HTML converter.**
+  Exercises an ADT case-enum with shared methods (`Block`: `Heading`/
+  `Paragraph`/`BulletItem`/`OrderedItem`/`CodeBlock`/`Blockquote`/`HRule`),
+  `select` + type-pattern binding, a `record` (`DocStats`), `extension
+  String` helpers, a cursor-style parser class with mutable state,
+  collection pipelines (`filter`/`map`/`groupBy`/`partition`/`find`/
+  `sortedBy`), nullable types with null-guards, string interpolation,
+  `while`/`foreach`, and `Regex::replace`/`Regex::groups` for inline
+  transforms.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- PR #741 added `run/MarkdownConverter.on` but didn't add a `CHANGELOG.md` entry.
- Backfills a `[Unreleased]` entry matching the style of the existing `ChemCalculator.on`/`NetworkMonitor.on` entries.

## Test plan
- Documentation-only change, no code touched.
- Full suite already verified green on this `develop` HEAD before this commit (3474 pass / 0 fail / 1 canceled, English locale).

---
_Generated by [Claude Code](https://claude.ai/code/session_01E64KjsTTHKfFwe5xW7H7Ky)_