### PR TITLE
docs(changelog): cut 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-08-18
+
 ### Added
 
 - **`onion.lock`: a build resolves the same artifacts the next time, and says so if it


### PR DESCRIPTION
Tag `v0.11.2` and its release exist; the published jar was downloaded, checksummed against `checksums.txt`, run, and used to build a project. RELEASING.md puts the heading after the release so a failed one never has to be reverted.

Release contents: `onion.lock` (#788).

🤖 Generated with [Claude Code](https://claude.com/claude-code)