### PR TITLE
fix: don't crash on try/catch assigned to a boxed captured local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pending reference on the exceptional path. This is the safe-indexing
   sibling of the plain array-index fix for the same underlying issue
   (#745, #752, and friends).
+- **`try`/`catch` assigned to a closure-captured (boxed) `var` no longer
+  crashes the compiler.** `x = try { ... } catch { ... }`, where `x` is a
+  `var` that some closure captures and mutates (so it is stored in a heap
+  box rather than a plain local slot), previously crashed with an `[I0000]`
+  internal error during bytecode verification whether the assignment ran
+  inside the capturing closure or in the variable's declaring scope: the
+  box reference was pushed onto the operand stack before evaluating the
+  right-hand side, and the JVM clears the stack when dispatching to an
+  exception handler, silently discarding the pending box reference on the
+  exceptional path. This is the boxed-local-variable sibling of the
+  field/array-assignment fixes for the same underlying issue (#745 and
+  friends).
 
 ## [0.10.36] - 2026-08-15
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -769,21 +769,40 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
         // Use frameIndex to handle nested closures correctly
         closureCtx.capturedBinding(set.frame, set.index) match
           case Some(binding) if binding.isBoxed =>
-            // Boxed captured variable: load box, compute value, put value into box
-            gen.loadThis()
+            // Boxed captured variable: load box, compute value, put value into box.
+            // If the value may run its own try/catch, the box reference can't stay
+            // on the operand stack across it -- the JVM clears the stack when
+            // dispatching to an exception handler, silently discarding the pending
+            // box reference on the exceptional path (the boxed-local sibling of the
+            // field/array-assignment fix for issue #745/#669).
             val boxType = boxAsmType(binding.tp)
-            gen.getField(
-              AsmUtil.objectType(closureCtx.closureClassName),
-              closureCtx.capturedFieldName(binding),
-              boxType
-            )
-            emitExpressionWithContext(gen, set.value, className, localVars)
             val valueType = boxedValueType(set.`type`)
-            if valueType.getSize() == 2 then
-              gen.dup2X1()
+            if TermContainsTry.contains(set.value) then
+              emitExpressionWithContext(gen, set.value, className, localVars)
+              val valueSlot = gen.newLocal(valueType)
+              gen.storeLocal(valueSlot)
+              gen.loadThis()
+              gen.getField(
+                AsmUtil.objectType(closureCtx.closureClassName),
+                closureCtx.capturedFieldName(binding),
+                boxType
+              )
+              gen.loadLocal(valueSlot)
+              gen.putField(boxType, "value", valueType)
+              gen.loadLocal(valueSlot)
             else
-              gen.dupX1()
-            gen.putField(boxType, "value", valueType)
+              gen.loadThis()
+              gen.getField(
+                AsmUtil.objectType(closureCtx.closureClassName),
+                closureCtx.capturedFieldName(binding),
+                boxType
+              )
+              emitExpressionWithContext(gen, set.value, className, localVars)
+              if valueType.getSize() == 2 then
+                gen.dup2X1()
+              else
+                gen.dupX1()
+              gen.putField(boxType, "value", valueType)
           case Some(binding) =>
             gen.loadThis()
             emitExpressionWithContext(gen, set.value, className, localVars)
@@ -820,14 +839,26 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
           val valueType = boxedValueType(set.`type`)
           localVars.slotOf(set.index) match
             case Some(slot) =>
-              // Update: load box, compute value, put into box.value
-              gen.loadLocal(slot)
-              emitExpressionWithContext(gen, set.value, className, localVars)
-              if valueType.getSize() == 2 then
-                gen.dup2X1()
+              // Update: load box, compute value, put into box.value.
+              // If the value may run its own try/catch, the box reference can't
+              // stay on the operand stack across it -- see the boxed-captured-
+              // variable branch above for why (issue #745/#669 sibling).
+              if TermContainsTry.contains(set.value) then
+                emitExpressionWithContext(gen, set.value, className, localVars)
+                val valueSlot = gen.newLocal(valueType)
+                gen.storeLocal(valueSlot)
+                gen.loadLocal(slot)
+                gen.loadLocal(valueSlot)
+                gen.putField(boxType, "value", valueType)
+                gen.loadLocal(valueSlot)
               else
-                gen.dupX1()
-              gen.putField(boxType, "value", valueType)
+                gen.loadLocal(slot)
+                emitExpressionWithContext(gen, set.value, className, localVars)
+                if valueType.getSize() == 2 then
+                  gen.dup2X1()
+                else
+                  gen.dupX1()
+                gen.putField(boxType, "value", valueType)
             case None =>
               // Initialize: compute value, create box, store box, return value
               emitExpressionWithContext(gen, set.value, className, localVars)

--- a/src/test/scala/onion/compiler/tools/TryInBoxedLocalAssignmentSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInBoxedLocalAssignmentSpec.scala
@@ -1,0 +1,71 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression assigned to a `var` that has been boxed because
+ * some closure captures it used to crash the compiler with an `[I0000]`
+ * internal error during bytecode verification: the JVM clears the operand
+ * stack when it dispatches to an exception handler, so the box reference
+ * already pushed before the `try` was silently discarded on the exceptional
+ * path, desyncing the merged stack shape from the normal path. This is the
+ * boxed-local-variable sibling of the field/array-assignment fix for the
+ * same underlying issue (#745 and friends).
+ *
+ * `emitSetLocal` in `AsmCodeGeneration.scala` now spills an already-pushed
+ * box reference into a local before evaluating a value that may run its own
+ * `try`, and reloads it afterward.
+ */
+class TryInBoxedLocalAssignmentSpec extends AbstractShellSpec {
+  describe("try/catch expression assigned to a closure-captured (boxed) local variable") {
+    it("does not corrupt the box reference when assigned from inside the capturing closure") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    var x: Int = 0
+          |    val f: () -> Int = () -> {
+          |      x = try { Integer::parseInt("7") } catch _: Exception { -1 }
+          |      return x
+          |    }
+          |    val ok: Int = f.call()
+          |    x = 0
+          |    val g: () -> Int = () -> {
+          |      x = try { Integer::parseInt("nope") } catch _: Exception { -1 }
+          |      return x
+          |    }
+          |    val caught: Int = g.call()
+          |    return ok + "|" + caught
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInClosureCapturedSet.on",
+        Array()
+      )
+      assert(Shell.Success("7|-1") == result)
+    }
+
+    it("does not corrupt the box reference when assigned from the declaring scope") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    var x: Int = 0
+          |    val f: () -> Int = () -> x
+          |    x = try { Integer::parseInt("7") } catch _: Exception { -1 }
+          |    val a: Int = f.call()
+          |    x = try { Integer::parseInt("nope") } catch _: Exception { -1 }
+          |    val b: Int = f.call()
+          |    return a + "|" + b
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInOuterBoxedSet.on",
+        Array()
+      )
+      assert(Shell.Success("7|-1") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Assigning a `try`/`catch` expression to a `var` that some closure captures and mutates (so it's boxed) crashed the compiler with an `[I0000]` internal error during bytecode verification. This happened both when the assignment ran inside the capturing closure and when it ran in the variable's declaring scope.
- Root cause: the JVM clears the operand stack when dispatching to an exception handler. `emitSetLocal` pushed the box reference *before* evaluating the right-hand side, so a throw inside the RHS's own `try` discarded that pending reference on the exceptional path, desyncing the merged stack shape — the boxed-local-variable sibling of the field/array-assignment fixes for the same underlying issue (#745 and friends).
- Fix: `emitSetLocal` in `AsmCodeGeneration.scala` now detects (via the existing `TermContainsTry` helper) when the RHS may run its own `try`/`catch`, and in that case evaluates the RHS first, spills it to a fresh local, and only then loads the box reference and stores into it — mirroring the established `visitSetField`/`visitSetArray` fix pattern.

## Test plan
- [x] Added `TryInBoxedLocalAssignmentSpec` covering both the closure-body-write and declaring-scope-write cases; confirmed both crash with `[I0000]` before the fix (red) and pass after (green).
- [x] Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3511 succeeded, 0 failed, 1 canceled, 0 ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VprM5ASqPHMjjwe7GDs5eA)_