### PR TITLE
fix(diagnostics): hint at `def` for a Java-style method declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leading `public`/`private`/`protected`) and points at the correct
   `def this(...) { ... }` form.
 
+- **Parser hint for a Java-style method with the return type before the name.**
+  Onion methods put their return type after the name via `def` (`def method():
+  void { ... }`); writing the Java form (`public void method() { ... }`) used
+  to trip the parser on the return-type identifier, expecting `:` (`public`/
+  `private`/`protected` are read as access-section markers, which only ever
+  appear as `public:`), without ever mentioning `def`. The diagnostic now
+  recognizes a leading access modifier followed by two identifiers before `(`
+  and points at the correct `public:` / `def method(): void { ... }` form.
+
 ## [0.15.0] - 2026-08-22
 
 ### Added

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -109,6 +109,7 @@ error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthe
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
+error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -109,6 +109,7 @@ error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこ�
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
+error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -302,6 +302,18 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val JavaStyleConstructor = """^\s*(?:public|private|protected)?\s*[A-Z][A-Za-z0-9_]*\s*\(""".r
 
+  /**
+   * A Java-style method declaration, `public void method() { }` (or `private`/`protected`,
+   * with any return-type spelling before the name). `public`/`private`/`protected` are
+   * access-*section* markers that only ever appear as `public:`, immediately followed by a
+   * colon -- every member's own return type instead comes after its name via `def`. The
+   * parser consumes the modifier and then trips on the return-type identifier that follows,
+   * expecting `:` -- never mentioning `def`. Requiring two identifiers (return type, then
+   * name) before the `(` keeps this from firing on the single-identifier
+   * `public ClassName(...)` constructor mistake, which gets its own hint.
+   */
+  private val JavaStyleMethodDeclaration = """^\s*(?:public|private|protected)\s+[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -326,6 +338,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.c_style_for")
     case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_import")
+    case _ if expected == "\":\"" && JavaStyleMethodDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.java_style_method")
     case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleConstructor.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_constructor")
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same

--- a/src/test/scala/onion/compiler/JavaStyleMethodHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleMethodHintI18nSpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-method hint (`commonSyntaxHint`'s `JavaStyleMethodDeclaration` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both locales, like every
+ * other hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class JavaStyleMethodHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_method"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `public void method() { }` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Point {
+        |  val x: Int
+        |  public void method() {
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("def"), s"expected the hint's `def` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleMethodHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleMethodHintSpec.scala
@@ -1,0 +1,80 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java-style method declaration -- `public void method() { }` -- with the return type
+ * before the name instead of using `def`. `public`/`private`/`protected` are access-*section*
+ * markers that only ever appear as `public:`, immediately followed by a colon; the parser
+ * consumes the modifier and then trips on the return-type identifier that follows, expecting
+ * `:` -- never mentioning `def` or the return type's actual position after the method name.
+ */
+class JavaStyleMethodHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style method declaration") {
+    it("hints at `def` for `public void method() { }` with no preceding section") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |  public void method() {
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def"), s"expected a hint mentioning `def`, got: $msgs")
+    }
+
+    it("hints at `def` for `private String getName() { }` inside a `public:` section") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val name: String
+          |public:
+          |  private String getName() {
+          |    return name
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def"), s"expected a hint mentioning `def`, got: $msgs")
+    }
+
+    it("does not fire for the correct `def` form") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |public:
+          |  def method(): void {
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `def` form, got: $msgs")
+    }
+
+    it("does not fire for the single-identifier Java-style constructor mistake") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |public:
+          |  public Point(x: Int) {
+          |    this.x = x
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def this"), s"expected the constructor hint, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `public void method() { }` (Java-style return-type-before-name) used to trip the parser on the return-type identifier, expecting `:`, without ever mentioning that Onion methods use `def method(): ReturnType { ... }`.
- Adds a `JavaStyleMethodDeclaration` pattern (leading `public`/`private`/`protected` followed by two identifiers before `(`) alongside the existing `JavaStyleConstructor` hint, so the diagnostic now points at the correct `public:` section marker + `def method(): void { ... }` form.
- Bilingual (en/ja) hint message, following the same pattern as the existing `java_style_constructor`/`java_style_import`/`c_style_for` hints.
- This exact mistake (`public void method()`) is already documented as wrong-vs-correct in `CLAUDE.md` / `docs/ja/CLAUDE_ja.md`'s syntax-mistakes tables; no doc changes were needed there.

## Test plan
- [x] New `JavaStyleMethodHintSpec` (asserts on the diagnostic text/`def`, not the JVM-locale-dependent full message)
- [x] New `JavaStyleMethodHintI18nSpec` (bilingual bundle resolution, per repo convention for hint messages)
- [x] Confirmed both specs fail before the fix (TDD red) and pass after (green)
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 3990 succeeded, 0 failed, 1 canceled (pre-existing)
- [x] Full suite green in Japanese locale: same command with `-Duser.language=ja` — 3990 succeeded, 0 failed, 1 canceled (pre-existing)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtFnAJ45V3acqqQ4YJ97KC)_