### PR TITLE
docs(changelog): cut 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-18
+
 ### Changed
 
 - **BREAKING: one arrow. The trailing-lambda arrow is `->`, and `=>` is no longer part of


### PR DESCRIPTION
Tag `v0.12.0` and its release exist; the published jar was downloaded, checksummed against `checksums.txt`, and run against the headline sample, the closed E0087 hole, the initializer-order fix, and the old-arrow hint. Heading finalized after the release per RELEASING.md.

Release contents: one arrow (`=>` removed), primary/secondary constructors, E0087–E0090 (#793).

🤖 Generated with [Claude Code](https://claude.com/claude-code)