### PR TITLE
test: add RunSamplesSpec coverage for 20 recently-added run/ examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`RunSamplesSpec` coverage for 20 `run/` examples that were added without a
+  corresponding test** (`ChemCalculator`, `CodeContest`, `CryptoPortfolio`,
+  `DependencyResolver`, `DnaAnalyzer`, `ElevatorDispatcher`,
+  `GenericLeaderboard`, `GeneticSequencer`, `HospitalWard`, `InsuranceClaims`,
+  `KaraokeNight`, `MarkdownConverter`, `MiniTypeChecker`, `NetworkMonitor`,
+  `PlantCare`, `RecipeVault`, `RuleEngine`, `SortAlgorithms`, `SupplyChain`,
+  `TransitPlanner`). Each already ran and compiled cleanly; `sbt test` simply
+  never exercised them, so a future regression in any of them would have gone
+  unnoticed. This closes the coverage gap.
+
 - **`RecordJsonSpec`/`RecordYamlSpec`, regression coverage for `derive!(Json, Yaml)`
   rejecting a nullable scalar record component** (`nickname: String?`). Docs describe
   `derive!` as supporting "scalar components only"; `ScalarConversions.isDerivable`

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -555,5 +555,85 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs TryCatchEdgeCases.on") {
       assert(Shell.Success(138) == runSample("run/TryCatchEdgeCases.on"))
     }
+
+    it("runs ChemCalculator.on") {
+      assert(Shell.Success(null) == runSample("run/ChemCalculator.on"))
+    }
+
+    it("runs CodeContest.on") {
+      assert(Shell.Success(null) == runSample("run/CodeContest.on"))
+    }
+
+    it("runs CryptoPortfolio.on") {
+      assert(Shell.Success(null) == runSample("run/CryptoPortfolio.on"))
+    }
+
+    it("runs DependencyResolver.on") {
+      assert(Shell.Success(null) == runSample("run/DependencyResolver.on"))
+    }
+
+    it("runs DnaAnalyzer.on") {
+      assert(Shell.Success(null) == runSample("run/DnaAnalyzer.on"))
+    }
+
+    it("runs ElevatorDispatcher.on") {
+      assert(Shell.Success(null) == runSample("run/ElevatorDispatcher.on"))
+    }
+
+    it("runs GenericLeaderboard.on") {
+      assert(Shell.Success(null) == runSample("run/GenericLeaderboard.on"))
+    }
+
+    it("runs GeneticSequencer.on") {
+      assert(Shell.Success(null) == runSample("run/GeneticSequencer.on"))
+    }
+
+    it("runs HospitalWard.on") {
+      assert(Shell.Success(null) == runSample("run/HospitalWard.on"))
+    }
+
+    it("runs InsuranceClaims.on") {
+      assert(Shell.Success(null) == runSample("run/InsuranceClaims.on"))
+    }
+
+    it("runs KaraokeNight.on") {
+      assert(Shell.Success(null) == runSample("run/KaraokeNight.on"))
+    }
+
+    it("runs MarkdownConverter.on") {
+      assert(Shell.Success(null) == runSample("run/MarkdownConverter.on"))
+    }
+
+    it("runs MiniTypeChecker.on") {
+      assert(Shell.Success(null) == runSample("run/MiniTypeChecker.on"))
+    }
+
+    it("runs NetworkMonitor.on") {
+      assert(Shell.Success(null) == runSample("run/NetworkMonitor.on"))
+    }
+
+    it("runs PlantCare.on") {
+      assert(Shell.Success(null) == runSample("run/PlantCare.on"))
+    }
+
+    it("runs RecipeVault.on") {
+      assert(Shell.Success(null) == runSample("run/RecipeVault.on"))
+    }
+
+    it("runs RuleEngine.on") {
+      assert(Shell.Success(null) == runSample("run/RuleEngine.on"))
+    }
+
+    it("runs SortAlgorithms.on") {
+      assert(Shell.Success(null) == runSample("run/SortAlgorithms.on"))
+    }
+
+    it("runs SupplyChain.on") {
+      assert(Shell.Success(null) == runSample("run/SupplyChain.on"))
+    }
+
+    it("runs TransitPlanner.on") {
+      assert(Shell.Success(null) == runSample("run/TransitPlanner.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `ChemCalculator`, `CodeContest`, `CryptoPortfolio`, `DependencyResolver`, `DnaAnalyzer`, `ElevatorDispatcher`, `GenericLeaderboard`, `GeneticSequencer`, `HospitalWard`, `InsuranceClaims`, `KaraokeNight`, `MarkdownConverter`, `MiniTypeChecker`, `NetworkMonitor`, `PlantCare`, `RecipeVault`, `RuleEngine`, `SortAlgorithms`, `SupplyChain`, and `TransitPlanner` were added to `run/` but never wired into `RunSamplesSpec`, so `sbt test` never exercised them and a regression in any of them would go unnoticed.
- Each already runs and compiles cleanly (verified individually via `sbt runScript`); this PR just closes the coverage gap by adding a `RunSamplesSpec` case for each, asserting `Shell.Success(null)` per the existing convention for output-only samples.
- Recorded the change in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *RunSamplesSpec'` — 135 tests, all passed
- [x] `sbt -Duser.language=en test` (full suite) — 3553 tests, all passed (1 canceled: pre-existing, environment-gated distribution smoke test unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01MKK9PYPESw19vEGf1eSzcv)_