### PR TITLE
test: add RunSamplesSpec coverage for 34 more run/ examples missing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`RunSamplesSpec` coverage for 34 more `run/` examples that were added
+  without a corresponding test** (`Automaton`, `EmployeeManager`,
+  `ExpenseAuditor`, `GameStore`, `MatrixCalc`, `MazeSolver`, `MiniRpg`,
+  `MovieRecommender`, `MuseumCollection`, `MusicLibrary`,
+  `NationalParkTracker`, `NutritionTracker`, `ParkingGarage`,
+  `PayrollReport`, `PlaylistManager`, `PokerHands`, `RankedChoice`,
+  `RecipeManager`, `RestaurantOrders`, `ShipmentTracker`, `ShoppingCart`,
+  `SnippetLibrary`, `SortingShowcase`, `SpaceMission`, `StockPortfolio`,
+  `StudentGradeBook`, `Sudoku`, `SudokuSolver`, `TaskPlanner`,
+  `TimesheetTracker`, `TournamentStandings`, `TournamentTracker`,
+  `VirtualMachine`, `VirtualShell`). Each already ran and compiled cleanly;
+  `sbt test` simply never exercised them, so a regression in any of them
+  would have gone unnoticed. `ExpenseAuditor` is a `tool`-declared script, so
+  its test drives the auto-CLI with a temp input/output file pair rather
+  than calling it with no arguments. `Calculator.on` (a Swing GUI program
+  requiring a display) is intentionally left uncovered, matching how the
+  repository already treats headless-incompatible samples.
+
 - **`RunSamplesSpec` coverage for 20 `run/` examples that were added without a
   corresponding test** (`ChemCalculator`, `CodeContest`, `CryptoPortfolio`,
   `DependencyResolver`, `DnaAnalyzer`, `ElevatorDispatcher`,

--- a/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RunSamplesSpec.scala
@@ -635,5 +635,150 @@ class RunSamplesSpec extends AbstractShellSpec {
     it("runs TransitPlanner.on") {
       assert(Shell.Success(null) == runSample("run/TransitPlanner.on"))
     }
+
+    it("runs Automaton.on") {
+      assert(Shell.Success(null) == runSample("run/Automaton.on"))
+    }
+
+    it("runs EmployeeManager.on") {
+      assert(Shell.Success(null) == runSample("run/EmployeeManager.on"))
+    }
+
+    it("runs ExpenseAuditor.on: audits expenses and writes a report") {
+      val dir = java.nio.file.Files.createTempDirectory("expense-auditor-spec")
+      val src = dir.resolve("expenses.txt"); val out = dir.resolve("report.txt")
+      java.nio.file.Files.writeString(src,
+        "2026-01-05|Travel|120.50|taxi to airport\n2026-01-06|Meals|500.00|team dinner\n")
+      def run(args: String*): Shell.Result =
+        shell.run(load("run/ExpenseAuditor.on"), "run/ExpenseAuditor.on", args.toArray)
+
+      assert(Shell.Success(0) == run(src.toString, out.toString))
+      val report = java.nio.file.Files.readString(out)
+      assert(report.nonEmpty, report)
+    }
+
+    it("runs GameStore.on") {
+      assert(Shell.Success(null) == runSample("run/GameStore.on"))
+    }
+
+    it("runs MatrixCalc.on") {
+      assert(Shell.Success(null) == runSample("run/MatrixCalc.on"))
+    }
+
+    it("runs MazeSolver.on") {
+      assert(Shell.Success(null) == runSample("run/MazeSolver.on"))
+    }
+
+    it("runs MiniRpg.on") {
+      assert(Shell.Success(null) == runSample("run/MiniRpg.on"))
+    }
+
+    it("runs MovieRecommender.on") {
+      assert(Shell.Success(null) == runSample("run/MovieRecommender.on"))
+    }
+
+    it("runs MuseumCollection.on") {
+      assert(Shell.Success(null) == runSample("run/MuseumCollection.on"))
+    }
+
+    it("runs MusicLibrary.on") {
+      assert(Shell.Success(null) == runSample("run/MusicLibrary.on"))
+    }
+
+    it("runs NationalParkTracker.on") {
+      assert(Shell.Success(null) == runSample("run/NationalParkTracker.on"))
+    }
+
+    it("runs NutritionTracker.on") {
+      assert(Shell.Success(null) == runSample("run/NutritionTracker.on"))
+    }
+
+    it("runs ParkingGarage.on") {
+      assert(Shell.Success(null) == runSample("run/ParkingGarage.on"))
+    }
+
+    it("runs PayrollReport.on") {
+      assert(Shell.Success(null) == runSample("run/PayrollReport.on"))
+    }
+
+    it("runs PlaylistManager.on") {
+      assert(Shell.Success(null) == runSample("run/PlaylistManager.on"))
+    }
+
+    it("runs PokerHands.on") {
+      assert(Shell.Success(null) == runSample("run/PokerHands.on"))
+    }
+
+    it("runs RankedChoice.on") {
+      assert(Shell.Success(null) == runSample("run/RankedChoice.on"))
+    }
+
+    it("runs RecipeManager.on") {
+      assert(Shell.Success(null) == runSample("run/RecipeManager.on"))
+    }
+
+    it("runs RestaurantOrders.on") {
+      assert(Shell.Success(null) == runSample("run/RestaurantOrders.on"))
+    }
+
+    it("runs ShipmentTracker.on") {
+      assert(Shell.Success(null) == runSample("run/ShipmentTracker.on"))
+    }
+
+    it("runs ShoppingCart.on") {
+      assert(Shell.Success(null) == runSample("run/ShoppingCart.on"))
+    }
+
+    it("runs SnippetLibrary.on") {
+      assert(Shell.Success(null) == runSample("run/SnippetLibrary.on"))
+    }
+
+    it("runs SortingShowcase.on") {
+      assert(Shell.Success(null) == runSample("run/SortingShowcase.on"))
+    }
+
+    it("runs SpaceMission.on") {
+      assert(Shell.Success(null) == runSample("run/SpaceMission.on"))
+    }
+
+    it("runs StockPortfolio.on") {
+      assert(Shell.Success(null) == runSample("run/StockPortfolio.on"))
+    }
+
+    it("runs StudentGradeBook.on") {
+      assert(Shell.Success(null) == runSample("run/StudentGradeBook.on"))
+    }
+
+    it("runs Sudoku.on") {
+      assert(Shell.Success(null) == runSample("run/Sudoku.on"))
+    }
+
+    it("runs SudokuSolver.on") {
+      assert(Shell.Success(null) == runSample("run/SudokuSolver.on"))
+    }
+
+    it("runs TaskPlanner.on") {
+      assert(Shell.Success(null) == runSample("run/TaskPlanner.on"))
+    }
+
+    it("runs TimesheetTracker.on") {
+      assert(Shell.Success(null) == runSample("run/TimesheetTracker.on"))
+    }
+
+    it("runs TournamentStandings.on") {
+      assert(Shell.Success(null) == runSample("run/TournamentStandings.on"))
+    }
+
+    it("runs TournamentTracker.on") {
+      assert(Shell.Success(null) == runSample("run/TournamentTracker.on"))
+    }
+
+    it("runs VirtualMachine.on") {
+      assert(Shell.Success(null) == runSample("run/VirtualMachine.on"))
+    }
+
+    it("runs VirtualShell.on") {
+      assert(Shell.Success(null) == runSample("run/VirtualShell.on"))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Followed up on the #766 coverage sweep: 34 more `run/` examples (`Automaton` through `VirtualShell`) had no corresponding `sbt test`, so a regression in any of them would go unnoticed.
- Each example already ran and compiled cleanly before this change; this closes a coverage gap rather than fixing a live bug.
- `ExpenseAuditor` is a `tool`-declared script, so its test drives the auto-CLI with a temp input/output file pair instead of calling it with no arguments.
- `Calculator.on` (a Swing GUI program requiring a display) is intentionally left uncovered, matching how the repo already treats headless-incompatible samples.

## Test plan
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test` — 3587 tests, all green (1 pre-existing, unrelated cancellation in `ProjectDistributionSpec`)
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.RunSamplesSpec'` — all 169 tests pass, including the 34 new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QDizCeqBkGF2pb8dwbbrXT)_