### PR TITLE
fix(diagnostics): hint at the unparenthesized form for catch (e: Exception) { }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `foreach (k, v) in Map[Object, List[Object]]`, `Double[]`/`Boolean[]`/`Int[]`
   arrays, records with compile-time examples, and nullable types.
 
+### Fixed
+
+- A Java-style parenthesized `catch (e: Exception) { }` clause now gets a
+  bilingual diagnostic hint pointing at the correct `catch e: Exception { }`
+  form, instead of an unhelpful expected-token dump.
+
 ## [0.14.0] - 2026-08-21
 
 ### Added

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -105,6 +105,7 @@ error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a 
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
+error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -105,6 +105,7 @@ error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポート
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
+error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -261,6 +261,15 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val FunDeclaration = """\b(?:fun|func|fn)\s+[A-Za-z_]\w*\s*\(""".r
 
+  /**
+   * A Java-style parenthesized catch clause, `catch (e: Exception) { }`. `catch`
+   * is a real keyword in Onion, but its variable is never parenthesized -- the
+   * parser expects the binding name directly after `catch` and trips on the `(`.
+   * `catch` cannot appear as an identifier (it is reserved), so `catch\s*\(`
+   * anywhere on the line can only be this mistake.
+   */
+  private val ParenthesizedCatchClause = """\bcatch\s*\(""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -273,6 +282,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
     // for `super` or `(` alone would fire at every expression position.
     case "(" if expected.contains("\"this\"") && !expected.contains("<ID>") =>
       Message("error.parsing.hint.old_super_init")
+    case "(" if expected.contains("<ID>") && ParenthesizedCatchClause.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.catch_parens")
     case "in" =>
       Message("error.parsing.hint.old_for_in")
     case _ if LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/CatchParensHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/CatchParensHintI18nSpec.scala
@@ -1,0 +1,26 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * The `catch (e: Exception) { }` hint (`commonSyntaxHint`'s parenthesized-catch
+ * case in Parsing.scala) must resolve in both locale bundles, with the Japanese
+ * entry actually written in Japanese rather than falling back to English.
+ */
+class CatchParensHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.catch_parens"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+}

--- a/src/test/scala/onion/compiler/tools/CatchParensHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CatchParensHintSpec.scala
@@ -1,0 +1,61 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java-style parenthesized `catch (e: Exception) { }` clause. `catch` is a
+ * real keyword in Onion, but its binding is never parenthesized, so the parser
+ * expects the variable name directly after `catch` and trips on the `(` with an
+ * expected-token dump that never mentions the actual mistake.
+ */
+class CatchParensHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("parenthesized catch clause") {
+    it("hints at the unparenthesized form for `catch (e: Exception) { }`") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    try {
+          |      IO::println("hi")
+          |    } catch (e: Exception) {
+          |      IO::println("caught")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("catch e: Exception"), s"expected a hint showing the unparenthesized form, got: $msgs")
+      assert(msgs.contains("catch (e: Exception)"), s"expected the hint to name the mistaken form, got: $msgs")
+    }
+
+    it("does not fire for the correct unparenthesized form") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    try {
+          |      IO::println("hi")
+          |    } catch e: Exception {
+          |      IO::println("caught")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for valid syntax, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- A Java-style parenthesized catch clause (`catch (e: Exception) { }`) previously produced only an unhelpful expected-token dump (`Encountered "(", but expecting <ID>, <QUOTED_ID>`) with no mention of the actual mistake. `catch` is a real keyword in Onion, but its binding is never parenthesized — the correct form is `catch e: Exception { }`.
- Adds a `commonSyntaxHint` case in `Parsing.scala` that detects `catch\s*\(` on the offending source line (via the same `sourceLine`-matching approach already used for the `switch`/`fun`/`func`/`fn` hints) and emits a bilingual hint pointing at the correct syntax.
- Adds the `error.parsing.hint.catch_parens` message key to both `errorMessage.properties` (English) and `errorMessage_ja.properties` (Japanese).

## Test plan

- [x] New unit test `CatchParensHintSpec` (positive case fires the hint; negative case confirms the correct unparenthesized form compiles cleanly with no errors)
- [x] New unit test `CatchParensHintI18nSpec` (confirms the message key resolves in both locale bundles, and that the Japanese entry is actually Japanese rather than an English fallback)
- [x] `sbt shutdown && sbt -Duser.language=en testFull` — 3950 tests, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change)
- [x] `sbt shutdown && sbt -Duser.language=ja testFull` — 3950 tests, 0 failed, 1 canceled (same pre-existing gated test)

## CHANGELOG

- Added a `### Fixed` entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013xDrFohPfqrMUsa1rLAxqX)_