### PR TITLE
docs(changelog): add SpreadsheetCalc.on entry to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `groupBy`, `sortedBy`, `fold`), closures stored in a `val` and invoked via
   `.call`, recursive helpers, string interpolation, and nullable-safe lookups.
 
+- **`run/SpreadsheetCalc.on`, a ~400-line mini spreadsheet evaluator with a
+  recursive-descent formula parser.** Covers ADT enums (`CellVal`, `FExpr`),
+  records, classes, user-defined generics, `HashMap`/`HashSet`, nullable
+  fields, `select`/pattern matching, and `try`/`catch`. The formula engine
+  supports literals, cell references, binary operators (`+ - * /`), range
+  notation (`A1:A3`), and aggregate functions (`SUM`, `MAX`, `MIN`, `AVG`),
+  plus cycle detection over circular formula references and a formatted
+  table report.
+
 ## [0.12.1] - 2026-08-19
 
 ### Fixed


### PR DESCRIPTION
## Summary

- PR #814 added `run/SpreadsheetCalc.on` but didn't record it in `CHANGELOG.md`'s `[Unreleased]` section, unlike the other recent corpus samples.
- Adds a one-item `### Added` entry describing the sample, matching the style of the existing `PackageDelivery.on` entry.

## Test plan

- Docs-only change; no code paths affected. Full test suite run separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfM2SrzKco3BbPk75rQySE)_