### PR TITLE
fix(diagnostics): hint at `def` for a Java-style method with no access modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java-style method declaration with no access modifier, `void greet(name: String) { }`.**
+  The existing hint for `public void method() { }` only matched when an access modifier
+  (`public`/`private`/`protected`) preceded the return type, since the parser trips on a
+  different token in that shape (`:`, expecting the modifier's section colon) than in the
+  no-modifier shape (the return-type identifier itself, expecting a member declarator like
+  `def`). The pattern and its guard now also recognize the bare `Type name(...)` form —
+  Java's package-private default, with no modifier at all — and point at the correct
+  `def name(...): Type { ... }` form. A negative lookahead keeps the now-optional modifier
+  from being skipped and reread as the return type, which would otherwise misfire on the
+  unrelated single-identifier `public ClassName(...)` constructor mistake.
+
 - **Parser hint for a Java/C#-style import alias written before the target, `Foo = java.lang.Long;`.**
   Onion's import aliases follow the target (`java.lang.Long as Foo`), never precede it with
   `=`. An import entry parses as a bare qualified name with an optional trailing `as alias`,

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -328,15 +328,21 @@ class Parsing(config: CompilerConfig) extends AnyRef
 
   /**
    * A Java-style method declaration, `public void method() { }` (or `private`/`protected`,
-   * with any return-type spelling before the name). `public`/`private`/`protected` are
-   * access-*section* markers that only ever appear as `public:`, immediately followed by a
-   * colon -- every member's own return type instead comes after its name via `def`. The
-   * parser consumes the modifier and then trips on the return-type identifier that follows,
-   * expecting `:` -- never mentioning `def`. Requiring two identifiers (return type, then
-   * name) before the `(` keeps this from firing on the single-identifier
-   * `public ClassName(...)` constructor mistake, which gets its own hint.
+   * or no modifier at all -- Java's package-private default -- with any return-type spelling
+   * before the name). `public`/`private`/`protected` are access-*section* markers that only
+   * ever appear as `public:`, immediately followed by a colon -- every member's own return
+   * type instead comes after its name via `def`. With a modifier, the parser consumes it and
+   * trips on the return-type identifier that follows, expecting `:`; with no modifier, a bare
+   * member declaration trips on the return-type identifier itself, expecting a member
+   * declarator (`def`, `val`, `var`, ...). Neither mentions `def`. Requiring two identifiers
+   * (return type, then name) before the `(` keeps this from firing on the single-identifier
+   * `public ClassName(...)` constructor mistake, which gets its own hint -- the negative
+   * lookahead stops the now-optional modifier group from being skipped and the modifier
+   * keyword itself reread as the return-type identifier, which would otherwise turn
+   * `public Point(x: Int)` (one identifier) into a false two-identifier match.
    */
-  private val JavaStyleMethodDeclaration = """^\s*(?:public|private|protected)\s+[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
+  private val JavaStyleMethodDeclaration =
+    """^\s*(?:public|private|protected)?\s*(?!public\b|private\b|protected\b)[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
 
   /**
    * A Java-style field or local-variable declaration, `String name;` or
@@ -434,7 +440,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
     case "=" if expected == "\".\"" && JavaStyleImportAlias.findFirstMatchIn(sourceLine).isDefined =>
       val m = JavaStyleImportAlias.findFirstMatchIn(sourceLine).get
       Message("error.parsing.hint.java_style_import_alias", m.group(2), m.group(1))
-    case _ if expected == "\":\"" && JavaStyleMethodDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+    case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleMethodDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_method")
     case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleConstructor.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.java_style_constructor")

--- a/src/test/scala/onion/compiler/tools/JavaStyleMethodHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleMethodHintSpec.scala
@@ -62,6 +62,30 @@ class JavaStyleMethodHintSpec extends AbstractShellSpec {
       assert(msgs.isEmpty, s"expected no errors for the correct `def` form, got: $msgs")
     }
 
+    it("hints at `def` for `void greet(name: String) { }` with no access modifier at all") {
+      val msgs = messages(
+        """
+          |class Greeter {
+          |public:
+          |  def this { }
+          |  void greet(name: String) {
+          |    IO::println(name)
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      // "def" alone is too weak here: the raw member-declarator expected-token
+      // dump for this shape ("abstract", "def", "final", ...) already contains
+      // the literal word, so a hint-specific phrase is required to prove the
+      // hint actually fired rather than trivially matching that dump. The hint
+      // message is bilingual, but its `def method(): void { ... }` code example
+      // is a literal, locale-invariant substring in both bundles.
+      assert(
+        msgs.contains("def method(): void { ... }"),
+        s"expected the java-style-method hint, got: $msgs"
+      )
+    }
+
     it("does not fire for the single-identifier Java-style constructor mistake") {
       val msgs = messages(
         """


### PR DESCRIPTION
## Summary

- The existing Java-style-method hint (`public void method() { }` → points at `def`) only fired when an access modifier preceded the return type. The parser trips on a different token depending on whether a modifier is present: with a modifier it expects `:` (the section colon); with no modifier, it expects a member declarator (`def`, `val`, `var`, ...). Only the modifier-present shape was recognized.
- Extends the pattern/guard so the bare `Type name(...) { }` form (Java's package-private default, e.g. `void greet(name: String) { }`) is also recognized and hinted.
- A negative lookahead stops the now-optional modifier group from being skipped and the modifier keyword itself reread as the return-type identifier — without it, `public Point(x: Int) { }` (the unrelated single-identifier Java-style-constructor mistake) would falsely match as a two-identifier method declaration.
- Adds `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] Added a red→green test for the no-modifier case in `JavaStyleMethodHintSpec.scala`, plus verified no regression in `JavaStyleConstructorHintSpec`, `JavaStyleFieldHintSpec`, `FunDeclarationHintSpec`, `FunExtensionDeclarationHintSpec`.
- [x] Full suite green in English locale: `sbt -Duser.language=en testFull` (4044 succeeded, 1 canceled [environment-gated dist smoke test], 0 failed).
- [x] Full suite green in Japanese locale: `sbt -Duser.language=ja testFull` (4044 succeeded, 1 canceled, 0 failed). Caught and fixed a locale-trap in my own new test along the way (it asserted English-only hint text; fixed to assert a locale-invariant literal code substring).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCY9WjESBBY5nMnyhibXma)_