### PR TITLE
Fix compiler crash: try/catch as an array-write index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`try`/`catch` as the index of an array *write* (`arr[try {...} catch
+  {...}] = value`) no longer crashes the compiler.** `visitSetArray` only
+  spilled the array reference into a local when the assigned *value* could
+  run its own `try`, never when the *index* could -- so an array reference
+  already pushed before evaluating such an index was silently discarded by
+  the JVM clearing the operand stack on the exceptional path, desyncing the
+  merged stack shape from the normal path with an `[I0000]` internal error.
+  This is the write-side sibling of the array-read fix for the same
+  underlying issue (#745, #752, and friends) -- the read path (`visitRefArray`)
+  already checked its index; the write path was missing the same check.
 - **A `var` declared inside a closure's own body and mutated only by a
   closure nested inside it now correctly shares storage with the declaring
   closure.** `ClosureCodegen.generateClosureMethod` built each closure's own

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -161,10 +161,13 @@ class AsmCodeGenerationVisitor(
   
   override def visitSetArray(node: SetArray): Unit =
     val valueType = asmType(node.`type`)
-    if TermContainsTry.contains(node.value) then
+    if TermContainsTry.contains(node.index) || TermContainsTry.contains(node.value) then
       // See visitSetField: the target/index can't stay live on the operand
-      // stack across a value that runs its own try/catch, since the JVM
-      // clears the stack when dispatching to an exception handler.
+      // stack across an index or value that runs its own try/catch, since
+      // the JVM clears the stack when dispatching to an exception handler.
+      // (The read-side sibling of this gap -- visitRefArray checking only
+      // its index -- was fixed already; this write side was missing the
+      // index check and only guarded against the value.)
       visitTerm(node.target)
       val targetSlot = gen.newLocal(asmType(node.target.`type`))
       gen.storeLocal(targetSlot)

--- a/src/test/scala/onion/compiler/tools/TryInArrayIndexAssignmentSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInArrayIndexAssignmentSpec.scala
@@ -1,0 +1,125 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as the index of an array-*write*
+ * (`arr[...] = value`) crashed the compiler with an `[I0000]` internal
+ * error during bytecode verification, the write-side sibling of
+ * `TryInArrayIndexSpec`'s read-side fix: `visitSetArray` only spilled the
+ * array reference into a local when the assigned *value* could run its own
+ * `try`, never when the *index* could -- so the array reference pushed
+ * before evaluating the index was still discarded by the JVM clearing the
+ * operand stack on the exceptional path, desyncing the merged stack shape
+ * from the normal path (the same family as #745/#669).
+ *
+ * `AsmCodeGenerationVisitor.visitSetArray` now also spills the array
+ * reference when the index may run its own `try`.
+ */
+class TryInArrayIndexAssignmentSpec extends AbstractShellSpec {
+  describe("try/catch expression as an array-write index") {
+    it("does not corrupt the array reference across a caught index expression") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[5]
+          |    arr[0] = 10
+          |    arr[1] = 20
+          |    arr[2] = 30
+          |    arr[try {
+          |      Integer::parseInt("nope")
+          |    } catch _: Exception {
+          |      1
+          |    }] = 99
+          |    return arr[0] + "," + arr[1] + "," + arr[2]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexAssignmentCaught.on",
+        Array()
+      )
+      assert(Shell.Success("10,99,30") == result)
+    }
+
+    it("does not corrupt the array reference on the non-throwing path") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[5]
+          |    arr[0] = 10
+          |    arr[1] = 20
+          |    arr[2] = 30
+          |    arr[try {
+          |      Integer::parseInt("2")
+          |    } catch _: Exception {
+          |      -1
+          |    }] = 99
+          |    return arr[0] + "," + arr[1] + "," + arr[2]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexAssignmentOk.on",
+        Array()
+      )
+      assert(Shell.Success("10,20,99") == result)
+    }
+
+    it("preserves left-to-right evaluation order around the spilled array reference") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static var log: String = ""
+          |
+          |  static def note(tag: String): String {
+          |    Test::log = Test::log + tag
+          |    return tag
+          |  }
+          |
+          |  static def getArr(a: Int[]): Int[] {
+          |    Test::note("G")
+          |    return a
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[3]
+          |    arr[0] = 100
+          |    arr[1] = 200
+          |    Test::getArr(arr)[try { Test::note("T"); 1 } catch _: Exception { -1 }] = 999
+          |    return Test::log + ":" + arr[0] + "," + arr[1]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexAssignmentOrder.on",
+        Array()
+      )
+      assert(Shell.Success("GT:100,999") == result)
+    }
+
+    it("leaves the assigned value as the expression's result") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[3]
+          |    val y: Int = arr[try {
+          |      Integer::parseInt("nope")
+          |    } catch _: Exception {
+          |      0
+          |    }] = 42
+          |    return y + "," + arr[0]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexAssignmentResult.on",
+        Array()
+      )
+      assert(Shell.Success("42,42") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `arr[try {...} catch {...}] = value` crashed the compiler with an `[I0000]` internal error (inconsistent stackmap frames).
- `visitSetArray` only spilled the array reference into a local when the assigned *value* could run its own `try`, never when the *index* could. Since the JVM clears the operand stack when dispatching to an exception handler, an array reference already pushed before evaluating such an index was silently discarded on the exceptional path, desyncing the merged stack shape from the normal path.
- This is the write-side sibling of the existing fix in `visitRefArray` (array *read*), which already guarded its index the same way — the write path was simply missing the equivalent check.
- Fix: extend the spill condition in `visitSetArray` to `TermContainsTry.contains(node.index) || TermContainsTry.contains(node.value)`.

## Test plan
- [x] Added `TryInArrayIndexAssignmentSpec.scala` covering: caught-exception index, non-throwing index, left-to-right evaluation order (target evaluated via a method call), and that the assignment expression still yields the assigned value.
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3519 succeeded, 0 failed, 0 aborted, 1 canceled (unrelated, pre-existing distribution-packaging integration test skip).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qcjf7LH7YyZ9MDmEPnaPju)_