### PR TITLE
Add regression coverage for try/catch in compound-assignment to a boxed captured local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -821,6 +821,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flows through the same `visitNewObject` path ordinary records use (already
   hardened by the #669/#745/#752 fixes), so this already passed; this closes
   a coverage gap rather than a live bug.
+- **`TryInCompoundBoxedLocalAssignmentSpec`, regression coverage for `try`/`catch`
+  on the right-hand side of a compound assignment (`+=`) to a closure-captured
+  (boxed) local variable** (`x += try {...} catch {...}`), both from inside the
+  capturing closure and from the declaring scope. `TryInCompoundFieldArrayAssignmentSpec`
+  already locked in the same `BinaryTerm`-wrapped-`try` shape for field/array
+  compound-assignment targets, but the boxed-local path in `emitSetLocal`
+  (`AsmCodeGeneration.scala`) was untested. `TermContainsTry.contains` already
+  recurses generically through a term's children, so both cases already passed;
+  this closes a coverage gap rather than a live bug.
 
 ### Fixed
 

--- a/src/test/scala/onion/compiler/tools/TryInCompoundBoxedLocalAssignmentSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TryInCompoundBoxedLocalAssignmentSpec.scala
@@ -1,0 +1,76 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A `try`/`catch` expression on the right-hand side of a compound assignment
+ * (`+=`) targeting a `var` that is boxed because a closure captures it.
+ * Compound assignment desugars `target op= value` to `target = target op
+ * value` (`SimpleExpressionTypingSupport.typeBinaryAssignmentSimple`), so the
+ * `try` ends up nested inside a `BinaryTerm` rather than directly as the
+ * assigned value -- the boxed-local sibling of
+ * `TryInCompoundFieldArrayAssignmentSpec`, which locked in the same shape for
+ * field/array targets but left the boxed-local path (`emitSetLocal` in
+ * `AsmCodeGeneration.scala`) uncovered. This closes that coverage gap rather
+ * than a live bug: `TermContainsTry.contains` recurses generically through a
+ * term's children, so it already detects the nested `try` and spills the box
+ * reference correctly in both cases below.
+ */
+class TryInCompoundBoxedLocalAssignmentSpec extends AbstractShellSpec {
+  describe("try/catch expression as the RHS of a compound assignment to a closure-captured (boxed) local variable") {
+    it("does not corrupt the box reference when compound-assigned from inside the capturing closure") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def risky(x: Int): Int {
+          |    if x > 0 { return x }
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    var x: Int = 10
+          |    val f: () -> Int = () -> {
+          |      x += try { Test::risky(5) } catch e: Exception { 0 }
+          |      return x
+          |    }
+          |    val a: Int = f.call()
+          |    x += try { Test::risky(-1) } catch e: Exception { 1 }
+          |    return a + "|" + x
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInCompoundBoxedLocalAssignmentInner.on",
+        Array()
+      )
+      assert(Shell.Success("15|16") == result)
+    }
+
+    it("does not corrupt the box reference when compound-assigned from the declaring scope") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def risky(x: Int): Int {
+          |    if x > 0 { return x }
+          |    throw new Exception("boom")
+          |  }
+          |
+          |  static def main(args: String[]): String {
+          |    var x: Int = 10
+          |    val f: () -> Int = () -> x
+          |    x += try { Test::risky(5) } catch e: Exception { 0 }
+          |    val a: Int = f.call()
+          |    x += try { Test::risky(-1) } catch e: Exception { 1 }
+          |    val b: Int = f.call()
+          |    return a + "|" + b
+          |  }
+          |}
+          |""".stripMargin,
+        "TryInCompoundBoxedLocalAssignmentOuter.on",
+        Array()
+      )
+      assert(Shell.Success("15|16") == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `TryInCompoundBoxedLocalAssignmentSpec`, covering a `try`/`catch` expression as the RHS of a compound assignment (`+=`) to a closure-captured (boxed) local variable — both from inside the capturing closure and from the declaring scope.
- `TryInCompoundFieldArrayAssignmentSpec` already locked in the same `BinaryTerm`-wrapped-`try` shape (from `target op= value` desugaring) for field/array compound-assignment targets, but the boxed-local path in `emitSetLocal` (`AsmCodeGeneration.scala`) was untested.
- `TermContainsTry.contains` already recurses generically through a term's children, so both new cases already pass. **This closes a coverage gap rather than a live bug.**
- One-line `CHANGELOG.md` entry under `[Unreleased] / Added`.

Background: I went looking for a live, unguarded sibling of the well-known operand-stack-desync bug family (#745/#669 and friends — pushing a receiver/box reference, then evaluating a sub-expression that may itself run `try`/`catch`, corrupting the stack on the exceptional path). I checked several candidates, including a 2–4-level-deep nested-closure capture chain with a `try`/`catch` assignment RHS — all already correctly guarded by the existing `TermContainsTry` spills. The one genuinely uncovered (but already-safe) combination was compound assignment to a boxed captured local, so I'm locking that in as a regression test per this repo's established "coverage gap" convention (see e.g. `ThreeLevelNestedClosureCapturedVariableSpec`, `TryInEnumCaseArgSpec`).

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *TryInCompoundBoxedLocalAssignmentSpec'` — 2/2 passed locally.
- [ ] Full suite (`SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull`) — **could not be completed locally this session**: first attempt hit `OutOfMemoryError` mid-suite (`RecordMethodsSpec` aborted, ~7 min in — matches the historical #691 OOM-under-4G-heap pattern); a clean retry (fresh `sbt shutdown` first) instead stalled for 27+ minutes with the JVM spending 95–100%+ CPU in GC pause and making no further progress, so it was killed rather than left to run indefinitely. This looks like transient resource pressure in this particular session's container, not a regression caused by this change (the diff only adds a test file + a changelog line, touching no compiler code). Opening as **draft** per the "don't merge without a locally-verified green full run" policy; please let CI's full run (a clean, dedicated environment) be the authoritative signal, and take this out of draft once it's green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxDGYXSTkSNyYFJZ1pjKhF)_