### PR TITLE
docs(changelog): note CpuScheduler.on sample in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`run/CpuScheduler.on`, a 464-line CPU scheduling simulator.** Runs FCFS,
+  SJF (non-preemptive), Round-Robin (quantum-based), and preemptive Priority
+  scheduling against a shared 5-process workload, rendering a text Gantt
+  chart and a per-process metrics table (wait/turnaround/response) for each
+  algorithm, then compares them and picks the one minimizing average wait
+  time. Exercises a data-carrying ADT case-enum dispatched via `select`,
+  class inheritance with per-algorithm overrides, primary-constructor
+  superclass delegation (`class Sub(args) extends Base(args)`), extension
+  methods on `Int`/`String`, and nullable-typed pick results.
+
 ## [0.13.0] - 2026-08-20
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds an `[Unreleased]` entry for `run/CpuScheduler.on` (merged in #826), following the existing changelog convention of documenting each user-visible `run/` sample addition.

## Test plan

- Docs-only change; full test suite (`sbt -Duser.language=en testFull`) already run green as part of #826 immediately prior to this commit, with no source changes since.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLeeN7ruTXoEwcH7f8ZXFz)_