### PR TITLE
fix(diagnostics): hint at `[...]` for a Java/C++-style generic `List&lt;String&gt;`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a Java/C++-style generic with angle brackets, `List<String>`.**
+  Onion's generics use square brackets (`List[String]`) — `<`/`>` are only comparison
+  operators, never valid inside a type — so in a type-annotation position (a `val`/`var`
+  declaration, a parameter type, ...) the parser accepted the bare type name and then
+  tripped several tokens later on the `<`, expecting the declaration to end (`=`, `;`, a
+  newline, ...), never mentioning `[`. The diagnostic now recognizes `Type<Args>` in a
+  type position and points at the correct `Type[Args]` form, naming the captured type
+  and its arguments.
+
 ## [0.16.0] - 2026-08-22
 
 ### Added

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -112,6 +112,7 @@ error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — wri
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
 error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
 error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not `:` — write `case s is String:`, not `case s: String:`.
+error.parsing.hint.java_style_generics=Hint: generics use square brackets, not angle brackets — write `{0}[{1}]`, not `{0}<{1}>`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -112,6 +112,7 @@ error.parsing.hint.java_style_import=ヒント: import は波かっこで囲み�
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
 error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
 error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:` ではなく `is` を使います — `case s: String:` ではなく `case s is String:` と書いてください。
+error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっこではなく角かっこを使います — `{0}<{1}>` ではなく `{0}[{1}]` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -338,6 +338,17 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val JavaStyleTypeCase = """^\s*case\s+[a-z_]\w*\s*:\s*[A-Z][\w.\[\]]*\??\s*:""".r
 
+  /**
+   * A Java/C++-style generic type with angle brackets, `List<String>`, in a type
+   * position (a `val`/`var` declaration's type, a parameter type, ...). Onion's
+   * generics use square brackets (`List[String]`) -- `<`/`>` are only comparison
+   * operators, never valid inside a type -- so the parser accepts the bare type
+   * name and then trips on the `<`, expecting the declaration to end (`=`, `;`,
+   * a newline, ...), never mentioning `[`. Capturing the base type name and the
+   * (non-nested) argument list lets the hint show the exact rewrite.
+   */
+  private val JavaStyleGenericAngleBrackets = """\b([A-Z][A-Za-z0-9_]*)<([A-Za-z_][\w\s,\[\]?]*)>""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -345,6 +356,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_conforms")
     case ":" if JavaStyleTypeCase.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.case_type_colon")
+    case "<" if JavaStyleGenericAngleBrackets.findFirstMatchIn(sourceLine).isDefined =>
+      val m = JavaStyleGenericAngleBrackets.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.java_style_generics", m.group(1), m.group(2).trim)
     case ":" if expected.contains("extends") =>
       Message("error.parsing.hint.old_extends")
     // The removed anonymous super-call form: `def this(x) : (x) { }`. After the colon the

--- a/src/test/scala/onion/compiler/JavaStyleGenericsHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleGenericsHintI18nSpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-generics hint (`commonSyntaxHint`'s `JavaStyleGenericAngleBrackets` case)
+ * must resolve through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class JavaStyleGenericsHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_generics"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `List<String>` type") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |  static def main(args: String[]): void {
+        |    var xs: List<String> = null
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The rewritten type shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("List[String]"), s"expected the hint's `List[String]` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleGenericsHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleGenericsHintSpec.scala
@@ -1,0 +1,73 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java/C++-style generic type with angle brackets, `List<String>`, in a type-annotation
+ * position (a `val`/`var` declaration, a parameter type, ...). Onion's generics use square
+ * brackets (`List[String]`) -- `<` and `>` are only comparison operators, never valid in a
+ * type -- so the parser accepts the bare type name and then trips on the `<`, expecting the
+ * declaration to end (`=`, `;`, newline, ...), never mentioning `[`.
+ */
+class JavaStyleGenericsHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style generic angle brackets") {
+    it("hints at `[...]` for a `var` declaration's type") {
+      val msgs = messages(
+        """
+          |class Main {
+          |  static def main(args: String[]): void {
+          |    var xs: List<String> = null
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("List[String]"), s"expected a hint mentioning `List[String]`, got: $msgs")
+    }
+
+    it("hints at `[...]` for a `val` declaration's type") {
+      val msgs = messages(
+        """
+          |class Main {
+          |  static def main(args: String[]): void {
+          |    val b: Box<String> = null
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("Box[String]"), s"expected a hint mentioning `Box[String]`, got: $msgs")
+    }
+
+    it("hints at `[...]` for a parameter's type") {
+      val msgs = messages(
+        """
+          |class Main {
+          |  static def foo(x: List<String>): void { }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("List[String]"), s"expected a hint mentioning `List[String]`, got: $msgs")
+    }
+
+    it("does not fire for the correct `List[String]` form") {
+      val msgs = messages(
+        """
+          |class Main {
+          |  static def main(args: String[]): void {
+          |    var xs: List[String] = null
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `List[String]` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Onion's generics use square brackets (`List[String]`), not angle brackets — `<`/`>` are only comparison operators, never valid inside a type. In a type-annotation position (a `val`/`var` declaration's type, a parameter type, ...), the parser used to accept the bare type name and then trip several tokens later on the `<`, expecting the declaration to end (`=`, `;`, a newline, ...), never mentioning `[`.
- The diagnostic now recognizes `Type<Args>` in a type position and points at the correct `Type[Args]` form, naming the captured type and its arguments (mirrors the existing `commonSyntaxHint` hints for other Java/Scala/Kotlin-style mistakes in `Parsing.scala`).
- Added bilingual (en/ja) hint message and a `CHANGELOG.md` entry.

## Test plan

- [x] New `JavaStyleGenericsHintSpec` (fires for `var`/`val`/parameter type positions; does not fire for correct `List[String]`)
- [x] New `JavaStyleGenericsHintI18nSpec` (resolves in both locales, actual Japanese text, hint text is locale-agnostic)
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4009 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution/packaging test)
- [x] Full suite green in Japanese locale: same command with `-Duser.language=ja` — 4009 succeeded, 0 failed, 1 canceled (same pre-existing test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MUvNzsYx4mrk1kJzFcBtwi)_