### PR TITLE
docs(stdlib): mention Archive::gunzipFile, and guard it against drift

### DIFF
--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1776,6 +1776,7 @@ val names = Archive::entries("out.zip")      // 展開せずに一覧
 val written = Archive::unzip("out.zip", "extracted")
 
 Archive::gzipFile("big.log", "big.log.gz")   // 全部をメモリに読まずストリーミング
+Archive::gunzipFile("big.log.gz", "big.log") // その逆
 val bytes = Archive::gunzip(Archive::gzip(text.getBytes()))
 ```
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1764,6 +1764,7 @@ val names = Archive::entries("out.zip")      // without extracting
 val written = Archive::unzip("out.zip", "extracted")
 
 Archive::gzipFile("big.log", "big.log.gz")   // streams, rather than reading it all in
+Archive::gunzipFile("big.log.gz", "big.log") // and the reverse
 val bytes = Archive::gunzip(Archive::gzip(text.getBytes()))
 ```
 

--- a/src/test/scala/onion/compiler/tools/StdlibDocArchiveModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocArchiveModuleParitySpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard for the "Archive" section of docs/reference/stdlib.md (and its Japanese
+ * translation) against `onion.Archive`'s public API. `gunzipFile` (see
+ * src/main/java/onion/Archive.java) sits right next to its documented sibling
+ * `gzipFile` but was never mentioned in either reference, making it undiscoverable
+ * without reading the Java source.
+ */
+class StdlibDocArchiveModuleParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def sectionUnder(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.trim == heading)
+    assert(start >= 0, s"could not find heading '$heading' — the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith("## ")).mkString("\n")
+  }
+
+  private val methods = Seq(
+    "zip", "zipDir", "entries", "unzip", "gzip", "gunzip", "gzipFile", "gunzipFile"
+  )
+
+  it("mentions every public onion.Archive method in the English Archive section") {
+    val en = sectionUnder(read("docs/reference/stdlib.md"), "## Archive")
+    methods.foreach { name =>
+      assert(en.contains(s"Archive::$name"),
+        s"docs/reference/stdlib.md's Archive section doesn't mention Archive::$name, " +
+        "a public onion.Archive method")
+    }
+  }
+
+  it("mentions every public onion.Archive method in the Japanese Archive section") {
+    val ja = sectionUnder(read("docs/ja/reference/stdlib.md"), "## Archive")
+    methods.foreach { name =>
+      assert(ja.contains(s"Archive::$name"),
+        s"docs/ja/reference/stdlib.md's Archive section doesn't mention Archive::$name, " +
+        "a public onion.Archive method")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `Archive::gzipFile` and `Archive::gunzipFile` are documented siblings in `src/main/java/onion/Archive.java`, but only `gzipFile` was ever mentioned in the Archive section of the stdlib reference — `gunzipFile` was undiscoverable without reading the Java source.
- Adds `Archive::gunzipFile` to the Archive code example in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- Adds `StdlibDocArchiveModuleParitySpec` (mirroring the existing `StdlibDocFilesModuleParitySpec` pattern) that checks every public `onion.Archive` method is mentioned in both references, so the same drift doesn't happen again unnoticed.

## Test plan
- [x] New spec fails before the doc fix (confirmed red), passes after (confirmed green)
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3759 tests, 0 failed, 1 canceled (environment-gated smoke test requiring `-Donion.dist.path`, expected)
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 3759 tests, 0 failed, 1 canceled (same)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ngxn1ewv95uwfT6vYktvdV)_