### PR TITLE
fix(release): sbt 2's CLI parser rejects space-separated task lists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Build artifacts
         env:
           SBT_OPTS: "-Xmx10G -XX:+UseG1GC -Xss16m"
-        run: sbt assembly dist
+        run: sbt "assembly; dist"
       - name: Collect artifacts
         run: |
           VERSION="${{ steps.version.outputs.version }}"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,7 +59,7 @@ is no manual `version := ...` line to update in `build.sbt`.
 To build the same artifacts locally without creating a release:
 
 ```bash
-sbt assembly dist
+sbt "assembly; dist"
 ```
 
 Outputs:

--- a/docs/ja/RELEASING.md
+++ b/docs/ja/RELEASING.md
@@ -54,7 +54,7 @@ Onion は **git タグ** をリリースの起点としています。バージ�
 リリースを作成せずに同じ成果物をローカルでビルドするには:
 
 ```bash
-sbt assembly dist
+sbt "assembly; dist"
 ```
 
 出力:


### PR DESCRIPTION
## Summary
- `sbt assembly dist` built both artifacts fine under sbt 1.x, but the "sbt 2" migration (d8d89150, the first commit after the `v0.10.37` tag) changed how the batch-mode CLI parser reads space-separated arguments — it now tries to parse `assembly dist` as a single expression and fails with `Expected whitespace character` / `Expected '/'`.
- No release had been cut since that migration landed, so the break went unexercised until now: the `v0.11.0` release run's `Test` step passed, then `Build artifacts` failed in under a second (a parse error, not a real build failure), skipping every step after it — no jar, no zip, no GitHub Release.
- Fixes the same pattern in `release.yml` and both `RELEASING.md` copies (en/ja) so a maintainer following the local-build instructions hits the working command instead of the same error.

## Test plan
- [x] Reproduced locally: `sbt assembly dist` fails with the identical parser error.
- [x] Verified the fix locally: `sbt "assembly; dist"` (semicolon-joined, single argument) builds both the fat jar and the dist zip successfully.
- [x] `sbt test` and `sbt -v +test` (single-task invocations elsewhere in the workflows) are unaffected — only multi-task, space-separated invocations hit this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGy4GX7i42EhJHjzbNPhw1)_