### PR TITLE
docs: fix stale => arrow syntax left over from the one-arrow change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check moved into `validateGroup`, so it now reaches the `W0016` path like the other
   three.
 
+- **README trailing-lambda examples still used the retired `=>` arrow.** `0.12.0`'s
+  one-arrow change (`->` everywhere, `=>` no longer part of the language) missed three
+  examples in `README.md` and one in `docs/guide/control-flow.md`, left over from before
+  the rename. One of them (`future.onComplete(onSuccess, onFailure) { result => ... }`)
+  was also calling a two-argument `onComplete` as if it took a third trailing block, so it
+  never compiled even with the arrow fixed — replaced with a `list.fold(0) { acc, x -> ... }`
+  example that actually demonstrates positional args plus a trailing lambda. All four
+  snippets are now verified against the compiler.
+
 ## [0.12.0] - 2026-08-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ Methods accepting a function as the last parameter can use trailing lambda synta
 list.map((x: Int) -> { return x * 2; })
 
 // With trailing lambda
-list.map { x => x * 2 }
+list.map { x -> x * 2 }
 
 // Multiple arguments + trailing lambda
-future.onComplete(onSuccess, onFailure) { result =>
-  println("Done: " + result)
+list.fold(0) { acc, x ->
+  acc + x
 }
 ```
 
@@ -252,8 +252,8 @@ record Hit(ip: String, method: String, path: String, status: Int)
   from re"(\S+) (\w+) (\S+) (\d+)"
 
 Hit::parseAll(file"access.log".text())          // List[Hit], bad lines skipped
-  .filter { h => h.status() >= 500 }
-  .groupBy { h => h.path() }
+  .filter { h -> h.status() >= 500 }
+  .groupBy { h -> h.path() }
   |> println
 ```
 

--- a/docs/guide/control-flow.md
+++ b/docs/guide/control-flow.md
@@ -340,7 +340,7 @@ val email: Option[String] = do[Option] {
 }
 
 // Equivalent to:
-// findUser(42).flatMap(user => getEmail(user).map(email => email))
+// findUser(42).flatMap((user) -> getEmail(user).map((email) -> email))
 ```
 
 ### With Result


### PR DESCRIPTION
## Summary
- `0.12.0`'s one-arrow change made `->` the only trailing-lambda arrow (`=>` is no longer part of the language), but three examples in `README.md` and one in `docs/guide/control-flow.md` still used the retired `=>`.
- One of the README examples (`future.onComplete(onSuccess, onFailure) { result => ... }`) was calling a two-argument `onComplete` as if it took a third trailing block, so it never actually compiled even with the arrow fixed. Replaced it with a `list.fold(0) { acc, x -> ... }` example that genuinely demonstrates positional args plus a trailing lambda.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

All four corrected/replaced snippets were run against the compiler (`sbt runScript`) to confirm they parse and produce the stated output.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3818 succeeded, 0 failed, 1 canceled (expected dist smoke-test gate)
- [x] Manually ran each corrected code snippet via `sbt runScript` and confirmed output matches the docs

---
_Generated by [Claude Code](https://claude.ai/code/session_01W48VA3e98dUJkUc5n7ueT5)_