### PR TITLE
test: add regression coverage for three-level nested closure capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ThreeLevelNestedClosureCapturedVariableSpec`, regression coverage for a
+  `var` relayed through *three* levels of closure nesting.**
+  `NestedClosureCapturedVariableSpec` (#756) locked in the two-levels-deep
+  case for a variable captured from an outer scope, relayed through one
+  intermediate closure, and mutated only by the innermost one. Both
+  `CapturedVariableScanner` (typing) and `ClosureCodegen.emitNewClosure`'s
+  `adjustedFrame`-based boxed-ness lookup (codegen) were written to recurse
+  to arbitrary depth rather than special-cased for exactly two levels, but
+  nothing exercised a third level of relay -- including the case where the
+  innermost closure's assigned value runs its own `try`/`catch` (the
+  #745/#669 stack-corruption family, reached via the relay path). Both new
+  cases already passed, so this closes a coverage gap rather than a live bug.
 - **`TryInCompoundFieldArrayAssignmentSpec`, regression coverage for `try`/`catch`
   as the right-hand side of a compound assignment (`+=`) on a field or array
   element** (`obj.field += try {...} catch {...}`, `arr[i] += try {...} catch

--- a/src/test/scala/onion/compiler/tools/ThreeLevelNestedClosureCapturedVariableSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ThreeLevelNestedClosureCapturedVariableSpec.scala
@@ -1,0 +1,77 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `NestedClosureCapturedVariableSpec` locked in the *two*-levels-deep case for
+ * a `var` relayed from an outer scope through an intermediate closure to the
+ * closure that actually mutates it (issue #756). Both `CapturedVariableScanner`
+ * (typing) and `ClosureCodegen.emitNewClosure`'s `adjustedFrame`-based boxed-ness
+ * lookup (codegen) were written to recurse to arbitrary depth rather than special-
+ * cased for exactly two levels -- but nothing exercises a *third* level, where
+ * the variable is relayed through two intermediate closures before the innermost
+ * one mutates it. This closes that coverage gap rather than a live bug: both
+ * cases already pass.
+ */
+class ThreeLevelNestedClosureCapturedVariableSpec extends AbstractShellSpec {
+  describe("a var captured only by a closure nested three levels deep") {
+    it("propagates the innermost closure's mutation back to the declaring scope") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    var x: Int = 0
+          |    val outer: () -> Int = () -> {
+          |      val middle: () -> Int = () -> {
+          |        val inner: () -> Int = () -> {
+          |          x = 7
+          |          return x
+          |        }
+          |        return inner.call()
+          |      }
+          |      return middle.call()
+          |    }
+          |    val ok: Int = outer.call()
+          |    return ok + x
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      // If the innermost closure's write is lost anywhere along the two-level
+      // relay (unboxed, disconnected copy), `x` in the declaring scope stays
+      // 0 and this totals 7, not 14.
+      assert(Shell.Success(14) == result)
+    }
+
+    it("does not crash when the innermost closure's assigned value runs its own try/catch") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    var x: Int = 0
+          |    val outer: () -> Int = () -> {
+          |      val middle: () -> Int = () -> {
+          |        val inner: () -> Int = () -> {
+          |          x = try { Integer::parseInt("7") } catch _: Exception { -1 }
+          |          return x
+          |        }
+          |        return inner.call()
+          |      }
+          |      return middle.call()
+          |    }
+          |    val ok: Int = outer.call()
+          |    return ok + "|" + x
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("7|7") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `NestedClosureCapturedVariableSpec` (#756) locked in the *two*-levels-deep case for a `var` relayed from an outer scope through one intermediate closure to the closure that mutates it. Both `CapturedVariableScanner` (typing) and `ClosureCodegen.emitNewClosure`'s `adjustedFrame`-based boxed-ness lookup (codegen) were written to recurse to arbitrary depth rather than special-cased for exactly two levels, but nothing exercised a *third* level of relay.
- Adds `ThreeLevelNestedClosureCapturedVariableSpec` covering: (1) the innermost closure's mutation propagating back through two levels of relay to the declaring scope, and (2) the `try`/`catch`-as-assigned-value crash variant (the #745/#669 stack-corruption family) reached via the three-level relay path.
- Both new cases already pass — this closes a coverage gap rather than a live bug — and adds a CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.ThreeLevelNestedClosureCapturedVariableSpec'` — 2/2 pass
- [x] `sbt -Duser.language=en test` (full suite) — 3528 succeeded, 0 failed, 1 canceled (gated distribution smoke test), all passed

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QCnHwRxvC67G9Z1Fwu8UF6)_