### PR TITLE
fix(diagnostics): hint at if/else when a ternary `?:` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A stray `cond ? a : b` ternary now gets a hint instead of a bare expected-token
+  dump.** Onion has no ternary operator — `if`/`else` works as an expression instead —
+  but a newcomer writing `?` still hits the parser at a point where the expected-token
+  list (`<EOF>, <EOL>, ";"`) never mentions the operator or the rewrite. `commonSyntaxHint`
+  in `Parsing.scala` gained a `case "?"` alongside the existing hints for old `<:`/`:`
+  inheritance syntax, `for x in xs`, and the retired `=>` arrow, naming the operator and
+  pointing at `if cond { a } else { b }`.
+
 - **`W0016` now also fires when a `@TailRecursive` mutual-recursion group's parameter
   lists don't match.** `0.12.0` documented `W0016` as covering all four requirements
   `MutualRecursionOptimization` places on a group, but the parameter-list check was the

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -98,6 +98,7 @@ error.parsing.hint.old_conforms=Hint: interfaces are named with `conforms`, not 
 error.parsing.hint.trailing_lambda_parens=Hint: a trailing lambda''s parameters aren''t parenthesized — write `'{' {0} -> ... '}'`, not `'{' ({0}) -> ... '}'`.
 error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `->`, the same as everywhere else — write `'{' x -> ... '}'`. (`=>` is no longer part of the language.)
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
+error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond '{' a '}' else '{' b '}'`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -98,6 +98,7 @@ error.parsing.hint.old_conforms=ヒント: インターフェースは `<:` で�
 error.parsing.hint.trailing_lambda_parens=ヒント: 末尾ラムダの引数は丸かっこで囲みません — `'{' ({0}) -> ... '}'` ではなく `'{' {0} -> ... '}'` と書いてください。
 error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他と同じ `->` です — `'{' x -> ... '}'` と書いてください。（`=>` は言語から無くなりました。）
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
+error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond '{' a '}' else '{' b '}'` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -223,6 +223,11 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_super_init")
     case "in" =>
       "Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`."
+    // There is no `cond ? a : b` ternary operator -- `if` is a statement, not an
+    // expression, so unlike the hints above this isn't a token swap; name the
+    // rewrite so the reader isn't left guessing what "unsupported" means here.
+    case "?" =>
+      Message("error.parsing.hint.ternary")
     case "else" =>
       "Hint: `else` must follow an `if` block. Onion does not support `if` as an expression; use `if (cond) { ... } else { ... }`."
     // Checked before the paren hint: `{ (k, v) => ... }` is wrong twice, and the arrow

--- a/src/test/scala/onion/compiler/tools/TernaryOperatorHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TernaryOperatorHintSpec.scala
@@ -1,0 +1,39 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no `cond ? a : b` ternary operator — `if`/`else` is a statement,
+ * not an expression, so the fix is a differently-shaped rewrite rather than a
+ * one-token swap. Without a hint, `?` fails with an expected-token dump that
+ * never says the operator doesn't exist.
+ */
+class TernaryOperatorHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("ternary operator") {
+    it("hints that Onion has no ?: operator") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 5
+          |    val y = (x > 3) ? 1 : 0
+          |    return y
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("if"), s"expected a hint mentioning if/else, got: $msgs")
+      assert(msgs.contains("?"), s"expected the hint to name the ternary operator, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Onion has no `cond ? a : b` ternary operator — `if`/`else` works as an expression instead — but writing `?` that way previously failed with a bare expected-token dump (`Encountered "?", but expecting <EOF>, <EOL>, ";"`) that never named the operator or the rewrite.
- Adds a `case "?"` to the existing `commonSyntaxHint` table in `Parsing.scala`, alongside the hints already there for old `<:`/`:` inheritance syntax, `for x in xs`, and the retired `=>` arrow. New hint: *"Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`."* (EN + JA).
- Adds `TernaryOperatorHintSpec` following the existing `TrailingLambdaParenHintSpec` pattern.
- CHANGELOG `[Unreleased]` entry added.

## Test plan

- [x] New test written first, confirmed red before the fix
- [x] `sbt -Duser.language=en testFull` — 3819 pass / 0 fail / 1 cancelled (the gated dist smoke test)
- [x] `sbt -Duser.language=ja testFull` — 3819 pass / 0 fail / 1 cancelled
- [x] Manually verified no regression on legitimate `?`-adjacent syntax (nullable types `T?`, `?.` safe-call, `?:` elvis)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kynt7pRhSYWotDwYKymA3H)_