### PR TITLE
Add parser hint for Java-style constructor declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leading `import` followed directly by a non-`{` token and points at the correct
   braced form.
 
+- **Parser hint for a Java-style constructor named after its class.** Onion
+  constructors are declared with `def this`, never a method sharing the
+  class's name (`public ClassName(...) { ... }`, as in Java/C#). With an
+  access modifier the parser trips on the class name expecting `:` (the
+  modifier is read as an access-section marker); without one it trips on the
+  class name itself expecting a member declarator -- neither previously
+  mentioned `def this`. The diagnostic now recognizes a capitalized
+  identifier directly followed by `(` at member position (with or without a
+  leading `public`/`private`/`protected`) and points at the correct
+  `def this(...) { ... }` form.
+
 ## [0.15.0] - 2026-08-22
 
 ### Added

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -108,6 +108,7 @@ error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
+error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -108,6 +108,7 @@ error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` 
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
+error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -289,6 +289,19 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val JavaStyleImport = """^\s*import\s+(?!\{)\S""".r
 
+  /**
+   * A Java-style constructor, named after the class instead of using `def this`:
+   * `public ClassName(...) { }`, or the same with no access modifier. `public`/
+   * `private`/`protected` are real keywords (access-section markers), so with a
+   * modifier the parser consumes it and trips on the class name, expecting `:` --
+   * without one, a bare capitalized identifier at member position trips on itself,
+   * expecting a member declarator (`def`, `val`, `var`, ...). Neither mentions
+   * `def this`. Requiring a capitalized identifier (Java/Onion class-naming
+   * convention) directly followed by `(` keeps this from firing on an ordinary
+   * lowercase-named call or declaration.
+   */
+  private val JavaStyleConstructor = """^\s*(?:public|private|protected)?\s*[A-Z][A-Za-z0-9_]*\s*\(""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -313,6 +326,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.c_style_for")
     case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_import")
+    case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleConstructor.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.java_style_constructor")
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/JavaStyleConstructorHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleConstructorHintI18nSpec.scala
@@ -1,0 +1,49 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-constructor hint (`commonSyntaxHint`'s `JavaStyleConstructor` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both locales, like every
+ * other hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class JavaStyleConstructorHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_constructor"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `public ClassName(...) { }` constructor") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Point {
+        |  val x: Int
+        |public:
+        |  public Point(x: Int) {
+        |    this.x = x
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("def this"), s"expected the hint's `def this` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleConstructorHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleConstructorHintSpec.scala
@@ -1,0 +1,89 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java-style constructor declaration -- `public ClassName(...) { }`, named after the
+ * class instead of using `def this`. `public`/`private`/`protected` are real keywords
+ * (access-section markers), so the parser consumes the modifier and then trips on the
+ * class name, expecting `:` -- never mentioning `def this`. Without a modifier the bare
+ * `ClassName(...) { }` trips at the class-name identifier itself, expecting a member
+ * declarator (`def`, `val`, `var`, ...).
+ */
+class JavaStyleConstructorHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style constructor declaration") {
+    it("hints at `def this` for `public ClassName(...) { }`") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |  val y: Int
+          |public:
+          |  public Point(x: Int, y: Int) {
+          |    this.x = x
+          |    this.y = y
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def this"), s"expected a hint mentioning `def this`, got: $msgs")
+    }
+
+    it("hints at `def this` for a no-arg `private ClassName() { }`") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |private:
+          |  private Point() {
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def this"), s"expected a hint mentioning `def this`, got: $msgs")
+    }
+
+    it("hints at `def this` for a bare `ClassName(...) { }` with no modifier") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |  val y: Int
+          |public:
+          |  Point(x: Int, y: Int) {
+          |    this.x = x
+          |    this.y = y
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def this"), s"expected a hint mentioning `def this`, got: $msgs")
+    }
+
+    it("does not fire for the correct `def this` form") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |  val y: Int
+          |public:
+          |  def this(x: Int, y: Int) {
+          |    this.x = x
+          |    this.y = y
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `def this` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Onion constructors are declared with `def this`, never a method sharing the class's name (`public ClassName(...) { }`, as in Java/C#).
- With an access modifier, the parser previously consumed it as an access-section marker and tripped on the class name expecting `:`; without a modifier, it tripped on the class name itself expecting a member declarator — neither case mentioned `def this`.
- Adds a `commonSyntaxHint` case (following the existing `switch`/`fun`/C-style-`for`/Java-style-`import` hints in `Parsing.scala`) that recognizes a capitalized identifier directly followed by `(` at member position and points at the correct `def this(...) { ... }` form.
- Bilingual (en/ja) hint text added to both `errorMessage.properties` bundles.

## Test plan

- [x] TDD: added `JavaStyleConstructorHintSpec` (modifier-prefixed, bare, no-arg, and negative cases) — confirmed red before the implementation, green after.
- [x] Added `JavaStyleConstructorHintI18nSpec` following the project's existing pattern for verifying a hint resolves correctly in both locale bundles.
- [x] Full suite: `SBT_OPTS="-Xmx11G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3983 succeeded, 0 failed, 1 canceled (pre-existing, environment-conditional distribution-packaging test), 524 suites.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GkrHWZndKfM1yiu8oiFJkF)_