### PR TITLE
fix(diagnostics): hint at `::` for a Java-style dot static call on a primitive type name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java-style dot static call on a primitive type name, `Long.toString(3L)`.**
+  `Int`/`Long`/`Double`/`Float`/`Boolean`/`Byte`/`Short`/`Char` are reserved keyword
+  tokens, valid only in a type position or directly before `::` for static member
+  access (`Long::toString(3L)`) — they can never start a value expression. So writing
+  the Java-style dot form doesn't fail on the `.`; the parser trips on the type name
+  itself, since no expression can start with that token, producing a generic
+  expected-token dump that never mentions `::`. The diagnostic now recognizes a
+  primitive type name directly followed by `.member` and points at the correct
+  `Type::member` form, naming the captured type and member.
+
 - **Parser hint for a Java/C++-style generic with angle brackets, `List<String>`.**
   Onion's generics use square brackets (`List[String]`) — `<`/`>` are only comparison
   operators, never valid inside a type — so in a type-annotation position (a `val`/`var`

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -113,6 +113,7 @@ error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `
 error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
 error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not `:` — write `case s is String:`, not `case s: String:`.
 error.parsing.hint.java_style_generics=Hint: generics use square brackets, not angle brackets — write `{0}[{1}]`, not `{0}<{1}>`.
+error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value — static members are accessed with `::`, not `.` — write `{0}::{1}`, not `{0}.{1}`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -113,6 +113,7 @@ error.parsing.hint.java_style_constructor=ヒント: コンストラクタはク
 error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
 error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:` ではなく `is` を使います — `case s: String:` ではなく `case s is String:` と書いてください。
 error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっこではなく角かっこを使います — `{0}<{1}>` ではなく `{0}[{1}]` と書いてください。
+error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型の名前です — 静的メンバーには `.` ではなく `::` を使います — `{0}.{1}` ではなく `{0}::{1}` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -349,6 +349,20 @@ class Parsing(config: CompilerConfig) extends AnyRef
    */
   private val JavaStyleGenericAngleBrackets = """\b([A-Z][A-Za-z0-9_]*)<([A-Za-z_][\w\s,\[\]?]*)>""".r
 
+  /**
+   * `Int`/`Long`/`Double`/`Float`/`Boolean`/`Byte`/`Short`/`Char` are reserved keyword
+   * tokens, valid only in a type position or directly before `::` for static member
+   * access (`Long::toString(3L)`) -- they can never start a value expression. So a
+   * Java-style `Long.toString(3L)` (dot instead of `::`) doesn't fail on the `.`; the
+   * parser trips on `Long` itself, since no expression can start with that token, and
+   * the generic expected-token dump never mentions `::`. Matching the *found* token
+   * against this set and the text right after it against this pattern (starting at the
+   * found token, like the other context-based hints above) recovers the member name for
+   * the rewrite.
+   */
+  private val PrimitiveTypeNames = Set("Int", "Long", "Double", "Float", "Boolean", "Byte", "Short", "Char")
+  private val DotAfterPrimitiveTypeName = """\A[A-Za-z]+\s*\.\s*([A-Za-z_]\w*)""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -377,6 +391,13 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.fun_extension_declaration", m.group(1), m.group(2))
     case _ if FunDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.fun_declaration")
+    // Checked after the `fun`/`func`/`fn` declaration hints above: `func Int.doubled()`
+    // is an extension-method mistake first (wrong keyword, no `extension` block) and a
+    // dot-vs-`::` mistake only incidentally, so the more specific extension-block hint
+    // must win when both match the same line.
+    case name if PrimitiveTypeNames.contains(name) && DotAfterPrimitiveTypeName.findFirstMatchIn(context).isDefined =>
+      val member = DotAfterPrimitiveTypeName.findFirstMatchIn(context).get.group(1)
+      Message("error.parsing.hint.primitive_dot_static", name, member)
     case _ if CStyleForLoop.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.c_style_for")
     case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/PrimitiveDotStaticCallHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/PrimitiveDotStaticCallHintI18nSpec.scala
@@ -1,0 +1,49 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The primitive-dot-static-call hint (`commonSyntaxHint`'s `PrimitiveDotStaticCall` case)
+ * must resolve through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class PrimitiveDotStaticCallHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.primitive_dot_static"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style dot static call on a primitive type name") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    IO::println(Long.toString(3L))
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example call shown in the hint is literal code, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("Long::toString"), s"expected the hint's example call, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/PrimitiveDotStaticCallHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/PrimitiveDotStaticCallHintSpec.scala
@@ -1,0 +1,69 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * `Int`/`Long`/`Double`/... are reserved keyword tokens in Onion, valid only in a type
+ * position or before `::` for static member access (`Long::toString(3L)`) -- they can
+ * never start a value expression. So a Java-style `Long.toString(3L)` (dot instead of
+ * `::`) doesn't fail on the `.`; the parser trips on `Long` itself, since no expression
+ * can start with that token, and the resulting message is a generic expected-token dump
+ * that never mentions `::`.
+ */
+class PrimitiveDotStaticCallHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style dot access on a primitive type name") {
+    it("hints at `::` for `Long.toString(3L)`") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    IO::println(Long.toString(3L))
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("Long::toString"), s"expected a hint mentioning `Long::toString`, got: $msgs")
+    }
+
+    it("hints for other primitive type names too, e.g. `Int.parseInt(...)`") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val n = Int.parseInt("3")
+          |    return n
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("Int::parseInt"), s"expected a hint mentioning `Int::parseInt`, got: $msgs")
+    }
+
+    it("does not fire for the correct `::` form") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    IO::println(Long::toString(3L))
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `::` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `Int`/`Long`/`Double`/`Float`/`Boolean`/`Byte`/`Short`/`Char` are reserved keyword tokens in Onion, valid only in a type position or directly before `::` for static member access (`Long::toString(3L)`) — they can never start a value expression.
- Writing the Java-style dot form, `Long.toString(3L)`, doesn't fail on the `.`; the parser trips on `Long` itself (no expression can start with that token), producing a generic expected-token dump that never mentions `::`.
- Adds a parser hint (following the same pattern as the existing `JavaStyleGenerics`/`JavaStyleImport`/... hints) that recognizes a primitive type name directly followed by `.member` and points at the correct `Type::member` form, naming the captured type and member.
- Checked *after* the existing `fun`/`func`/`fn` extension-method hints, so a genuine `func Int.doubled()` mistake still gets the more specific extension-block hint instead of this one.
- Bilingual (`en`/`ja`) message bundle entries added, with dedicated specs (a behavior spec + an i18n-bundle-resolution spec) following the existing hint-testing conventions.

## Test plan

- [x] New tests added first (TDD), confirmed red before the fix
- [x] `PrimitiveDotStaticCallHintSpec` / `PrimitiveDotStaticCallHintI18nSpec` green
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4015 succeeded, 0 failed, 1 canceled (a pre-existing, self-guarded distribution smoke test unrelated to this change)
- [x] Full suite green in Japanese locale: same command with `-Duser.language=ja` — 4015 succeeded, 0 failed, 1 canceled

`CHANGELOG.md`'s `[Unreleased]` section updated.


---
_Generated by [Claude Code](https://claude.ai/code/session_017VdVWfM9gm4bFntDi6r8Ku)_