### PR TITLE
fix(diagnostics): hint at select for a Kotlin-style when expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never mentions `val`. The diagnostic now recognizes `try (Type name = ...)` and points at the
   correct `try (val name: Type = ...)` form, naming the captured type and name.
 
+- **Parser hint for a Kotlin-style `when` expression, `when (x) { ... }`.**
+  Onion has no standalone `when` control-flow keyword -- `select` covers the same ground.
+  Unlike `switch`, `when` IS reserved in Onion, but only as the case-guard keyword
+  (`case p when guard:`), so opening a block with it at statement position trips the parser
+  right on the `when` token itself, with an expected-token dump that names whatever would
+  legally close the enclosing block instead -- never mentioning `select`. The diagnostic now
+  recognizes a leading `when` and points at the correct `select value { case 1: ...; else: ... }`
+  form, the same way the existing `switch` hint does.
+
 ## [0.17.0] - 2026-08-23
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -104,6 +104,7 @@ error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
+error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -104,6 +104,7 @@ error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算�
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
+error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -249,6 +249,18 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val LeadingSwitchStatement = """^\s*switch\b""".r
 
   /**
+   * A Kotlin-style `when` expression used as a statement, `when (x) { ... }` or
+   * `when x { ... }`. Unlike `switch`, `when` IS reserved in Onion -- but only
+   * as the case-guard keyword (`case p when guard:`) -- so opening a block with
+   * it at statement position trips the parser right on the `when` token itself,
+   * with an expected-token dump that names whatever would legally close the
+   * enclosing block instead, never mentioning `select`. Matching for `when` at
+   * the start of the line (mirroring the `switch` hint) keeps this from firing
+   * on a guard clause elsewhere on the line.
+   */
+  private val LeadingWhenStatement = """^\s*when\b""".r
+
+  /**
    * A Kotlin (`fun`), Swift/Go (`func`), or Rust (`fn`) function/method
    * declaration. None of these are keywords in Onion (which uses `def`), so at
    * statement position the keyword parses as a bare identifier reference and the
@@ -451,6 +463,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_for_in")
     case _ if LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.switch_not_supported")
+    case "when" if LeadingWhenStatement.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.when_not_supported")
     case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       val m = FunExtensionDeclaration.findFirstMatchIn(sourceLine).get
       Message("error.parsing.hint.fun_extension_declaration", m.group(1), m.group(2))

--- a/src/test/scala/onion/compiler/tools/WhenStatementHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/WhenStatementHintSpec.scala
@@ -1,0 +1,80 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no Kotlin-style `when` expression -- `select` covers the same ground.
+ * `when` IS reserved in Onion, but only as the case-guard keyword (`case p when
+ * guard:`); using it to open a block at statement position trips the parser right
+ * on the `when` token itself, with an expected-token dump that names whatever
+ * would legally close the enclosing block instead, never mentioning `select`.
+ */
+class WhenStatementHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("when statement") {
+    it("hints at select for an unparenthesized when") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    when x {
+          |    case 1: IO::println("one")
+          |    else: IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("select"), s"expected a hint mentioning select, got: $msgs")
+      assert(msgs.contains("when"), s"expected the hint to name when, got: $msgs")
+    }
+
+    it("hints at select for a parenthesized when") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    when (x) {
+          |    case 1: IO::println("one")
+          |    else: IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("select"), s"expected a hint mentioning select, got: $msgs")
+      assert(msgs.contains("when"), s"expected the hint to name when, got: $msgs")
+    }
+
+    it("does not fire for a legitimate case-guard `when`") {
+      val msgs = messages(
+        """
+          |class Sample {
+          |public:
+          |  def describe(x: Int): String = {
+          |    select x {
+          |    case n when n > 0: return "positive"
+          |    else: return "other"
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("select"), s"hint should not fire for a valid case-guard when, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion has no standalone `when` control-flow keyword. `when` IS reserved, but only as the case-guard keyword (`case p when guard:`), so a Kotlin-style `when (x) { ... }` at statement position trips the parser right on the `when` token with an expected-token dump that never mentions `select`.
- Adds the same leading-token hint the existing `switch` diagnostic uses, pointing at the correct `select value { case 1: ...; else: ... }` form, with matching en/ja resource strings.
- Adds `WhenStatementHintSpec` (TDD: unparenthesized `when`, parenthesized `when`, and a negative case confirming a legitimate `case p when guard:` clause does not misfire).

## Why this is a draft, not a ready-to-merge PR

Per this repo's session-routine policy, a PR should only be merged after a locally-confirmed full green test run under the mandated command (`SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test`, then repeated with `-Duser.language=ja`). I could not obtain that clean confirmation in this sandboxed session:

- **This change's own tests**: `WhenStatementHintSpec` passed cleanly in both English and Japanese locale runs (confirmed directly in the test logs before the environment issue below occurred).
- **Full `testFull` (en, locale default heap / warm server)**: ran to completion, 4065/4065 tests passed, 1 canceled, 0 failed.
- **Full `testFull` under a genuinely fresh sbt server with the prescribed `-Xmx4G` budget**: attempted twice (once each for `en` and `ja` locale, each with `sbt shutdown` first to force a truly fresh JVM). Both attempts reproducibly hung in a GC-overhead livelock (CPU pinned at 200-300%+, RSS plateaued near the 4G ceiling, zero log progress for 3+ minutes) at the exact same suite location, around `RegexLiteralValidationSpec`/`GenericArrayTypeInferenceSpec`. This is unrelated to the diagnostics change in this PR (which completes and passes well before that point in the suite) and looks like a resource constraint specific to this sandboxed session (4 vCPUs available), not a code regression — but per policy I'm not merging without a clean local confirmation.

Given the project's actual GitHub Actions CI has a long history of running the full suite cold without this issue (per `CLAUDE.md`'s own note that CI is unaffected by local/incremental-state traps), it seems likely this is environment-specific rather than a real regression. Recommend checking CI on this PR before merging, and possibly filing a follow-up if the stall reproduces there too.

## Test plan
- [x] `WhenStatementHintSpec` (new): all 3 cases pass in both en and ja locales
- [x] Full `testFull` (en locale, default/warm heap): 4065 passed, 0 failed, 1 canceled
- [ ] Full `testFull` under the prescribed fresh 4G heap budget (en and ja): could not complete in this environment (see above) — please confirm via CI


---
_Generated by [Claude Code](https://claude.ai/code/session_01BnoXnYgha7WdYH5xF4gjh9)_