### PR TITLE
Add regression coverage for try/catch as an enum case constructor argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handling were each tested individually, but never combined in the same
   write; the combination already passed, so this closes a coverage gap rather
   than a live bug.
+- **`TryInEnumCaseArgSpec`, regression coverage for `try`/`catch` used as an
+  argument to an `enum case` constructor invocation**
+  (`new Circle(try {...} catch {...})`). The generated constructor already
+  flows through the same `visitNewObject` path ordinary records use (already
+  hardened by the #669/#745/#752 fixes), so this already passed; this closes
+  a coverage gap rather than a live bug.
 
 ## [0.10.37] - 2026-08-16
 

--- a/src/test/scala/onion/compiler/tools/TryInEnumCaseArgSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInEnumCaseArgSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression used as an argument to an `enum case`
+ * constructor invocation (`new Circle(try {...} catch {...})`) is another
+ * sibling of the #669/#745/#752 stack-corruption family: the JVM clears the
+ * operand stack when it dispatches to an exception handler, so an
+ * already-pushed receiver would be silently discarded on the exceptional
+ * path if evaluation weren't routed through a spill-to-locals-and-reload
+ * sequence.
+ *
+ * An `enum case`'s generated constructor already flows through the same
+ * `visitNewObject` path an ordinary record's constructor uses (see
+ * `TryInConstructorArgAndCollectionLiteralSpec`), which is already
+ * hardened, so this already passes; this closes a coverage gap rather than
+ * a live bug. (`TryAsCallArgumentSpec` covers a *homogeneous* enum's
+ * `select` arms and a plain instance-method receiver, but not a
+ * `case`-enum's own constructor call.)
+ */
+class TryInEnumCaseArgSpec extends AbstractShellSpec {
+  describe("try/catch expression as an enum case constructor argument") {
+    it("does not corrupt the case record across a caught constructor argument") {
+      val result = shell.run(
+        """
+          |enum Shape {
+          |  case Circle(radius: Double)
+          |  case Square(side: Double)
+          |public:
+          |  def area(): Double = select this {
+          |    case c is Circle: c.radius() * c.radius()
+          |    case s is Square: s.side() * s.side()
+          |  }
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val c1: Shape = new Circle(try { Double::parseDouble("nope") } catch e: Exception { 2.0 })
+          |    val c2: Shape = new Circle(try { Double::parseDouble("3.0") } catch e: Exception { -1.0 })
+          |    return "" + c1.area() + "|" + c2.area()
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInEnumCaseArg.on",
+        Array()
+      )
+      assert(Shell.Success("4.0|9.0") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `TryInEnumCaseArgSpec`, regression coverage for a `try`/`catch` expression used as an argument to an `enum case` constructor invocation (`new Circle(try {...} catch {...})`).
- This position is a sibling of the #669/#745/#752 stack-corruption family (the JVM clears the operand stack on entry to an exception handler, so an already-pushed receiver can be silently discarded). An `enum case`'s generated constructor already routes through the same `visitNewObject` path an ordinary record's constructor uses, which those fixes already hardened — so the new test already passes. This closes a coverage gap rather than fixing a live bug.
- Adds a matching `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *TryInEnumCaseArgSpec'` — 1/1 passed
- [x] Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3530 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test that self-cancels without `-Donion.dist.path=...`), 485 suites completed, 0 aborted

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cz1F4G72RLnVskz6whSPQH)_