### PR TITLE
fix(release): sbt 2 moved build output under target/out/jvm/...

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,11 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           mkdir -p release-artifacts
-          FAT_JAR="target/scala-3.3.7/onion-${VERSION}.jar"
+          OUT_DIR="target/out/jvm/scala-3.3.7/onion"
+          FAT_JAR="$OUT_DIR/onion-${VERSION}.jar"
           test -f "$FAT_JAR"
           cp "$FAT_JAR" "release-artifacts/onion-${VERSION}.jar"
-          cp "target/onion-dist-${VERSION}.zip" "release-artifacts/onion-dist-${VERSION}.zip"
+          cp "$OUT_DIR/onion-dist-${VERSION}.zip" "release-artifacts/onion-dist-${VERSION}.zip"
       - name: Generate checksums
         run: |
           cd release-artifacts

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -62,9 +62,9 @@ To build the same artifacts locally without creating a release:
 sbt "assembly; dist"
 ```
 
-Outputs:
-- `target/scala-3.3.7/onion-<version>.jar` (fat jar)
-- `target/onion-dist-<version>.zip` (distribution archive)
+Outputs (sbt 2's default layout nests build products under `target/out/<platform>/<scalaVersion>/<project>/`):
+- `target/out/jvm/scala-3.3.7/onion/onion-<version>.jar` (fat jar)
+- `target/out/jvm/scala-3.3.7/onion/onion-dist-<version>.zip` (distribution archive)
 
 ## Hotfix releases
 

--- a/docs/ja/RELEASING.md
+++ b/docs/ja/RELEASING.md
@@ -57,9 +57,9 @@ Onion は **git タグ** をリリースの起点としています。バージ�
 sbt "assembly; dist"
 ```
 
-出力:
-- `target/scala-3.3.7/onion-<version>.jar` (fat jar)
-- `target/onion-dist-<version>.zip` (配布用アーカイブ)
+出力 (sbt 2 の既定レイアウトではビルド成果物が `target/out/<platform>/<scalaVersion>/<project>/` 以下に配置される):
+- `target/out/jvm/scala-3.3.7/onion/onion-<version>.jar` (fat jar)
+- `target/out/jvm/scala-3.3.7/onion/onion-dist-<version>.zip` (配布用アーカイブ)
 
 ## ホットフィックスリリース
 


### PR DESCRIPTION
## Summary
- Follow-up to #780. With the CLI-parsing fix in place, the `v0.11.0` release run got one step further: `Test` and `Build artifacts` now pass, but `Collect artifacts` fails on `test -f target/scala-3.3.7/onion-${VERSION}.jar` — that path no longer exists.
- sbt 2's default layout nests build products under `target/out/<platform>/<scalaVersion>/<project>/` instead of sbt 1's flat `target/<scalaVersion>/`. Confirmed locally: the fat jar and dist zip both land in `target/out/jvm/scala-3.3.7/onion/`.
- Updates the same stale path in both `RELEASING.md` copies (en/ja), whose "Local artifact inspection" section pointed at the old flat path.

## Test plan
- [x] Verified locally that `target/out/jvm/scala-3.3.7/onion/onion-<version>.jar` and `.../onion-dist-<version>.zip` exist after `sbt "assembly; dist"`, matching the corrected `release.yml` path.
- [x] The failing `test -f` command from the actual v0.11.0 CI run reproduces against the old path and succeeds against the new one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGy4GX7i42EhJHjzbNPhw1)_