### PR TITLE
test: cover try/catch in both the index and value of an array write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`TryInArrayIndexAssignmentSpec`, regression coverage for `try`/`catch` used
+  as *both* the index and the assigned value of the same array write**
+  (`arr[try {...} catch {...}] = try {...} catch {...}`). The existing index-side
+  fix (#758 write-side sibling of #745/#669) and the pre-existing value-side
+  handling were each tested individually, but never combined in the same
+  write; the combination already passed, so this closes a coverage gap rather
+  than a live bug.
+
 ## [0.10.37] - 2026-08-16
 
 ### Added

--- a/src/test/scala/onion/compiler/tools/TryInArrayIndexAssignmentSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInArrayIndexAssignmentSpec.scala
@@ -15,6 +15,12 @@ import onion.tools.Shell
  *
  * `AsmCodeGenerationVisitor.visitSetArray` now also spills the array
  * reference when the index may run its own `try`.
+ *
+ * The final case below combines the index-side fix with the pre-existing
+ * value-side handling: both the index and the assigned value run their own
+ * `try`/`catch` in the same array write, which no earlier spec exercised
+ * together. It already passes, so this closes a coverage gap rather than a
+ * live bug.
  */
 class TryInArrayIndexAssignmentSpec extends AbstractShellSpec {
   describe("try/catch expression as an array-write index") {
@@ -120,6 +126,30 @@ class TryInArrayIndexAssignmentSpec extends AbstractShellSpec {
         Array()
       )
       assert(Shell.Success("42,42") == result)
+    }
+
+    it("does not corrupt the array reference when both the index and the value run their own try/catch") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val arr: Int[] = new Int[3]
+          |    arr[0] = 100
+          |    arr[1] = 200
+          |    arr[2] = 300
+          |    arr[try { Integer::parseInt("1") } catch _: Exception { -1 }] =
+          |      try { Integer::parseInt("nope") } catch _: Exception { 999 }
+          |    arr[try { Integer::parseInt("nope") } catch _: Exception { 2 }] =
+          |      try { Integer::parseInt("42") } catch _: Exception { -1 }
+          |    return arr[0] + "," + arr[1] + "," + arr[2]
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInArrayIndexAndValueAssignment.on",
+        Array()
+      )
+      assert(Shell.Success("100,999,42") == result)
     }
   }
 }


### PR DESCRIPTION
## Summary
- `TryInArrayIndexAssignmentSpec` tested `try`/`catch` in an array-write index or the assigned value separately, but never both in the same write (`arr[try {...} catch {...}] = try {...} catch {...}`).
- The combination already passes — this closes a coverage gap rather than fixing a live bug.
- Records the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.TryInArrayIndexAssignmentSpec'` — 5/5 passed
- [x] `sbt -Duser.language=en test` — full suite: 3529 succeeded, 0 failed, 1 canceled (pre-existing, unrelated `sbt dist` packaging integration test), exit code 0

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_019FkkA1k77oqDBM4Nf9dnah)_