### PR TITLE
fix(diagnostics): hint at the parenthesized form for a Java-style record body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java-style record body, `record Point { int x; int y; }`.**
+  Onion records declare their components in parentheses right after the name --
+  `record Point(x: Int, y: Int)` -- never in a brace body. `record`'s grammar
+  requires `(` (or `[` to start type parameters) directly after the name, so the
+  parser accepts `record Point` and then trips on the `{`, with a generic
+  expected-token dump that never mentions the parenthesized form. The diagnostic
+  now recognizes `record Name { ... }` (with or without a generic `[T]`) and
+  points at the correct `record Name(x: Int, y: Int)` form, naming the captured
+  record name. The correct form -- a parenthesized component list optionally
+  followed by its own `{ ... }` method body -- is unaffected.
+
 - **New diagnostic `E0091` for a class used as a value, `System.currentTimeMillis()` instead of `System::currentTimeMillis()`.**
   A bare capitalized name that resolves to a real class -- not a local variable or field -- used
   where a value is expected (typically as the target of `.member`) is the Java/Kotlin habit of

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -117,6 +117,7 @@ error.parsing.hint.java_style_field=Hint: a field or local variable is declared 
 error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not `:` — write `case s is String:`, not `case s: String:`.
 error.parsing.hint.java_style_generics=Hint: generics use square brackets, not angle brackets — write `{0}[{1}]`, not `{0}<{1}>`.
 error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value — static members are accessed with `::`, not `.` — write `{0}::{1}`, not `{0}.{1}`.
+error.parsing.hint.java_style_record_body=Hint: a record''s components are declared in parentheses after its name, not in a brace body — write `record {0}(x: Int, y: Int)`, not `record {0} '{' x; y '}'`. A record may still take a `'{' ... '}'` body after the parentheses, for extra methods.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -117,6 +117,7 @@ error.parsing.hint.java_style_field=ヒント: フィールドやローカル変
 error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:` ではなく `is` を使います — `case s: String:` ではなく `case s is String:` と書いてください。
 error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっこではなく角かっこを使います — `{0}<{1}>` ではなく `{0}[{1}]` と書いてください。
 error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型の名前です — 静的メンバーには `.` ではなく `::` を使います — `{0}.{1}` ではなく `{0}::{1}` と書いてください。
+error.parsing.hint.java_style_record_body=ヒント: レコードのコンポーネントは波かっこの本体ではなく、名前の直後の丸かっこで宣言します — `record {0} '{' x; y '}'` ではなく `record {0}(x: Int, y: Int)` と書いてください。丸かっこの後ろに追加のメソッド用の `'{' ... '}'` 本体を続けることもできます。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -398,6 +398,21 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val PrimitiveTypeNames = Set("Int", "Long", "Double", "Float", "Boolean", "Byte", "Short", "Char")
   private val DotAfterPrimitiveTypeName = """\A[A-Za-z]+\s*\.\s*([A-Za-z_]\w*)""".r
 
+  /**
+   * A Java-style record body, `record Point { int x; int y; }`, that puts the
+   * components inside a brace body instead of Onion's parenthesized component
+   * list. `record`'s grammar is `"record" id() [type_params()] "(" args() ")"
+   * [brace-body]` -- after the name (and optional `[T]`), the parser requires
+   * `(` (or `[` to start the type parameters) and trips on the `{`, with an
+   * expected-token dump that never mentions the parenthesized form. Requiring
+   * the `record` keyword itself (reserved, so it never appears as an
+   * identifier) directly followed by a name and optional `[...]` keeps this
+   * from firing on the correct `record Point(x: Int, y: Int) { ... }` form,
+   * whose brace body comes after a already-closed parenthesized list.
+   */
+  private val JavaStyleRecordBody =
+    """^\s*record\s+([A-Za-z_]\w*)(?:\[[^\]]*\])?\s*\{""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -450,6 +465,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
     case _ if JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       val m = JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).get
       Message("error.parsing.hint.java_style_field", m.group(1), m.group(2))
+    case "{" if expected.contains("\"(\"") && JavaStyleRecordBody.findFirstMatchIn(sourceLine).isDefined =>
+      val m = JavaStyleRecordBody.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.java_style_record_body", m.group(1))
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/JavaStyleRecordBodyHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleRecordBodyHintI18nSpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-record-body hint (`commonSyntaxHint`'s `JavaStyleRecordBody` case)
+ * must resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that match -- see OldForInHintI18nSpec for the motivating
+ * regression.
+ */
+class JavaStyleRecordBodyHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_record_body"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `record Point { ... }` body") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |record Point {
+        |  int x
+        |  int y
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("record Point("), s"expected the hint's `record Point(` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleRecordBodyHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleRecordBodyHintSpec.scala
@@ -1,0 +1,74 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java-style record body, `record Point { int x; int y; }`, that puts the
+ * components inside a brace body instead of Onion's parenthesized component
+ * list. The parser accepts `record Name` and then requires either `[` (type
+ * parameters) or `(` (the component list) -- it trips on the `{` with an
+ * expected-token dump that never mentions the parenthesized form.
+ */
+class JavaStyleRecordBodyHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style record body") {
+    it("hints at the parenthesized component list for `record Point { ... }`") {
+      val msgs = messages(
+        """
+          |record Point {
+          |  int x
+          |  int y
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("record Point("), s"expected a hint mentioning `record Point(`, got: $msgs")
+    }
+
+    it("hints for a generic record, `record Box[T] { ... }`") {
+      val msgs = messages(
+        """
+          |record Box[T] {
+          |  T value
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("record Box("), s"expected a hint mentioning `record Box(`, got: $msgs")
+    }
+
+    it("does not fire for the correct `record Point(x: Int, y: Int)` form") {
+      val msgs = messages(
+        """
+          |record Point(x: Int, y: Int)
+          |class Main {
+          |public:
+          |  static def main(args: String[]): void {
+          |    val p: Point = new Point(1, 2)
+          |    IO::println(p.x())
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `record Point(x: Int, y: Int)` form, got: $msgs")
+    }
+
+    it("does not fire for a record with a correct parenthesized list followed by a method body") {
+      val msgs = messages(
+        """
+          |record Point(x: Int, y: Int) {
+          |public:
+          |  def sum: Int = x + y
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for a record with a correct trailing body, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `record Point { int x; int y; }` (Java-style, components in a brace body) currently fails with a generic expected-token dump (`Encountered "{", but expecting "(", "["`) that never mentions the correct form. This exact mistake is already listed in `CLAUDE.md`'s syntax-mistake table but wasn't covered by a diagnostic hint.
- Add a parser hint recognizing `record Name { ... }` (with or without a generic `[T]`) and pointing at the correct `record Name(x: Int, y: Int)` form, naming the captured record name.
- Add bilingual (en/ja) hint text following the existing `error.parsing.hint.*` convention, plus a `CHANGELOG.md` entry.

## Test plan
- [x] Added `JavaStyleRecordBodyHintSpec` (fires for `record Point { ... }` and generic `record Box[T] { ... }`; does not fire for the correct parenthesized form, with or without a trailing method body)
- [x] Added `JavaStyleRecordBodyHintI18nSpec` (hint resolves in both locales; Japanese text differs from English)
- [x] Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 4057 succeeded, 0 failed, 1 canceled (pre-existing, opt-in `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TVjHo7xWZUMLpSWvNQmUWt)_