### PR TITLE
fix(diagnostics): route the missing-block parser hint through the bilingual bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Added `error.parsing.hint.old_for_in` to both `errorMessage.properties` and
   `errorMessage_ja.properties` and pointed the hint at it.
 
+- **`commonSyntaxHint`'s fallback "a block is expected" hint was also hard-coded
+  English**, same bug as the `for x in xs` hint above: a `while`/`if` head missing its
+  `{ ... }` block (e.g. `while true` / `if true` on its own line) fell through to a raw
+  string literal instead of the `error.parsing.hint.*` bundle lookup every other hint
+  uses, so the hint sentence stayed English even under a Japanese locale. Added
+  `error.parsing.hint.block_expected` to both `errorMessage.properties` and
+  `errorMessage_ja.properties` and pointed the fallback case at it.
+
 ## [0.12.0] - 2026-08-18
 
 ### Changed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
+error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラク�
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
+error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -238,7 +238,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
       val params = ParenthesizedTrailingLambdaHead.findFirstMatchIn(context).get.group(1).trim
       Message("error.parsing.hint.trailing_lambda_parens", params)
     case _ if expected.contains("{") && !Set(";", "<EOL>", "<EOF>").exists(expected.contains) =>
-      "Hint: a block `{ ... }` is expected here."
+      Message("error.parsing.hint.block_expected")
     case _ =>
       ""
   }

--- a/src/test/scala/onion/compiler/BlockExpectedHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/BlockExpectedHintI18nSpec.scala
@@ -46,6 +46,10 @@ class BlockExpectedHintI18nSpec extends AnyFunSpec with Diagrams {
       case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
       case _ => ""
     }
-    assert(msgs.contains(en.getString(key)), s"expected the bundled hint text, got: $msgs")
+    // The compiler resolves error.parsing.hint.* through the JVM's ambient default locale
+    // (see onion.compiler.toolbox.Message), not a fixed bundle, so the expected text must
+    // follow the same locale this suite is actually running under.
+    val expected = if (java.util.Locale.getDefault.getLanguage == "ja") ja.getString(key) else en.getString(key)
+    assert(msgs.contains(expected), s"expected the bundled hint text, got: $msgs")
   }
 }

--- a/src/test/scala/onion/compiler/BlockExpectedHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/BlockExpectedHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * `commonSyntaxHint`'s final fallback case (fired when `{` is expected but none of the
+ * more specific hints match, e.g. a `while`/`if` head missing its block) returned a
+ * hard-coded English string instead of going through the bilingual `error.parsing.hint.*`
+ * bundle lookup every other hint in that match uses — so a Japanese-locale diagnostic came
+ * out with the hint sentence stuck in English mid-message. Both locale bundles must carry
+ * the key, and the Japanese entry must actually be Japanese.
+ */
+class BlockExpectedHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.block_expected"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("routes the missing-block hint through the bundle, not a hard-coded literal") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    while true
+        |      IO::println("x")
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains(en.getString(key)), s"expected the bundled hint text, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- `commonSyntaxHint`'s fallback case in `Parsing.scala` (fired when `{` is expected but no more specific hint applies — e.g. a `while`/`if` head missing its block, like `while true` or `if true` on its own line) returned a hard-coded English string instead of going through the `error.parsing.hint.*` bundle lookup every other hint in that match uses.
- Same bug class as the earlier `for x in xs` hint fix (#801): a Japanese-locale syntax error came out in Japanese with this one hint sentence stuck in English mid-message.
- Added `error.parsing.hint.block_expected` to both `errorMessage.properties` and `errorMessage_ja.properties`, and pointed the fallback case at `Message("error.parsing.hint.block_expected")`.
- Added `CHANGELOG.md` entry under `[Unreleased]`.
- Follow-up fixup commit: the new spec's third case originally asserted the compiler's diagnostic output against the English bundle unconditionally. `Message()` resolves `error.parsing.hint.*` through the JVM's ambient default locale, so under `-Duser.language=ja` the compiler correctly emits the Japanese hint and the English-only assertion went red — caught by running the full suite under both locales before merge, per this repo's testing policy. Fixed to compare against whichever bundle matches `Locale.getDefault()`.

## Test plan
- [x] New test `BlockExpectedHintI18nSpec` (TDD: confirmed red before the fix, green after).
- [x] Full suite `sbt -Duser.language=en testFull` — 3829 tests, all green.
- [x] Full suite `sbt -Duser.language=ja testFull` — 3829 tests, all green (after the locale-assertion fixup above).
- [x] GitHub Actions CI green on the final commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXNwGoeFiE3zvmKjRLAm1R)_