### PR TITLE
test: regression coverage for derive!(Json, Yaml) rejecting nullable scalar components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`RecordJsonSpec`/`RecordYamlSpec`, regression coverage for `derive!(Json, Yaml)`
+  rejecting a nullable scalar record component** (`nickname: String?`). Docs describe
+  `derive!` as supporting "scalar components only"; `ScalarConversions.isDerivable`
+  only matches the exact non-null scalar types, so a nullable wrapper around an
+  otherwise-supported type is already rejected with E0062 the same way a wholly
+  unsupported component type (a nested record) is -- but only the JSON side had a
+  regression for the nested-record case, and neither side tested the nullable case.
+  Both already behaved correctly; this closes a coverage gap rather than a live bug.
+
 - **`TryInArrayIndexAssignmentSpec`, regression coverage for `try`/`catch` used
   as *both* the index and the assigned value of the same array write**
   (`arr[try {...} catch {...}] = try {...} catch {...}`). The existing index-side

--- a/src/test/scala/onion/compiler/tools/RecordJsonSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RecordJsonSpec.scala
@@ -148,6 +148,25 @@ class RecordJsonSpec extends AbstractShellSpec {
       assert(result.isInstanceOf[Shell.Failure])
     }
 
+    it("rejects a nullable scalar component (String?) (E0062)") {
+      // ScalarConversions.isDerivable only matches the exact non-null scalar types, so a
+      // nullable wrapper around an otherwise-supported type (String? vs String) is rejected
+      // the same way a wholly-unsupported component type (a nested record) is above. Docs
+      // say "scalar components only"; this locks in that nullability is part of that bar.
+      val result = shell.run(
+        """
+          |record Person(name: String, nickname: String?) derive!(Json)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "x" }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(result.isInstanceOf[Shell.Failure])
+    }
+
     it("rejects an unknown derive! marker (E0063)") {
       val result = shell.run(
         """

--- a/src/test/scala/onion/compiler/tools/RecordYamlSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RecordYamlSpec.scala
@@ -107,6 +107,40 @@ class RecordYamlSpec extends AbstractShellSpec {
       assert(Shell.Success("123,true") == result)
     }
 
+    it("rejects an unsupported component type (E0062)") {
+      // RecordJsonSpec covers this for derive!(Json); derive!(Yaml) shares the same
+      // TypingOutlinePass.isDataDerivableType check (both markers reuse one toMap/fromMap
+      // core), but had no direct regression here before this test.
+      val result = shell.run(
+        """
+          |record Inner(z: Int)
+          |record Bad(a: String, b: Inner) derive!(Yaml)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "x" }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(result.isInstanceOf[Shell.Failure])
+    }
+
+    it("rejects a nullable scalar component (String?) (E0062)") {
+      val result = shell.run(
+        """
+          |record Person(name: String, nickname: String?) derive!(Yaml)
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String { return "x" }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(result.isInstanceOf[Shell.Failure])
+    }
+
     it("coexists with derive!(Json) — all four methods on one record") {
       val result = shell.run(
         """


### PR DESCRIPTION
## Summary
- `derive!(Json, Yaml)` docs say component types must be scalar. `ScalarConversions.isDerivable` only matches the exact non-null scalar types, so a nullable component (`String?` vs `String`) already hits `E0062` the same way a wholly unsupported component type (a nested record) does.
- Only `RecordJsonSpec` had a regression for the nested-record rejection case, and neither `RecordJsonSpec` nor `RecordYamlSpec` tested the nullable-component case at all. Both already behaved correctly (verified manually before writing these); this closes a coverage gap rather than fixing a live bug — no production code changed.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RecordJsonSpec onion.compiler.tools.RecordYamlSpec'` — 19/19 pass
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3533 succeeded / 0 failed / 1 canceled (expected dist-path-gated smoke test)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQPSUzXZaqJVCNaQDmeKGW)_