### PR TITLE
fix: don't crash on try/catch as a binary operator's right operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`try`/`catch` as the right-hand operand of a binary operator no longer
+  crashes the compiler.** `1 + (try { ... } catch { ... })`, and the same for
+  other arithmetic, bitwise, and comparison operators, previously crashed
+  with an `[I0000]` internal error during bytecode verification: the JVM
+  clears the operand stack when dispatching to an exception handler, so a
+  left operand already pushed before the `try`'d right operand ran was
+  silently discarded on the exceptional path. This is the binary-operator
+  sibling of the constructor-argument, list/map-literal, and field/array-
+  assignment fixes for the same underlying issue (#669 and friends).
+
 ## [0.10.36] - 2026-08-15
 
 ### Added

--- a/src/main/scala/onion/compiler/backend/asm/TermEmitter.scala
+++ b/src/main/scala/onion/compiler/backend/asm/TermEmitter.scala
@@ -11,31 +11,50 @@ final class TermEmitter(
   asmType: Type => AsmType,
   visitTerm: Term => Unit
 ) {
+  // Push lhs then rhs for an arithmetic/bitwise/comparison operator. If rhs
+  // may run its own try/catch, lhs can't stay on the operand stack across it:
+  // the JVM clears the stack when dispatching to an exception handler, so an
+  // already-pushed lhs would be silently discarded on the exceptional path,
+  // desyncing the merged stack shape from the normal path (the binary-operator
+  // sibling of issue #669/#745/#747/#750). Spill it into a local instead and
+  // reload it once rhs has settled -- mirroring
+  // AsmCodeGenerationVisitor.visitSetField/visitSetArray. LOGICAL_AND/OR and
+  // ELVIS don't need this: their short-circuit branching already consumes lhs
+  // off the stack before rhs runs.
+  private def pushOperands(node: BinaryTerm): Unit =
+    if TermContainsTry.contains(node.rhs) then
+      visitTerm(node.lhs)
+      val lhsSlot = gen.newLocal(asmType(node.lhs.`type`))
+      gen.storeLocal(lhsSlot)
+      visitTerm(node.rhs)
+      val rhsSlot = gen.newLocal(asmType(node.rhs.`type`))
+      gen.storeLocal(rhsSlot)
+      gen.loadLocal(lhsSlot)
+      gen.loadLocal(rhsSlot)
+    else
+      visitTerm(node.lhs)
+      visitTerm(node.rhs)
+
   def emitBinaryTerm(node: BinaryTerm): Unit =
     node.kind match
       case ADD =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.ADD, asmType(node.`type`))
 
       case SUBTRACT =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.SUB, asmType(node.`type`))
 
       case MULTIPLY =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.MUL, asmType(node.`type`))
 
       case DIVIDE =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.DIV, asmType(node.`type`))
 
       case MOD =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.REM, asmType(node.`type`))
 
       case LOGICAL_AND =>
@@ -61,33 +80,27 @@ final class TermEmitter(
         gen.visitLabel(endLabel)
 
       case BIT_AND =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.AND, asmType(node.`type`))
 
       case BIT_OR =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.OR, asmType(node.`type`))
 
       case XOR =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.XOR, asmType(node.`type`))
 
       case BIT_SHIFT_L2 =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.SHL, asmType(node.lhs.`type`))
 
       case BIT_SHIFT_R2 =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.SHR, asmType(node.lhs.`type`))
 
       case BIT_SHIFT_R3 =>
-        visitTerm(node.lhs)
-        visitTerm(node.rhs)
+        pushOperands(node)
         gen.math(GeneratorAdapter.USHR, asmType(node.lhs.`type`))
 
       case LESS_THAN =>
