### PR TITLE
fix: don't crash on a try/catch expression as an array-literal element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now spill an already-pushed target (and index) into locals before
   evaluating a value that may run its own `try`, mirroring the existing
   `emitArgumentsWithAdaptation` fix for call arguments.
+- **A `try { ... } catch e: T { ... }` expression used as an array-literal
+  element (`new Int[]{1, try { ... } catch _: Exception { -1 }, 3}`) crashed
+  the compiler with the same `[I0000] Inconsistent stackmap frames` error**,
+  the array-literal sibling of the fix above. `visitNewArrayWithValues` left
+  the array reference and element index on the operand stack (via `dup()`
+  and a pushed constant) while evaluating each element, which the JVM
+  silently discards on the exceptional path; it now evaluates any element
+  that may run its own `try` first with an empty operand stack, stashes the
+  result in a local, and only then reloads the array reference, index, and
+  value for the `arrayStore`, mirroring `visitSetField`/`visitSetArray`.
 
 ## [0.10.35] - 2026-08-14
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -476,12 +476,32 @@ class AsmCodeGenerationVisitor(
     val componentType = asmType(node.arrayType.component)
     gen.push(node.values.length)
     gen.newArray(componentType)
-    for (i <- node.values.indices) {
-      gen.dup()
-      gen.push(i)
-      visitTerm(node.values(i))
-      gen.arrayStore(componentType)
-    }
+    if node.values.exists(TermContainsTry.contains) then
+      // See visitSetField/visitSetArray: nothing may be left on the operand
+      // stack (array ref, index, or otherwise) while an element's own
+      // evaluation runs a try/catch, since the JVM clears the stack when
+      // dispatching to an exception handler — it must be evaluated with an
+      // empty stack, then the array ref/index/value reloaded from locals
+      // for the store.
+      val arraySlot = gen.newLocal(asmType(node.arrayType))
+      gen.storeLocal(arraySlot)
+      for (i <- node.values.indices) {
+        visitTerm(node.values(i))
+        val valueSlot = gen.newLocal(componentType)
+        gen.storeLocal(valueSlot)
+        gen.loadLocal(arraySlot)
+        gen.push(i)
+        gen.loadLocal(valueSlot)
+        gen.arrayStore(componentType)
+      }
+      gen.loadLocal(arraySlot)
+    else
+      for (i <- node.values.indices) {
+        gen.dup()
+        gen.push(i)
+        visitTerm(node.values(i))
+        gen.arrayStore(componentType)
+      }
 
   override def visitRefStaticField(node: RefStaticField): Unit =
     val ownerType = AsmUtil.objectType(node.target.name)

--- a/src/test/scala/onion/compiler/tools/TryInArrayLiteralSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInArrayLiteralSpec.scala
@@ -1,0 +1,55 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as an element of an array-literal
+ * (`new T[]{ ... }`) crashed the compiler with an `[I0000]` internal error
+ * during bytecode verification, the array-literal sibling of issue #745's
+ * field/array-assignment bug: `visitNewArrayWithValues` `dup()`s the array
+ * reference before evaluating each element, and the JVM clears the operand
+ * stack when it dispatches to an exception handler, so that dup()'d
+ * reference was silently discarded on the exceptional path, desyncing the
+ * merged stack shape from the normal path.
+ *
+ * `AsmCodeGenerationVisitor.visitNewArrayWithValues` now spills the array
+ * reference into a local before evaluating any element when at least one
+ * element may run its own `try`, and reloads it for each `arrayStore`.
+ */
+class TryInArrayLiteralSpec extends AbstractShellSpec {
+  describe("try/catch expression as an array-literal element") {
+    it("does not corrupt the array reference across a caught and an uncaught element (issue #747-sibling)") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[]{1, try { Integer::parseInt("7") } catch _: Exception { -1 }, 3}
+          |    return arr[0] + "|" + arr[1] + "|" + arr[2]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayLiteralElement.on",
+        Array()
+      )
+      assert(Shell.Success("1|7|3") == result)
+    }
+
+    it("propagates the caught branch's value when parsing fails") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[]{try { Integer::parseInt("nope") } catch _: Exception { -1 }, 2}
+          |    return arr[0] + "|" + arr[1]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayLiteralElementCaught.on",
+        Array()
+      )
+      assert(Shell.Success("-1|2") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `new Int[]{1, try { ... } catch _: Exception { -1 }, 3}` crashed the compiler with `[I0000] Internal compiler error in LawCheck: Inconsistent stackmap frames` — the array-literal sibling of issue #745's field/array-assignment bug (fixed in #746).
- `visitNewArrayWithValues` left the array reference (via `dup()`) and the element index (a pushed constant) on the operand stack while evaluating each element. The JVM clears the operand stack when it dispatches to an exception handler, so those silently vanished on the exceptional path, desyncing the merged stack shape from the normal path.
- Fix: any element that may run its own `try` is now evaluated first with an empty operand stack, its result stashed in a local, and the array reference/index/value reloaded fresh right before the `arrayStore` — mirroring the existing `visitSetField`/`visitSetArray` fix.

## Test plan

- [x] Added `TryInArrayLiteralSpec` (two cases: caught + uncaught element, and a leading caught element) — red before the fix, green after.
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.TryInArrayLiteralSpec onion.compiler.tools.TryInFieldAssignmentSpec onion.compiler.tools.RunSamplesSpec'` — 118/118 passing (confirms no regression across the existing `run/` sample corpus, which exercises many array literals).
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3488 tests, 0 failed, 1 canceled (pre-existing, unrelated to this change) — all green.
- [x] `CHANGELOG.md` updated under `[Unreleased]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcJyY1piV1VrNjLfqo4Gho)_