### PR TITLE
fix(diagnostics): hint at val for a Java-style try-with-resources declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a Java-style try-with-resources declaration, `try (Res r = new Res()) { ... }`.**
+  Onion's resource clause always starts with `val` before the name (`try (val r = new Res())`) --
+  never with the type before it, and never `var`. The clause's grammar is only attempted with a
+  2-token lookahead (`"(" ("val"|"var")`); when the second token is a type name instead, the
+  lookahead fails, the whole optional resource clause is skipped, and the parser trips on the `(`
+  itself, expecting the `{` of a resourceless `try` block -- a generic expected-token dump that
+  never mentions `val`. The diagnostic now recognizes `try (Type name = ...)` and points at the
+  correct `try (val name: Type = ...)` form, naming the captured type and name.
+
 ## [0.17.0] - 2026-08-23
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -118,6 +118,7 @@ error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not 
 error.parsing.hint.java_style_generics=Hint: generics use square brackets, not angle brackets — write `{0}[{1}]`, not `{0}<{1}>`.
 error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value — static members are accessed with `::`, not `.` — write `{0}::{1}`, not `{0}.{1}`.
 error.parsing.hint.java_style_record_body=Hint: a record''s components are declared in parentheses after its name, not in a brace body — write `record {0}(x: Int, y: Int)`, not `record {0} '{' x; y '}'`. A record may still take a `'{' ... '}'` body after the parentheses, for extra methods.
