### PR TITLE
docs(changelog): cut 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-18
+
 ### Added
 
 - **Semantic tokens in the language server — the colouring a TextMate grammar cannot


### PR DESCRIPTION
The tag `v0.11.1` and its GitHub Release exist, and the published jar has been downloaded, checksummed against `checksums.txt`, and run. The heading is therefore safe to finalize.

RELEASING.md puts the heading after the release because one committed before a failed release has to be reverted — the release-and-revert loop issue #334 describes. This release did fail twice before landing, both times on GitHub 503s during a platform incident (once creating the tag, once creating the release), so the ordering earned its keep today.

Release contents: semantic tokens in the language server (#784).

🤖 Generated with [Claude Code](https://claude.com/claude-code)