### PR TITLE
fix(diagnostics): correct the dangling-else parser hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A dangling `else` (one with no matching `if` immediately before it) got a hint
+  claiming Onion doesn't support `if` as an expression.** `if`/`else` has always worked
+  as an expression (`val x = if cond { a } else { b }`), so the hint's suggested fix —
+  "use `if (cond) { ... } else { ... }`" — didn't even address a dangling `else`, whose
+  actual fix is adding the missing `if`, not rewriting anything as an expression. The
+  `case "else"` branch of `commonSyntaxHint` in `Parsing.scala` now reports a
+  `error.parsing.hint.dangling_else` hint (added to both `errorMessage.properties` and
+  `errorMessage_ja.properties`) that names the real requirement: `else` must directly
+  follow an `if` block's closing `}`.
+
 - **The ternary and old-trailing-arrow parser hints printed literal single-quote
   characters around their braces instead of the braces alone**, e.g. `if cond '{' a '}'
   else '{' b '}'` instead of `if cond { a } else { b }`. Both hints are looked up through

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -99,6 +99,7 @@ error.parsing.hint.trailing_lambda_parens=Hint: a trailing lambda''s parameters 
 error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `->`, the same as everywhere else — write `{ x -> ... }`. (`=>` is no longer part of the language.)
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
+error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -99,6 +99,7 @@ error.parsing.hint.trailing_lambda_parens=ヒント: 末尾ラムダの引数は
 error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他と同じ `->` です — `{ x -> ... }` と書いてください。（`=>` は言語から無くなりました。）
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
+error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -223,13 +223,13 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_super_init")
     case "in" =>
       "Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`."
-    // There is no `cond ? a : b` ternary operator -- `if` is a statement, not an
-    // expression, so unlike the hints above this isn't a token swap; name the
-    // rewrite so the reader isn't left guessing what "unsupported" means here.
+    // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
+    // ground as an expression, so unlike the hints above this isn't a token swap;
+    // name the rewrite so the reader isn't left guessing what "unsupported" means here.
     case "?" =>
       Message("error.parsing.hint.ternary")
     case "else" =>
-      "Hint: `else` must follow an `if` block. Onion does not support `if` as an expression; use `if (cond) { ... } else { ... }`."
+      Message("error.parsing.hint.dangling_else")
     // Checked before the paren hint: `{ (k, v) => ... }` is wrong twice, and the arrow
     // is the part the writer will not spot on their own.
     case "{" if OldArrowTrailingLambdaHead.findFirstMatchIn(context).isDefined =>

--- a/src/test/scala/onion/compiler/tools/DanglingElseHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DanglingElseHintSpec.scala
@@ -1,0 +1,41 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A dangling `else` (one with no matching `if` immediately before it) fails
+ * parsing at the enclosing block's closing `}`. The hint attached to that
+ * error must not claim `if`/`else` cannot be used as an expression — Onion
+ * fully supports that (`val x = if cond { a } else { b }`), so the fix is to
+ * add the missing `if`, not to rewrite anything as an expression.
+ */
+class DanglingElseHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("dangling else") {
+    it("does not claim if/else is unsupported as an expression") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    else {
+          |      IO::println("b")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("does not support"), s"hint wrongly claims if/else-as-expression is unsupported, got: $msgs")
+      assert(msgs.contains("if") && msgs.contains("else"), s"expected a hint mentioning if/else, got: $msgs")
+    }
+  }
+}

--- a/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
@@ -53,5 +53,23 @@ class HintMessageFormatSpec extends AbstractShellSpec {
       assert(!msgs.contains("'{'") && !msgs.contains("'}'"), s"hint leaked MessageFormat quoting: $msgs")
       assert(msgs.contains("{ x -> ... }"), s"expected literal braces in the hint, got: $msgs")
     }
+
+    it("renders a literal brace for the dangling-else hint, not a quoted placeholder") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    else {
+          |      IO::println("b")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("'{'") && !msgs.contains("'}'"), s"hint leaked MessageFormat quoting: $msgs")
+      assert(msgs.contains("`}`"), s"expected a literal closing brace in the hint, got: $msgs")
+    }
   }
 }


### PR DESCRIPTION
## Summary

- A dangling `else` (no matching `if` directly before it) fails parsing at the enclosing block's closing `}`. The hint attached to that error claimed **"Onion does not support `if` as an expression"** — which is false (`val x = if cond { a } else { b }` has always worked, and `docs/guide/control-flow.md` documents it) — and its suggested fix didn't address the actual problem, which is a missing `if`, not an expression rewrite.
- The `case "else"` branch of `commonSyntaxHint` in `Parsing.scala` now reports a new `error.parsing.hint.dangling_else` message via the bilingual `Message()` pipeline (previously this branch was a hardcoded English literal), naming the real requirement: `else` must directly follow an `if` block's closing `}`.
- Also corrected a stale comment above the ternary-operator hint that repeated the same "`if` is a statement, not an expression" misconception.
- Added `DanglingElseHintSpec` (TDD: written first, confirmed red against the old message) and extended `HintMessageFormatSpec` with a case for the new key, since it's a zero-argument `Message()` lookup and must not leak `MessageFormat`'s `'{'`/`'}'` quoting (the same class of bug fixed for the ternary/old-trailing-arrow hints in the immediately preceding PR).

## Test plan

- [x] `sbt -Duser.language=en testFull` — 3823 succeeded, 0 failed, 1 canceled
- [x] `sbt -Duser.language=ja testFull` — 3823 succeeded, 0 failed, 1 canceled
- [x] New/changed tests assert on locale-independent substrings (literal code tokens like `` `if` ``, `` `else` ``, `` `}` ``), not localized prose


---
_Generated by [Claude Code](https://claude.ai/code/session_01JhFgXoPXQHxXzJJEGiiqHi)_