### PR TITLE
test: add regression coverage for try/catch as compound-assignment RHS on field/array targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`TryInCompoundFieldArrayAssignmentSpec`, regression coverage for `try`/`catch`
+  as the right-hand side of a compound assignment (`+=`) on a field or array
+  element** (`obj.field += try {...} catch {...}`, `arr[i] += try {...} catch
+  {...}`). Compound assignment desugars `target op= value` to `target = target
+  op value`, so the `try` ends up nested inside a `BinaryTerm` rather than
+  directly as the assigned value -- unlike the plain-assignment cases already
+  covered by `TryInFieldAssignmentSpec`/`TryInArrayIndexAssignmentSpec`. This
+  locks in that `TermContainsTry.contains`'s generic recursion still finds the
+  nested `try` and `visitSetField`/`visitSetArray` still spill the
+  receiver/array-and-index correctly (the #745/#752 stack-corruption family);
+  all three new cases already passed, so this closes a coverage gap rather
+  than a live bug.
 - **`run/TryCatchEdgeCases.on`, a regression sample combining `try`/`catch`
   with expression positions not covered by any single existing
   `TryInXxxSpec`.** A `select` scrutinee, a `select` case guard, a `while`

--- a/src/test/scala/onion/compiler/tools/TryInCompoundFieldArrayAssignmentSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInCompoundFieldArrayAssignmentSpec.scala
@@ -1,0 +1,108 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression on the right-hand side of a compound assignment
+ * (`+=`, `-=`, ...) targeting a field or array element. Compound assignment
+ * desugars `target op= value` to `target = target op value`
+ * (`SimpleExpressionTypingSupport.typeBinaryAssignmentSimple`), so the `try`
+ * ends up nested inside a `BinaryTerm` rather than directly as the assigned
+ * value -- unlike the plain-assignment cases already covered by
+ * `TryInFieldAssignmentSpec`/`TryInArrayIndexAssignmentSpec`. This locks in
+ * that `TermContainsTry.contains` (which recurses generically through a
+ * term's children) still detects the nested `try` and
+ * `visitSetField`/`visitSetArray` still spill the receiver/array-and-index
+ * before evaluating it, for both the field and array-element cases (the
+ * `#745`/`#752` family of stack-corruption bugs).
+ */
+class TryInCompoundFieldArrayAssignmentSpec extends AbstractShellSpec {
+  describe("try/catch expression as the RHS of a compound assignment") {
+    it("does not corrupt the receiver of a field compound assignment (obj.field += try {...} catch {...})") {
+      val result = shell.run(
+        """
+          |class Box {
+          |public:
+          |  var n: Int
+          |  def this(initial: Int) { n = initial }
+          |}
+          |class Test {
+          |public:
+          |  static def risky(x: Int): Int {
+          |    if x > 0 { return x }
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val b: Box = new Box(10)
+          |    b.n += try { Test::risky(5) } catch e: Exception { 0 }
+          |    val afterOk: Int = b.n
+          |    b.n += try { Test::risky(-1) } catch e: Exception { 1 }
+          |    return afterOk + "|" + b.n
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInCompoundFieldAssignment.on",
+        Array()
+      )
+      assert(Shell.Success("15|16") == result)
+    }
+
+    it("does not corrupt the array reference/index of an array-element compound assignment (arr[i] += try {...} catch {...})") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def risky(x: Int): Int {
+          |    if x > 0 { return x }
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[2]
+          |    arr[0] = 10
+          |    arr[1] = 20
+          |    arr[0] += try { Test::risky(5) } catch e: Exception { 0 }
+          |    arr[1] += try { Test::risky(-1) } catch e: Exception { 1 }
+          |    return arr[0] + "|" + arr[1]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInCompoundArrayAssignment.on",
+        Array()
+      )
+      assert(Shell.Success("15|21") == result)
+    }
+
+    it("evaluates a side-effecting array index exactly once around the spilled temp") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static var log: String = ""
+          |
+          |  static def nextIndex(): Int {
+          |    Test::log = Test::log + "I"
+          |    return 0
+          |  }
+          |
+          |  static def risky(): Int {
+          |    Test::log = Test::log + "T"
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[1]
+          |    arr[0] = 100
+          |    arr[Test::nextIndex()] += try { Test::risky() } catch e: Exception { 5 }
+          |    return Test::log + ":" + arr[0]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInCompoundArrayAssignmentIndexOnce.on",
+        Array()
+      )
+      assert(Shell.Success("IT:105") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `TryInCompoundFieldArrayAssignmentSpec`, covering `try`/`catch` as the right-hand side of a compound assignment (`+=`) targeting a field or array element: `obj.field += try {...} catch {...}` and `arr[i] += try {...} catch {...}`, plus a case checking a side-effecting array index is evaluated exactly once.
- Compound assignment desugars `target op= value` to `target = target op value` (`SimpleExpressionTypingSupport.typeBinaryAssignmentSimple`), so the `try` ends up nested inside a `BinaryTerm` rather than directly as the assigned value — unlike the plain-assignment cases already covered by `TryInFieldAssignmentSpec`/`TryInArrayIndexAssignmentSpec`.
- This closes a coverage gap in the `#745`/`#752` stack-corruption bug family, not a live bug: all three new cases already pass, since `TermContainsTry.contains`'s generic reflective recursion already finds the nested `try` inside the `BinaryTerm`, and `visitSetField`/`visitSetArray` already spill the receiver/array-and-index before evaluating it regardless of nesting depth.
- Records the addition in `CHANGELOG.md` under `[Unreleased] > Added`.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3526 tests, 0 failed, 1 canceled (same cancellation as the pre-existing baseline), `All tests passed.`

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011Gcw42PMiBWxcoi3KR81KK)_