### PR TITLE
fix(diagnostics): suggest the right name on a pure case mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A name that differs from the real one only by case (`.Length()` instead of
+  `.length()`, `UserName` instead of `userName`, `myclass` instead of `MyClass`)
+  got no "did you mean" suggestion**, just a bare not-found error. `Suggestions.findSimilar`
+  compares names case-insensitively but then filtered out `distance == 0` results —
+  meant to skip a self-match, it also threw away the single most common typo of all,
+  since a real case-sensitive exact match would never have reached the not-found path
+  to begin with. The filter now keeps `distance == 0`, so a pure case mismatch is always
+  suggested, for variables, methods, fields, and classes alike.
+- **A lowercase, Java/Scala-style primitive type name (`int`, `boolean`, `long`, ...)
+  got a generic "check spelling or add import" instead of a suggestion**, because
+  Onion's primitive keywords (`Int`, `Boolean`, `Long`, ...) were never in the
+  class-not-found candidate list — they aren't classes, so nothing offered them as
+  a match. They're now added to the candidates the "did you mean" check draws from,
+  so `var x: int = 0` suggests `Int`.
+
 ## [0.12.1] - 2026-08-19
 
 ### Fixed

--- a/src/main/scala/onion/compiler/toolbox/Suggestions.scala
+++ b/src/main/scala/onion/compiler/toolbox/Suggestions.scala
@@ -47,7 +47,11 @@ object Suggestions {
     }
 
     scored
