### PR TITLE
fix(diagnostics): hint at select for a Java/JS-style switch statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A Java/JS/C-style `switch` statement (`switch x { case 1: ... }` or
+  `switch (x) { ... }`) got a bare expected-token dump with no mention of
+  `select`.** `switch` isn't a keyword in Onion, so it parses as a bare
+  identifier-reference statement and the parser actually trips on whatever
+  follows it — the condition, or the `{` of a parenthesized condition —
+  never on `switch` itself, so no existing hint (all of which match on the
+  *offending* token) could name it. `commonSyntaxHint` in `Parsing.scala`
+  now also receives the full source line of the error and matches a leading
+  `switch` there, so both spellings now hint at `select value { case 1:
+  ...; else: ... }`.
+
 - **A name that differs from the real one only by case (`.Length()` instead of
   `.length()`, `UserName` instead of `userName`, `myclass` instead of `MyClass`)
   got no "did you mean" suggestion**, just a bare not-found error. `Suggestions.findSimilar`

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
+error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラク�
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
+error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -123,7 +123,12 @@ class Parsing(config: CompilerConfig) extends AnyRef
       problems += CompileError(
         fileName,
         new Location(error.line, error.column),
-        syntaxErrorMessage(error.found, error.expected, contextAt(sourceText, error.line, error.column))
+        syntaxErrorMessage(
+          error.found,
+          error.expected,
+          contextAt(sourceText, error.line, error.column),
+          sourceLineAt(sourceText, error.line)
+        )
       )
     }
   }
@@ -147,7 +152,12 @@ class Parsing(config: CompilerConfig) extends AnyRef
       problems += CompileError(
         fileName,
         new Location(error.beginLine, error.beginColumn),
-        syntaxErrorMessage(error.image, expected, contextAt(sourceText, error.beginLine, error.beginColumn))
+        syntaxErrorMessage(
+          error.image,
+          expected,
+          contextAt(sourceText, error.beginLine, error.beginColumn),
+          sourceLineAt(sourceText, error.beginLine)
+        )
       )
     }
   }
@@ -157,15 +167,34 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * to look past the offending token (bounded so a pathological file can't
    * make the regex match slow).
    */
