### PR TITLE
docs(changelog): record ConnectFour, Mandelbrot, and MarkovText samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `groupBy`), recursive tree traversal, nullable types, closures, string
   interpolation, and `foreach` over integer ranges and map entries.
 
+- **Three new `run/` samples: `ConnectFour.on`, `Mandelbrot.on`, and
+  `MarkovText.on`.** `ConnectFour.on` (286 lines) is a deterministic AI-vs-AI
+  Connect Four match over ADT enums (`Cell`, `GameResult`), an `interface AI`
+  with two implementing strategies, and a flat-array 2-D grid.
+  `Mandelbrot.on` (279 lines) renders the Mandelbrot set and several Julia
+  sets as ASCII art using a `record Complex` with operator methods
+  (`plus`/`times`), a homogeneous enum, extension methods on `Double`, and
+  top-level `example` clauses checked at compile time. `MarkovText.on`
+  (312 lines) is a bigram Markov chain text generator covering an ADT
+  case-enum, records with `example` clauses, extension methods on `String`
+  and `Int`, `foreach (k, v)` map destructuring, and collection pipelines.
+
 ### Fixed
 
 - **`new T[null]` (a `null` literal used as an array-size expression) crashed the


### PR DESCRIPTION
## Summary

Adds a single `[Unreleased] → Added` entry covering the three `run/` samples merged today, which landed without a CHANGELOG note:

- **#820** — `ConnectFour.on` (286 lines), deterministic AI-vs-AI Connect Four
- **#821** — `Mandelbrot.on` (279 lines), ASCII Mandelbrot/Julia fractal renderer
- **#822** — `MarkovText.on` (312 lines), bigram Markov chain text generator

Docs-only change; no source or test files touched.

## Verification

Full suite run in the English locale on the merge base:

```
sbt shutdown && SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull
...
Total number of tests run: 3872
Suites: completed 514, aborted 0
Tests: succeeded 3872, failed 0, canceled 1, ignored 0, pending 0
All tests passed.
```

The one cancelled test is the distribution smoke test gated behind `-Donion.dist.path`, as documented in `docs/quality-bar.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011CDB1qU59vDb5BM95AwTBD)_