### PR TITLE
Fix transitive closure capture: doubly-nested closure mutations now box correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `var` mutated only by a closure nested two (or more) levels deep now
+  correctly shares storage with the declaring scope.** `CapturedVariableScanner`
+  (used during typing to decide which variables need heap-boxed storage)
+  only ever examined the closure immediately enclosing a variable's use; a
+  variable referenced solely inside a closure nested *inside* that one was
+  never marked as boxed, so each closure level silently got its own
+  disconnected copy instead of sharing one cell — a write from the innermost
+  closure was invisible to the declaring scope. This is the transitive-capture
+  sibling of the single-level fix in #214. A related codegen bug compounded
+  it: even once boxing was correctly inferred, `ClosureCodegen.emitNewClosure`
+  determined a captured variable's boxed-ness via a lookup that only
+  understood a closure's own frame-0 locals, so a variable merely *relayed*
+  through an intermediate closure was still treated as unboxed. Combined with
+  a `try`/`catch` as the assigned value, the unboxed path also crashed the
+  compiler with an `[I0000]` internal error (inconsistent stackmap frames):
+  the JVM clears the operand stack when dispatching to the `catch` handler,
+  discarding the pending `this` reference the unboxed-assignment path had
+  already pushed, desyncing the merged stack shape from the normal path (the
+  same family of issue as #745/#669, reached via a different unguarded path).
 - **`try`/`catch` as the right-hand operand of a binary operator no longer
   crashes the compiler.** `1 + (try { ... } catch { ... })`, and the same for
   other arithmetic, bitwise, and comparison operators, previously crashed

--- a/src/main/scala/onion/compiler/CapturedVariableScanner.scala
+++ b/src/main/scala/onion/compiler/CapturedVariableScanner.scala
@@ -175,27 +175,36 @@ object CapturedVariableScanner {
   }
 
   /**
-   * Find all variable references in a closure body
+   * Find all variable references in a closure body, including references made
+   * only by a closure nested inside it (at any depth). A variable mutated
+   * solely by a doubly-(or deeper-)nested closure still needs boxing in the
+   * scope that declares it -- the immediately-enclosing closure merely relays
+   * a reference to it without itself naming the variable, so stopping at one
+   * level (as this used to) silently missed it. Each nested closure's own
+   * parameters shadow any outer variable of the same name, so they are
+   * excluded from the result rather than treated as captures.
    */
-  private def findReferencedVariables(node: AST.Node): Set[String] = {
+  private def findReferencedVariables(node: AST.Node, excluded: Set[String] = Set.empty): Set[String] = {
     val result = mutable.Set[String]()
 
     def visit(n: AST.Node): Unit = {
       n match {
         case id: AST.Id =>
-          result += id.name
+          if (!excluded.contains(id.name)) result += id.name
 
         case assign: AST.Assignment =>
           // Check if lhs is an Id (simple variable assignment)
           assign.lhs match {
-            case id: AST.Id => result += id.name
+            case id: AST.Id => if (!excluded.contains(id.name)) result += id.name
             case other => visit(other)
           }
           visit(assign.rhs)
           return // Special handling done, don't use visitChildren
 
-        case _: AST.ClosureExpression =>
-          return // Don't descend into nested closures
+        case closure: AST.ClosureExpression =>
+          val nestedExcluded = excluded ++ closure.args.map(_.name)
+          result ++= findReferencedVariables(closure.body, nestedExcluded)
+          return // Special handling done, don't use visitChildren
 
         case _ =>
       }

--- a/src/main/scala/onion/compiler/backend/asm/ClosureCodegen.scala
+++ b/src/main/scala/onion/compiler/backend/asm/ClosureCodegen.scala
@@ -25,9 +25,26 @@ final class ClosureCodegen(
     // (Do not capture the closure's own parameters/locals.)
     val rawCapturedVars = CapturedVariableCollector.collect(closure.block, closure.frame)
 
-    // Correct the isBoxed flags using localVars (which has the correct info from parent scope)
+    // Correct the isBoxed flags using localVars (which has the correct info from parent scope).
+    // `v.frameIndex` is relative to the closure being created; adjusting by one
+    // level closer gives its meaning in the CURRENT (enclosing) context. When
+    // that adjusted frame is > 0, the variable is not the enclosing closure's
+    // own local -- it is itself a variable the enclosing closure captured (and
+    // is merely relaying), so its boxed-ness lives in that closure's own
+    // capturedBinding table, keyed by (frame, index). `LocalVarContext.isBoxed`
+    // only tracks frame-0 locals (via boxedSet), so calling it here for a
+    // relayed capture always answered false, silently un-boxing any variable
+    // captured through two or more levels of closure nesting -- which then
+    // either dropped a nested closure's mutation on the floor or (when paired
+    // with a `try`/`catch` RHS) crashed codegen (the same operand-stack-
+    // clearing issue as #745/#669, but reached via a different unguarded path).
     val capturedVars = rawCapturedVars.map { v =>
-      val isBoxed = localVars.isBoxed(v.index)
+      val adjustedFrame = v.frameIndex - 1
+      val isBoxed = localVars match
+        case closureCtx: ClosureLocalVarContext if adjustedFrame > 0 =>
+          closureCtx.capturedBinding(adjustedFrame, v.index).exists(_.isBoxed)
+        case _ =>
+          localVars.isBoxed(v.index)
       new ClosureLocalBinding(v.frameIndex, v.index, v.tp, v.isMutable, isBoxed)
     }
 

--- a/src/test/scala/onion/compiler/tools/NestedClosureCapturedVariableSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NestedClosureCapturedVariableSpec.scala
@@ -1,0 +1,80 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `var` that is only ever read/assigned by a closure nested *inside* another
+ * closure (not directly by the closure immediately enclosing it) was never
+ * marked as boxed: `CapturedVariableScanner.scan` only scans one closure level
+ * deep and explicitly refuses to descend into a closure nested within the one
+ * it is examining ("they will be handled separately" -- but nothing else ever
+ * examines it). This is the transitive-capture sibling of issue #214, which
+ * fixed the single-level (closure directly captures the outer var) case.
+ *
+ * Two symptoms of the same root cause:
+ *  - Silently wrong results: each closure level got its own disconnected
+ *    plain-field copy instead of sharing one heap-boxed cell, so a mutation
+ *    made by the inner closure was invisible to the declaring scope.
+ *  - A compiler crash ([I0000], inconsistent stackmap frames) when the value
+ *    assigned from the innermost closure runs its own `try`/`catch`: codegen's
+ *    unboxed-captured-variable assignment path pushes `this` before evaluating
+ *    the value, and (like issue #745/#669 and friends) the JVM clears the
+ *    operand stack when dispatching to the `catch` handler, discarding the
+ *    pending `this` on the exceptional path and desyncing the merged stack
+ *    shape from the normal path.
+ */
+class NestedClosureCapturedVariableSpec extends AbstractShellSpec {
+  describe("a var captured only by a closure nested two levels deep") {
+    it("propagates the innermost closure's mutation back to the declaring scope") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    var x: Int = 0
+          |    val outer: () -> Int = () -> {
+          |      val inner: () -> Int = () -> {
+          |        x = 7
+          |        return x
+          |      }
+          |      return inner.call()
+          |    }
+          |    val ok: Int = outer.call()
+          |    return ok + x
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      // If the inner closure's write is lost (unboxed, disconnected copy),
+      // `x` in the declaring scope stays 0 and this totals 7, not 14.
+      assert(Shell.Success(14) == result)
+    }
+
+    it("does not crash when the innermost closure's assigned value runs its own try/catch") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    var x: Int = 0
+          |    val outer: () -> Int = () -> {
+          |      val inner: () -> Int = () -> {
+          |        x = try { Integer::parseInt("7") } catch _: Exception { -1 }
+          |        return x
+          |      }
+          |      return inner.call()
+          |    }
+          |    val ok: Int = outer.call()
+          |    return ok + "|" + x
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("7|7") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `CapturedVariableScanner` (used during typing to decide which captured `var`s need heap-boxed storage) only ever scanned one closure level deep. A variable referenced/mutated solely inside a closure nested *inside* another closure was never marked boxed, so each closure level got its own disconnected plain-field copy instead of sharing one cell — a write from the innermost closure was silently invisible to the declaring scope. This is the transitive-capture sibling of the single-level fix in #214.
- Fixed `findReferencedVariables` to recurse into nested closures (excluding each nested closure's own parameter names, which shadow outer variables of the same name) so a transitively-captured variable is correctly detected at every enclosing level.
- Even with boxing correctly inferred at the typing level, a second, independent codegen bug remained: `ClosureCodegen.emitNewClosure` determined a captured variable's boxed-ness via `LocalVarContext.isBoxed`, which only tracks frame-0 locals. For a variable merely *relayed* through an intermediate closure (adjusted frame > 0), this always answered `false`, so the relayed capture was still treated as unboxed. Fixed by consulting the enclosing closure's own `capturedBinding(frame, index)` table when the adjusted frame is non-zero.
- The unboxed path also crashed the compiler with `[I0000]` (inconsistent stackmap frames) whenever the assigned value ran its own `try`/`catch`: the JVM clears the operand stack when dispatching to the `catch` handler, discarding the `this` reference the unboxed-assignment codegen path had already pushed — the same operand-stack-clearing bug family as #745/#669, reached via a different, previously-unguarded path.

## Test plan

- Added `NestedClosureCapturedVariableSpec` (TDD: confirmed red against the old code, green after the fix) covering both symptoms:
  - a doubly-nested closure's mutation now propagates back to the declaring scope
  - a doubly-nested closure assigning a `try`/`catch` result no longer crashes the compiler
- `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test`: **3513 succeeded, 0 failed** (1 pre-existing, environment-gated `ProjectDistributionSpec` cancellation unrelated to this change — requires `-Donion.dist.path=...`).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018UJ5XpHw4JUUv4mrvJsvK5)_