### PR TITLE
Fix compiler crash: try/catch as an array-index expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently discarded on the exceptional path. This is the binary-operator
   sibling of the constructor-argument, list/map-literal, and field/array-
   assignment fixes for the same underlying issue (#669 and friends).
+- **`try`/`catch` as an array-index expression no longer crashes the
+  compiler.** `arr[try { ... } catch { ... }]` previously crashed with an
+  `[I0000]` internal error during bytecode verification: the array reference
+  was pushed onto the operand stack before evaluating the index, and the JVM
+  clears the stack when dispatching to an exception handler, silently
+  discarding that reference on the exceptional path. This is the array-read
+  sibling of the array-write fix for the same underlying issue (#745 and
+  friends).
 
 ## [0.10.36] - 2026-08-15
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -83,9 +83,23 @@ class AsmCodeGenerationVisitor(
     gen.arrayLength()
   
   override def visitRefArray(node: RefArray): Unit =
-    visitTerm(node.target)
-    visitTerm(node.index)
-    gen.arrayLoad(asmType(node.`type`))
+    if TermContainsTry.contains(node.index) then
+      // See visitSetArray: the target can't stay live on the operand stack
+      // across an index expression that runs its own try/catch, since the
+      // JVM clears the stack when dispatching to an exception handler.
+      visitTerm(node.target)
+      val targetSlot = gen.newLocal(asmType(node.target.`type`))
+      gen.storeLocal(targetSlot)
+      visitTerm(node.index)
+      val indexSlot = gen.newLocal(AsmType.INT_TYPE)
+      gen.storeLocal(indexSlot)
+      gen.loadLocal(targetSlot)
+      gen.loadLocal(indexSlot)
+      gen.arrayLoad(asmType(node.`type`))
+    else
+      visitTerm(node.target)
+      visitTerm(node.index)
+      gen.arrayLoad(asmType(node.`type`))
 
   /**
    * Non-null assertion: target!! — throw NullPointerException on null,

--- a/src/test/scala/onion/compiler/tools/TryInArrayIndexSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInArrayIndexSpec.scala
@@ -1,0 +1,107 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as the index of an array-read (`arr[...]`)
+ * crashed the compiler with an `[I0000]` internal error during bytecode
+ * verification, the read-side sibling of issue #745's array-assignment bug:
+ * `visitRefArray` pushes the array reference unconditionally before
+ * evaluating the index, and the JVM clears the operand stack when it
+ * dispatches to an exception handler, so that already-pushed reference was
+ * silently discarded on the exceptional path, desyncing the merged stack
+ * shape from the normal path.
+ *
+ * `AsmCodeGenerationVisitor.visitRefArray` now spills the array reference
+ * into a local before evaluating an index that may run its own `try`, and
+ * reloads it afterward.
+ */
+class TryInArrayIndexSpec extends AbstractShellSpec {
+  describe("try/catch expression as an array-index") {
+    it("does not corrupt the array reference across a caught index expression") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[5]
+          |    arr[0] = 10
+          |    arr[1] = 20
+          |    arr[2] = 30
+          |    val y: Int = arr[try {
+          |      Integer::parseInt("nope")
+          |    } catch _: Exception {
+          |      1
+          |    }]
+          |    return y + ""
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexCaught.on",
+        Array()
+      )
+      assert(Shell.Success("20") == result)
+    }
+
+    it("does not corrupt the array reference on the non-throwing path") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[5]
+          |    arr[0] = 10
+          |    arr[1] = 20
+          |    arr[2] = 30
+          |    val y: Int = arr[try {
+          |      Integer::parseInt("2")
+          |    } catch _: Exception {
+          |      -1
+          |    }]
+          |    return y + ""
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexOk.on",
+        Array()
+      )
+      assert(Shell.Success("30") == result)
+    }
+
+    it("preserves left-to-right evaluation order around the spilled array reference") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static var log: String = ""
+          |
+          |  static def note(tag: String): String {
+          |    Test::log = Test::log + tag
+          |    return tag
+          |  }
+          |
+          |  static def getArr(a: Int[]): Int[] {
+          |    Test::note("G")
+          |    return a
+          |  }
+          |
+          |  static def boom(): Int {
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[3]
+          |    arr[0] = 100
+          |    arr[1] = 200
+          |    val y: Int = Test::getArr(arr)[try { Test::note("T"); Test::boom() } catch _: Exception { 1 }]
+          |    return Test::log + ":" + y
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexOrder.on",
+        Array()
+      )
+      assert(Shell.Success("GT:200") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `arr[try { ... } catch { ... }]` crashed the compiler with an `[I0000]` internal error during bytecode verification ("Inconsistent stackmap frames").
- Root cause: `visitRefArray` pushed the array reference onto the operand stack before evaluating the index. The JVM clears the operand stack when dispatching to an exception handler, so an already-pushed array reference was silently discarded on the exceptional path whenever the index contained its own `try`/`catch`, desyncing the merged stack shape from the normal path.
- This is the array-*read* sibling of the array-*write* fix already in place in `visitSetArray` (and the constructor-argument / list-literal / field-assignment / binary-operator fixes for the same underlying issue, #669 and friends).
- Fix mirrors the existing `visitSetArray` pattern: when `TermContainsTry.contains(node.index)`, spill the array reference into a local before evaluating the index, then reload both before the `arrayLoad`.

## Test plan

- [x] Added `TryInArrayIndexSpec` (3 cases: caught-branch value, non-throwing-branch value, left-to-right evaluation order across the spill) — reproduced the crash before the fix (red), verified passing after (green).
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3502 tests succeeded, 0 failed, 1 canceled (pre-existing, unrelated).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018FtRJcxfznDXGajpnwfwxa)_