### PR TITLE
fix(diagnostics): stop the ternary/trailing-arrow hints leaking quote chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The ternary and old-trailing-arrow parser hints printed literal single-quote
+  characters around their braces instead of the braces alone**, e.g. `if cond '{' a '}'
+  else '{' b '}'` instead of `if cond { a } else { b }`. Both hints are looked up through
+  the zero-argument `Message(property)`, which returns the resource bundle string as-is
+  and never runs it through `MessageFormat` — so the `'{'`/`'}'` brace-escaping
+  convention, needed only when a lookup actually formats arguments (as
+  `trailing_lambda_parens` does), leaked its escaping quotes straight into the message.
+  `errorMessage.properties` and `errorMessage_ja.properties` now spell both hints with
+  plain braces.
+
 - **A stray `cond ? a : b` ternary now gets a hint instead of a bare expected-token
   dump.** Onion has no ternary operator — `if`/`else` works as an expression instead —
   but a newcomer writing `?` still hits the parser at a point where the expected-token

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -96,9 +96,9 @@ error.semantic.shapeFormatUnknown=unknown shape format `{0}`. Supported formats:
 error.parsing.hint.old_extends=Hint: a superclass is named with `extends`, not `:` — write `class A extends B`.
 error.parsing.hint.old_conforms=Hint: interfaces are named with `conforms`, not `<:` — write `class A conforms I` (and `class A extends B conforms I`).
 error.parsing.hint.trailing_lambda_parens=Hint: a trailing lambda''s parameters aren''t parenthesized — write `'{' {0} -> ... '}'`, not `'{' ({0}) -> ... '}'`.
-error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `->`, the same as everywhere else — write `'{' x -> ... '}'`. (`=>` is no longer part of the language.)
+error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `->`, the same as everywhere else — write `{ x -> ... }`. (`=>` is no longer part of the language.)
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
-error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond '{' a '}' else '{' b '}'`.
+error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -96,9 +96,9 @@ error.semantic.shapeFormatUnknown=未知の shape フォーマット `{0}` で�
 error.parsing.hint.old_extends=ヒント: 親クラスは `:` ではなく `extends` で指定します — `class A extends B` と書いてください。
 error.parsing.hint.old_conforms=ヒント: インターフェースは `<:` ではなく `conforms` で指定します — `class A conforms I`（親クラスと併用する場合は `class A extends B conforms I`）と書いてください。
 error.parsing.hint.trailing_lambda_parens=ヒント: 末尾ラムダの引数は丸かっこで囲みません — `'{' ({0}) -> ... '}'` ではなく `'{' {0} -> ... '}'` と書いてください。
-error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他と同じ `->` です — `'{' x -> ... '}'` と書いてください。（`=>` は言語から無くなりました。）
+error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他と同じ `->` です — `{ x -> ... }` と書いてください。（`=>` は言語から無くなりました。）
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
-error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond '{' a '}' else '{' b '}'` と書いてください。
+error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * `commonSyntaxHint` in `Parsing.scala` looks up some hints via the zero-argument
+ * `Message(property)`, which returns the resource bundle string as-is — it never runs
+ * `MessageFormat`. A property text written with MessageFormat's quoting convention
+ * (`'{'`/`'}'` to escape a literal brace) is therefore never unescaped, so the single
+ * quotes leak into the message the user sees instead of the brace they were meant to
+ * protect. Only properties that are looked up through an *args*-taking `Message(...)`
+ * overload actually go through `MessageFormat.format`, where that quoting is required.
+ */
+class HintMessageFormatSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("hints resolved via the zero-argument Message lookup") {
+    it("renders literal braces for the ternary hint, not quoted placeholders") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val y = (1 > 0) ? 1 : 0
+          |    return y
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("'{'") && !msgs.contains("'}'"), s"hint leaked MessageFormat quoting: $msgs")
+      assert(msgs.contains("if cond { a } else { b }"), s"expected literal braces in the hint, got: $msgs")
+    }
+
+    it("renders literal braces for the old-trailing-arrow hint, not quoted placeholders") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs = [1, 2, 3].filter { x => x > 1 }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("'{'") && !msgs.contains("'}'"), s"hint leaked MessageFormat quoting: $msgs")
+      assert(msgs.contains("{ x -> ... }"), s"expected literal braces in the hint, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `commonSyntaxHint` in `Parsing.scala` resolves the ternary hint (`case "?"`) and the old-trailing-arrow hint (`case "{" if OldArrowTrailingLambdaHead...`) via the zero-argument `Message(property)`, which just returns the resource bundle string — it never runs the text through `MessageFormat`.
- Both property values were written with MessageFormat's `'{'`/`'}'` brace-escaping convention anyway (only needed by lookups that actually format arguments, like `trailing_lambda_parens` does), so the escaping single quotes leaked straight into what the user sees, e.g. `write \`if cond '{' a '}' else '{' b '}'\`` instead of `write \`if cond { a } else { b }\``.
- Fixed by writing both hints with plain braces in `errorMessage.properties` and `errorMessage_ja.properties`, since these two lookups never pass through `MessageFormat`.
- Added `HintMessageFormatSpec` (new) asserting the rendered hints contain literal braces and no stray `'{'`/`'}'` quoting, verified red before the fix and green after, in both English and Japanese locales.
- Added a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.HintMessageFormatSpec onion.compiler.tools.TernaryOperatorHintSpec onion.compiler.tools.TrailingLambdaParenHintSpec'` — green
- [x] Same, `-Duser.language=ja` — green
- [x] `sbt shutdown && sbt -Duser.language=en testFull` — 3821 passed, 0 failed, 1 cancelled (expected: dist smoke test gated behind `-Donion.dist.path`)

---
Generated by an automated Onion maintenance session.


---
_Generated by [Claude Code](https://claude.ai/code/session_019FNVuTeT8AK1KpKmQiZuhN)_