### PR TITLE
fix(diagnostics): hint at extension block for `fun Type.method(...)` receiver syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Kotlin-style extension-function declaration, `fun String.twice() { }`.**
+  The existing `fun`/`func`/`fn` hint only matched `<kw> name(`, so a receiver-dot
+  declaration (the identifier after the keyword is the receiver *type*, followed by
+  `.`, not `(`) never matched and fell through to a generic parse error instead of
+  naming Onion's `def`-based equivalent. The diagnostic now recognizes `fun
+  Type.method(` (and the `func`/`fn` spellings) and points at the correct `extension
+  Type { def method(...) { ... } }` form, naming the captured receiver type and
+  method.
+
 - **Parser hint for a Java/Scala-style type-pattern `select` case, `case s: String:`.**
   Onion's `select` type patterns use `is` (`case s is String:`), never a colon after the
   binding name. The parser used to read `s` alone as an ordinary value pattern and only

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -104,6 +104,7 @@ error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn` keyword. Write `def name(...): ReturnType { ... }`.
+error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -104,6 +104,7 @@ error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉�
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
+error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -262,6 +262,17 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val FunDeclaration = """\b(?:fun|func|fn)\s+[A-Za-z_]\w*\s*\(""".r
 
   /**
+   * A Kotlin-style extension-function declaration, `fun String.twice(): String { ... }`.
+   * This is a more specific form of the `fun`/`func`/`fn` mistake above: the receiver-dot
+   * syntax means [[FunDeclaration]]'s `<kw> name(` pattern never matches -- the identifier
+   * directly after the keyword is the *receiver type*, followed by `.`, not `(` -- so without
+   * its own case this would fall through to the generic parse error instead of naming Onion's
+   * `extension` block. Capturing the receiver type and method name lets the hint show the
+   * exact rewrite instead of just pointing at `def`.
+   */
+  private val FunExtensionDeclaration = """\b(?:fun|func|fn)\s+([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\(""".r
+
+  /**
    * A Java-style parenthesized catch clause, `catch (e: Exception) { }`. `catch`
    * is a real keyword in Onion, but its variable is never parenthesized -- the
    * parser expects the binding name directly after `catch` and trips on the `(`.
@@ -347,6 +358,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_for_in")
     case _ if LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.switch_not_supported")
+    case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+      val m = FunExtensionDeclaration.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.fun_extension_declaration", m.group(1), m.group(2))
     case _ if FunDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.fun_declaration")
     case _ if CStyleForLoop.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/FunExtensionDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/FunExtensionDeclarationHintI18nSpec.scala
@@ -1,0 +1,42 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Kotlin-style extension-function hint (`commonSyntaxHint`'s `FunExtensionDeclaration`
+ * case) must resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that match -- see OldForInHintI18nSpec for the motivating
+ * regression.
+ */
+class FunExtensionDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.fun_extension_declaration"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Kotlin-style `fun String.twice(): String { }` extension declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src = "fun String.twice(): String { return this + this }\n"
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("extension String"), s"expected the hint's `extension String` example, got: $msgs")
+    assert(msgs.contains("def twice"), s"expected the hint's `def twice` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/FunExtensionDeclarationHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FunExtensionDeclarationHintSpec.scala
@@ -1,0 +1,48 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Kotlin-style extension-function declaration, `fun String.twice(): String { ... }`,
+ * is a more specific mistake than the bare `fun name(...)` case ([[FunDeclarationHintSpec]]):
+ * the receiver-dot syntax means the generic `fun`/`func`/`fn` hint's `<kw> name(` pattern
+ * never matches (the identifier right after the keyword is the receiver type, followed by
+ * `.`, not `(`), so without its own case this falls through to a generic parse error
+ * instead of naming Onion's `extension` block.
+ */
+class FunExtensionDeclarationHintSpec extends AbstractShellSpec {
+  private def messages(src: String): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  describe("fun Type.method(...) extension declaration") {
+    it("hints at an extension block for a top-level Kotlin-style receiver method") {
+      val msgs = messages("fun String.twice(): String { return this + this }\n")
+      assert(msgs.contains("extension"), s"expected a hint mentioning extension, got: $msgs")
+      assert(msgs.contains("String"), s"expected the hint to name the receiver type, got: $msgs")
+      assert(msgs.contains("twice"), s"expected the hint to name the method, got: $msgs")
+    }
+
+    it("hints at an extension block for a func-spelled receiver method") {
+      val msgs = messages("func Int.doubled(): Int { return this * 2 }\n")
+      assert(msgs.contains("extension"), s"expected a hint mentioning extension, got: $msgs")
+      assert(msgs.contains("doubled"), s"expected the hint to name the method, got: $msgs")
+    }
+
+    it("still hints at def (not extension) for a receiver-less fun declaration") {
+      val msgs = messages("fun greet(): void { IO::println(\"hi\") }\n")
+      assert(msgs.contains("def"), s"expected a hint mentioning def, got: $msgs")
+      assert(!msgs.contains("extension"), s"receiver-less fun should not mention extension, got: $msgs")
+    }
+
+    it("does not fire for a call to a method literally named fun") {
+      val msgs = messages("val x = fun(1, 2)\n")
+      assert(!msgs.contains("extension"), s"hint should not fire for a fun(...) call, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- The existing Kotlin-style `fun`/`func`/`fn` hint (`FunDeclaration` in `Parsing.scala`) only matches `<kw> name(`. A receiver-dot extension-function declaration such as `fun String.twice(): String { ... }` has `.` between the receiver type and the method name, so it never matched and silently fell through to a generic parse error, missing the exact rewrite CLAUDE.md documents (`extension String { def twice() { } }`).
- Adds a more specific `FunExtensionDeclaration` regex/case, checked before the generic `fun` case, that captures the receiver type and method name and points at the correct `extension Type { def method(...) { ... } }` form (also covers `func`/`fn` spellings).
- New bilingual message key `error.parsing.hint.fun_extension_declaration` in both `errorMessage.properties` and `errorMessage_ja.properties`.

## Test plan

- [x] New `FunExtensionDeclarationHintI18nSpec` (bilingual message-bundle resolution + locale-agnostic fire assertion, mirrors `JavaStyleConstructorHintI18nSpec`)
- [x] New `FunExtensionDeclarationHintSpec` (behavioral coverage: `fun`/`func` receiver forms, receiver-less `fun` still hints `def` not `extension`, `fun(...)` call still doesn't fire)
- [x] Confirmed both new specs failed before the fix (red) and pass after (green)
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4002 succeeded, 0 failed, 1 canceled (pre-existing opt-in dist smoke test, gated by an unset system property)
- [x] Full suite green in Japanese locale: same command with `-Duser.language=ja` — 4002 succeeded, 0 failed, 1 canceled (same pre-existing skip)

## Changelog

Added an entry under `[Unreleased]` / Fixed.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_014XwSKaN32cpgXbqiLJNUMV)_