### PR TITLE
Add parser hint for Java-style field/local declarations without val/var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java-style field or local declaration, `String name;` / `String name = "x";`.**
+  Onion fields and locals are declared with `val`/`var` before the name (`var name: String`),
+  never with the type before it. As a class member the parser trips on the type identifier
+  itself, expecting a member declarator (`def`, `val`, `var`, ...); as a local statement the
+  type is read as a bare expression and the parser trips on the name that follows, expecting
+  a statement terminator. Neither mentions `val`/`var`. The diagnostic now recognizes a
+  capitalized type name (optionally bracketed or nullable) directly followed by a second
+  identifier and `=`/`;`/end-of-line, and points at the correct `var name: Type` form, naming
+  the captured type and name.
+
 - **Parser hint for a Java-style dot static call on a primitive type name, `Long.toString(3L)`.**
   `Int`/`Long`/`Double`/`Float`/`Boolean`/`Byte`/`Short`/`Char` are reserved keyword
   tokens, valid only in a type position or directly before `::` for static member

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,7 @@ These are frequently confused with other languages. **Always check these:**
 | `public ClassName(x: Int) { }` | `def this(x: Int) { }` - with params |
 | `catch (e: Exception) { }` | `catch e: Exception { }` - no parentheses |
 | `public void method()` | `public: def method(): void` - section-based access |
