### PR TITLE
docs(claude-md): list Db, Archive, Concurrent, Net, Server in the stdlib overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,11 @@ All phases extend `Processor[A, B]` trait and can be composed using `andThen()`:
 - `Http` - HTTP client
 - `Regex` - Regular expressions
 - `Option`, `Result`, `Future` - Functional types
+- `Db` - JDBC access (connect, query, update, transactions)
+- `Archive` - Zip/gzip creation and extraction
+- `Concurrent` - Thread pools, counters, locks, channels
+- `Net` - TCP sockets (connect, listen)
+- `Server` - Minimal HTTP server (routing, request/response)
 
 ## Testing
 

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -155,6 +155,11 @@ Onionコンパイラは、古典的なコンパイラアーキテクチャに従
 - `Http` - HTTPクライアント
 - `Regex` - 正規表現
 - `Option`, `Result`, `Future` - 関数型
+- `Db` - JDBCアクセス (connect, query, update, トランザクション)
+- `Archive` - Zip/gzipの作成と展開
+- `Concurrent` - スレッドプール、カウンタ、ロック、チャネル
+- `Net` - TCPソケット (connect, listen)
+- `Server` - 最小限のHTTPサーバー (ルーティング、リクエスト/レスポンス)
 
 ## テスト
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md` and `docs/ja/CLAUDE_ja.md` still listed only the pre-v0.10 standard library set (IO, Strings, Rand, Assert, Timing, Files, DateTime, Json, Http, Regex, Option/Result/Future).
- The five modules added since (`onion.Db`, `onion.Archive`, `onion.Concurrent`, `onion.Net`, `onion.Server`) are already documented in `docs/reference/stdlib.md` / `docs/ja/reference/stdlib.md`, but were missing from the guidance file Claude Code reads first — a doc/implementation sync gap.
- Adds a one-line entry per module to both the English and Japanese lists.

Docs-only change, no code/behavior change.

## Test plan
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3753 tests, 0 failed, 1 canceled, all green

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZ5VrcCPk6s9opuUW1Adbg)_