-      .filter { case (_, distance) => distance <= maxDistance && distance > 0 }
+      // distance == 0 means `name` and `candidate` differ only in case (an exact,
+      // same-case match would already have resolved, so this call would never have
+      // been reached) -- that's the single most common typo of all and the best
+      // possible suggestion, not a false positive to exclude.
+      .filter { case (_, distance) => distance <= maxDistance }
       .sortBy { case (candidate, distance) =>
         // Prefer shorter edit distances, then shorter names
         (distance, candidate.length)

--- a/src/main/scala/onion/compiler/typing/NameResolution.scala
+++ b/src/main/scala/onion/compiler/typing/NameResolution.scala
@@ -25,6 +25,16 @@ final case class TypeAliasEntry(
   imports: Seq[ImportItem]
 )
 
+object NameResolver {
+  /** Onion's primitive type keywords, capitalized (`void` is the one exception --
+    * it is already lowercase in the grammar). Included as class-not-found
+    * suggestion candidates so a Java/Scala-style lowercase spelling (`int`, `boolean`,
+    * ...), which parses as an ordinary unresolved reference type, gets "did you mean
+    * `Int`?" instead of a bare "check spelling or add import". */
+  private[typing] val PrimitiveTypeNames: Seq[String] =
+    Seq("Int", "Long", "Short", "Byte", "Char", "Float", "Double", "Boolean")
+}
+
 class NameResolver(private val context: NameResolutionContext) {
   private def imports: Seq[ImportItem] = context.imports
 
@@ -62,7 +72,7 @@ class NameResolver(private val context: NameResolutionContext) {
   def getCandidateClassNames: Array[String] = {
     val localClasses = context.table.classes.values.map(_.name).toSeq
     val importedClasses = imports.filterNot(_.isOnDemand).map(_.simpleName)
-    (localClasses ++ importedClasses).distinct.toArray
+    (localClasses ++ importedClasses ++ NameResolver.PrimitiveTypeNames).distinct.toArray
   }
 
   def map(descriptor: AST.TypeDescriptor): Type = descriptor match {

--- a/src/test/scala/onion/compiler/tools/DidYouMeanSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DidYouMeanSpec.scala
@@ -3,6 +3,26 @@ package onion.compiler.tools
 import onion.tools.Shell
 
 class DidYouMeanSpec extends AbstractShellSpec {
+
+  /** Runs `source`, capturing stdout+stderr, and asserts it's a compile failure
+    * whose diagnostics contain every string in `mustContain`. Assertions are made
+    * on error codes and on the suggested identifier itself (both locale-independent)
+    * rather than on the localized "did you mean" wording around it.
+    */
+  private def failsWithSuggestion(source: String, mustContain: String*): Unit = {
+    val buf = new java.io.ByteArrayOutputStream()
+    val ps = new java.io.PrintStream(buf, true, "UTF-8")
+    val (o, e) = (System.out, System.err)
+    val r =
+      try {
+        System.setOut(ps); System.setErr(ps)
+        Console.withOut(ps) { Console.withErr(ps) { shell.run(source, "None", Array()) } }
+      } finally { System.setOut(o); System.setErr(e) }
+    val out = new String(buf.toByteArray, "UTF-8")
+    assert(r.isInstanceOf[Shell.Failure], s"expected a compile failure, got $r\n$out")
+    for (s <- mustContain) assert(out.contains(s), s"expected '$s' in diagnostics, got:\n$out")
+  }
+
   describe("Error messages with suggestions") {
     describe("for method names") {
       it("reports error for typo in method name") {
@@ -23,8 +43,11 @@ class DidYouMeanSpec extends AbstractShellSpec {
         assert(result.isInstanceOf[Shell.Failure])
       }
 
-      it("reports error for method name with wrong case") {
-        val result = shell.run(
+      it("reports error and a suggestion for a method name with wrong case") {
+        // A pure case mismatch is the most unambiguous typo there is: the
+        // lowercased name always matches exactly one real member, so the
+        // suggestion must be there, not just the failure.
+        failsWithSuggestion(
           """
             |class Test {
             |public:
@@ -33,11 +56,8 @@ class DidYouMeanSpec extends AbstractShellSpec {
             |  }
             |}
             |""".stripMargin,
-          "None",
-          Array()
+          "E0005", "length"
         )
-        // "did you mean: length" suggestion will be shown
-        assert(result.isInstanceOf[Shell.Failure])
       }
     }
 
@@ -80,6 +100,21 @@ class DidYouMeanSpec extends AbstractShellSpec {
         // "did you mean: userName" suggestion will be shown
         assert(result.isInstanceOf[Shell.Failure])
       }
+
+      it("reports error and a suggestion for a variable name with wrong case") {
+        failsWithSuggestion(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val userName = "Alice";
+            |    return UserName;
+            |  }
+            |}
+            |""".stripMargin,
+          "E0002", "userName"
+        )
+      }
     }
 
     describe("for class names") {
@@ -100,6 +135,57 @@ class DidYouMeanSpec extends AbstractShellSpec {
         // Class not found error will be shown
         // "did you mean: ArrayList" suggestion may be shown if in import scope
         assert(result.isInstanceOf[Shell.Failure])
+      }
+
+      it("reports error and a suggestion for a local class name with wrong case") {
+        failsWithSuggestion(
+          """
+            |class MyClass {
+            |public:
+            |  def this {}
+            |}
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    var x: myclass = new MyClass();
+            |    return "ok";
+            |  }
+            |}
+            |""".stripMargin,
+          "E0003", "MyClass"
+        )
+      }
+    }
+
+    describe("for primitive type names") {
+      it("reports error and a suggestion for a Java/Scala-style lowercase primitive name") {
+        failsWithSuggestion(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    var x: int = 0;
+            |    return "ok";
+            |  }
+            |}
+            |""".stripMargin,
+          "E0003", "Int"
+        )
+      }
+
+      it("suggests Boolean for the lowercase spelling boolean") {
+        failsWithSuggestion(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    var x: boolean = true;
+            |    return "ok";
+            |  }
+            |}
+            |""".stripMargin,
+          "E0003", "Boolean"
+        )
       }
     }
   }


### PR DESCRIPTION
## Summary

- `Suggestions.findSimilar` compares names case-insensitively but then discarded any candidate at edit distance 0, meant to skip a name matching itself. Since an exact same-case match would already have resolved (never reaching a not-found path at all), a distance-0 result can only mean the name differs from a real one by case alone — `.Length()` vs `.length()`, `UserName` vs `userName`, `myclass` vs `MyClass`. That's the single most common and unambiguous typo there is, and it was silently dropped for variables, methods, fields, and classes alike.
- Added Onion's primitive type keywords (`Int`, `Boolean`, `Long`, ...) to the class-not-found suggestion candidates, so a Java/Scala lowercase spelling (`int`, `boolean`) — which parses as an ordinary unresolved reference type — now suggests the capitalized form instead of a bare "check spelling or add import".

## Test plan

- [x] Added/strengthened cases in `DidYouMeanSpec` asserting the error code *and* the actual suggested identifier (locale-independent) for: wrong-case method call, wrong-case variable reference, wrong-case local class reference, and lowercase primitive type names (`int`, `boolean`).
- [x] `sbt shutdown && SBT_OPTS="-Xmx10G" sbt -Duser.language=en testFull` — 3833 succeeded / 0 failed / 1 canceled (expected: gated distribution smoke test) / 0 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BSkm4CbSzrDYqaSPVaB1D7)_