### PR TITLE
fix(diagnostics): hint at the braced form for a Java-style unbraced import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overloading, raw regex/resource literals, pipeline `|>`, regex `select`
   patterns, auto-CLI). Brought fully in sync, row-for-row, with `CLAUDE.md`.
 
+- **Parser hint for a Java/C#-style unbraced `import java.util.List;`.** Onion's
+  `import` decl always wraps its targets in braces (`import { java.util.List }`);
+  writing the unbraced Java/C# form used to fall through to the generic
+  "a block `{ ... }` is expected here" hint, which reads as if a code block were
+  missing rather than braces around the import. The diagnostic now recognizes a
+  leading `import` followed directly by a non-`{` token and points at the correct
+  braced form.
+
 ## [0.15.0] - 2026-08-22
 
 ### Added

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -107,6 +107,7 @@ error.parsing.hint.fun_declaration=Hint: functions and methods are declared with
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
+error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -107,6 +107,7 @@ error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
+error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -280,6 +280,15 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val CStyleForLoop = """^\s*for\s*\(""".r
 
+  /**
+   * A Java/C#-style unbraced `import java.util.List;` (or wildcard/no-semicolon variant).
+   * Onion's `import` decl always wraps its targets in braces -- `import { java.util.List }`
+   * -- so the parser consumes the `import` keyword and then trips on the identifier that
+   * follows, expecting `{`. `import` cannot appear as an identifier (it is reserved), so a
+   * leading `import\s+` followed directly by a non-`{` on the line can only be this mistake.
+   */
+  private val JavaStyleImport = """^\s*import\s+(?!\{)\S""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -302,6 +311,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.fun_declaration")
     case _ if CStyleForLoop.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.c_style_for")
+    case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.java_style_import")
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/JavaStyleImportHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleImportHintI18nSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-import hint (`commonSyntaxHint`'s `JavaStyleImport` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like every other
+ * hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class JavaStyleImportHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_import"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style unbraced import") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |import java.util.List;
+        |
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example import shown in the hint is literal code, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("import { java.util.List }"), s"expected the hint's example import, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleImportHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleImportHintSpec.scala
@@ -1,0 +1,72 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion's `import` decl always wraps its targets in braces (`import { java.util.List }`),
+ * unlike the Java/C#-style `import java.util.List;` form. `import` is a real keyword, so
+ * the parser consumes it and then trips on the identifier that follows, expecting `{` --
+ * the generic "block expected" fallback fires instead of anything mentioning braced imports.
+ */
+class JavaStyleImportHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style import statement") {
+    it("hints at the braced form for `import java.util.List;`") {
+      val msgs = messages(
+        """
+          |import java.util.List;
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("import { java.util.List }"), s"expected a hint mentioning the braced form, got: $msgs")
+    }
+
+    it("hints for a wildcard import with no trailing semicolon") {
+      val msgs = messages(
+        """
+          |import java.util.*
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("import { java.util.List }"), s"expected a hint mentioning the braced form, got: $msgs")
+    }
+
+    it("does not fire for the correct braced import") {
+      val msgs = messages(
+        """
+          |import {
+          |  java.util.List
+          |}
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for a correctly braced import, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Onion's `import` decl always wraps its targets in braces (`import { java.util.List }`), unlike the Java/C#-style `import java.util.List;` form — a documented common mistake (already listed in `CLAUDE.md`'s syntax-mistakes table).
- Writing the unbraced form used to fall through to the generic `block_expected` hint ("a block `{ ... }` is expected here"), which misleadingly reads as if a code block is missing rather than braces around the import.
- Adds a `JavaStyleImport` regex hint (mirroring the existing `CStyleForLoop` hint pattern) that recognizes a leading `import` followed directly by a non-`{` token and points at the correct braced form, in both English and Japanese bundles.

## Test plan

- [x] New tests added first and confirmed red before the fix (`JavaStyleImportHintSpec`, `JavaStyleImportHintI18nSpec`)
- [x] `sbt -Duser.language=en testFull` — 3976 tests, all passed
- [x] `sbt -Duser.language=ja testFull` — 3976 tests, all passed
- [x] `CHANGELOG.md` `[Unreleased]` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qe6YfJQVLqmzRiMGAe7nDC)_