### PR TITLE
fix(diagnostics): route CONSTRUCTOR_NOT_FOUND's available-constructors list through the bilingual bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `CONSTRUCTOR_NOT_FOUND` (E0021) diagnostic's "Available constructors:" list header
+  was always English**, even under a Japanese-locale JVM where the rest of the message
+  (`constructor applicable for ... is not found`) was correctly translated —
+  `SemanticErrorReporter.reportConstructorNotFound` built that header from a hard-coded
+  string literal instead of going through the bilingual `errorMessage*.properties` bundle
+  every other suggestion (`error.suggestion.candidates`, `suggestion.didYouMean`, ...) uses.
+  It now resolves `error.suggestion.availableConstructors` from the bundle, so the header
+  is Japanese under `-Duser.language=ja` like the rest of the message.
+
 - **A Java/JS/C-style `switch` statement (`switch x { case 1: ... }` or
   `switch (x) { ... }`) got a bare expected-token dump with no mention of
   `select`.** `switch` isn't a keyword in Onion, so it parses as a bare

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -66,6 +66,7 @@ suggestion.nullableToNonNull=hint: the value is nullable; use `!!` to assert non
 suggestion.fieldNotMethod=hint: {0} is a field, not a method; access it without parentheses ({0})
 error.parsing.unterminated_string=unterminated string literal: missing closing quote.
 error.suggestion.candidates=available: {0}
+error.suggestion.availableConstructors=available constructors:
 error.semantic.typeParameterMayBeNull=value of type parameter {0} may be null and cannot be dereferenced directly. Use ?. / ?: / a null check (if x != null), or declare a non-null bound ([{0} extends SomeType]).
 error.semantic.nullableMemberAccess=value of type {0} may be null and cannot be dereferenced directly. Use ?. to access it safely, ?: to provide a default, !! to assert non-null, or check for null first (if x != null).
 error.semantic.staticCallOnInstance={0} is a variable, not a type. Use . to call an instance method ({0}.method()); :: is only for static members of a type.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -65,6 +65,7 @@ suggestion.nullableToNonNull=\u30D2\u30F3\u30C8: \u5024\u306F null \u8A31\u5BB9\
 suggestion.fieldNotMethod=ヒント: {0} はメソッドではなくフィールドです。括弧なしでアクセスしてください ({0})。
 error.parsing.unterminated_string=\u6587\u5b57\u5217\u30ea\u30c6\u30e9\u30eb\u304c\u9589\u3058\u3089\u308c\u3066\u3044\u307e\u305b\u3093\u3002\u9589\u3058\u5f15\u7528\u7b26 " \u3092\u8ffd\u52a0\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 error.suggestion.candidates=\u5019\u88dc: {0}
+error.suggestion.availableConstructors=\u5229\u7528\u53ef\u80fd\u306a\u30b3\u30f3\u30b9\u30c8\u30e9\u30af\u30bf:
 error.semantic.typeParameterMayBeNull=型パラメータ {0} の値はnullの可能性があるため、直接参照できません。?. / ?: / nullチェック（if x != null）を使うか、非nullの境界（[{0} extends SomeType]）を宣言してください。
 error.semantic.nullableMemberAccess=型 {0} の値はnullの可能性があるため、直接参照できません。安全に参照するには ?.、デフォルト値を与えるには ?:、非nullを断言するには !!、または先にnullチェック（if x != null）を行ってください。
 error.semantic.staticCallOnInstance={0} は変数であり、型ではありません。インスタンスメソッドの呼び出しには . を使ってください（{0}.method()）。:: は型の静的メンバー専用です。

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -630,7 +630,7 @@ class SemanticErrorReporter(threshold: Int) {
         val ctorSignatures = constructors.map { ctor =>
           s"  ${typeRef.name}(${ctor.getArgs.map(onion.compiler.toolbox.TypeFormatting.sourceForm).mkString(", ")})"
         }
-        Some(s"Available constructors:${Systems.lineSeparator}${ctorSignatures.mkString(Systems.lineSeparator)}")
+        Some(s"${message("error.suggestion.availableConstructors")}${Systems.lineSeparator}${ctorSignatures.mkString(Systems.lineSeparator)}")
       } else None
     } else None
 

--- a/src/test/scala/onion/compiler/ConstructorNotFoundHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/ConstructorNotFoundHintI18nSpec.scala
@@ -1,0 +1,61 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * `SemanticErrorReporter.reportConstructorNotFound`'s "Available constructors:" list was a
+ * hard-coded English literal, unlike every other suggestion appended to a not-found
+ * diagnostic (`error.suggestion.candidates`, `suggestion.didYouMean`, ...), which all go
+ * through the bilingual `errorMessage*.properties` bundle. Under a Japanese-locale JVM the
+ * base "constructor ... is not found" message came out in Japanese with the constructor
+ * list header stuck in English.
+ */
+class ConstructorNotFoundHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.suggestion.availableConstructors"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  private val src =
+    """
+      |class Foo {
+      |public:
+      |  def this(x: Int) { }
+      |}
+      |class Main {
+      |public:
+      |  static def main(args: String[]): Int {
+      |    val f = new Foo("bad")
+      |    return 0
+      |  }
+      |}
+      |""".stripMargin
+
+  private def compileErrors(): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).nonEmpty)
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text, distinct from English") {
+    val text = ja.getString(key)
+    assert(!text.toLowerCase(java.util.Locale.ROOT).contains("available"), s"leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("routes the available-constructors list through the bundle, not a hard-coded literal") {
+    val msgs = compileErrors()
+    // The constructor signature itself is literal code, identical in both bundles, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("Foo(Int)"), s"expected the available constructor signature, got: $msgs")
+    assert(!msgs.contains("Available constructors:"), s"the header leaked hard-coded English, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary

- `SemanticErrorReporter.reportConstructorNotFound` built the "Available constructors:" list header from a hard-coded English string literal, unlike every other not-found suggestion in the reporter (`error.suggestion.candidates`, `suggestion.didYouMean`, `suggestion.fieldNotMethod`, ...), which all resolve through `errorMessage*.properties` via `Message`/`message(...)`.
- Under a Japanese-locale JVM (`-Duser.language=ja`), the base `CONSTRUCTOR_NOT_FOUND` (E0021) message translated correctly, but the constructor-list header stayed in English mid-message.
- Added `error.suggestion.availableConstructors` to both `errorMessage.properties` and `errorMessage_ja.properties`, and routed the code through it.

## Test plan

- [x] Added `ConstructorNotFoundHintI18nSpec` (TDD: confirmed red before the fix — bundle key missing, hard-coded English leaking into the compiled diagnostic).
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3846 tests, 0 failed (1 pre-existing, unrelated `canceled` distribution-packaging integration test).
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 3846 tests, 0 failed (same pre-existing cancellation).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015QmazJcxocbjeoWz5F4F2V)_