### PR TITLE
fix(diagnostics): hint at def for a fun/func/fn declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A Kotlin (`fun`), Swift/Go (`func`), or Rust (`fn`) function/method declaration
+  got a bare expected-token dump with no mention of `def`.** None of `fun`, `func`,
+  or `fn` are keywords in Onion, so at statement position the keyword parses as a
+  bare identifier reference and the parser trips on the declaration *name* that
+  follows (`Encountered "greet"`), while inside a class/interface body it trips on
+  the keyword itself — neither message names `def`. `commonSyntaxHint` in
+  `Parsing.scala` now matches the full source line for a `fun`/`func`/`fn <name>(`
+  declaration (the same source-line strategy as the `switch` hint, since the
+  offending token is never the keyword itself at statement position) and hints
+  `def name(...): ReturnType { ... }`. A real call to a method literally named
+  `fun`/`func`/`fn` is unaffected (`fun(...)` has no name between the identifier
+  and the paren, so it never matches).
+
 - **`new T[null]` (a `null` literal used as an array-size expression) crashed the
   compiler with an internal error (`I0000: Bad type on operand stack`)** instead
   of being rejected during type checking. `ConstructionTyping.typeNewArray` typed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -103,6 +103,7 @@ error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
+error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -103,6 +103,7 @@ error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算�
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
+error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -248,6 +248,19 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val LeadingSwitchStatement = """^\s*switch\b""".r
 
+  /**
+   * A Kotlin (`fun`), Swift/Go (`func`), or Rust (`fn`) function/method
+   * declaration. None of these are keywords in Onion (which uses `def`), so at
+   * statement position the keyword parses as a bare identifier reference and the
+   * parser trips on the declaration name that follows, while inside a
+   * class/interface body it trips on the keyword itself -- neither mentions
+   * `def`. Matching the source line for `<kw> name(` catches both. A real call
+   * to a method named `fun`/`func`/`fn` is `fun(...)` with no name between the
+   * keyword and the paren, so it never matches; `fun name(` is not a valid Onion
+   * expression anyway.
+   */
+  private val FunDeclaration = """\b(?:fun|func|fn)\s+[A-Za-z_]\w*\s*\(""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -264,6 +277,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_for_in")
     case _ if LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.switch_not_supported")
+    case _ if FunDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.fun_declaration")
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/tools/FunDeclarationHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FunDeclarationHintSpec.scala
@@ -1,0 +1,56 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion declares functions and methods with `def`, not the `fun` (Kotlin),
+ * `func` (Swift/Go), or `fn` (Rust) keyword. None of those are keywords in
+ * Onion, so the parser trips either on the declaration name that follows (at
+ * statement position) or on the keyword itself (inside a class/interface body),
+ * never mentioning `def`. The hint keys off the source line so both spellings
+ * are covered.
+ */
+class FunDeclarationHintSpec extends AbstractShellSpec {
+  private def messages(src: String): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  describe("fun/func/fn declaration") {
+    it("hints at def for a top-level Kotlin-style fun declaration") {
+      val msgs = messages("fun greet(): void { IO::println(\"hi\") }\n")
+      assert(msgs.contains("def"), s"expected a hint mentioning def, got: $msgs")
+      assert(msgs.contains("fun"), s"expected the hint to name fun, got: $msgs")
+    }
+
+    it("hints at def for a Swift/Go-style func member") {
+      val msgs = messages(
+        """
+          |interface I {
+          |  func foo(): Int
+          |}
+          |""".stripMargin
+      )
+      assert(msgs.contains("def"), s"expected a hint mentioning def, got: $msgs")
+    }
+
+    it("hints at def for a Rust-style fn declaration") {
+      val msgs = messages("fn main(): void { }\n")
+      assert(msgs.contains("def"), s"expected a hint mentioning def, got: $msgs")
+    }
+
+    it("does not fire for an unrelated bare-identifier-statement typo") {
+      val msgs = messages("foo bar\n")
+      assert(!msgs.contains("declared with"), s"hint should not fire without a leading fun/func/fn, got: $msgs")
+    }
+
+    it("does not fire for a call to a method literally named fun") {
+      val msgs = messages("val x = fun(1, 2)\n")
+      assert(!msgs.contains("declared with"), s"hint should not fire for a fun(...) call, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A Kotlin (`fun`), Swift/Go (`func`), or Rust (`fn`) function/method declaration produced a bare expected-token dump with no mention of Onion's `def`:

```
fun greet(): void { ... }
  → Syntax error. Encountered "greet", but expecting <EOF>, <EOL>, ";"
```

None of `fun`, `func`, or `fn` are keywords in Onion, so at statement position the keyword parses as a bare identifier reference and the parser trips on the declaration *name* that follows; inside a class/interface body it trips on the keyword itself. Neither message names `def`.

## Change

`commonSyntaxHint` in `Parsing.scala` now matches the full source line for a `fun`/`func`/`fn <name>(` declaration — the same source-line strategy already used for the `switch` → `select` hint (#807), because the offending token is never the keyword itself at statement position — and appends:

```
Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn` keyword. Write `def name(...): ReturnType { ... }`.
```

The hint is bilingual (added to both `errorMessage.properties` and `errorMessage_ja.properties`). A real call to a method literally named `fun`/`func`/`fn` is unaffected: `fun(...)` has no name between the identifier and the paren, so the regex never matches (verified by a negative test).

## Testing

- New `FunDeclarationHintSpec` (5 cases: `fun`/`func`/`fn` positives, plus two negatives — an unrelated bare-identifier typo and a `fun(...)` call).
- Full suite green in **both** locales: `-Duser.language=en` and `-Duser.language=ja`, 3883 passed / 0 failed / 1 pre-existing cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pp2kvzea4p6QCnTzcxd3Ax)_