### PR TITLE
fix(diagnostics): suggest the closest enclosing label on E0058

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   candidate parameter names along. It now has a dedicated handler that builds
   the suggestion from the callee's parameter names, for static calls,
   instance calls, unqualified calls, and constructor calls alike.
+- **`break`/`continue` with a misspelled label (`break outr` instead of
+  `break outer`) got a bare "label not found" with no "did you mean"
+  suggestion**, the one `*_NOT_FOUND` diagnostic still on the plain
+  data-driven message path. `LocalContext` already tracked every enclosing
+  labeled loop's name in `labelStack` but exposed no way to read it back;
+  it now has a `labels` accessor, and `LABEL_NOT_FOUND` (E0058) has a
+  dedicated handler that suggests the closest enclosing label name.
 
 ## [0.12.1] - 2026-08-19
 

--- a/src/main/scala/onion/compiler/LocalContext.scala
+++ b/src/main/scala/onion/compiler/LocalContext.scala
@@ -170,6 +170,9 @@ class LocalContext {
 
   def hasLabel(name: String): Boolean = labelStack.contains(name)
 
+  /** Labels of enclosing labeled loops, for "did you mean" suggestions on an unbound label. */
+  def labels: Array[String] = labelStack.toArray
+
   def openLoop[A](body: => A): A = {
     loopDepth += 1
     try body

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -47,6 +47,9 @@ import onion.compiler.exceptions.CompilationException
  *   - METHOD_NOT_FOUND
  *   - FIELD_NOT_FOUND
  *   - CLASS_NOT_FOUND
+ *   - CONSTRUCTOR_NOT_FOUND
+ *   - UNKNOWN_PARAMETER_NAME
+ *   - LABEL_NOT_FOUND
  *
  * == Compilation Context ==
  *
@@ -386,10 +389,7 @@ class SemanticErrorReporter(threshold: Int) {
       "error.semantic.mapNotDirectlyIterable",
       Seq(items => typeName(items(0)))
     ),
-    SemanticError.LABEL_NOT_FOUND -> ErrorDef(
-      "error.semantic.labelNotFound",
-      Seq(items => asString(items(0)))
-    ),
+    // LABEL_NOT_FOUND handled specially with suggestions
     SemanticError.REGEX_PATTERN_INVALID -> ErrorDef(
       "error.semantic.regexPatternInvalid",
       Seq(items => asString(items(0)))
@@ -554,6 +554,22 @@ class SemanticErrorReporter(threshold: Int) {
   }
 
   /**
+   * Handles LABEL_NOT_FOUND with optional suggestions for similar labels
+   * among the enclosing labeled loops.
+   */
+  private def reportLabelNotFound(position: Location, items: Array[AnyRef]): Unit = {
+    val name = asString(items(0))
+    val baseMessage = format(message("error.semantic.labelNotFound"), Seq(name))
+
+    val suggestion = if (items.length > 1) {
+      val candidates = items(1).asInstanceOf[Array[String]]
+      toolbox.Suggestions.formatSuggestion(name, candidates.toSeq)
+    } else None
+
+    problem(position, appendSuggestion(baseMessage, suggestion))
+  }
+
+  /**
    * Handles CLASS_NOT_FOUND with optional suggestions for similar class names.
    */
   private def reportClassNotFound(position: Location, items: Array[AnyRef]): Unit = {
@@ -679,6 +695,8 @@ class SemanticErrorReporter(threshold: Int) {
         reportMethodNotFound(position, items)
       case SemanticError.FIELD_NOT_FOUND =>
         reportFieldNotFound(position, items)
+      case SemanticError.LABEL_NOT_FOUND =>
+        reportLabelNotFound(position, items)
       case SemanticError.CLASS_NOT_FOUND =>
         reportClassNotFound(position, items)
       case SemanticError.CONSTRUCTOR_NOT_FOUND =>

--- a/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
+++ b/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
@@ -70,7 +70,7 @@ final class BlockElementLowering(
         bodyContext.report(BREAK_OUTSIDE_LOOP, node)
         new NOP(node.location)
       } else if (node.label != null && !context.hasLabel(node.label)) {
-        bodyContext.report(LABEL_NOT_FOUND, node, node.label)
+        bodyContext.report(LABEL_NOT_FOUND, node, node.label, context.labels)
         new NOP(node.location)
       } else {
         new Break(node.location, node.label)
@@ -80,7 +80,7 @@ final class BlockElementLowering(
         bodyContext.report(CONTINUE_OUTSIDE_LOOP, node)
         new NOP(node.location)
       } else if (node.label != null && !context.hasLabel(node.label)) {
-        bodyContext.report(LABEL_NOT_FOUND, node, node.label)
+        bodyContext.report(LABEL_NOT_FOUND, node, node.label, context.labels)
         new NOP(node.location)
       } else {
         new Continue(node.location, node.label)

--- a/src/test/scala/onion/compiler/tools/LabelNotFoundSpec.scala
+++ b/src/test/scala/onion/compiler/tools/LabelNotFoundSpec.scala
@@ -61,5 +61,37 @@ class LabelNotFoundSpec extends AbstractShellSpec {
           |""".stripMargin
       ).contains("E0058"))
     }
+
+    it("suggests the enclosing label's name for a near-miss typo") {
+      // Assert on the error code and the suggested identifier only (both
+      // locale-independent) rather than the localized "did you mean" wording.
+      val buf = new java.io.ByteArrayOutputStream()
+      val ps = new java.io.PrintStream(buf, true, "UTF-8")
+      val (o, e) = (System.out, System.err)
+      val r =
+        try {
+          System.setOut(ps); System.setErr(ps)
+          Console.withOut(ps) { Console.withErr(ps) {
+            shell.run(
+              """
+                |class Test {
+                |public:
+                |  static def main(args: String[]): void {
+                |    outer: foreach i: Int in 0..3 {
+                |      break outr
+                |    }
+                |  }
+                |}
+                |""".stripMargin,
+              "None",
+              Array()
+            )
+          } }
+        } finally { System.setOut(o); System.setErr(e) }
+      val out = new String(buf.toByteArray, "UTF-8")
+      assert(r.isInstanceOf[onion.tools.Shell.Failure], s"expected a compile failure, got $r\n$out")
+      assert(out.contains("E0058"), s"expected E0058 in diagnostics, got:\n$out")
+      assert(out.contains("outer"), s"expected suggestion 'outer' in diagnostics, got:\n$out")
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `break`/`continue` with a misspelled label (`break outr` instead of `break outer`) got a bare "label not found" (E0058) with no "did you mean" suggestion — the one `*_NOT_FOUND` diagnostic still on the plain data-driven message path, unlike `VARIABLE_NOT_FOUND`, `METHOD_NOT_FOUND`, `FIELD_NOT_FOUND`, `CLASS_NOT_FOUND`, `CONSTRUCTOR_NOT_FOUND`, and `UNKNOWN_PARAMETER_NAME`, which all already suggest a similar name.
- `LocalContext` already tracked every enclosing labeled loop's name in `labelStack` but exposed no way to read it back; it now has a `labels` accessor.
- `LABEL_NOT_FOUND` (E0058) has a dedicated handler in `SemanticErrorReporter` (mirroring the existing `CLASS_NOT_FOUND`/`UNKNOWN_PARAMETER_NAME` handlers) that suggests the closest enclosing label name via `Suggestions.formatSuggestion`.
- Also updated the reporter's stale doc comment listing which errors get suggestions (it was missing `CONSTRUCTOR_NOT_FOUND` and `UNKNOWN_PARAMETER_NAME` too).

## Test plan
- [x] Added a test to `LabelNotFoundSpec` asserting E0058 + the suggested label name (locale-independent, per this repo's testing conventions) for `break outr` inside `outer: foreach ...`.
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3838/3838 passed.
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 3838/3838 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZjvwiAMZ3JbkeTtqeFA8X)_