### PR TITLE
docs(changelog): add BrainFuck.on entry to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plus cycle detection over circular formula references and a formatted
   table report.
 
+- **`run/BrainFuck.on`, a 357-line Brainfuck interpreter** with five verified
+  demo programs and analytical reporting sections. Covers a data-carrying
+  ADT case-enum (`BfInstr`, 8 cases, `JumpFwd`/`JumpBck` each carrying an
+  `Int` target) matched exhaustively via `select`, an `Int[]` data tape,
+  extension methods on `Int` (`clamp`, `mod256`, `toHex`) and `String`
+  (`repeat`, `padRight`), a mutable class with public getters (`BfMachine`),
+  `Map[String,Int]` with `foreach (k,v)`, collection pipelines, string
+  interpolation, nullable types, and runtime Brainfuck code generation (a
+  3×3 multiplication table computed via generated BF programs).
+
 ## [0.12.1] - 2026-08-19
 
 ### Fixed


### PR DESCRIPTION
## Summary

- #816 (`run/BrainFuck.on`) merged without a `CHANGELOG.md` entry. This adds one to `[Unreleased]` under `### Added`, matching the format used for the other recent large samples (`PackageDelivery.on`, `SpreadsheetCalc.on`).

## Notes

Docs-only change, no code touched. Local `sbt -Duser.language=en testFull` did not complete in this session — the 4G-heap local run thrashed on GC for ~1h without finishing (system has 15G RAM and 4 cores available, so this looks like an environment/heap-sizing issue with the locally recommended `-Xmx4G`, not a code regression). CI (`scala.yml`) runs with `-Xmx10G` and passed cleanly on the parent BrainFuck.on PR (#816, both check runs green); will confirm this PR's own CI is green before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_015j5J4g7Wy4P4jAEy3M3FKo)_