### PR TITLE
fix: don't crash on try/catch as a safe array-index expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discarding earlier dimensions on the exceptional path. This is the
   array-creation sibling of the array-index and array-assignment fixes for
   the same underlying issue (#745, #752, and friends).
+- **`try`/`catch` as the index of a safe array-read (`arr?[...]`) no longer
+  crashes the compiler.** `arr?[try { ... } catch { ... }]` previously
+  crashed with an `[I0000]` internal error during bytecode verification:
+  the array reference (plus a duplicate for the null check) was pushed onto
+  the operand stack before evaluating the index, and the JVM clears the
+  stack when dispatching to an exception handler, silently discarding the
+  pending reference on the exceptional path. This is the safe-indexing
+  sibling of the plain array-index fix for the same underlying issue
+  (#745, #752, and friends).
 
 ## [0.10.36] - 2026-08-15
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -135,8 +135,21 @@ class AsmCodeGenerationVisitor(
     visitTerm(node.target)
     gen.dup()
     gen.visitJumpInsn(Opcodes.IFNULL, nullLabel)
-    visitTerm(node.index)
-    gen.arrayLoad(asmType(node.arrayType.base))
+    if TermContainsTry.contains(node.index) then
+      // See visitRefArray: the target can't stay live on the operand stack
+      // across an index expression that runs its own try/catch, since the
+      // JVM clears the stack when dispatching to an exception handler.
+      val targetSlot = gen.newLocal(asmType(node.target.`type`))
+      gen.storeLocal(targetSlot)
+      visitTerm(node.index)
+      val indexSlot = gen.newLocal(AsmType.INT_TYPE)
+      gen.storeLocal(indexSlot)
+      gen.loadLocal(targetSlot)
+      gen.loadLocal(indexSlot)
+      gen.arrayLoad(asmType(node.arrayType.base))
+    else
+      visitTerm(node.index)
+      gen.arrayLoad(asmType(node.arrayType.base))
     node.arrayType.base match
       case bt: BasicType if bt != BasicType.VOID => gen.box(asmType(bt))
       case _ =>

--- a/src/test/scala/onion/compiler/tools/TryInSafeArrayIndexSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInSafeArrayIndexSpec.scala
@@ -1,0 +1,132 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as the index of a safe array-read
+ * (`arr?[...]`) crashed the compiler with an `[I0000]` internal error during
+ * bytecode verification, the safe-indexing sibling of the plain array-index
+ * bug fixed for `visitRefArray`: `visitSafeRefArray` pushes the array
+ * reference (and a duplicate for the null check) before evaluating the
+ * index, and the JVM clears the operand stack when it dispatches to an
+ * exception handler, so the pending array reference was silently discarded
+ * on the exceptional path, desyncing the merged stack shape from the normal
+ * path.
+ *
+ * `AsmCodeGenerationVisitor.visitSafeRefArray` now spills the array
+ * reference into a local before evaluating an index that may run its own
+ * `try`, and reloads it afterward.
+ */
+class TryInSafeArrayIndexSpec extends AbstractShellSpec {
+  describe("try/catch expression as a safe array-index") {
+    it("does not corrupt the array reference across a caught index expression") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[5]
+          |    arr[0] = 10
+          |    arr[1] = 20
+          |    arr[2] = 30
+          |    val maybe: Int[]? = arr
+          |    val y: Int? = maybe?[try {
+          |      Integer::parseInt("nope")
+          |    } catch _: Exception {
+          |      1
+          |    }]
+          |    return y + ""
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInSafeArrayIndexCaught.on",
+        Array()
+      )
+      assert(Shell.Success("20") == result)
+    }
+
+    it("does not corrupt the array reference on the non-throwing path") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[5]
+          |    arr[0] = 10
+          |    arr[1] = 20
+          |    arr[2] = 30
+          |    val maybe: Int[]? = arr
+          |    val y: Int? = maybe?[try {
+          |      Integer::parseInt("2")
+          |    } catch _: Exception {
+          |      -1
+          |    }]
+          |    return y + ""
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInSafeArrayIndexOk.on",
+        Array()
+      )
+      assert(Shell.Success("30") == result)
+    }
+
+    it("still yields null for a null receiver when the index contains a try/catch") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val none: Int[]? = null
+          |    val y: Int? = none?[try {
+          |      Integer::parseInt("nope")
+          |    } catch _: Exception {
+          |      1
+          |    }]
+          |    return "" + y
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInSafeArrayIndexNull.on",
+        Array()
+      )
+      assert(Shell.Success("null") == result)
+    }
+
+    it("preserves left-to-right evaluation order around the spilled array reference") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static var log: String = ""
+          |
+          |  static def note(tag: String): String {
+          |    Test::log = Test::log + tag
+          |    return tag
+          |  }
+          |
+          |  static def getArr(a: Int[]): Int[]? {
+          |    Test::note("G")
+          |    return a
+          |  }
+          |
+          |  static def boom(): Int {
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[3]
+          |    arr[0] = 100
+          |    arr[1] = 200
+          |    val y: Int? = Test::getArr(arr)?[try { Test::note("T"); Test::boom() } catch _: Exception { 1 }]
+          |    return Test::log + ":" + y
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInSafeArrayIndexOrder.on",
+        Array()
+      )
+      assert(Shell.Success("GT:200") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `arr?[index]` (safe array indexing) crashed the compiler with an `[I0000]` internal error when `index` contained its own `try`/`catch`, e.g. `arr?[try { ... } catch { ... }]`.
- Root cause: `AsmCodeGenerationVisitor.visitSafeRefArray` pushes the array reference (plus a duplicate for the null check) before evaluating the index. The JVM clears the operand stack when dispatching to an exception handler, so a `try`/`catch` index silently discarded the pending array reference on the exceptional path, desyncing the normal-path/exception-path stack shapes — which the bytecode verifier rejects.
- This is the safe-indexing sibling of the already-fixed plain array-index case (`visitRefArray`, #745/#752). Applied the identical fix: spill the target into a local before evaluating an index that may run its own `try`/`catch`, then reload it.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] Added `TryInSafeArrayIndexSpec` (4 cases: caught-exception path, non-throwing path, null-receiver short-circuit, left-to-right evaluation order) — confirmed red before the fix, all 4 pass after.
- [x] Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3509 succeeded, 0 failed, 1 canceled (unrelated environment-dependent distribution-packaging test).