+error.parsing.hint.java_style_try_resource=Hint: a try-with-resources declaration starts with `val` before the name, not with the type before it, and is always `val` (never `var`) — write `try (val {1}: {0} = ...)`, not `try ({0} {1} = ...)`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -118,6 +118,7 @@ error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:`
 error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっこではなく角かっこを使います — `{0}<{1}>` ではなく `{0}[{1}]` と書いてください。
 error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型の名前です — 静的メンバーには `.` ではなく `::` を使います — `{0}.{1}` ではなく `{0}::{1}` と書いてください。
 error.parsing.hint.java_style_record_body=ヒント: レコードのコンポーネントは波かっこの本体ではなく、名前の直後の丸かっこで宣言します — `record {0} '{' x; y '}'` ではなく `record {0}(x: Int, y: Int)` と書いてください。丸かっこの後ろに追加のメソッド用の `'{' ... '}'` 本体を続けることもできます。
+error.parsing.hint.java_style_try_resource=ヒント: try-with-resources の宣言は名前の前に型ではなく `val` を書きます。常に `val`（`var` は不可）です — `try ({0} {1} = ...)` ではなく `try (val {1}: {0} = ...)` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -413,6 +413,21 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val JavaStyleRecordBody =
     """^\s*record\s+([A-Za-z_]\w*)(?:\[[^\]]*\])?\s*\{""".r
 
+  /**
+   * A Java-style try-with-resources declaration, `try (Res r = new Res()) { ... }`,
+   * that puts the type before the name instead of using `val`/`var`. The resource
+   * clause's grammar (`"(" resource_list() ")"`, each resource starting with
+   * `val`/`var`) is only attempted with a 2-token lookahead (`"(" ("val"|"var")`) --
+   * when the second token is a type name instead, the lookahead fails, the whole
+   * optional clause is skipped, and the parser trips on the `(` itself, expecting
+   * the `{` of a resourceless `try` block. Neither mentions `val`/`var`. Requiring
+   * a capitalized leading identifier (Java/Onion type-naming convention), optionally
+   * bracketed or nullable, directly followed by a second identifier and `=` keeps
+   * this from firing on the correct `try (val r = ...)`/`try (var r = ...)` form.
+   */
+  private val JavaStyleTryResource =
+    """\btry\s*\(\s*([A-Z][A-Za-z0-9_]*(?:\[[^\]]*\])?\??)\s+([A-Za-z_]\w*)\s*=""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -468,6 +483,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
     case "{" if expected.contains("\"(\"") && JavaStyleRecordBody.findFirstMatchIn(sourceLine).isDefined =>
       val m = JavaStyleRecordBody.findFirstMatchIn(sourceLine).get
       Message("error.parsing.hint.java_style_record_body", m.group(1))
+    case "(" if expected.contains("{") && JavaStyleTryResource.findFirstMatchIn(sourceLine).isDefined =>
+      val m = JavaStyleTryResource.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.java_style_try_resource", m.group(1), m.group(2))
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/JavaStyleTryResourceHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleTryResourceHintI18nSpec.scala
@@ -1,0 +1,56 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-try-resource hint (`commonSyntaxHint`'s `JavaStyleTryResource`
+ * case) must resolve through the bilingual `error.parsing.hint.*` bundle in
+ * both locales, like every other hint in that match -- see
+ * JavaStyleRecordBodyHintI18nSpec for the same pattern.
+ */
+class JavaStyleTryResourceHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_try_resource"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `try (Res r = ...) { ... }` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Res {
+        |public:
+        |  def this { }
+        |  def close: void { }
+        |}
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    try (Res r = new Res()) {
+        |      IO::println("using")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("val r: Res"), s"expected the hint's `val r: Res` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleTryResourceHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleTryResourceHintSpec.scala
@@ -1,0 +1,69 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java-style try-with-resources declaration, `try (Res r = new Res()) { ... }`,
+ * that puts the type before the name instead of using `val`/`var`. Onion's
+ * resource clause is `"(" resource_list() ")"` where each resource starts with
+ * `val`/`var`, and that whole clause is only attempted with a 2-token lookahead
+ * (`"(" ("val"|"var")`) -- when the second token is a type name instead, the
+ * lookahead fails, the optional resource clause is skipped entirely, and the
+ * parser trips on the `(` itself, expecting the `{` of a resourceless `try`
+ * block. The expected-token dump never mentions `val`/`var`.
+ */
+class JavaStyleTryResourceHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style try-with-resources declaration") {
+    it("hints at `val`/`var` for `try (Res r = ...) { ... }`") {
+      val msgs = messages(
+        """
+          |class Res {
+          |public:
+          |  def this { }
+          |  def close: void { }
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): void {
+          |    try (Res r = new Res()) {
+          |      IO::println("using")
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("val r: Res"), s"expected a hint mentioning `val r: Res`, got: $msgs")
+    }
+
+    it("does not fire for the correct `try (val r = ...) { ... }` form") {
+      val msgs = messages(
+        """
+          |import { java.lang.AutoCloseable }
+          |class Res conforms AutoCloseable {
+          |public:
+          |  def this { }
+          |  def close: void { }
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): void {
+          |    try (val r = new Res()) {
+          |      IO::println("using")
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `try (val r = ...)` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion's try-with-resources clause always starts with `val` before the name (`try (val r = new Res())`) — never with the type before it, and never `var`.
- The resource clause's grammar is only attempted with a 2-token lookahead (`"(" ("val"|"var")`); when the second token is a type name instead (the Java-style `try (Res r = new Res())` mistake), the lookahead fails, the whole optional resource clause is skipped, and the parser trips on the `(` itself, expecting the `{` of a resourceless `try` block — a generic expected-token dump that never mentions `val`.
- Adds a dedicated bilingual parser hint recognizing `try (Type name = ...)` and pointing at the correct `try (val name: Type = ...)` form, following the same pattern as the other `JavaStyle*` hints in `Parsing.scala`.

## Test plan
- [x] New targeted specs (`JavaStyleTryResourceHintSpec`, `JavaStyleTryResourceHintI18nSpec`) written first (red), then green after the fix.
- [ ] Full suite (`sbt -Duser.language=en testFull`) — running; this PR stays draft until confirmed green in both locales.

---
Draft PR opened while the full local test suite (English + Japanese locales) finishes running; will mark ready and merge once confirmed green, per this repo's release-automation policy.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01ARVZtX6LHdaUfUGQBqqwjg)_