+| `String name;` (field/local) | `var name: String` (or `val`) - type comes after the name, via `val`/`var` |
 | `def method(): T { }` | `def method: T { }` - parentheses optional if no params |
 | `@Override void method()` | `override def method(): void` - keyword not annotation |
 | `fun String.twice()` (Kotlin) | `extension String { def twice() { } }` - extension block |

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -374,6 +374,7 @@ try {
 | `public ClassName(x: Int) { }` | `def this(x: Int) { }` - 引数付き |
 | `catch (e: Exception) { }` | `catch e: Exception { }` - 括弧なし |
 | `public void method()` | `public: def method(): void` - セクションベースのアクセス |
+| `String name;`（フィールド/ローカル） | `var name: String`（または`val`）- 型は名前の後、`val`/`var`を介して書く |
 | `def method(): T { }` | `def method: T { }` - 引数なしなら括弧省略可 |
 | `@Override void method()` | `override def method(): void` - アノテーションではなくキーワード |
 | `fun String.twice()` (Kotlin風) | `extension String { def twice() { } }` - extensionブロック |

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -111,6 +111,7 @@ error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
 error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
+error.parsing.hint.java_style_field=Hint: a field or local variable is declared with `val`/`var` before the name, not with the type before it — write `var {1}: {0}` (or `val {1}: {0}` if it never changes), not `{0} {1}`.
 error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not `:` — write `case s is String:`, not `case s: String:`.
 error.parsing.hint.java_style_generics=Hint: generics use square brackets, not angle brackets — write `{0}[{1}]`, not `{0}<{1}>`.
 error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value — static members are accessed with `::`, not `.` — write `{0}::{1}`, not `{0}.{1}`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -111,6 +111,7 @@ error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっ�
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
 error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
+error.parsing.hint.java_style_field=ヒント: フィールドやローカル変数は名前の前に型ではなく `val`/`var` を書いて宣言します — `{0} {1}` ではなく `var {1}: {0}`（値が変わらないなら `val {1}: {0}`）と書いてください。
 error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:` ではなく `is` を使います — `case s: String:` ではなく `case s is String:` と書いてください。
 error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっこではなく角かっこを使います — `{0}<{1}>` ではなく `{0}[{1}]` と書いてください。
 error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型の名前です — 静的メンバーには `.` ではなく `::` を使います — `{0}.{1}` ではなく `{0}::{1}` と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -326,6 +326,22 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val JavaStyleMethodDeclaration = """^\s*(?:public|private|protected)\s+[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
 
   /**
+   * A Java-style field or local-variable declaration, `String name;` or
+   * `String name = "x";`, that puts the type before the name instead of using
+   * `val`/`var`. As a class member this trips the parser on the type identifier
+   * itself, expecting a member declarator (`def`, `val`, `var`, ...); as a local
+   * statement the type is read as a bare expression and the parser trips on the
+   * name that follows, expecting a statement terminator. Neither mentions
+   * `val`/`var`. Requiring a capitalized leading identifier (Java/Onion type-naming
+   * convention), optionally bracketed (`List[String]`) or nullable (`String?`),
+   * directly followed by a second identifier and then `=`/`;`/end-of-line keeps
+   * this from firing on an ordinary call or expression -- a call's next
+   * non-whitespace character after the name is always `(`, never a second name.
+   */
+  private val JavaStyleFieldDeclaration =
+    """^\s*(?:public|private|protected)?\s*([A-Z][A-Za-z0-9_]*(?:\[[^\]]*\])?\??)\s+([A-Za-z_]\w*)\s*(?:=|;|$)""".r
+
+  /**
    * A Java/Scala-style type-pattern `select` case, `case s: String:` (or with extra
    * spacing, `case s : String :`). Onion's `case` patterns use `is` for a type test
    * (`case s is String:`) -- a colon straight after the binding name is never valid
@@ -406,6 +422,12 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.java_style_method")
     case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleConstructor.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_constructor")
+    // Checked after the constructor/method hints above, whose own patterns (a lone
+    // capitalized identifier, or two identifiers before `(`) would otherwise shadow it:
+    // this one has no `(` at all -- `Type name` ends in `=`, `;`, or end-of-line.
+    case _ if JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+      val m = JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.java_style_field", m.group(1), m.group(2))
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/JavaStyleFieldHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleFieldHintI18nSpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-field hint (`commonSyntaxHint`'s `JavaStyleFieldDeclaration` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both locales, like every
+ * other hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class JavaStyleFieldHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_field"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `String name;` field declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Point {
+        |  String name;
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("var name: String"), s"expected the hint's `var name: String` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleFieldHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleFieldHintSpec.scala
@@ -1,0 +1,91 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java-style field or local-variable declaration -- `String name;` or
+ * `String name = "x";` -- that puts the type before the name instead of using
+ * `val`/`var`. As a class member the parser trips on the type identifier itself,
+ * expecting a member declarator; as a local statement the type is read as a bare
+ * expression and the parser trips on the name that follows. Neither mentions
+ * `val`/`var`.
+ */
+class JavaStyleFieldHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style field/local declaration") {
+    it("hints at `val`/`var` for a field declared `String name;`") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  String name;
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("var name: String"), s"expected a hint mentioning `var name: String`, got: $msgs")
+    }
+
+    it("hints at `val`/`var` for a local declared `String x = \"a\";`") {
+      val msgs = messages(
+        """
+          |def main: void {
+          |  String x = "a"
+          |  IO::println(x)
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("var x: String"), s"expected a hint mentioning `var x: String`, got: $msgs")
+    }
+
+    it("hints at `val`/`var` for a bracketed generic type, `List[String] items;`") {
+      val msgs = messages(
+        """
+          |class Box {
+          |  List[String] items;
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("var items: List[String]"), s"expected a hint mentioning `var items: List[String]`, got: $msgs")
+    }
+
+    it("does not fire for the correct `var name: String` field form") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  var name: String
+          |public:
+          |  def this(n: String) { name = n }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `var name: String` form, got: $msgs")
+    }
+
+    it("does not fire for an ordinary constructor call statement") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |public:
+          |  def this(x: Int) { self.x = x }
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): void {
+          |    val p: Point = new Point(3)
+          |    IO::println(p)
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for an ordinary `new Point(3)` call, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a parser diagnostic hint for the Java-style field/local declaration mistake, `String name;` or `String name = "x";`, which puts the type before the name instead of using `val`/`var`.
- As a class member, the parser currently trips on the type identifier itself, expecting a member declarator (`def`, `val`, `var`, ...); as a local statement, the type is read as a bare expression and the parser trips on the name that follows, expecting a statement terminator. Neither existing error mentions `val`/`var`.
- The new hint recognizes a capitalized leading type name (optionally bracketed, e.g. `List[String]`, or nullable, e.g. `String?`) directly followed by a second identifier and `=`/`;`/end-of-line, and points at the correct `var name: Type` form, naming the captured type and name.
- Adds bilingual (en/ja) hint message resolution, keeps `CLAUDE.md` / `docs/ja/CLAUDE_ja.md` common-mistakes tables in sync, and records the change in `CHANGELOG.md`.

## Test plan

- [x] New TDD specs: `src/test/scala/onion/compiler/tools/JavaStyleFieldHintSpec.scala` (fires for a field, a local, a bracketed generic type; does not fire for the correct `var` form or an ordinary constructor call)
- [x] New i18n spec: `src/test/scala/onion/compiler/JavaStyleFieldHintI18nSpec.scala` (resolves in both bundles, no leaked untranslated text)
- [x] Full suite, English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4035 tests, 0 failed, 1 pre-existing unrelated cancellation (`ProjectDistributionSpec`, gated on a system property)
- [x] Full suite, Japanese locale: same command with `-Duser.language=ja` — 4035 tests, 0 failed, same cancellation

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqkPpiaBrLUaEbMCdXBMd7)_