-  private def contextAt(sourceText: String, line: Int, column: Int): String = {
+  private def lineStartOffset(sourceText: String, line: Int): Int = {
     var offset = 0
     var currentLine = 1
     while (currentLine < line && offset >= 0 && offset < sourceText.length) {
       val nl = sourceText.indexOf('\n', offset)
       if (nl < 0) offset = sourceText.length else { offset = nl + 1; currentLine += 1 }
     }
-    val start = math.min(sourceText.length, offset + column - 1)
+    offset
+  }
+
+  private def contextAt(sourceText: String, line: Int, column: Int): String = {
+    val start = math.min(sourceText.length, lineStartOffset(sourceText, line) + column - 1)
     sourceText.substring(start, math.min(sourceText.length, start + 200))
+  }
+
+  /**
+   * The full text of the 1-based source line containing (line, column), for
+   * hints that need to recognize a whole malformed statement (e.g. a leading
+   * `switch`) rather than just the token at the error position -- the error
+   * itself is often reported several tokens past the actual mistake.
+   */
+  private def sourceLineAt(sourceText: String, line: Int): String = {
+    val start = lineStartOffset(sourceText, line)
+    val end = sourceText.indexOf('\n', start) match {
+      case -1 => sourceText.length
+      case i => i
+    }
+    sourceText.substring(start, end)
   }
 
   /**
@@ -179,14 +208,14 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * (complete strings lex as a single STRING token); report it as such
    * instead of listing unrelated expected tokens.
    */
-  private def syntaxErrorMessage(found: String, expected: String, context: String = ""): String = {
+  private def syntaxErrorMessage(found: String, expected: String, context: String = "", sourceLine: String = ""): String = {
     // At EOF the expected-token list is a large, unhelpful dump; report the real
     // problem (an unclosed block/paren) instead.
     if (found == null || found.isEmpty) return Message("error.parsing.unexpected_eof")
     val base =
       if (found == "\"") Message("error.parsing.unterminated_string")
       else Message("error.parsing.syntax_error", displayTokenImage(found), expected)
-    val hint = commonSyntaxHint(found, expected, context)
+    val hint = commonSyntaxHint(found, expected, context, sourceLine)
     if (hint.isEmpty) base else base + " " + hint
   }
 
@@ -209,7 +238,17 @@ class Parsing(config: CompilerConfig) extends AnyRef
   /**
    * Add friendly hints for common syntax mistakes.
    */
-  private def commonSyntaxHint(found: String, expected: String, context: String): String = found match {
+  /**
+   * A Java/JS/C-style `switch` statement at the start of a source line. `switch`
+   * isn't a keyword in Onion -- it parses as a bare identifier-reference
+   * statement -- so the parser actually trips on whatever follows it (the
+   * condition, or the `{` of a parenthesized condition), never on `switch`
+   * itself. Matching the *line*, not the token that triggered the error,
+   * catches `switch x { ... }` and `switch (x) { ... }` alike.
+   */
+  private val LeadingSwitchStatement = """^\s*switch\b""".r
+
+  private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
     case "<:" =>
@@ -223,6 +262,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_super_init")
     case "in" =>
       Message("error.parsing.hint.old_for_in")
+    case _ if LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.switch_not_supported")
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
@@ -54,6 +54,25 @@ class HintMessageFormatSpec extends AbstractShellSpec {
       assert(msgs.contains("{ x -> ... }"), s"expected literal braces in the hint, got: $msgs")
     }
 
+    it("renders literal braces for the switch-statement hint, not quoted placeholders") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    switch (1) {
+          |    case 1: IO::println("one")
+          |    else: IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("'{'") && !msgs.contains("'}'"), s"hint leaked MessageFormat quoting: $msgs")
+      assert(msgs.contains("select value { case 1: ...; else: ... }"), s"expected literal braces in the hint, got: $msgs")
+    }
+
     it("renders a literal brace for the dangling-else hint, not a quoted placeholder") {
       val msgs = messages(
         """

--- a/src/test/scala/onion/compiler/tools/SwitchStatementHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SwitchStatementHintSpec.scala
@@ -1,0 +1,77 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no `switch` statement -- `select` covers the same ground. `switch`
+ * isn't a keyword in Onion, so it parses as a bare identifier reference and the
+ * parser actually trips on whatever follows it (the condition, or the `{` of a
+ * parenthesized condition), never mentioning `select`.
+ */
+class SwitchStatementHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("switch statement") {
+    it("hints at select for an unparenthesized switch") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    switch x {
+          |    case 1: IO::println("one")
+          |    else: IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("select"), s"expected a hint mentioning select, got: $msgs")
+      assert(msgs.contains("switch"), s"expected the hint to name switch, got: $msgs")
+    }
+
+    it("hints at select for a parenthesized switch") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    switch (x) {
+          |    case 1: IO::println("one")
+          |    else: IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("select"), s"expected a hint mentioning select, got: $msgs")
+      assert(msgs.contains("switch"), s"expected the hint to name switch, got: $msgs")
+    }
+
+    it("does not fire for an unrelated bare-identifier-statement typo") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foo bar
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("select"), s"hint should not fire without a leading `switch`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `switch x { case 1: ... }` (or `switch (x) { ... }`) got a bare expected-token dump with no mention of `select`, Onion's actual construct for this.
- `switch` isn't a keyword in Onion, so it parses as a bare identifier-reference statement, and the parser actually trips on whatever follows it — the condition, or the `{` of a parenthesized condition — never on `switch` itself. Every existing `commonSyntaxHint` case matches on the *offending* token, so none of them could ever fire here.
- `commonSyntaxHint` in `Parsing.scala` now also receives the full source line of the error (a new `sourceLineAt` helper, sharing the existing line-offset logic with `contextAt` via a small refactor) and matches a leading `switch` there instead of the offending token, so both spellings (`switch x { ... }` and `switch (x) { ... }`) now hint at `select value { case 1: ...; else: ... }`.
- Added `error.parsing.hint.switch_not_supported` to both `errorMessage.properties` and `errorMessage_ja.properties`.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] New `SwitchStatementHintSpec` (TDD: confirmed both cases red before the fix, green after), plus a negative case confirming the hint does **not** fire for an unrelated bare-identifier-statement typo (`foo bar`).
- [x] Extended `HintMessageFormatSpec` with a case for the new hint, confirming it renders literal braces (`select value { case 1: ...; else: ... }`) rather than leaking `MessageFormat`'s `'{'`/`'}'` quoting — the same regression class fixed in #799.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3843 succeeded, 0 failed, 1 canceled (expected: the dist smoke test, gated behind `-Donion.dist.path`).
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 3843 succeeded, 0 failed, 1 canceled (same).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PjVNBhs4DLvQ4dWH6iHeC1)_