### PR TITLE
fix: don't crash compiling try/catch assigned to a field or array element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check.** Field access on the same nullable value already reported `E0070`;
   `MethodTargetTypingSupport`'s method-call path just never had a
   `NullableType` case to route through it.
+- **Assigning a `try { ... } catch e: T { ... }` expression directly to a
+  field or array element crashed the compiler with `[I0000] Internal
+  compiler error in LawCheck: Inconsistent stackmap frames`** (issue #745),
+  most visibly inside a constructor. The JVM clears the operand stack when
+  it dispatches to an exception handler, so a receiver (or array ref/index)
+  already pushed before the `try` silently vanished on the exceptional path,
+  desyncing the merged stack shape from the normal path — the field/array
+  sibling of issue #669's call-argument bug. `visitSetField`/`visitSetArray`
+  now spill an already-pushed target (and index) into locals before
+  evaluating a value that may run its own `try`, mirroring the existing
+  `emitArgumentsWithAdaptation` fix for call arguments.
 
 ## [0.10.35] - 2026-08-14
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -133,16 +133,36 @@ class AsmCodeGenerationVisitor(
     gen.visitLabel(endLabel)
   
   override def visitSetArray(node: SetArray): Unit =
-    visitTerm(node.target)
-    visitTerm(node.index)
-    visitTerm(node.value)
-    // Duplicate value for return
     val valueType = asmType(node.`type`)
-    if valueType.getSize() == 2 then
-      gen.dup2X2()
+    if TermContainsTry.contains(node.value) then
+      // See visitSetField: the target/index can't stay live on the operand
+      // stack across a value that runs its own try/catch, since the JVM
+      // clears the stack when dispatching to an exception handler.
+      visitTerm(node.target)
+      val targetSlot = gen.newLocal(asmType(node.target.`type`))
+      gen.storeLocal(targetSlot)
+      visitTerm(node.index)
+      val indexSlot = gen.newLocal(AsmType.INT_TYPE)
+      gen.storeLocal(indexSlot)
+      visitTerm(node.value)
+      val valueSlot = gen.newLocal(valueType)
+      gen.storeLocal(valueSlot)
+      gen.loadLocal(targetSlot)
+      gen.loadLocal(indexSlot)
+      gen.loadLocal(valueSlot)
+      gen.arrayStore(valueType)
+      // Assignment is itself an expression; leave the assigned value as its result.
+      gen.loadLocal(valueSlot)
     else
-      gen.dupX2()
-    gen.arrayStore(valueType)
+      visitTerm(node.target)
+      visitTerm(node.index)
+      visitTerm(node.value)
+      // Duplicate value for return
+      if valueType.getSize() == 2 then
+        gen.dup2X2()
+      else
+        gen.dupX2()
+      gen.arrayStore(valueType)
   
   override def visitBegin(node: Begin): Unit =
     for i <- node.terms.indices do
@@ -401,17 +421,38 @@ class AsmCodeGenerationVisitor(
     gen.getField(ownerType, node.field.name, asmType(node.field.`type`))
   
   override def visitSetField(node: SetField): Unit =
-    visitTerm(node.target)
-    visitTerm(node.value)
-    // Duplicate value for return
     val valueType = asmType(node.`type`)
-    asmCodeGen.adaptValueOnStack(gen, node.value.`type`, valueType)
-    if valueType.getSize() == 2 then
-      gen.dup2X1()
-    else
-      gen.dupX1()
     val ownerType = AsmUtil.objectType(node.field.affiliation.name)
-    gen.putField(ownerType, node.field.name, valueType)
+    if TermContainsTry.contains(node.value) then
+      // The target must survive node.value's evaluation, but it can't stay on
+      // the operand stack if node.value runs its own try/catch: the JVM
+      // clears the stack when dispatching to an exception handler, so a bare
+      // target pushed before the try region would vanish on the exceptional
+      // path, desyncing the merged stack shape from the normal path (issue
+      // #745, the field-assignment sibling of issue #669's call-argument fix).
+      // Stash it in a local instead and reload it once the value is settled.
+      visitTerm(node.target)
+      val targetSlot = gen.newLocal(asmType(node.target.`type`))
+      gen.storeLocal(targetSlot)
+      visitTerm(node.value)
+      asmCodeGen.adaptValueOnStack(gen, node.value.`type`, valueType)
+      val valueSlot = gen.newLocal(valueType)
+      gen.storeLocal(valueSlot)
+      gen.loadLocal(targetSlot)
+      gen.loadLocal(valueSlot)
+      gen.putField(ownerType, node.field.name, valueType)
+      // Assignment is itself an expression; leave the assigned value as its result.
+      gen.loadLocal(valueSlot)
+    else
+      visitTerm(node.target)
+      visitTerm(node.value)
+      // Duplicate value for return
+      asmCodeGen.adaptValueOnStack(gen, node.value.`type`, valueType)
+      if valueType.getSize() == 2 then
+        gen.dup2X1()
+      else
+        gen.dupX1()
+      gen.putField(ownerType, node.field.name, valueType)
   
   override def visitNewObject(node: NewObject): Unit =
     val classType = AsmUtil.objectType(node.constructor.affiliation.name)

--- a/src/test/scala/onion/compiler/tools/TryInFieldAssignmentSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInFieldAssignmentSpec.scala
@@ -1,0 +1,113 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression assigned directly to a field or array element
+ * used to crash the compiler with an `[I0000]` internal error during
+ * bytecode verification (issue #745), the field/array-assignment sibling of
+ * issue #669's call-argument bug: the JVM clears the operand stack when it
+ * dispatches to an exception handler, so a receiver (or array ref/index)
+ * already pushed before the `try` was silently discarded on the exceptional
+ * path, desyncing the merged stack shape from the normal path — most visibly
+ * inside a constructor, where the receiver is pushed before `super()`
+ * returns.
+ *
+ * `AsmCodeGenerationVisitor.visitSetField`/`visitSetArray` now spill an
+ * already-pushed target (and index) into locals before evaluating a value
+ * that may run its own `try`, and reload them afterward.
+ */
+class TryInFieldAssignmentSpec extends AbstractShellSpec {
+  describe("try/catch expression assigned to a field or array element") {
+    it("does not corrupt the receiver of a field assignment inside a constructor (issue #745)") {
+      val result = shell.run(
+        """
+          |class C {
+          |  var _entries: List[Int]
+          |
+          |public:
+          |  def this(fail: Boolean) {
+          |    _entries = try {
+          |      if fail { throw new Exception("boom") }
+          |      [1, 2, 3]
+          |    } catch e: Exception {
+          |      [9, 9]
+          |    }
+          |  }
+          |
+          |  def entries(): List[Int] = _entries
+          |}
+          |
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val ok: C = new C(false)
+          |    val caught: C = new C(true)
+          |    return ok.entries().size + "|" + caught.entries().size
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInConstructorFieldAssignment.on",
+        Array()
+      )
+      assert(Shell.Success("3|2") == result)
+    }
+
+    it("preserves left-to-right evaluation order around the spilled receiver") {
+      val result = shell.run(
+        """
+          |class Box {
+          |public:
+          |  var v: Int
+          |}
+          |class Test {
+          |public:
+          |  static var log: String = ""
+          |
+          |  static def note(tag: String): String {
+          |    Test::log = Test::log + tag
+          |    return tag
+          |  }
+          |
+          |  static def getBox(b: Box): Box {
+          |    Test::note("G")
+          |    return b
+          |  }
+          |
+          |  static def boom(): Int {
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val b: Box = new Box()
+          |    Test::getBox(b).v = try { Test::note("T"); Test::boom() } catch _: Exception { 42 }
+          |    return Test::log + ":" + b.v
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInFieldAssignmentOrder.on",
+        Array()
+      )
+      assert(Shell.Success("GT:42") == result)
+    }
+
+    it("does not corrupt the array/index of an array-element assignment") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[3]
+          |    arr[0] = try { Integer::parseInt("7") } catch _: Exception { -1 }
+          |    arr[1] = try { Integer::parseInt("nope") } catch _: Exception { -1 }
+          |    return arr[0] + "|" + arr[1]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayAssignment.on",
+        Array()
+      )
+      assert(Shell.Success("7|-1") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #745 — assigning a `try { ... } catch e: T { ... }` expression directly to a field (`_x = try { ... } catch ...`) crashed the compiler with `[I0000] Internal compiler error in LawCheck: Inconsistent stackmap frames`, most visibly inside a constructor.
- Root cause: the JVM clears the operand stack when it dispatches to an exception handler. `visitSetField`/`visitSetArray` pushed the assignment target (and, for arrays, the index) onto the stack *before* evaluating the value, then used `dupX1`/`dupX2` tricks to combine them after. If the value expression contained its own `try`/`catch`, that already-pushed target silently vanished on the exceptional path, desyncing the merged stack shape between the normal and exceptional paths — the field/array-assignment sibling of issue #669's call-argument bug (`emitArgumentsWithAdaptation`).
- Fix: `visitSetField`/`visitSetArray` now detect (via the existing `TermContainsTry` helper) when the value may run its own `try`, and in that case spill the already-pushed target/index into locals before evaluating the value, then reload them — mirroring the established `emitArgumentsWithAdaptation` pattern. The common case (no nested `try`) is untouched and keeps the original dup-based bytecode.

## Test plan

- [x] Added `TryInFieldAssignmentSpec` (3 cases): the issue's constructor-field-assignment repro (normal + catch paths), left-to-right evaluation order around the spilled receiver, and the analogous array-element-assignment case.
- [x] Confirmed all three cases fail with `[I0000]` against the pre-fix code (reverted via `git stash`), and pass against the fix.
- [x] Full suite: `SBT_OPTS="-Xmx9G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3483 passed, 0 failed, 1 canceled (pre-existing, unrelated `ProjectDistributionSpec` environment-gated test).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QrojhjzpV1hvnX8pnTWikC)_