### PR TITLE
docs(changelog): record the W0016 parameter-list fix as unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`W0016` now also fires when a `@TailRecursive` mutual-recursion group's parameter
+  lists don't match.** `0.12.0` documented `W0016` as covering all four requirements
+  `MutualRecursionOptimization` places on a group, but the parameter-list check was the
+  one requirement `validateGroup` never made — it lived in `transformGroup`, which
+  silently `return`ed instead of reporting. A group whose members differed only in
+  argument count or per-position types therefore compiled with no diagnostic at all,
+  which is the same silent `StackOverflowError` risk `W0016` exists to prevent. The
+  check moved into `validateGroup`, so it now reaches the `W0016` path like the other
+  three.
+
 ## [0.12.0] - 2026-08-18
 
 ### Changed


### PR DESCRIPTION
## Summary
- `v0.12.0` was tagged before #792 merged, so the released build does not contain the parameter-list check — yet the `0.12.0` changelog entry for `W0016` already describes the optimization as requiring the group to "share one parameter list" and says `W0016` fires "naming the failed requirement".
- That leaves the one requirement `validateGroup` never actually checked documented as covered in a release that does not cover it.
- Adds an `[Unreleased] / Fixed` entry recording the behavior #792 introduced, so the next cut describes what actually changed.

Changelog-only; no source or test changes.

## Test plan
- [x] Full suite green under the English locale (`sbt -Duser.language=en testFull`) on this branch: 3818 tests succeeded, 0 failed, 507 suites completed, 0 aborted. The single canceled test is the pre-existing opt-in `ProjectDistributionSpec` dist smoke test that requires `-Donion.dist.path`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013nycDaxUgdrwA8Xq5rmJQ2)_