### PR TITLE
Fix: box a var declared inside a closure when a closure nested inside it captures it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `var` declared inside a closure's own body and mutated only by a
+  closure nested inside it now correctly shares storage with the declaring
+  closure.** `ClosureCodegen.generateClosureMethod` built each closure's own
+  local-variable context with only parameter registration, never consulting
+  the boxed-variable information typing already computes for the closure's
+  frame -- unlike the top-level-method codegen path, which always does
+  both. So a `var` declared inside a closure and mutated by a closure
+  nested inside it got a disconnected unboxed copy per closure level
+  instead of sharing one heap-boxed cell, silently dropping the inner
+  closure's write. When the assigned value ran its own `try`/`catch`, the
+  same gap crashed the compiler with `[I0000] Inconsistent stackmap
+  frames` (the same family as #745/#669). This is the same-closure sibling
+  of the cross-closure-relay fix for issue #756.
+
 - **A `var` mutated only by a closure nested two (or more) levels deep now
   correctly shares storage with the declaring scope.** `CapturedVariableScanner`
   (used during typing to decide which variables need heap-boxed storage)

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -743,6 +743,15 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
             // For frame=0 (current closure's own variables/parameters)
             if ref.frame == 0 && closureCtx.isParameter(ref.index) then
               gen.loadArg(ref.index)
+            else if ref.frame == 0 && closureCtx.isBoxed(ref.index) then
+              // Boxed own local (captured and mutated by a closure nested inside
+              // this one): load box, then get value field, mirroring the
+              // top-level-method boxed-local path below.
+              val boxType = boxAsmType(ref.`type`)
+              val slot = closureCtx.slotOf(ref.index).getOrElse(closureCtx.getOrAllocateSlot(ref.index, boxType))
+              gen.loadLocal(slot)
+              gen.getField(boxType, "value", boxedValueType(ref.`type`))
+              if !ref.`type`.isBasicType then gen.checkCast(asmType(ref.`type`))
             else if ref.frame == 0 then
               val slot = closureCtx.slotOf(ref.index).getOrElse(closureCtx.getOrAllocateSlot(ref.index, asmType(ref.`type`)))
               gen.loadLocal(slot)
@@ -820,14 +829,53 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
             // For frame=0 (current closure's own variables/parameters)
             if set.frame != 0 then
               throw new IllegalStateException(s"Non-captured variable with frame=${set.frame}, index=${set.index} in closure context")
-            emitExpressionWithContext(gen, set.value, className, localVars)
-            val valueType = asmType(set.`type`)
-            if valueType.getSize() == 2 then gen.dup2() else gen.dup()
-            if closureCtx.isParameter(set.index) then
-              gen.storeArg(set.index)
+            if closureCtx.isBoxed(set.index) then
+              // Boxed own local (captured and mutated by a closure nested inside
+              // this one): mirror the top-level-method boxed-local path below --
+              // box-reference-then-value ordering, with the try/catch guard for
+              // the same operand-stack-clearing reason as issue #745/#669.
+              val boxType = boxAsmType(set.`type`)
+              val valueType = boxedValueType(set.`type`)
+              closureCtx.slotOf(set.index) match
+                case Some(slot) =>
+                  if TermContainsTry.contains(set.value) then
+                    emitExpressionWithContext(gen, set.value, className, localVars)
+                    val valueSlot = gen.newLocal(valueType)
+                    gen.storeLocal(valueSlot)
+                    gen.loadLocal(slot)
+                    gen.loadLocal(valueSlot)
+                    gen.putField(boxType, "value", valueType)
+                    gen.loadLocal(valueSlot)
+                  else
+                    gen.loadLocal(slot)
+                    emitExpressionWithContext(gen, set.value, className, localVars)
+                    if valueType.getSize() == 2 then
+                      gen.dup2X1()
+                    else
+                      gen.dupX1()
+                    gen.putField(boxType, "value", valueType)
+                case None =>
+                  // Initialize: compute value, create box, store box, return value
+                  emitExpressionWithContext(gen, set.value, className, localVars)
+                  val tempSlot = gen.newLocal(valueType)
+                  gen.storeLocal(tempSlot)
+                  gen.newInstance(boxType)
+                  gen.dup()
+                  gen.loadLocal(tempSlot)
+                  val ctorDesc = AsmType.getMethodDescriptor(AsmType.VOID_TYPE, valueType)
+                  gen.invokeConstructor(boxType, AsmMethod("<init>", ctorDesc))
+                  val slot = closureCtx.allocateSlot(set.index, boxType)
+                  gen.storeLocal(slot)
+                  gen.loadLocal(tempSlot) // Return the value
             else
-              val slot = closureCtx.slotOf(set.index).getOrElse(closureCtx.getOrAllocateSlot(set.index, valueType))
-              gen.storeLocal(slot)
+              emitExpressionWithContext(gen, set.value, className, localVars)
+              val valueType = asmType(set.`type`)
+              if valueType.getSize() == 2 then gen.dup2() else gen.dup()
+              if closureCtx.isParameter(set.index) then
+                gen.storeArg(set.index)
+              else
+                val slot = closureCtx.slotOf(set.index).getOrElse(closureCtx.getOrAllocateSlot(set.index, valueType))
+                gen.storeLocal(slot)
       case _ =>
         val setValueType = asmType(set.`type`)
         if localVars.isParameter(set.index) then

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -829,14 +829,28 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
             // For frame=0 (current closure's own variables/parameters)
             if set.frame != 0 then
               throw new IllegalStateException(s"Non-captured variable with frame=${set.frame}, index=${set.index} in closure context")
-            if closureCtx.isBoxed(set.index) then
+            // Parameters take precedence over the boxed-own-local path below,
+            // mirroring the top-level-method precedence a few lines down
+            // (isParameter is checked before isBoxed there too): a closure's
+            // own parameter slot already holds the raw argument value (from
+            // withParameters), not a box, even when CapturedVariableScanner
+            // marks that index boxed -- e.g. a synthetic type-cast-adaptation
+            // self-assignment the closure-typing prologue inserts for a
+            // generic parameter. Treating that pre-existing slot as an
+            // already-allocated box would read/write through a JVM slot that
+            // actually holds a plain (unboxed) value.
+            if closureCtx.isParameter(set.index) then
+              emitExpressionWithContext(gen, set.value, className, localVars)
+              val valueType = asmType(set.`type`)
+              if valueType.getSize() == 2 then gen.dup2() else gen.dup()
+              gen.storeArg(set.index)
+            else if closureCtx.isBoxed(set.index) then
               // Boxed own local (captured and mutated by a closure nested inside
               // this one): mirror the top-level-method boxed-local path below --
               // box-reference-then-value ordering, with the try/catch guard for
               // the same operand-stack-clearing reason as issue #745/#669.
               val boxType = boxAsmType(set.`type`)
               val valueType = boxedValueType(set.`type`)
-              System.err.println(s"[DEBUG] set.index=${set.index} isParameter=${closureCtx.isParameter(set.index)} slotOf=${closureCtx.slotOf(set.index)} isCapturedIdx=${closureCtx.isCapturedVariable(set.index)}")
               closureCtx.slotOf(set.index) match
                 case Some(slot) =>
                   if TermContainsTry.contains(set.value) then
@@ -872,11 +886,8 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
               emitExpressionWithContext(gen, set.value, className, localVars)
               val valueType = asmType(set.`type`)
               if valueType.getSize() == 2 then gen.dup2() else gen.dup()
-              if closureCtx.isParameter(set.index) then
-                gen.storeArg(set.index)
-              else
-                val slot = closureCtx.slotOf(set.index).getOrElse(closureCtx.getOrAllocateSlot(set.index, valueType))
-                gen.storeLocal(slot)
+              val slot = closureCtx.slotOf(set.index).getOrElse(closureCtx.getOrAllocateSlot(set.index, valueType))
+              gen.storeLocal(slot)
       case _ =>
         val setValueType = asmType(set.`type`)
         if localVars.isParameter(set.index) then

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -836,6 +836,7 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
               // the same operand-stack-clearing reason as issue #745/#669.
               val boxType = boxAsmType(set.`type`)
               val valueType = boxedValueType(set.`type`)
+              System.err.println(s"[DEBUG] set.index=${set.index} isParameter=${closureCtx.isParameter(set.index)} slotOf=${closureCtx.slotOf(set.index)} isCapturedIdx=${closureCtx.isCapturedVariable(set.index)}")
               closureCtx.slotOf(set.index) match
                 case Some(slot) =>
                   if TermContainsTry.contains(set.value) then

--- a/src/main/scala/onion/compiler/backend/asm/ClosureCodegen.scala
+++ b/src/main/scala/onion/compiler/backend/asm/ClosureCodegen.scala
@@ -50,7 +50,7 @@ final class ClosureCodegen(
 
     val outerThisType = CapturedVariableCollector.findOuterThis(closure.block)
 
-    val closureBytes = generateClosureClass(closureClassName, interfaceType, closure.method, closure.block, capturedVars, outerThisType)
+    val closureBytes = generateClosureClass(closureClassName, interfaceType, closure.method, closure.block, closure.frame, capturedVars, outerThisType)
     registerCompiledClass(CompiledClass(closureClassName.replace('/', '.'), outputDirectory, closureBytes))
 
     val closureType = AsmUtil.objectType(closureClassName)
@@ -121,6 +121,7 @@ final class ClosureCodegen(
     interfaceType: ClassType,
     method: TypedAST.Method,
     block: ActionStatement,
+    frame: onion.compiler.LocalFrame,
     capturedVars: Seq[ClosureLocalBinding],
     outerThisType: Option[ClassType]
   ): Array[Byte] = {
@@ -153,7 +154,7 @@ final class ClosureCodegen(
       )
 
     generateClosureConstructor(cw, className, capturedVars, outerThisType)
-    generateClosureMethod(cw, className, method, block, capturedVars)
+    generateClosureMethod(cw, className, method, block, frame, capturedVars)
     generateBridgeMethod(cw, className, interfaceType, method)
 
     cw.visitEnd()
@@ -250,6 +251,7 @@ final class ClosureCodegen(
     className: String,
     method: TypedAST.Method,
     block: ActionStatement,
+    frame: onion.compiler.LocalFrame,
     capturedVars: Seq[ClosureLocalBinding]
   ): Unit = {
     val argTypes = method.arguments.map(asmType)
@@ -265,6 +267,7 @@ final class ClosureCodegen(
 
     val closureLocalVars = new ClosureLocalVarContext(gen, className, capturedVars)
       .withParameters(isStatic = false, argTypes)
+      .withBoxedVariables(frame)
 
     asmCodeGen.emitStatementWithContext(gen, block, className, closureLocalVars)
 

--- a/src/test/scala/onion/compiler/tools/ClosureOwnLocalCapturedByNestedClosureSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ClosureOwnLocalCapturedByNestedClosureSpec.scala
@@ -1,0 +1,83 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `var` declared *inside* a closure's own body (not relayed from an outer
+ * scope -- that's the case #756/`NestedClosureCapturedVariableSpec` fixed)
+ * that is captured and mutated by a closure nested inside it was never
+ * marked as boxed at codegen time: `ClosureCodegen.generateClosureMethod`
+ * builds its `ClosureLocalVarContext` with only `.withParameters(...)`, never
+ * `.withBoxedVariables(frame)` -- unlike the top-level method path in
+ * `AsmCodeGeneration.codeMethod`, which always calls both. Typing correctly
+ * determines the variable needs boxing (`TypedAST.NewClosure.frame` carries
+ * that info), but codegen never consults it for a closure's own frame.
+ *
+ * Two symptoms of the same root cause, matching the family of bugs fixed for
+ * the relayed-capture case:
+ *  - Silently wrong results: the inner closure's mutation never reaches the
+ *    outer closure's own copy of the local.
+ *  - A compiler crash ([I0000], inconsistent stackmap frames) when the value
+ *    assigned from the inner closure runs its own `try`/`catch`.
+ */
+class ClosureOwnLocalCapturedByNestedClosureSpec extends AbstractShellSpec {
+  describe("a var declared inside a closure and captured only by a closure nested inside it") {
+    it("propagates the inner closure's mutation back to the declaring closure") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    var y: Int = 0
+          |    val outer: () -> Int = () -> {
+          |      var localVar: Int = 1
+          |      val inner: () -> Int = () -> {
+          |        localVar = 42
+          |        return localVar
+          |      }
+          |      inner.call()
+          |      y = localVar
+          |      return y
+          |    }
+          |    outer.call()
+          |    return y
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      // If the inner closure's write is lost (unboxed, disconnected copy),
+      // `y` stays 1 instead of picking up the inner closure's write of 42.
+      assert(Shell.Success(42) == result)
+    }
+
+    it("does not crash when the inner closure's assigned value runs its own try/catch") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    var y: Int = 0
+          |    val outer: () -> Int = () -> {
+          |      var localVar: Int = 1
+          |      val inner: () -> Int = () -> {
+          |        localVar = try { Integer::parseInt("42") } catch _: Exception { -1 }
+          |        return localVar
+          |      }
+          |      inner.call()
+          |      y = localVar
+          |      return y
+          |    }
+          |    outer.call()
+          |    return "" + y
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("42") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- A `var` declared *inside* a closure's own body (not relayed from an outer scope -- that's the case #756 fixed) that is captured and mutated by a closure nested inside it was never marked as boxed at codegen time. `ClosureCodegen.generateClosureMethod` built each closure's own `ClosureLocalVarContext` with only `.withParameters(...)`, never `.withBoxedVariables(frame)` -- unlike the top-level method path in `AsmCodeGeneration.codeMethod`, which always calls both. Typing already determines via `TypedAST.NewClosure.frame` which of a closure's own locals need heap-boxed storage, but codegen never consulted it.
- Symptom 1 (silent, worse than a crash): the inner closure's mutation never reached the outer closure's own copy of the local.
- Symptom 2: when the assigned value ran its own `try`/`catch`, the same gap crashed the compiler with `[I0000] Inconsistent stackmap frames` (same family as #745/#669).
- Fix threads `closure.frame` from `emitNewClosure` through `generateClosureClass` into `generateClosureMethod` so it can call `withBoxedVariables(frame)`, and adds the corresponding boxed-value read/write paths to `emitRefLocal`/`emitSetLocal` for a closure's own (non-captured) locals, mirroring the existing top-level-method logic.
- While validating against the `run/` example corpus, this surfaced a second latent bug: a closure parameter that also gets marked boxed (via a compiler-generated generic-argument-cast prologue in `ClosureTyping`) was being treated as an already-boxed slot when it was really the raw parameter slot, crashing bytecode verification. Fixed by giving `isParameter` precedence over the boxed-own-local path in `emitSetLocal`, matching the precedence `emitRefLocal` and the top-level-method path already use.

## Test plan

- [x] Added `ClosureOwnLocalCapturedByNestedClosureSpec` (TDD: red before the fix, green after) covering both the silent-mutation-loss case and the try/catch-crash case.
- [x] `sbt -Duser.language=en test` -- full suite green: 3515 succeeded, 0 failed, 1 pre-existing environment-gated cancellation (distribution packaging test, unrelated).
- [x] Verified `run/GenericLeaderboard.on` and `run/CodeContest.on` (which regressed against an earlier iteration of this fix, caught by `SampleCompilesSpec`/`MutationFuzzSpec`) compile and run correctly.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_014DPfnBAznbvrxJVqCcfirJ)_