### PR TITLE
fix(diagnostics): hint at `is` for a Java/Scala-style type-pattern case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java/Scala-style type-pattern `select` case, `case s: String:`.**
+  Onion's `select` type patterns use `is` (`case s is String:`), never a colon after the
+  binding name. The parser used to read `s` alone as an ordinary value pattern and only
+  trip on the *second* colon meant to introduce the type, several characters later on the
+  same line, without ever mentioning `is`. The diagnostic now recognizes a `case <name>:
+  <Type>:` line and points at the correct `case s is String:` form.
+
 - **Parser hint for a C-style `for (init; cond; step)` loop.** Onion's `for` loop
   never parenthesizes its clauses; writing the C/Java/JS form used to trip the
   parser several tokens past the actual mistake with an unhelpful expected-token

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -110,6 +110,7 @@ error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
 error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
+error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not `:` — write `case s is String:`, not `case s: String:`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -110,6 +110,7 @@ error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっ�
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
 error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
+error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:` ではなく `is` を使います — `case s: String:` ではなく `case s is String:` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -314,11 +314,26 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val JavaStyleMethodDeclaration = """^\s*(?:public|private|protected)\s+[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
 
+  /**
+   * A Java/Scala-style type-pattern `select` case, `case s: String:` (or with extra
+   * spacing, `case s : String :`). Onion's `case` patterns use `is` for a type test
+   * (`case s is String:`) -- a colon straight after the binding name is never valid
+   * there, so the parser reads `s` alone as an ordinary value pattern (an
+   * ExpressionPattern) and only trips on the *second* colon that was meant to
+   * introduce the type, several characters later on the same line -- never
+   * mentioning `is`. Requiring a lower-case binding name (Onion's variable-naming
+   * convention) before the first colon and a capitalized type name before the
+   * second keeps this from firing on an ordinary multi-value case like `case 1, 2:`.
+   */
+  private val JavaStyleTypeCase = """^\s*case\s+[a-z_]\w*\s*:\s*[A-Z][\w.\[\]]*\??\s*:""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
     case "<:" =>
       Message("error.parsing.hint.old_conforms")
+    case ":" if JavaStyleTypeCase.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.case_type_colon")
     case ":" if expected.contains("extends") =>
       Message("error.parsing.hint.old_extends")
     // The removed anonymous super-call form: `def this(x) : (x) { }`. After the colon the

--- a/src/test/scala/onion/compiler/CaseTypeColonHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/CaseTypeColonHintI18nSpec.scala
@@ -1,0 +1,53 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The case-type-colon hint (`commonSyntaxHint`'s `JavaStyleTypeCase` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like every other
+ * hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class CaseTypeColonHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.case_type_colon"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java/Scala-style `case s: String:` type pattern") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Sample {
+        |public:
+        |  def describe(x: Object): String = {
+        |    select x {
+        |    case s: String:
+        |      return s
+        |    else:
+        |      return "other"
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("case s is String"), s"expected the hint's `case s is String` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/CaseTypeColonHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CaseTypeColonHintSpec.scala
@@ -1,0 +1,62 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java/Scala-style type-pattern case, `case s: String:`. Onion's `select` uses `is`
+ * for a type test (`case s is String:`); a colon after the binding name is never valid
+ * there, so the parser consumes `s` as an ordinary value pattern and trips several
+ * characters later, on the *second* colon that introduces the branch body -- never
+ * mentioning `is`.
+ */
+class CaseTypeColonHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java/Scala-style type-pattern case") {
+    it("hints at `is` for `case s: String:`") {
+      val msgs = messages(
+        """
+          |class Sample {
+          |public:
+          |  def describe(x: Object): String = {
+          |    select x {
+          |    case s: String:
+          |      return s
+          |    else:
+          |      return "other"
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("is"), s"expected a hint mentioning `is`, got: $msgs")
+      assert(msgs.contains("case s is String"), s"expected the hint's example, got: $msgs")
+    }
+
+    it("does not fire for the correct `case s is String:` form") {
+      val msgs = messages(
+        """
+          |class Sample {
+          |public:
+          |  def describe(x: Object): String = {
+          |    select x {
+          |    case s is String:
+          |      return s
+          |    else:
+          |      return "other"
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `case s is String:` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `select`'s type patterns use `is` (`case s is String:`), never a colon after the binding name — writing the Java/Scala-style `case s: String:` used to leave the parser reading `s` alone as an ordinary value pattern, tripping several characters later on the *second* colon meant to introduce the type, without ever mentioning `is`.
- Adds a `commonSyntaxHint` case that recognizes a `case <name>: <Type>:` line and points at the correct `case s is String:` form, following the same pattern as the existing C-style-for/Java-style-import/Java-style-constructor/Java-style-method hints.
- Adds the bilingual `error.parsing.hint.case_type_colon` message (en/ja).

## Test plan

- [x] TDD: added failing specs first (`CaseTypeColonHintSpec`, `CaseTypeColonHintI18nSpec`), confirmed red, then implemented the hint and confirmed green.
- [x] `sbt -Duser.language=en test` — 3982 tests, 0 failed (1 canceled: pre-existing environment-gated distribution smoke test, unrelated).
- [x] `sbt -Duser.language=ja testFull` — 3995 tests, 0 failed (same 1 canceled).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159XRLfFQsE1SaJQC4UVLaH)_