### PR TITLE
fix(tco): warn W0016 when mutual-recursion group's parameter lists mismatch

### DIFF
--- a/src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala
+++ b/src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala
@@ -178,7 +178,22 @@ class MutualRecursionOptimization(config: CompilerConfig)
 
     // Check 3: All methods must be in same class (already guaranteed by our collection)
 
-    // Check 4: All tail calls must be to methods in the group
+    // Check 4: All methods must share one parameter list (count and per-position types),
+    // since the state machine has a single set of loop variables shared by every member.
+    val paramCounts = group.map(_.arguments.length).toSet
+    if (paramCounts.size > 1) {
+      break(Some(s"Methods have different parameter counts: ${paramCounts.mkString(", ")}"))
+    }
+    val paramCount = group.head.arguments.length
+    val incompatibleParam = (0 until paramCount).find { paramIdx =>
+      group.map(_.arguments(paramIdx).name).toSet.size > 1
+    }
+    incompatibleParam.foreach { paramIdx =>
+      val paramTypes = group.map(_.arguments(paramIdx).name).toSet
+      break(Some(s"Methods have incompatible parameter lists: parameter $paramIdx has different types: ${paramTypes.mkString(", ")}"))
+    }
+
+    // Check 5: All tail calls must be to methods in the group
     val groupNames = group.map(_.name).toSet
     var validationError: Option[String] = None
     val iterator = group.iterator
@@ -231,31 +246,8 @@ class MutualRecursionOptimization(config: CompilerConfig)
       }
     }
 
-    // Step 1: Check parameter compatibility
-    val paramCounts = group.map(_.arguments.length).toSet
-    if (paramCounts.size > 1) {
-      if (config.verbose) {
-        trace(s"[Mutual TCO] ERROR: Methods have different parameter counts: $paramCounts")
-      }
-      return
-    }
-
+    // Parameter compatibility is already guaranteed by validateGroup before this is called.
     val paramCount = group.head.arguments.length
-
-    // Check parameter types are compatible across all methods
-    val incompatibleParam = (0 until paramCount).find { paramIdx =>
-      val paramTypesSet = group.map(_.arguments(paramIdx).name).toSet
-      val incompatible = paramTypesSet.size > 1
-      if (incompatible) {
-        if (config.verbose) {
-          trace(s"[Mutual TCO] ERROR: Parameter $paramIdx has different types: $paramTypesSet")
-        }
-      }
-      incompatible
-    }
-    if (incompatibleParam.nonEmpty) {
-      return
-    }
 
     // Step 2: Create state machine method name and structure
     val stateMachineMethodName = group.map(_.name).mkString("_")

--- a/src/test/scala/onion/compiler/tools/IneffectiveTailRecursiveWarningSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IneffectiveTailRecursiveWarningSpec.scala
@@ -69,6 +69,31 @@ class IneffectiveTailRecursiveWarningSpec extends AnyFunSpec {
       assert(result.diagnostics.warnings.filter(_.category.code == "W0016").isEmpty)
     }
 
+    it("warns when the group's parameter lists don't match") {
+      val result = compileWarnings(
+        """
+          |class Parity {
+          |private:
+          |  @TailRecursive
+          |  def isEven(n: Int): Boolean {
+          |    if n == 0 { return true }
+          |    return isOdd(n - 1, 0)
+          |  }
+          |  @TailRecursive
+          |  def isOdd(n: Int, extra: Int): Boolean {
+          |    if n == 0 { return false }
+          |    return isEven(n - 1)
+          |  }
+          |public:
+          |  def check(n: Int): Boolean = isEven(n)
+          |}
+          |""".stripMargin)
+      assert(!result.hasErrors)
+      val w16 = result.diagnostics.warnings.filter(_.category.code == "W0016")
+      assert(w16.length == 2, s"expected 2 W0016 (one per method), got: ${result.diagnostics.warnings.map(_.message)}")
+      assert(w16.forall(_.message.contains("parameter")))
+    }
+
     it("fails compilation under warnings-as-errors") {
       val result = compileWarnings(
         """


### PR DESCRIPTION
## Summary
- `MutualRecursionOptimization.validateGroup` checked privacy, return type, and tail-call locality, but never parameter-list compatibility — that check lived only in `transformGroup`, which just silently `return`ed on failure instead of reporting anything.
- A `@TailRecursive` mutual-recursion group that fails solely on parameter shape (different arg counts or per-position types) compiled clean with zero diagnostics, reproducing the exact silent runtime-`StackOverflowError` risk that W0016 (#791) was built to catch — just via a path `validateGroup` didn't cover.
- Moved the parameter-count/type check into `validateGroup` so it flows through the existing `reportIneffective` → `W0016` path, and dropped the now-dead duplicate check from `transformGroup`.

## Test plan
- [x] Added a failing-first (TDD red) test case to `IneffectiveTailRecursiveWarningSpec` reproducing a private group with mismatched parameter lists; confirmed it failed before the fix (no W0016 emitted) and passes after.
- [x] Full suite green under the English locale (`sbt -Duser.language=en testFull`): 3793 tests succeeded, 0 failed, 506 suites completed, 0 aborted. The single canceled test is the pre-existing opt-in `ProjectDistributionSpec` dist smoke test that requires `-Donion.dist.path`.
- [x] GitHub Actions `test` checks green on this head.

No CHANGELOG entry added: the existing `[Unreleased]` W0016 entry already states that the optimization requires the group to share one parameter list and that W0016 names the failed requirement. This PR makes that documented behavior actually true rather than changing it.