@@ -149,8 +162,7 @@ final class TermEmitter(
             throw new UnsupportedOperationException(s"Bitwise NOT not supported for type: ${node.`type`}")
 
   private def emitComparison(node: BinaryTerm, opcode: Int): Unit =
-    visitTerm(node.lhs)
-    visitTerm(node.rhs)
+    pushOperands(node)
     val trueLabel = gen.newLabel()
     val endLabel = gen.newLabel()
     gen.ifCmp(asmType(node.lhs.`type`), opcode, trueLabel)

--- a/src/test/scala/onion/compiler/tools/TryInBinaryOperandSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInBinaryOperandSpec.scala
@@ -1,0 +1,106 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as the right-hand operand of a binary
+ * operator (arithmetic, bitwise, or comparison) crashed the compiler with an
+ * `[I0000]` internal error during bytecode verification -- another sibling of
+ * issue #669/#745/#747/#750: the JVM clears the operand stack when it
+ * dispatches to an exception handler, so a left-hand operand already pushed
+ * before the `try` was silently discarded on the exceptional path, desyncing
+ * the merged stack shape from the normal path.
+ *
+ * `TermEmitter.emitBinaryTerm`/`emitComparison` now spill an already-pushed
+ * left-hand operand into a local before evaluating a right-hand operand that
+ * may run its own `try`, and reload it afterward -- mirroring
+ * `AsmCodeGenerationVisitor.visitSetField`/`visitSetArray`.
+ */
+class TryInBinaryOperandSpec extends AbstractShellSpec {
+  describe("try/catch expression as the right-hand operand of a binary operator") {
+    it("does not corrupt the left operand of an arithmetic expression") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val ok: Int = 1 + (try { Integer::parseInt("7") } catch _: Exception { -1 })
+          |    val caught: Int = 1 + (try { Integer::parseInt("nope") } catch _: Exception { -1 })
+          |    return ok + "|" + caught
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInBinaryArithmetic.on",
+        Array()
+      )
+      assert(Shell.Success("8|0") == result)
+    }
+
+    it("does not corrupt the left operand of a comparison expression") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val ok: Boolean = 5 < (try { Integer::parseInt("7") } catch _: Exception { -1 })
+          |    val caught: Boolean = 5 < (try { Integer::parseInt("nope") } catch _: Exception { -1 })
+          |    return ok + "|" + caught
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInBinaryComparison.on",
+        Array()
+      )
+      assert(Shell.Success("true|false") == result)
+    }
+
+    it("does not corrupt a Long left operand across a try'd right operand") {
+      val result = shell.run(
+        """
+          |import {
+          |  java.lang.Long as JLong;
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val ok: Long = 10L + (try { JLong::parseLong("7") } catch _: Exception { -1L })
+          |    val caught: Long = 10L + (try { JLong::parseLong("nope") } catch _: Exception { -1L })
+          |    return ok + "|" + caught
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInBinaryLong.on",
+        Array()
+      )
+      assert(Shell.Success("17|9") == result)
+    }
+
+    it("preserves left-to-right evaluation order around the spilled left operand") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static var log: String = ""
+          |
+          |  static def note(tag: String): Int {
+          |    Test::log = Test::log + tag
+          |    return 1
+          |  }
+          |
+          |  static def boom(): Int {
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val total: Int = Test::note("L") + (try { Test::note("R"); Test::boom() } catch _: Exception { 42 })
+          |    return Test::log + ":" + total
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInBinaryOrder.on",
+        Array()
+      )
+      assert(Shell.Success("LR:43") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `1 + (try { ... } catch { ... })` — and the same for other arithmetic, bitwise, and comparison operators — crashed the compiler with an `[I0000]` internal error during bytecode verification.
- Root cause: the JVM clears the operand stack when it dispatches to an exception handler. `TermEmitter.emitBinaryTerm`/`emitComparison` pushed the left operand, then evaluated the right operand; if the right operand contained its own `try`/`catch` and it threw, the left operand already sitting on the stack was silently discarded on the exceptional path, desyncing the merged stack shape from the normal path.
- This is the binary-operator sibling of the constructor-argument (#669), list/map-literal, and field/array-assignment (#745) fixes for the same underlying issue.
- Fix: `TermEmitter` now spills an already-pushed left operand into a local before evaluating a right operand that may run its own `try`, and reloads it afterward — mirroring `AsmCodeGenerationVisitor.visitSetField`/`visitSetArray`. `&&`/`||` and `?:` needed no change since their short-circuit branching already consumes the left operand off the stack before the right operand runs.

## Test plan

- [x] Added `TryInBinaryOperandSpec` (arithmetic, comparison, Long-typed operands, and left-to-right evaluation order) — confirmed red before the fix, green after.
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3499 succeeded, 0 failed, 1 canceled (pre-existing, environment-conditional dist smoke test unrelated to this change).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PuWcQByu4PWCZ9KeHtYXuX)_