### PR TITLE
fix(diagnostics): hint at conforms for a Java-style implements clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recognizes a leading `when` and points at the correct `select value { case 1: ...; else: ... }`
   form, the same way the existing `switch` hint does.
 
+- **Parser hint for a Java-style `implements` clause, `class A implements I { ... }`.**
+  Onion names interfaces with `conforms`, not `implements` -- and `implements` is not a
+  keyword at all, so it lexes as a plain identifier. A class header with no
+  `extends`/`conforms`/`{` after the name is already a complete, body-less class
+  declaration, so `implements Interface` is read as the start of a brand new top-level
+  statement: a bare reference to the identifier `implements`, immediately followed by the
+  interface name, where only a statement terminator is valid. The parser trips on the
+  interface name several tokens past the actual mistake, with an expected-token dump that
+  never mentions `conforms`. The diagnostic now recognizes `class A implements I` (with or
+  without a preceding `extends`, and with multiple comma-separated interfaces) and points at
+  the correct `class A conforms I` form, naming the captured class and interface list.
+
 ## [0.17.0] - 2026-08-23
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -120,6 +120,7 @@ error.parsing.hint.java_style_generics=Hint: generics use square brackets, not a
 error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value — static members are accessed with `::`, not `.` — write `{0}::{1}`, not `{0}.{1}`.
 error.parsing.hint.java_style_record_body=Hint: a record''s components are declared in parentheses after its name, not in a brace body — write `record {0}(x: Int, y: Int)`, not `record {0} '{' x; y '}'`. A record may still take a `'{' ... '}'` body after the parentheses, for extra methods.
 error.parsing.hint.java_style_try_resource=Hint: a try-with-resources declaration starts with `val` before the name, not with the type before it, and is always `val` (never `var`) — write `try (val {1}: {0} = ...)`, not `try ({0} {1} = ...)`.
+error.parsing.hint.java_style_implements=Hint: interfaces are named with `conforms`, not Java''s `implements` — write `class {0} conforms {1}`, not `class {0} implements {1}`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -120,6 +120,7 @@ error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっ
 error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型の名前です — 静的メンバーには `.` ではなく `::` を使います — `{0}.{1}` ではなく `{0}::{1}` と書いてください。
 error.parsing.hint.java_style_record_body=ヒント: レコードのコンポーネントは波かっこの本体ではなく、名前の直後の丸かっこで宣言します — `record {0} '{' x; y '}'` ではなく `record {0}(x: Int, y: Int)` と書いてください。丸かっこの後ろに追加のメソッド用の `'{' ... '}'` 本体を続けることもできます。
 error.parsing.hint.java_style_try_resource=ヒント: try-with-resources の宣言は名前の前に型ではなく `val` を書きます。常に `val`（`var` は不可）です — `try ({0} {1} = ...)` ではなく `try (val {1}: {0} = ...)` と書いてください。
+error.parsing.hint.java_style_implements=ヒント: インターフェースは Java の `implements` ではなく `conforms` で指定します — `class {0} implements {1}` ではなく `class {0} conforms {1}` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -440,11 +440,31 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val JavaStyleTryResource =
     """\btry\s*\(\s*([A-Z][A-Za-z0-9_]*(?:\[[^\]]*\])?\??)\s+([A-Za-z_]\w*)\s*=""".r
 
