### PR TITLE
chore(compiler): fix deprecated mutable Set -- usage in CapturedVariableScanner

### DIFF
--- a/src/main/scala/onion/compiler/CapturedVariableScanner.scala
+++ b/src/main/scala/onion/compiler/CapturedVariableScanner.scala
@@ -232,6 +232,6 @@ object CapturedVariableScanner {
     // nested closure. A locally-declared variable that IS captured by a nested
     // closure must stay in the result so it gets marked as boxed (the nested
     // closure needs to read/write through the same heap cell).
-    (result -- (locallyDeclared -- capturedByNested)).toSet
+    (result.toSet -- (locallyDeclared.toSet -- capturedByNested.toSet))
   }
 }


### PR DESCRIPTION
## Summary

- `CapturedVariableScanner.findReferencedVariables` computed its result with `mutable.Set -- mutable.Set`, which triggers Scala 2.13+'s "`--` on SetOps is deprecated, consider requiring an immutable Set" warning twice on every `sbt compile`.
- Converts `result`, `locallyDeclared`, and `capturedByNested` to immutable `Set`s before the difference. No behavior change — same elements, same order-independent result (the method already returns `Set[String]`).

## Test plan

- [x] `sbt compile` — no deprecation warnings, builds clean
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3940 succeeded, 0 failed, 1 canceled, 0 ignored (matches the existing baseline)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S35ujLvx6vic3TjmfGR1n8)_