### PR TITLE
Fix compiler crash (I0000) on null array-size expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`new T[null]` (a `null` literal used as an array-size expression) crashed the
+  compiler with an internal error (`I0000: Bad type on operand stack`)** instead
+  of being rejected during type checking. `ConstructionTyping.typeNewArray` typed
+  each dimension expression but never checked it was actually an `Int` (or an
+  integer type unboxable to one), so a `null` literal — or any other
+  non-integer size expression — reached code generation and produced bytecode
+  that pushed a null reference where the JVM's `newarray`/`multianewarray`
+  expects an `int` on the operand stack, which the verifier rejects at class
+  load time. It now runs the same `Boxing.tryUnboxToInteger` + integer-type
+  check `typeIndexing` already uses for array indices, and reports
+  `INCOMPATIBLE_TYPE` (E0000) on the offending dimension instead. Found by
+  `MutationFuzzSpec` (issue #812).
+
 - **A `CONSTRUCTOR_NOT_FOUND` (E0021) diagnostic's "Available constructors:" list header
   was always English**, even under a Japanese-locale JVM where the rest of the message
   (`constructor applicable for ... is not found`) was correctly translated —

--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -105,10 +105,17 @@ final class ConstructionTyping(
 
   def typeNewArray(node: AST.NewArray, context: LocalContext): Option[Term] = {
     val typeRefOpt = typing.mapFromDeclared(node.typeRef, bodyContext.mapper)
-    val parameters = typedTerms(node.args.toArray, context)
+    val untypedArgs = node.args.toArray
+    val parameters = typedTerms(untypedArgs, context)
     if (typeRefOpt.isEmpty || parameters == null) return None
-    val resultType = typing.loadArray(typeRefOpt.get, parameters.length)
-    Some(new NewArray(resultType, parameters))
+    val sizes = parameters.map(Boxing.tryUnboxToInteger(bodyContext.table, _))
+    val badIndex = sizes.indexWhere(size => !(size.isBasicType && size.`type`.asInstanceOf[BasicType].isInteger))
+    if (badIndex >= 0) {
+      bodyContext.report(INCOMPATIBLE_TYPE, untypedArgs(badIndex), BasicType.INT, sizes(badIndex).`type`)
+      return None
+    }
+    val resultType = typing.loadArray(typeRefOpt.get, sizes.length)
+    Some(new NewArray(resultType, sizes))
   }
 
   def typeNewArrayWithValues(node: AST.NewArrayWithValues, context: LocalContext): Option[Term] = {

--- a/src/test/scala/onion/compiler/tools/DynamicArraySizeSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DynamicArraySizeSpec.scala
@@ -153,6 +153,40 @@ class DynamicArraySizeSpec extends AbstractShellSpec {
       assert(Shell.Success(7) == result)
     }
 
+    it("rejects a null size expression with a diagnostic instead of crashing (new Boolean[null])") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val arr: Boolean[] = new Boolean[null]
+          |    return arr.length
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Failure(-1) == result)
+    }
+
+    it("rejects a null size expression in one dimension of a multi-dimensional array") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val grid = new Int[2][null]
+          |    return grid.length
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Failure(-1) == result)
+    }
+
     it("allocates with an uppercase variable size (new Int[N], not a type arg)") {
       val result = shell.run(
         """


### PR DESCRIPTION
## Summary

- Fixes #812: `new T[null]` (a `null` literal used as an array-size expression) crashed the compiler with `I0000: Internal compiler error ... Bad type on operand stack` instead of failing with a normal diagnostic.
- Root cause: `ConstructionTyping.typeNewArray` typed each dimension expression but never checked it was actually an `Int` (or an integer type unboxable to one). A `null`-typed dimension reached code generation and produced bytecode that pushes a null reference where `newarray`/`multianewarray` expects an `int` on the operand stack — rejected by the JVM bytecode verifier at class-load time.
- Fix: `typeNewArray` now runs each dimension through `Boxing.tryUnboxToInteger` + an integer-type check, the same pattern `typeIndexing` already uses for array indices, and reports `INCOMPATIBLE_TYPE` (E0000) on the offending dimension instead of letting it reach codegen.

## Verification

- New repro: `new Boolean[null]` now produces a clean `E0000` diagnostic instead of crashing.
- Existing valid cases (single/multi-dimensional arrays with variable, literal, and expression sizes) still compile and run correctly.
- Added two regression tests to `DynamicArraySizeSpec` (single-dim and one-dimension-of-multi-dim null size), both asserting `Shell.Failure(-1)` (locale-agnostic).
- `MutationFuzzSpec` (the deterministic fuzz test that originally caught this via a mutant of `run/GraphAlgorithms.on`) now passes.
- Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — **3857 succeeded, 0 failed, 1 canceled** (the canceled test is an opt-in dist smoke test that self-cancels without `-Donion.dist.path=...`, expected/pre-existing behavior, unrelated to this change).
  - Note: the mandated `-Xmx4G` heap causes severe GC thrashing on this suite in this environment and never completes in reasonable time; `-Xmx8G` was needed to get a clean, fast (~100s) run. Worth a follow-up look at whether the suite's memory footprint has grown past what `-Xmx4G` can sustain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyLGghzoxDBztkQfkyuTqK)_