### PR TITLE
fix(fmt): stop onion fmt collapsing a whitespace-only file to empty

### DIFF
--- a/src/main/scala/onion/tools/format/OnionFormatter.scala
+++ b/src/main/scala/onion/tools/format/OnionFormatter.scala
@@ -96,6 +96,14 @@ object OnionFormatter:
 
   def format(source: String): FormatResult =
     val lexemes = lex(source)
+    // A source with no real token and no comment -- whitespace only, or empty -- has no
+    // lexeme for the loop below to visit, so it fell straight through to an empty
+    // StringBuilder and collapsed a whitespace-only file to nothing. No rule anchors to
+    // whitespace with no token around it, so it is left exactly as written.
+    if lexemes.isEmpty then FormatResult(source, changed = false)
+    else formatLexemes(source, lexemes)
+
+  private def formatLexemes(source: String, lexemes: Seq[Lexeme]): FormatResult =
     val out = new StringBuilder
     var previous: Option[Lexeme] = None
 

--- a/src/test/scala/onion/tools/format/OnionFormatterSpec.scala
+++ b/src/test/scala/onion/tools/format/OnionFormatterSpec.scala
@@ -156,3 +156,12 @@ class OnionFormatterSpec extends AnyFunSuite with Matchers:
     OnionFormatter.format("val a = 1\n").changed shouldBe false
     OnionFormatter.format("val  a = 1\n").changed shouldBe false // no rule applies
     OnionFormatter.format("f(a , b)\n").changed shouldBe true
+
+  test("leaves a whitespace-only file untouched, since it has no tokens for a rule to apply to"):
+    // The lexer produces no lexeme at all when a source has neither a real token nor a
+    // comment, and the main loop is a no-op over an empty sequence -- which silently
+    // collapsed the file to an empty string instead of leaving whitespace it has no rule
+    // for exactly as written, the same "byte for byte" guarantee every other test here
+    // checks for whitespace that does have a token around it.
+    val source = "   \n\n  \t \n"
+    OnionFormatter.format(source) shouldBe OnionFormatter.FormatResult(source, changed = false)


### PR DESCRIPTION
## Summary

- `OnionFormatter.format` lexes a source into "lexemes" (tokens + comments) and formats
  by iterating that sequence. A `.on` file with no real token and no comment (whitespace
  or blank lines only) produces an empty lexeme sequence, so the loop is a no-op and the
  trailing-newline logic never runs either — the formatter silently rewrote such a file
  down to an empty string and reported it as `changed`.
- This violates the formatter's own documented invariant: whitespace nothing anchors to
  should be reproduced byte for byte, the same guarantee already held for whitespace next
  to a real token.
- Fix: when `lex(source)` yields no lexemes at all, `format` now returns the source
  unchanged (`changed = false`) instead of falling through to the empty-builder path.

## Testing

- Added a regression test in `OnionFormatterSpec` asserting a whitespace-only source is
  returned byte-for-byte unchanged with `changed = false`.
- Ran the targeted suite (`OnionFormatterSpec`, `FormatCommandSpec`, `LspFormattingSpec`)
  under the English locale: **36/36 passing**.

## Why this is a draft

This session's mandate requires the **full** `-Duser.language=en testFull` suite to pass
green before merging. I ran it twice in this environment; both times it stalled deep into
the suite (~13.3k output lines in) under severe, sustained GC pressure (heap repeatedly
reported near-zero free of a 4G max, 90–99% of wall time spent in GC pauses) and produced
no further output for 12+ minutes before I killed it. The two stalls happened at different
points in the suite (once near `StringsEnrichedSpec`, once near `NamedArgumentSpec`), which
points to a resource-exhaustion condition in this sandbox rather than a specific hung test.

Since I could not get a full green run in the time available, per this project's workflow
I'm leaving this as a draft with the targeted-suite result reported above rather than
merging on partial verification. A maintainer (or a retry in a less memory-constrained
environment) should run the full suite before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmGbaPx9UfrJRDXS69U6jz)_