### PR TITLE
fix(diagnostics): hint at the unparenthesized form for C-style `for (init; cond; step)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a C-style `for (init; cond; step)` loop.** Onion's `for` loop
+  never parenthesizes its clauses; writing the C/Java/JS form used to trip the
+  parser several tokens past the actual mistake with an unhelpful expected-token
+  dump. The diagnostic now recognizes a leading `for (` and points at the correct
+  `for var i: Int = 0; i < 10; i++ { ... }` form.
+
 ## [0.15.0] - 2026-08-22
 
 ### Added

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -106,6 +106,7 @@ error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
+error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -106,6 +106,7 @@ error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はあ�
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
+error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -270,6 +270,16 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val ParenthesizedCatchClause = """\bcatch\s*\(""".r
 
+  /**
+   * A C/Java/JS-style parenthesized `for (init; cond; step)` loop. Onion's `for` is
+   * a real keyword but its three clauses are never parenthesized, so the parser treats
+   * the `(` as the start of a parenthesized initializer expression and trips several
+   * tokens later -- on whatever follows the type name -- never mentioning that `for`
+   * itself takes no parens. `for` cannot appear as an identifier (it is reserved), so
+   * a leading `for\s*\(` on the line can only be this mistake.
+   */
+  private val CStyleForLoop = """^\s*for\s*\(""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -290,6 +300,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.switch_not_supported")
     case _ if FunDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.fun_declaration")
+    case _ if CStyleForLoop.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.c_style_for")
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/CStyleForLoopHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/CStyleForLoopHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The C-style-for-loop hint (`commonSyntaxHint`'s `CStyleForLoop` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like every other
+ * hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class CStyleForLoopHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.c_style_for"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a C-style parenthesized for loop") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    for (int i = 0; i < 10; i++) {
+        |      IO::println(i)
+        |    }
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example loop shown in the hint is literal code, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("for var i: Int = 0; i < 10; i++"), s"expected the hint's example loop, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/CStyleForLoopHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CStyleForLoopHintSpec.scala
@@ -1,0 +1,74 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion's `for` loop is never parenthesized (`for var i: Int = 0; i < 10; i++ { ... }`),
+ * unlike the C/Java/JS `for (init; cond; step) { ... }` form. `for` is a real keyword, so
+ * the parser consumes it and then tries to parse the `(` as the start of a parenthesized
+ * initializer expression -- it trips several tokens later (on the identifier after the
+ * type name, or similar), never mentioning that `for` itself takes no parens.
+ */
+class CStyleForLoopHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("C-style for loop") {
+    it("hints at the unparenthesized form for `for (int i = 0; i < 10; i++)`") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    for (int i = 0; i < 10; i++) {
+          |      IO::println(i)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("for var i"), s"expected a hint mentioning the unparenthesized form, got: $msgs")
+    }
+
+    it("hints for a for loop with only whitespace between `for` and `(`") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    for   (var i = 0; i < 10; i = i + 1) {
+          |      IO::println(i)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("for var i"), s"expected a hint mentioning the unparenthesized form, got: $msgs")
+    }
+
+    it("does not fire for the correct unparenthesized for loop") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    for var i: Int = 0; i < 10; i++ {
+          |      IO::println(i)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for a correct for loop, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion's `for` loop never parenthesizes its clauses (`for var i: Int = 0; i < 10; i++ { ... }`), unlike the C/Java/JS `for (init; cond; step) { ... }` form. Since `for` is a real keyword, the parser used to consume the `(` as the start of a parenthesized initializer expression and trip several tokens later with an unhelpful expected-token dump (`Encountered "i", but expecting ")"`) that never mentioned `for` itself.
- Adds a `commonSyntaxHint` case (mirroring the existing `switch`/`fun`/`catch`-parens hints in `Parsing.scala`) that recognizes a leading `for (` on the source line and points at the correct unparenthesized form, with bilingual (en/ja) message bundle entries.
- Adds a `[Unreleased]` CHANGELOG entry.

## Test plan
- [x] TDD: added `CStyleForLoopHintSpec` (tools package, behavioral) and `CStyleForLoopHintI18nSpec` (bundle + locale coverage, mirroring `OldForInHintI18nSpec`); confirmed both were red before the fix and green after (`sbt -Duser.language=en 'testOnly onion.compiler.tools.CStyleForLoopHintSpec onion.compiler.CStyleForLoopHintI18nSpec'`).
- [ ] **Full suite not confirmed green.** `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` was started and ran for over an hour; it stalled for 20+ minutes with no new test output while spending 90–120% of CPU time in GC pauses with the heap nearly full (0.01–0.02GB free of a 4.00GB max) — likely GC thrashing on this larger test corpus (200+ `run/` example programs, mutation fuzzer, crash-reproducer corpus) under the mandated 4G heap in this environment, rather than a genuine test failure. The run was killed rather than left to hang indefinitely or reported as green without real confirmation.
- Per repo policy, this PR is left as **draft** and unmerged until the full English-locale suite can be confirmed green — either by a maintainer, or by a subsequent scheduled run with more headroom (e.g. a larger heap, or narrowing to the affected spec packages first).


---
_Generated by [Claude Code](https://claude.ai/code/session_014LhBt1fEmwSNx8kjvmouTS)_