### PR TITLE
Add parser hint for a Java/C#-style import alias, `Foo = pkg.Class;`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java/C#-style import alias written before the target, `Foo = java.lang.Long;`.**
+  Onion's import aliases follow the target (`java.lang.Long as Foo`), never precede it with
+  `=`. An import entry parses as a bare qualified name with an optional trailing `as alias`,
+  so the parser reads the leading identifier as the start of that name and trips on the `=`,
+  expecting only `.` to continue it — never mentioning `as`. The diagnostic now recognizes
+  this shape and points at the correct `Target as Alias` form, naming the captured target
+  and alias.
+
 - **Parser hint for a Java-style field or local declaration, `String name;` / `String name = "x";`.**
   Onion fields and locals are declared with `val`/`var` before the name (`var name: String`),
   never with the type before it. As a class member the parser trips on the type identifier

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -109,6 +109,7 @@ error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
+error.parsing.hint.java_style_import_alias=Hint: an import''s alias is named with `as`, not `=` — write `{0} as {1}`, not `{1} = {0}`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
 error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
 error.parsing.hint.java_style_field=Hint: a field or local variable is declared with `val`/`var` before the name, not with the type before it — write `var {1}: {0}` (or `val {1}: {0}` if it never changes), not `{0} {1}`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -109,6 +109,7 @@ error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` 
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
+error.parsing.hint.java_style_import_alias=ヒント: import のエイリアスは `=` ではなく `as` で指定します — `{1} = {0}` ではなく `{0} as {1}` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
 error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
 error.parsing.hint.java_style_field=ヒント: フィールドやローカル変数は名前の前に型ではなく `val`/`var` を書いて宣言します — `{0} {1}` ではなく `var {1}: {0}`（値が変わらないなら `val {1}: {0}`）と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -301,6 +301,19 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val JavaStyleImport = """^\s*import\s+(?!\{)\S""".r
 
   /**
+   * A Java/C#-style import alias written before the target, `Foo = java.lang.Long`,
+   * instead of Onion's `java.lang.Long as Foo`. Import entries are parsed as a bare
+   * qualified name (`import_id() "."` repeated) with an optional trailing `as alias`
+   * -- so the parser reads the leading identifier as the start of that qualified name
+   * and trips on the `=`, expecting `.` to continue it, never mentioning `as`. That
+   * "expecting only a bare `.`" shape is unique to this production (an ordinary
+   * assignment statement never fails to parse this way), so no import-keyword context
+   * is needed to scope it.
+   */
+  private val JavaStyleImportAlias =
+    """^\s*([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\.\*)?)\s*;?\s*$""".r
+
+  /**
    * A Java-style constructor, named after the class instead of using `def this`:
    * `public ClassName(...) { }`, or the same with no access modifier. `public`/
    * `private`/`protected` are real keywords (access-section markers), so with a
@@ -418,6 +431,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.c_style_for")
     case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_import")
+    case "=" if expected == "\".\"" && JavaStyleImportAlias.findFirstMatchIn(sourceLine).isDefined =>
+      val m = JavaStyleImportAlias.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.java_style_import_alias", m.group(2), m.group(1))
     case _ if expected == "\":\"" && JavaStyleMethodDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_method")
     case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleConstructor.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/JavaStyleImportAliasHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleImportAliasHintI18nSpec.scala
@@ -1,0 +1,53 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-import-alias hint (`commonSyntaxHint`'s `JavaStyleImportAlias` case)
+ * must resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that match -- see OldForInHintI18nSpec for the motivating
+ * regression.
+ */
+class JavaStyleImportAliasHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_import_alias"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style import alias written before the target") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |import {
+        |  Foo = java.lang.Long;
+        |}
+        |
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The captured identifiers are literal source text, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("java.lang.Long as Foo"), s"expected the hint's `java.lang.Long as Foo` rewrite, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleImportAliasHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleImportAliasHintSpec.scala
@@ -1,0 +1,112 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java/C#-style import alias written before the target, `Foo = java.lang.Long`,
+ * instead of Onion's `java.lang.Long as Foo`. Import entries parse as a bare
+ * qualified name with an optional trailing `as alias`, so the parser reads the
+ * leading identifier as the start of that qualified name and trips on the `=`,
+ * expecting `.` to continue it -- never mentioning `as`.
+ */
+class JavaStyleImportAliasHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style import alias") {
+    it("hints at `as` for `Foo = java.lang.Long;` inside an import block") {
+      val msgs = messages(
+        """
+          |import {
+          |  Foo = java.lang.Long;
+          |}
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("java.lang.Long as Foo"), s"expected a hint mentioning `java.lang.Long as Foo`, got: $msgs")
+    }
+
+    it("hints at `as` with no trailing semicolon") {
+      val msgs = messages(
+        """
+          |import {
+          |  JLong = java.lang.Long
+          |}
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("java.lang.Long as JLong"), s"expected a hint mentioning `java.lang.Long as JLong`, got: $msgs")
+    }
+
+    it("does not fire for the correct `as` alias form") {
+      val msgs = messages(
+        """
+          |import {
+          |  java.lang.Long as JLong;
+          |}
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `as` alias form, got: $msgs")
+    }
+
+    it("does not fire for an ordinary assignment statement") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    var x: Int = 0
+          |    x = 5
+          |    return x
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for an ordinary assignment statement, got: $msgs")
+    }
+
+    it("does not fire for an unrelated `module foo = bar` mistake") {
+      // A malformed `module` declaration's expected-token set also lists `.` (among
+      // `;`, a newline, ...), since `module` parses a dotted qualified name too -- but
+      // as one option among several, never as the sole expected token the way an
+      // import entry's does. This guards against matching on that broader set.
+      val msgs = messages(
+        """
+          |module foo = bar
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains(" as "), s"expected no import-alias hint for an unrelated `module` mistake, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion's import aliases follow the target (`java.lang.Long as Foo`), never precede it with `=` (`Foo = java.lang.Long`). An import entry parses as a bare qualified name with an optional trailing `as alias`, so writing the alias first makes the parser read the identifier as the start of that qualified name and trip on `=`, expecting only `.` to continue it — the generic error never mentions `as`.
- Adds a `commonSyntaxHint` case (`Parsing.scala`) that recognizes this shape (guarded on the single-expected-token `.` case, which is unique to the import-entry production, so it does not misfire on an unrelated parse failure like a malformed `module foo = bar` declaration whose expected-token set also happens to include `.` among others) and points at the correct `Target as Alias` form, naming the captured target and alias.
- Adds bilingual (`errorMessage.properties` / `errorMessage_ja.properties`) hint text following the existing `error.parsing.hint.*` conventions.
- Adds a behavior spec (`JavaStyleImportAliasHintSpec`) and a locale-independence spec (`JavaStyleImportAliasHintI18nSpec`), matching the pattern of the existing `JavaStyleImport*` hint tests.
- Notes the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.JavaStyleImportAliasHintSpec onion.compiler.JavaStyleImportAliasHintI18nSpec'` — 8/8 passed
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4043 succeeded, 0 failed, 1 canceled
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4043 succeeded, 0 failed, 1 canceled (same canceled test as the English run)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PjoAc5nooF7oqDfgbnuFB6)_