### PR TITLE
test: add execution-level regression coverage for AccessLogAnalyzer.on

### DIFF
--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -533,5 +533,23 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs LogAnalytics.on") {
       assert(Shell.Success(null) == runSample("run/LogAnalytics.on"))
     }
+
+    it("runs AccessLogAnalyzer.on and reports deterministic aggregate stats") {
+      val (result, output) = runSampleWithStdinCapturingStdout("run/AccessLogAnalyzer.on", "")
+      assert(Shell.Success(null) == result)
+      assert(output.contains("Parsed 15 entries"))
+      assert(output.contains("Total requests : 15"))
+      assert(output.contains("Successful     : 9 (60.0%)"))
+      assert(output.contains("Errors         : 5 (33.3%)"))
+      assert(output.contains("Total bytes    : 25353"))
+      assert(output.contains("/api/data                            3 hits  33.0% err  avg 5896.0 B"))
+      assert(output.contains("192.168.1.10       5 req  2 err"))
+      assert(output.contains("[ALERT] 192.168.1.10 -- multiple errors detected"))
+      assert(output.contains("[ALERT] 10.0.0.99 -- multiple errors detected"))
+      assert(output.contains("Last error from 192.168.1.10: 500 GET /api/data"))
+      assert(output.contains("Successes: 9   Failures: 6"))
+      assert(output.contains("Recursive total bytes: 25353"))
+      assert(output.contains("Analysis complete."))
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `RunSamplesSpec.scala` asserts actual `Shell` output for a curated subset of `run/*.on` samples, but `run/AccessLogAnalyzer.on` (added to the corpus in an earlier PR) had no execution-level assertion — only the blanket compile-check in `SampleProgramsSpec`.
- Adds an `it("runs AccessLogAnalyzer.on and reports deterministic aggregate stats")` block that runs the sample and asserts on key computed values from its output (totals, percentages, top path stats, per-IP counts, suspicious-client alerts, the `do[Option]` last-error message, and the partition/recursion totals).
- Confirmed the program's `groupBy`/`foreach (k, v) in map` output is deterministic: `Colls.groupBy` (src/main/java/onion/Colls.java:722) backs its result with a `LinkedHashMap`, so iteration follows first-appearance order for the fixed sample log — safe to assert on exactly.

## Test plan

- [x] `sbt 'testOnly *RunSamplesSpec -- -z "AccessLogAnalyzer"'` — new test passes in isolation
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — full suite green: 3495 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated distribution smoke test, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtDspdYtH7nc8ZKfe2oWgW)_