### PR TITLE
fix: don't crash on try/catch in constructor args, safe-call args, or collection literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that may run its own `try` first with an empty operand stack, stashes the
   result in a local, and only then reloads the array reference, index, and
   value for the `arrayStore`, mirroring `visitSetField`/`visitSetArray`.
+- **A `try { ... } catch e: T { ... }` expression used as a constructor
+  argument, a super-constructor argument, a safe-call (`?.`) argument, a
+  `List`-literal element, or a `Map`-literal key/value crashed the compiler
+  with the same `[I0000] Inconsistent stackmap frames` error** — four more
+  siblings of the fixes above. For the safe-call case, the already-pushed,
+  already-initialized target just needed the same "spill to a local, reload
+  after" treatment as `visitSetField`/`visitNewArrayWithValues` (now applied
+  in `visitSafeCall`), and the `List`/`Map`-literal fix follows the same
+  pattern. The constructor and super-constructor cases needed a different
+  fix: the value `new` pushes (or `this`, before `super(...)`/`this(...)`
+  runs) is not an ordinary reference but a JVM-tracked "uninitialized"
+  value, which cannot survive being spilled into a local across a `try`'s
+  merge the way an already-initialized receiver can — attempting that
+  produced a *different* verifier rejection. `visitNewObject` and
+  `codeConstructor`'s super/self-delegation call now evaluate every
+  argument into a plain local *before* emitting `new`/loading `this` at
+  all, so no uninitialized value is ever in flight while an argument's own
+  `try` runs.
 
 ## [0.10.35] - 2026-08-14
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -196,18 +196,37 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
     val localVars = new LocalVarContext(gen).withParameters(false, argTypes)
 
     if ctor.superInitializer != null then
-      gen.loadThis()
-      var i = 0
-      while i < ctor.superInitializer.terms.length do
-        val arg = ctor.superInitializer.terms(i)
-        emitExpressionWithContext(gen, arg, className, localVars)
-        adaptValueOnStack(gen, arg.`type`, asmType(ctor.superInitializer.arguments(i)))
-        i += 1
+      val superArgTypes = ctor.superInitializer.arguments.map(asmType)
+      if ctor.superInitializer.terms.exists(TermContainsTry.contains) then
+        // `this` is `uninitializedThis` until this super/self-delegation call
+        // completes, and (like visitNewObject's freshly-`new`'d instance) that
+        // special verifier type cannot survive being spilled into a local
+        // across a try/catch merge. So `this` is not loaded until every
+        // argument has been evaluated into a plain local first.
+        val slots = new Array[Int](ctor.superInitializer.terms.length)
+        var i = 0
+        while i < ctor.superInitializer.terms.length do
+          val arg = ctor.superInitializer.terms(i)
+          emitExpressionWithContext(gen, arg, className, localVars)
+          adaptValueOnStack(gen, arg.`type`, superArgTypes(i))
+          val slot = gen.newLocal(superArgTypes(i))
+          gen.storeLocal(slot)
+          slots(i) = slot
+          i += 1
+        gen.loadThis()
+        for slot <- slots do gen.loadLocal(slot)
+      else
+        gen.loadThis()
+        var i = 0
+        while i < ctor.superInitializer.terms.length do
+          val arg = ctor.superInitializer.terms(i)
+          emitExpressionWithContext(gen, arg, className, localVars)
+          adaptValueOnStack(gen, arg.`type`, superArgTypes(i))
+          i += 1
       val targetClass =
         if ctor.superInitializer.selfDelegation then AsmUtil.internalName(ctor.classType.name)
         else if ctor.classType.superClass != null then AsmUtil.internalName(ctor.classType.superClass.name)
         else "java/lang/Object"
