### PR TITLE
fix: don't crash on try/catch as a multi-dim array-creation dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discarding that reference on the exceptional path. This is the array-read
   sibling of the array-write fix for the same underlying issue (#745 and
   friends).
+- **`try`/`catch` as a later dimension of a multi-dimensional array creation
+  no longer crashes the compiler.** `new Int[3][try { ... } catch { ... }]`
+  previously crashed with an `[I0000]` internal error during bytecode
+  verification: every dimension was pushed onto the operand stack
+  unconditionally before the `multianewarray` instruction, and the JVM
+  clears the stack when dispatching to an exception handler, silently
+  discarding earlier dimensions on the exceptional path. This is the
+  array-creation sibling of the array-index and array-assignment fixes for
+  the same underlying issue (#745, #752, and friends).
 
 ## [0.10.36] - 2026-08-15
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -550,13 +550,27 @@ class AsmCodeGenerationVisitor(
       gen.invokeConstructor(classType, AsmMethod("<init>", AsmType.getMethodDescriptor(AsmType.VOID_TYPE, argTypes*)))
   
   override def visitNewArray(node: NewArray): Unit =
-    for param <- node.parameters do
-      visitTerm(param)
     val componentType = asmType(node.arrayType.component)
     if node.parameters.length == 1 then
+      visitTerm(node.parameters(0))
       gen.newArray(componentType)
+    else if node.parameters.exists(TermContainsTry.contains) then
+      // See visitNewObject: a later dimension's own try/catch would otherwise
+      // discard earlier dimensions already sitting on the operand stack,
+      // since the JVM clears the stack when dispatching to an exception
+      // handler. So every dimension is evaluated into a plain local first,
+      // and only then are they reloaded for multianewarray.
+      val slots = new Array[Int](node.parameters.length)
+      for i <- node.parameters.indices do
+        visitTerm(node.parameters(i))
+        val slot = gen.newLocal(AsmType.INT_TYPE)
+        gen.storeLocal(slot)
+        slots(i) = slot
+      for slot <- slots do gen.loadLocal(slot)
+      gen.visitMultiANewArrayInsn(asmType(node.arrayType).getDescriptor, node.parameters.length)
     else
-      val dims = Array.fill(node.parameters.length)(AsmType.INT_TYPE)
+      for param <- node.parameters do
+        visitTerm(param)
       gen.visitMultiANewArrayInsn(asmType(node.arrayType).getDescriptor, node.parameters.length)
 
   override def visitNewArrayWithValues(node: NewArrayWithValues): Unit =

--- a/src/test/scala/onion/compiler/tools/TryInArrayDimensionSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInArrayDimensionSpec.scala
@@ -1,0 +1,93 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as a later dimension of a multi-dimensional
+ * array creation (`new Int[dim1][dim2]`) crashed the compiler with an
+ * `[I0000]` internal error during bytecode verification: `visitNewArray`
+ * pushed every dimension unconditionally before the `multianewarray`
+ * instruction, and the JVM clears the operand stack when it dispatches to an
+ * exception handler, so an earlier dimension already pushed was silently
+ * discarded on the exceptional path, desyncing the merged stack shape from
+ * the normal path. This is the array-creation sibling of the array-index,
+ * array-assignment, and `new` (constructor-argument) fixes for the same
+ * underlying issue (#745, #752, and friends).
+ *
+ * `AsmCodeGenerationVisitor.visitNewArray` now evaluates every dimension into
+ * a plain local first (mirroring `visitNewObject`) whenever any dimension may
+ * run its own `try`, and only then reloads them for `multianewarray`.
+ */
+class TryInArrayDimensionSpec extends AbstractShellSpec {
+  describe("try/catch expression as a multi-dimensional array-creation dimension") {
+    it("does not corrupt earlier dimensions across a caught later dimension") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[][] = new Int[3][try {
+          |      Integer::parseInt("nope")
+          |    } catch _: Exception {
+          |      2
+          |    }]
+          |    return arr.length + "," + arr[0].length
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayDimensionCaught.on",
+        Array()
+      )
+      assert(Shell.Success("3,2") == result)
+    }
+
+    it("does not corrupt earlier dimensions on the non-throwing path") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[][] = new Int[3][try {
+          |      Integer::parseInt("4")
+          |    } catch _: Exception {
+          |      -1
+          |    }]
+          |    return arr.length + "," + arr[0].length
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayDimensionOk.on",
+        Array()
+      )
+      assert(Shell.Success("3,4") == result)
+    }
+
+    it("preserves left-to-right evaluation order across dimensions") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static var log: String = ""
+          |
+          |  static def note(tag: String, value: Int): Int {
+          |    Test::log = Test::log + tag
+          |    return value
+          |  }
+          |
+          |  static def boom(): Int {
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val arr: Int[][] = new Int[Test::note("D", 2)][try { Test::note("T", 0); Test::boom() } catch _: Exception { 5 }]
+          |    return Test::log + ":" + arr.length + "," + arr[0].length
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayDimensionOrder.on",
+        Array()
+      )
+      assert(Shell.Success("DT:2,5") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `new Int[3][try { ... } catch { ... }]` crashed the compiler with an `[I0000]` internal error during bytecode verification: `visitNewArray` pushed every array dimension unconditionally before the `multianewarray` instruction, and the JVM clears the operand stack when dispatching to an exception handler, so an earlier dimension already pushed was silently discarded on the exceptional path, desyncing the merged stack shape from the normal path.
- This is the array-creation sibling of the array-index (#752) and array-assignment (#745) fixes for the same underlying issue.
- `visitNewArray` now evaluates every dimension into a plain local first (mirroring the existing `visitNewObject` approach) whenever any dimension may run its own `try`, and only then reloads them for `multianewarray`.

## Test plan
- [x] Added `TryInArrayDimensionSpec` (3 cases: caught path, non-throwing path, left-to-right evaluation order) — confirmed red on the pre-fix code (stashed the fix, all 3 failed with the `[I0000]` crash), green after restoring the fix.
- [x] Full suite in English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3505 succeeded, 0 failed, 1 canceled.
- [x] `CHANGELOG.md` updated under `[Unreleased]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SgPy9vE7u3aNDneK5Z7mBy)_