### PR TITLE
fix(diagnostics): suggest the right parameter name on E0043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   class-not-found candidate list — they aren't classes, so nothing offered them as
   a match. They're now added to the candidates the "did you mean" check draws from,
   so `var x: int = 0` suggests `Int`.
+- **A misspelled named-argument name (`f(x = 1, kount = 2)`) got a bare
+  "unknown parameter name" with no "did you mean" suggestion**, unlike every
+  sibling not-found diagnostic (variable, method, field, class), which all
+  suggest a similar name. `UNKNOWN_PARAMETER_NAME` (E0043) was the one
+  not-found error still wired through the plain data-driven message path in
+  `SemanticErrorReporter`, so none of its six call sites ever passed the
+  candidate parameter names along. It now has a dedicated handler that builds
+  the suggestion from the callee's parameter names, for static calls,
+  instance calls, unqualified calls, and constructor calls alike.
 
 ## [0.12.1] - 2026-08-19
 

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -325,10 +325,6 @@ class SemanticErrorReporter(threshold: Int) {
     ),
 
     // Pattern matching errors
-    SemanticError.UNKNOWN_PARAMETER_NAME -> ErrorDef(
-      "error.semantic.unknownParameterName",
-      Seq(items => asString(items(0)))
-    ),
     SemanticError.DUPLICATE_ARGUMENT -> ErrorDef(
       "error.semantic.duplicateArgument",
       Seq(items => asString(items(0)))
@@ -573,6 +569,22 @@ class SemanticErrorReporter(threshold: Int) {
   }
 
   /**
+   * Handles UNKNOWN_PARAMETER_NAME with optional suggestions for similar
+   * parameter names.
+   */
+  private def reportUnknownParameterName(position: Location, items: Array[AnyRef]): Unit = {
+    val name = asString(items(0))
+    val baseMessage = format(message("error.semantic.unknownParameterName"), Seq(name))
+
+    val suggestion = if (items.length > 1) {
+      val candidates = items(1).asInstanceOf[Array[String]]
+      toolbox.Suggestions.formatSuggestion(name, candidates.toSeq)
+    } else None
+
+    problem(position, appendSuggestion(baseMessage, suggestion))
+  }
+
+  /**
    * Handles CONSTRUCTOR_NOT_FOUND with available constructors display.
    */
   private def reportConstructorNotFound(position: Location, items: Array[AnyRef]): Unit = {
@@ -671,6 +683,8 @@ class SemanticErrorReporter(threshold: Int) {
         reportClassNotFound(position, items)
       case SemanticError.CONSTRUCTOR_NOT_FOUND =>
         reportConstructorNotFound(position, items)
+      case SemanticError.UNKNOWN_PARAMETER_NAME =>
+        reportUnknownParameterName(position, items)
       case SemanticError.AMBIGUOUS_METHOD =>
         reportAmbiguousMethod(position, items)
       case SemanticError.AMBIGUOUS_CONSTRUCTOR =>

--- a/src/main/scala/onion/compiler/typing/ArgumentHelpers.scala
+++ b/src/main/scala/onion/compiler/typing/ArgumentHelpers.scala
@@ -81,6 +81,13 @@ private[typing] object ArgumentHelpers {
   }
 
   /**
+   * Every parameter name across a set of overload candidates, for use as the
+   * "did you mean" suggestion pool when a named argument matches none of them.
+   */
+  def parameterNameCandidates(candidates: Iterable[Method]): Array[String] =
+    candidates.flatMap(_.argumentsWithDefaults.map(_.name)).toSet.toArray
+
+  /**
    * Fill missing arguments with default values.
    *
    * If params array is smaller than the method's parameter count,

--- a/src/main/scala/onion/compiler/typing/CallArgumentTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/CallArgumentTypingSupport.scala
@@ -141,7 +141,7 @@ private[compiler] final class CallArgumentTypingSupport(
           sawNamed = true
           val paramIndex = paramNames.indexOf(named.name)
           if (paramIndex < 0) {
-            bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+            bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name, paramNames)
             hasError = true
           } else if (filled(paramIndex)) {
             bodyContext.report(DUPLICATE_ARGUMENT, named, named.name)

--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -558,7 +558,10 @@ final class ConstructionTyping(
       }
       unknownNamed match {
         case Some(named) =>
-          bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+          val paramNames = typeRef.constructors.collect {
+            case cd: ConstructorDefinition => cd.argumentsWithDefaults.map(_.name)
+          }.flatten.distinct.toArray
+          bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name, paramNames)
         case None =>
           // Type the arguments anyway to provide better error messages
           val parameters = typedTerms(node.args.toArray.filterNot(_.isInstanceOf[AST.NamedArgument]), context)
@@ -667,7 +670,7 @@ final class ConstructionTyping(
           // Find parameter by name
           val paramIndex = paramNames.indexOf(named.name)
           if (paramIndex < 0) {
-            bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+            bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name, paramNames)
             hasError = true
           } else if (filled(paramIndex)) {
             bodyContext.report(DUPLICATE_ARGUMENT, named, named.name)

--- a/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
@@ -227,7 +227,9 @@ private[compiler] final class InstanceMethodCallSupport(
     overloadSupport.selectNamedArgumentMethod(candidates, node.args) match {
       case CandidateSelection.NoMatch =>
         ArgumentHelpers.findUnknownNamedArg(candidates.asScala, node.args) match {
-          case Some(named) => bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+          case Some(named) =>
+            bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name,
+              ArgumentHelpers.parameterNameCandidates(candidates.asScala))
           case None => calls.reportMethodNotFound(node, targetType, node.name, Array[Type]())
         }
         None

--- a/src/main/scala/onion/compiler/typing/StaticMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/StaticMethodCallSupport.scala
@@ -303,7 +303,9 @@ private[compiler] final class StaticMethodCallSupport(
     overloadSupport.selectNamedArgumentMethod(candidates, node.args) match {
       case CandidateSelection.NoMatch =>
         ArgumentHelpers.findUnknownNamedArg(candidates.asScala, node.args) match {
-          case Some(named) => typing.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+          case Some(named) =>
+            typing.report(UNKNOWN_PARAMETER_NAME, named, named.name,
+              ArgumentHelpers.parameterNameCandidates(candidates.asScala))
           case None => calls.reportMethodNotFound(node, typeRef, node.name, Array[Type]())
         }
         None

--- a/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
@@ -292,7 +292,9 @@ private[compiler] final class UnqualifiedMethodCallSupport(
     overloadSupport.selectNamedArgumentMethod(candidates, node.args) match {
       case CandidateSelection.NoMatch =>
         ArgumentHelpers.findUnknownNamedArg(candidates.asScala, node.args) match {
-          case Some(named) => bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name)
+          case Some(named) =>
+            bodyContext.report(UNKNOWN_PARAMETER_NAME, named, named.name,
+              ArgumentHelpers.parameterNameCandidates(candidates.asScala))
           case None => calls.reportMethodNotFound(node, targetType, node.name, Array[Type]())
         }
         None

--- a/src/test/scala/onion/compiler/tools/DidYouMeanSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DidYouMeanSpec.scala
@@ -188,5 +188,76 @@ class DidYouMeanSpec extends AbstractShellSpec {
         )
       }
     }
+
+    describe("for named-argument names") {
+      // The typo ("kount") shares no substring with the real name ("count"),
+      // so matching on "count" in the output can only be the suggestion --
+      // never an echo of the misspelled argument from the base message.
+      it("suggests the right parameter name on a static call") {
+        failsWithSuggestion(
+          """
+            |class T {
+            |public:
+            |  static def f(x: Int, count: Int): Int = x + count
+            |  static def main(args: String[]): Int { return f(x = 1, kount = 2) }
+            |}
+            |""".stripMargin,
+          "E0043", "count"
+        )
+      }
+
+      it("suggests the right parameter name on an instance call") {
+        failsWithSuggestion(
+          """
+            |class T {
+            |public:
+            |  def this {}
+            |  def f(x: Int, count: Int): Int = x + count
+            |}
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int { return new T().f(x = 1, kount = 2) }
+            |}
+            |""".stripMargin,
+          "E0043", "count"
+        )
+      }
+
+      it("suggests the right parameter name on an unqualified call") {
+        failsWithSuggestion(
+          """
+            |class T {
+            |public:
+            |  def this {}
+            |  def f(x: Int, count: Int): Int = x + count
+            |  def g(): Int = f(x = 1, kount = 2)
+            |}
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int { return new T().g() }
+            |}
+            |""".stripMargin,
+          "E0043", "count"
+        )
+      }
+
+      it("suggests the right parameter name on a constructor call") {
+        failsWithSuggestion(
+          """
+            |class P {
+            |  val x: Int
+            |  val count: Int
+            |public:
+            |  def this(x: Int, count: Int) { self.x = x; self.count = count }
+            |}
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int { val p = new P(x = 1, kount = 2); return 0 }
+            |}
+            |""".stripMargin,
+          "E0043", "count"
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `UNKNOWN_PARAMETER_NAME` (E0043) was the one "not found" diagnostic still routed through `SemanticErrorReporter`'s plain data-driven message path, unlike its siblings (variable/method/field/class not-found), which all offer a "did you mean" suggestion.
- A misspelled named argument (`f(x = 1, kount = 2)`) therefore got only a bare `unknown parameter name: kount`, with no hint toward the real parameter name, even though the candidate names were available at every call site.
- Added a dedicated `reportUnknownParameterName` handler (mirroring `reportClassNotFound`) and wired each of the six report call sites — static calls, instance calls, unqualified calls, and constructor calls, on both the overload-search and direct-argument-binding paths — to pass the callee's parameter names through to it.

## Test plan

- [x] Added 4 new cases to `DidYouMeanSpec` (static/instance/unqualified/constructor calls) asserting `E0043` plus the actual suggested parameter name, using a typo (`kount`) chosen to share no substring with the real name (`count`) so the assertion can't pass on an echo of the bad name.
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3837/3837 passed (1 pre-existing, environment-gated cancellation unrelated to this change).
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 3837/3837 passed (same).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9qSXeQrd1HWmee9m59tC6)_