### PR TITLE
fix(diagnostics): suggest the closest base method name on E0068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   labeled loop's name in `labelStack` but exposed no way to read it back;
   it now has a `labels` accessor, and `LABEL_NOT_FOUND` (E0058) has a
   dedicated handler that suggests the closest enclosing label name.
+- **A misspelled `override` target (`override def great()` instead of
+  `override def greet()`) got a bare "does not override any method" with no
+  "did you mean" suggestion**, the last `*_NOT_FOUND` diagnostic still on the
+  plain data-driven message path. `DuplicationChecks.checkOverrideTargets`
+  already collects every overridable base-class/interface method name while
+  checking the override target; it now passes that list along, and
+  `OVERRIDE_TARGET_NOT_FOUND` (E0068) has a dedicated handler that suggests
+  the closest matching base method name.
 
 ## [0.12.1] - 2026-08-19
 

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -50,6 +50,7 @@ import onion.compiler.exceptions.CompilationException
  *   - CONSTRUCTOR_NOT_FOUND
  *   - UNKNOWN_PARAMETER_NAME
  *   - LABEL_NOT_FOUND
+ *   - OVERRIDE_TARGET_NOT_FOUND
  *
  * == Compilation Context ==
  *
@@ -288,10 +289,7 @@ class SemanticErrorReporter(threshold: Int) {
       "error.semantic.finalMethodOverride",
       Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
     ),
-    SemanticError.OVERRIDE_TARGET_NOT_FOUND -> ErrorDef(
-      "error.semantic.overrideTargetNotFound",
-      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
+    // OVERRIDE_TARGET_NOT_FOUND handled specially with suggestions
 
     // Generic type errors
     SemanticError.TYPE_NOT_GENERIC -> ErrorDef(
@@ -601,6 +599,24 @@ class SemanticErrorReporter(threshold: Int) {
   }
 
   /**
+   * Handles OVERRIDE_TARGET_NOT_FOUND with optional suggestions for similar
+   * method names among the base class's/interfaces' overridable methods.
+   */
+  private def reportOverrideTargetNotFound(position: Location, items: Array[AnyRef]): Unit = {
+    val name = asString(items(0))
+    val paramDescriptor = asString(items(1))
+    val className = asString(items(2))
+    val baseMessage = format(message("error.semantic.overrideTargetNotFound"), Seq(name, paramDescriptor, className))
+
+    val suggestion = if (items.length > 3) {
+      val candidates = items(3).asInstanceOf[Array[String]]
+      toolbox.Suggestions.formatSuggestion(name, candidates.toSeq)
+    } else None
+
+    problem(position, appendSuggestion(baseMessage, suggestion))
+  }
+
+  /**
    * Handles CONSTRUCTOR_NOT_FOUND with available constructors display.
    */
   private def reportConstructorNotFound(position: Location, items: Array[AnyRef]): Unit = {
@@ -703,6 +719,8 @@ class SemanticErrorReporter(threshold: Int) {
         reportConstructorNotFound(position, items)
       case SemanticError.UNKNOWN_PARAMETER_NAME =>
         reportUnknownParameterName(position, items)
+      case SemanticError.OVERRIDE_TARGET_NOT_FOUND =>
+        reportOverrideTargetNotFound(position, items)
       case SemanticError.AMBIGUOUS_METHOD =>
         reportAmbiguousMethod(position, items)
       case SemanticError.AMBIGUOUS_CONSTRUCTOR =>

--- a/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
+++ b/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
@@ -165,12 +165,14 @@ private[compiler] object DuplicationChecks {
       }
     }
 
+    val baseNames = baseKeys.map(_._1).toArray.distinct
+
     for (impl <- overrideMethods) {
       val implKeys = allErasedParamDescriptors(impl.arguments, typing).map(desc => (impl.name, desc))
       if !implKeys.exists(baseKeys.contains) then
         val location = typing.lookupAST(impl.asInstanceOf[Node]).map(_.location).getOrElse(fallback)
         val paramDescriptor = impl.arguments.map(_.name).mkString(", ")
-        typing.report(SemanticError.OVERRIDE_TARGET_NOT_FOUND, location, impl.name, paramDescriptor, clazz.name)
+        typing.report(SemanticError.OVERRIDE_TARGET_NOT_FOUND, location, impl.name, paramDescriptor, clazz.name, baseNames)
     }
   }
 

--- a/src/test/scala/onion/compiler/tools/OverrideTargetNotFoundSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OverrideTargetNotFoundSpec.scala
@@ -100,5 +100,43 @@ class OverrideTargetNotFoundSpec extends AbstractShellSpec {
       )
       assert(!results.map(_._1).contains(Some("E0068")))
     }
+
+    it("suggests the closest base-class method name for a near-miss typo") {
+      // Assert on the error code and the suggested identifier only (both
+      // locale-independent) rather than the localized "did you mean" wording.
+      val buf = new java.io.ByteArrayOutputStream()
+      val ps = new java.io.PrintStream(buf, true, "UTF-8")
+      val (o, e) = (System.out, System.err)
+      val r =
+        try {
+          System.setOut(ps); System.setErr(ps)
+          Console.withOut(ps) { Console.withErr(ps) {
+            shell.run(
+              """
+                |class Base {
+                |public:
+                |  def greet(): String { return "base"; }
+                |}
+                |class Sub extends Base {
+                |public:
+                |  override def great(): String { return "sub"; }
+                |}
+                |class Test {
+                |public:
+                |  static def main(args: String[]): Int {
+                |    return new Sub().great().length();
+                |  }
+                |}
+                |""".stripMargin,
+              "None",
+              Array()
+            )
+          } }
+        } finally { System.setOut(o); System.setErr(e) }
+      val out = new String(buf.toByteArray, "UTF-8")
+      assert(r.isInstanceOf[onion.tools.Shell.Failure], s"expected a compile failure, got $r\n$out")
+      assert(out.contains("E0068"), s"expected E0068 in diagnostics, got:\n$out")
+      assert(out.contains("greet"), s"expected suggestion 'greet' in diagnostics, got:\n$out")
+    }
   }
 }


### PR DESCRIPTION
## Summary
- A misspelled `override` target (`override def great()` instead of `override def greet()`) got a bare "does not override any method" error with no "did you mean" suggestion — the last `*_NOT_FOUND` diagnostic still on the plain data-driven message path (following up on the E0043/E0058 suggestion fixes).
- `DuplicationChecks.checkOverrideTargets` already collects every overridable base-class/interface method name while checking the override target; it now passes that list along, and `OVERRIDE_TARGET_NOT_FOUND` (E0068) has a dedicated handler that suggests the closest matching base method name.

## Test plan
- [x] Added a regression test asserting E0068 + the suggested name (locale-agnostic) for a near-miss override typo, plus confirmed existing E0068 tests still pass.
- [x] `sbt -Duser.language=en testFull` — 3839 succeeded, 0 failed, 1 benign self-skipped smoke test.
- [x] `sbt -Duser.language=ja testFull` — 3839 succeeded, 0 failed, 1 benign self-skipped smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J9G6AL2KurKA1WB7Sv3tWt)_