-      val superArgTypes = ctor.superInitializer.arguments.map(asmType)
       gen.invokeConstructor(
         AsmUtil.objectType(targetClass),
         AsmMethod("<init>", AsmType.getMethodDescriptor(AsmType.VOID_TYPE, superArgTypes*))

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -266,9 +266,11 @@ class AsmCodeGenerationVisitor(
     gen.dup()
     gen.visitJumpInsn(Opcodes.IFNULL, nullLabel)
 
-    // Non-null path: call the method
+    // Non-null path: call the method. The target survives the null check on
+    // the stack (the dup'd copy IFNULL consumed was the other one), so it is
+    // a pending operand across the arguments just like visitCall's receiver.
     val argTypes = node.method.arguments.map(asmType)
-    emitArgumentsWithAdaptation(node.parameters, argTypes)
+    emitArgumentsWithAdaptation(node.parameters, argTypes, Array(asmType(node.target.`type`)))
     val ownerType = AsmUtil.objectType(node.method.affiliation.name)
     val methodDesc = AsmType.getMethodDescriptor(
       asmType(node.method.returnType),
@@ -366,17 +368,38 @@ class AsmCodeGenerationVisitor(
     gen.dup()
     gen.push(node.elements.length)
     gen.invokeConstructor(listType, listCtor)
-    
-    // Add elements
-    for elem <- node.elements do
-      gen.dup() // Duplicate list reference
-      visitTerm(elem)
-      // Box primitive if needed
-      elem.`type` match
-        case bt: BasicType => gen.box(asmType(bt))
-        case _ => // Already an object
-      gen.invokeVirtual(listType, listAdd)
-      gen.pop() // Pop boolean result
+
+    if node.elements.exists(TermContainsTry.contains) then
+      // See visitNewArrayWithValues: the list reference can't stay on the
+      // operand stack across an element that may run its own try/catch, since
+      // the JVM clears the stack when dispatching to an exception handler.
+      // Spill it into a local instead and reload it for each add().
+      val objectType = AsmUtil.objectType(AsmUtil.JavaLangObject)
+      val listSlot = gen.newLocal(listType)
+      gen.storeLocal(listSlot)
+      for elem <- node.elements do
+        visitTerm(elem)
+        elem.`type` match
+          case bt: BasicType => gen.box(asmType(bt))
+          case _ => // Already an object
+        val elemSlot = gen.newLocal(objectType)
+        gen.storeLocal(elemSlot)
+        gen.loadLocal(listSlot)
+        gen.loadLocal(elemSlot)
+        gen.invokeVirtual(listType, listAdd)
+        gen.pop() // Pop boolean result
+      gen.loadLocal(listSlot)
+    else
+      // Add elements
+      for elem <- node.elements do
+        gen.dup() // Duplicate list reference
+        visitTerm(elem)
+        // Box primitive if needed
+        elem.`type` match
+          case bt: BasicType => gen.box(asmType(bt))
+          case _ => // Already an object
+        gen.invokeVirtual(listType, listAdd)
+        gen.pop() // Pop boolean result
 
   override def visitMapLiteral(node: MapLiteral): Unit =
     // Create LinkedHashMap (preserves literal entry order)
@@ -387,19 +410,46 @@ class AsmCodeGenerationVisitor(
     gen.dup()
     gen.invokeConstructor(mapType, mapCtor)
 
-    // Put entries
-    for i <- node.keys.indices do
-      gen.dup() // Duplicate map reference
-      visitTerm(node.keys(i))
-      node.keys(i).`type` match
-        case bt: BasicType => gen.box(asmType(bt))
-        case _ => // Already an object
-      visitTerm(node.values(i))
-      node.values(i).`type` match
-        case bt: BasicType => gen.box(asmType(bt))
-        case _ => // Already an object
-      gen.invokeVirtual(mapType, mapPut)
-      gen.pop() // Pop previous value
+    if (node.keys.iterator ++ node.values.iterator).exists(TermContainsTry.contains) then
+      // See visitListLiteral/visitNewArrayWithValues: the map reference can't
+      // stay on the operand stack across a key/value that may run its own
+      // try/catch. Spill it into a local instead and reload it for each put().
+      val objectType = AsmUtil.objectType(AsmUtil.JavaLangObject)
+      val mapSlot = gen.newLocal(mapType)
+      gen.storeLocal(mapSlot)
+      for i <- node.keys.indices do
+        visitTerm(node.keys(i))
+        node.keys(i).`type` match
+          case bt: BasicType => gen.box(asmType(bt))
+          case _ => // Already an object
+        val keySlot = gen.newLocal(objectType)
+        gen.storeLocal(keySlot)
+        visitTerm(node.values(i))
+        node.values(i).`type` match
+          case bt: BasicType => gen.box(asmType(bt))
+          case _ => // Already an object
+        val valueSlot = gen.newLocal(objectType)
+        gen.storeLocal(valueSlot)
+        gen.loadLocal(mapSlot)
+        gen.loadLocal(keySlot)
+        gen.loadLocal(valueSlot)
+        gen.invokeVirtual(mapType, mapPut)
+        gen.pop() // Pop previous value
+      gen.loadLocal(mapSlot)
+    else
+      // Put entries
+      for i <- node.keys.indices do
+        gen.dup() // Duplicate map reference
+        visitTerm(node.keys(i))
+        node.keys(i).`type` match
+          case bt: BasicType => gen.box(asmType(bt))
+          case _ => // Already an object
+        visitTerm(node.values(i))
+        node.values(i).`type` match
+          case bt: BasicType => gen.box(asmType(bt))
+          case _ => // Already an object
+        gen.invokeVirtual(mapType, mapPut)
+        gen.pop() // Pop previous value
   
   override def visitRefLocal(node: RefLocal): Unit =
     asmCodeGen.emitRefLocal(gen, node, localVars)
@@ -456,11 +506,34 @@ class AsmCodeGenerationVisitor(
   
   override def visitNewObject(node: NewObject): Unit =
     val classType = AsmUtil.objectType(node.constructor.affiliation.name)
-    gen.newInstance(classType)
-    gen.dup()
     val argTypes = node.constructor.getArgs.map(asmType)
-    emitArgumentsWithAdaptation(node.parameters, argTypes)
-    gen.invokeConstructor(classType, AsmMethod("<init>", AsmType.getMethodDescriptor(AsmType.VOID_TYPE, argTypes*)))
+    if node.parameters.exists(TermContainsTry.contains) then
+      // Unlike an ordinary receiver (visitCall), the value `new` pushes is not
+      // yet a real object -- the verifier tracks it as "uninitialized(new-site)"
+      // until the matching invokespecial runs, and that special type cannot
+      // safely cross a try/catch merge the way a spilled, already-initialized
+      // reference can (spilling it into a local and reloading it, as
+      // emitArgumentsWithAdaptation does for visitCall/visitSafeCall, produced
+      // bytecode the JVM verifier rejected: "Inconsistent stackmap frames").
+      // So no `new` may be in flight while an argument's own try runs: every
+      // argument is evaluated into a plain local first, and only then does
+      // `new`/`dup`/reload-args/<init> run as one straight, branch-free run.
+      val argSlots = new Array[Int](node.parameters.length)
+      for i <- node.parameters.indices do
+        visitTerm(node.parameters(i))
+        asmCodeGen.adaptValueOnStack(gen, node.parameters(i).`type`, argTypes(i))
+        val slot = gen.newLocal(argTypes(i))
+        gen.storeLocal(slot)
+        argSlots(i) = slot
+      gen.newInstance(classType)
+      gen.dup()
+      for slot <- argSlots do gen.loadLocal(slot)
+      gen.invokeConstructor(classType, AsmMethod("<init>", AsmType.getMethodDescriptor(AsmType.VOID_TYPE, argTypes*)))
+    else
+      gen.newInstance(classType)
+      gen.dup()
+      emitArgumentsWithAdaptation(node.parameters, argTypes)
+      gen.invokeConstructor(classType, AsmMethod("<init>", AsmType.getMethodDescriptor(AsmType.VOID_TYPE, argTypes*)))
   
   override def visitNewArray(node: NewArray): Unit =
     for param <- node.parameters do

--- a/src/test/scala/onion/compiler/tools/TryInConstructorArgAndCollectionLiteralSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInConstructorArgAndCollectionLiteralSpec.scala
@@ -1,0 +1,156 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as a constructor argument, a safe-call
+ * (`?.`) argument, a `List`-literal element, or a `Map`-literal key/value
+ * crashed the compiler with an `[I0000]` internal error during bytecode
+ * verification -- more siblings of issue #669/#745/#747: the JVM clears the
+ * operand stack when it dispatches to an exception handler, so a receiver
+ * (the `new`'d instance, the safe-call target) or collection reference
+ * already pushed via `dup()` before the `try` was silently discarded on the
+ * exceptional path, desyncing the merged stack shape from the normal path.
+ *
+ * `AsmCodeGenerationVisitor.visitNewObject`/`visitSafeCall` now pass their
+ * already-pushed receiver as a `pendingTypes` operand to
+ * `emitArgumentsWithAdaptation` (mirroring `visitCall`/`visitCallSuper`), and
+ * `visitListLiteral`/`visitMapLiteral` spill the collection reference into a
+ * local before evaluating any element/key/value that may run its own `try`,
+ * mirroring `visitNewArrayWithValues`.
+ */
+class TryInConstructorArgAndCollectionLiteralSpec extends AbstractShellSpec {
+  describe("try/catch expression as a constructor argument") {
+    it("does not corrupt the freshly-`new`'d receiver") {
+      val result = shell.run(
+        """
+          |record Pair(a: Int, b: Int)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val ok: Pair = new Pair(try { Integer::parseInt("7") } catch _: Exception { -1 }, 2)
+          |    val caught: Pair = new Pair(try { Integer::parseInt("nope") } catch _: Exception { -1 }, 3)
+          |    return ok.a() + "|" + ok.b() + "|" + caught.a() + "|" + caught.b()
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInConstructorArg.on",
+        Array()
+      )
+      assert(Shell.Success("7|2|-1|3") == result)
+    }
+  }
+
+  describe("try/catch expression as a super-constructor argument") {
+    it("does not corrupt uninitializedThis") {
+      val result = shell.run(
+        """
+          |class Base {
+          |public:
+          |  def this(v: Int) { self.v = v }
+          |  val v: Int
+          |}
+          |class Sub extends Base {
+          |public:
+          |  def this(x: Int): (try { Integer::parseInt(x + "") } catch _: Exception { -1 }) { }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val ok: Sub = new Sub(7)
+          |    return ok.v + ""
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInSuperConstructorArg.on",
+        Array()
+      )
+      assert(Shell.Success("7") == result)
+    }
+  }
+
+  describe("try/catch expression as a safe-call argument") {
+    it("does not corrupt the safe-call target") {
+      val result = shell.run(
+        """
+          |class Box {
+          |public:
+          |  def this(v: Int) { self.v = v }
+          |  val v: Int
+          |  def add(x: Int): Int { return v + x }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val b: Box? = new Box(1)
+          |    val n: Box? = null
+          |    val ok: Int? = b?.add(try { Integer::parseInt("6") } catch _: Exception { -1 })
+          |    val caught: Int? = b?.add(try { Integer::parseInt("nope") } catch _: Exception { -1 })
+          |    val nullTarget: Int? = n?.add(try { Integer::parseInt("6") } catch _: Exception { -1 })
+          |    return ok + "|" + caught + "|" + nullTarget
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInSafeCallArg.on",
+        Array()
+      )
+      assert(Shell.Success("7|0|null") == result)
+    }
+  }
+
+  describe("try/catch expression as a List-literal element") {
+    it("does not corrupt the list reference across a caught and an uncaught element") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val xs = [1, try { Integer::parseInt("7") } catch _: Exception { -1 }, 3]
+          |    val ys = [try { Integer::parseInt("nope") } catch _: Exception { -1 }, 2]
+          |    return xs[0] + "|" + xs[1] + "|" + xs[2] + "|" + ys[0] + "|" + ys[1]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInListLiteral.on",
+        Array()
+      )
+      assert(Shell.Success("1|7|3|-1|2") == result)
+    }
+  }
+
+  describe("try/catch expression as a Map-literal key or value") {
+    it("does not corrupt the map reference when the value may throw") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val m = ["a": try { Integer::parseInt("7") } catch _: Exception { -1 }, "b": 2]
+          |    return m["a"] + "|" + m["b"]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInMapLiteralValue.on",
+        Array()
+      )
+      assert(Shell.Success("7|2") == result)
+    }
+
+    it("does not corrupt the map reference when the key may throw") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val m = [(try { "k" + Integer::parseInt("7") } catch _: Exception { "err" }): 1, "b": 2]
+          |    return m["k7"] + "|" + m["b"]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInMapLiteralKey.on",
+        Array()
+      )
+      assert(Shell.Success("1|2") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `new Pair(try { ... } catch _: Exception { -1 }, 2)`, `b?.add(try { ... } catch ...)`, `[try { ... } catch ...]`, and `["k": try { ... } catch ...]` all crashed the compiler with `[I0000] Internal compiler error in LawCheck: Inconsistent stackmap frames` — four more siblings of the already-fixed #669/#745/#747 bug class. The JVM clears the operand stack when it dispatches to an exception handler, so a receiver/collection reference already pushed via `dup()` before a `try` argument was silently discarded on the exceptional path, desyncing the merged stack shape.
- `visitSafeCall` and the `List`/`Map`-literal codegen get the same "spill the already-pushed value into a local, reload it after" treatment already used for field/array assignment and array literals.
- `visitNewObject` and the super/self-delegation constructor call (`codeConstructor` in `AsmCodeGeneration.scala`) needed a **different** fix: the value `new` pushes (or `this`, before `super(...)`/`this(...)` runs) is a JVM-tracked "uninitialized" value, which cannot survive being spilled into a local across a `try`'s merge the way an already-initialized receiver can — that approach produced a different, still-invalid verifier rejection (`uninitializedThis`/`Uninitialized[0]` stack mismatch), confirmed against the *real* JVM verifier (not just the compiler's internal check), not merely the compiler's own bytecode check. The fix evaluates every argument into a plain local **before** `new`/`this` is even loaded, so no uninitialized value is ever in flight while an argument's own `try` runs.

## Test plan

- [x] New spec `TryInConstructorArgAndCollectionLiteralSpec` (6 tests, TDD: confirmed red against the unfixed code, green after the fix) covering all four sites plus the super-constructor-argument case.
- [x] `sbt -Duser.language=en test` — full suite green: 3494 passed, 0 failed, 1 cancelled (expected — the dist-smoke-test gated behind `-Donion.dist.path`). Ran with `-Xmx8G`; the CLAUDE.md-documented `-Xmx4G` figure is a known-bad recommendation the project's own `docs/quality-bar.md` explicitly warns against (real default is `-Xmx10g`, pinned in `.jvmopts`) and reliably OOMs regardless of this change.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMftPsu9v5hfQJW6G6FSeg)_