+  /**
+   * A Java-style `class A implements I { ... }` declaration. `implements` is not a
+   * keyword in Onion -- interfaces are named with `conforms` -- so it lexes as a
+   * plain identifier. A class header with no `extends`/`conforms`/`{` after the name
+   * (optionally with a primary-constructor parameter list) is already a complete,
+   * body-less class declaration, so `implements Interface` is read as the start of a
+   * brand new top-level statement: a bare reference to the identifier `implements`,
+   * immediately followed by the interface name, where only a statement terminator
+   * is valid. The parser trips on the interface name several tokens past the actual
+   * mistake, with an expected-token dump (`<EOF>`, `<EOL>`, `;`) that never mentions
+   * `conforms`. Anchoring on `class` (reserved, never an identifier) at the start of
+   * the line keeps this from firing on an unrelated use of `implements` as an
+   * ordinary identifier elsewhere.
+   */
+  private val JavaStyleImplements =
+    """^\s*class\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*(?:extends\s+[A-Za-z_][\w.\[\]]*(?:\([^)]*\))?\s*)?implements\s+([A-Za-z_][\w.\[\], ]*?)\s*\{?\s*$""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
     case "<:" =>
       Message("error.parsing.hint.old_conforms")
+    case _ if JavaStyleImplements.findFirstMatchIn(sourceLine).isDefined =>
+      val m = JavaStyleImplements.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.java_style_implements", m.group(1), m.group(2).trim)
     case ":" if JavaStyleTypeCase.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.case_type_colon")
     case "<" if JavaStyleGenericAngleBrackets.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/JavaStyleImplementsHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleImplementsHintI18nSpec.scala
@@ -1,0 +1,53 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style-`implements` hint (`commonSyntaxHint`'s `JavaStyleImplements`
+ * case) must resolve through the bilingual `error.parsing.hint.*` bundle in
+ * both locales, like every other hint in that match -- see
+ * JavaStyleRecordBodyHintI18nSpec for the same pattern.
+ */
+class JavaStyleImplementsHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_implements"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `class Person implements Greeter { ... }` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |interface Greeter { def greet(): String }
+        |class Person implements Greeter {
+        |public:
+        |  def this {}
+        |  def greet(): String = "hi"
+        |}
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int { return 0 }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("class Person conforms Greeter"), s"expected the hint's `class Person conforms Greeter` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JavaStyleImplementsHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JavaStyleImplementsHintSpec.scala
@@ -1,0 +1,101 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java-style `class A implements I { ... }` declaration. `implements` is not
+ * a keyword in Onion (interfaces are named with `conforms`) -- it lexes as a
+ * plain identifier, so `class Person` alone (with no `extends`/`conforms`/`{`)
+ * is already a complete, body-less class declaration, and `implements Greeter`
+ * is read as the start of a *new* top-level statement: a bare reference to the
+ * identifier `implements`, followed by `Greeter`, where only a statement
+ * terminator is valid. The parser trips several tokens past the actual
+ * mistake and the expected-token dump never mentions `conforms`.
+ */
+class JavaStyleImplementsHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("Java-style `implements` declaration") {
+    it("hints at `conforms` for `class Person implements Greeter { ... }`") {
+      val msgs = messages(
+        """
+          |interface Greeter { def greet(): String }
+          |class Person implements Greeter {
+          |public:
+          |  def this {}
+          |  def greet(): String = "hi"
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("class Person conforms Greeter"), s"expected a hint mentioning `class Person conforms Greeter`, got: $msgs")
+    }
+
+    it("hints at `conforms` when combined with `extends`") {
+      val msgs = messages(
+        """
+          |interface Greeter { def greet(): String }
+          |class Animal { public: def this {} }
+          |class Dog extends Animal implements Greeter {
+          |public:
+          |  def this {}
+          |  def greet(): String = "woof"
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("conforms Greeter"), s"expected a hint mentioning `conforms Greeter`, got: $msgs")
+    }
+
+    it("hints with multiple interfaces, `implements A, B`") {
+      val msgs = messages(
+        """
+          |interface Greeter { def greet(): String }
+          |interface Named { def name(): String }
+          |class Person implements Greeter, Named {
+          |public:
+          |  def this {}
+          |  def greet(): String = "hi"
+          |  def name(): String = "p"
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("conforms Greeter, Named"), s"expected a hint mentioning `conforms Greeter, Named`, got: $msgs")
+    }
+
+    it("does not fire for the correct `conforms` form") {
+      val msgs = messages(
+        """
+          |interface Greeter { def greet(): String }
+          |class Person conforms Greeter {
+          |public:
+          |  def this {}
+          |  def greet(): String = "hi"
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `conforms` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `class A implements I { ... }` is not valid Onion (interfaces are named with `conforms`), but `implements` isn't a reserved keyword either, so it lexes as a plain identifier. `class A` alone (no `extends`/`conforms`/`{`) already parses as a complete class declaration, so `implements I` is read as the start of a brand new top-level statement, and the parser trips several tokens past the actual mistake with an expected-token dump that never mentions `conforms`.
- Adds a parser hint recognizing `class A implements I` (optionally combined with `extends`, and with multiple comma-separated interfaces) that points at the correct `class A conforms I` form.
- Adds bilingual (en/ja) message bundle entries and a `CHANGELOG.md` entry, following the existing pattern used by the other Java/Kotlin-style syntax hints in this file.

## Test plan
- [x] New TDD tests: `JavaStyleImplementsHintSpec` (functional, 4 cases) and `JavaStyleImplementsHintI18nSpec` (bilingual bundle resolution, 3 cases) — both green.
- [x] Full suite, English locale: `4065` succeeded, `0` failed (1 pre-existing environment-gated cancel unrelated to this change).
- [x] Full suite, Japanese locale: `4072` succeeded, `0` failed (same pre-existing cancel).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017c2XDvBAzfgdQMNvEqDUb5

---
_Generated by [Claude Code](https://claude.ai/code/session_017c2XDvBAzfgdQMNvEqDUb5)_