### PR TITLE
fix(diagnostics): hint at `val`/`var` for a JS-style `const` declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a JS/TS-style `const x = 1` variable declaration.**
+  `const` is a reserved keyword token (`K_CONST`) that no grammar production ever
+  references -- Onion declares variables with `val` (immutable) or `var` (mutable) --
+  so meeting it can only mean this mistake. It trips the parser immediately, at
+  either top level or inside a block, with a generic expected-token dump that
+  never mentions `val`/`var`. The diagnostic now recognizes a leading `const` and
+  points at the correct `val name: Type = value` (or `var`, if it changes) form.
+
 - **Parser hint for a Java-style try-with-resources declaration, `try (Res r = new Res()) { ... }`.**
   Onion's resource clause always starts with `val` before the name (`try (val r = new Res())`) --
   never with the type before it, and never `var`. The clause's grammar is only attempted with a

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -121,6 +121,7 @@ error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value �
 error.parsing.hint.java_style_record_body=Hint: a record''s components are declared in parentheses after its name, not in a brace body — write `record {0}(x: Int, y: Int)`, not `record {0} '{' x; y '}'`. A record may still take a `'{' ... '}'` body after the parentheses, for extra methods.
 error.parsing.hint.java_style_try_resource=Hint: a try-with-resources declaration starts with `val` before the name, not with the type before it, and is always `val` (never `var`) — write `try (val {1}: {0} = ...)`, not `try ({0} {1} = ...)`.
 error.parsing.hint.java_style_implements=Hint: interfaces are named with `conforms`, not Java''s `implements` — write `class {0} conforms {1}`, not `class {0} implements {1}`.
+error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -121,6 +121,7 @@ error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型�
 error.parsing.hint.java_style_record_body=ヒント: レコードのコンポーネントは波かっこの本体ではなく、名前の直後の丸かっこで宣言します — `record {0} '{' x; y '}'` ではなく `record {0}(x: Int, y: Int)` と書いてください。丸かっこの後ろに追加のメソッド用の `'{' ... '}'` 本体を続けることもできます。
 error.parsing.hint.java_style_try_resource=ヒント: try-with-resources の宣言は名前の前に型ではなく `val` を書きます。常に `val`（`var` は不可）です — `try ({0} {1} = ...)` ではなく `try (val {1}: {0} = ...)` と書いてください。
 error.parsing.hint.java_style_implements=ヒント: インターフェースは Java の `implements` ではなく `conforms` で指定します — `class {0} implements {1}` ではなく `class {0} conforms {1}` と書いてください。
+error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -462,6 +462,14 @@ class Parsing(config: CompilerConfig) extends AnyRef
     // `<:` no longer appears in any production, so meeting one can only be old source.
     case "<:" =>
       Message("error.parsing.hint.old_conforms")
+    // `const` is a reserved keyword token (K_CONST) that no production ever
+    // references, so it can only reach the parser as a JS/TS-style `const x = 1`
+    // variable declaration. It trips the parser immediately -- at statement
+    // position `const` fits no production (a generic top-level or member dump),
+    // and inside a block it isn't a valid statement start either -- with an
+    // expected-token dump that never mentions `val`/`var`.
+    case "const" =>
+      Message("error.parsing.hint.js_style_const")
     case _ if JavaStyleImplements.findFirstMatchIn(sourceLine).isDefined =>
       val m = JavaStyleImplements.findFirstMatchIn(sourceLine).get
       Message("error.parsing.hint.java_style_implements", m.group(1), m.group(2).trim)

--- a/src/test/scala/onion/compiler/JsStyleConstHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JsStyleConstHintI18nSpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The JS-style-`const` hint (`commonSyntaxHint`'s `"const"` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both
+ * locales, like every other hint in that match -- see
+ * JavaStyleImplementsHintI18nSpec for the same pattern.
+ */
+class JsStyleConstHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.js_style_const"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JS-style `const x: Int = 5` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |const x: Int = 5
+        |IO::println(x)
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("val name: Type = value"), s"expected the hint's `val name: Type = value` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JsStyleConstHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JsStyleConstHintSpec.scala
@@ -1,0 +1,59 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A JS/TS-style `const x = 1` variable declaration. `const` is a reserved
+ * keyword token (`K_CONST`) that no production ever references, so it can
+ * only reach the parser as this mistake. It trips the parser immediately --
+ * at statement position `const` fits no production -- with an expected-token
+ * dump that never mentions `val`/`var`.
+ */
+class JsStyleConstHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("JS-style `const` declaration") {
+    it("hints at `val`/`var` for a top-level `const x: Int = 5`") {
+      val msgs = messages(
+        """
+          |const x: Int = 5
+          |IO::println(x)
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("val name: Type = value"), s"expected a hint mentioning `val name: Type = value`, got: $msgs")
+    }
+
+    it("hints at `val`/`var` for a `const` declaration inside a method body") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    const x: Int = 5
+          |    IO::println(x)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("val name: Type = value"), s"expected a hint mentioning `val name: Type = value`, got: $msgs")
+    }
+
+    it("does not fire for the correct `val` form") {
+      val msgs = messages(
+        """
+          |val x: Int = 5
+          |IO::println(x)
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `val` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`const` is a reserved keyword token (`K_CONST`) in the grammar that **no production ever references**. Onion declares variables with `val` (immutable) or `var` (mutable), so a `const` token reaching the parser can only mean one thing: a JS/TS-style `const x = 1` declaration.

It trips the parser immediately, in both positions, with a generic expected-token dump that never mentions `val`/`var`:

```
$ onion script.on
script.on:1:1: Syntax error. Encountered "const", but expecting "abstract", "class", "record", "def", ... (16 more)
  1 | const x: Int = 5
    | ^
```

```
script.on:4:5: Syntax error. Encountered "const", but expecting "}"
  4 |     const x: Int = 5
    |     ^
```

Neither dump points at the fix.

## Change

Add a `case "const"` to `commonSyntaxHint` (matching on the *found* token, since `const` is reserved and can never be an identifier — no source-line regex needed, unlike the `implements`/`when` hints) and the corresponding `error.parsing.hint.js_style_const` entry in both message bundles:

> Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.

## Tests

- `JsStyleConstHintSpec` — fires at top level, fires inside a method body, does not fire for the correct `val` form.
- `JsStyleConstHintI18nSpec` — key resolves in both bundles, Japanese is actually translated, and the hint fires end-to-end.

Assertions are on the hint's **literal example text** (identical in both bundles), so they are locale-independent.

## Verification

Full suite green in **both** locales on a fresh sbt server:

- `sbt -Duser.language=en testFull` → `Tests: succeeded 4078, failed 0, canceled 1` — All tests passed
- `sbt -Duser.language=ja testFull` → `Tests: succeeded 4078, failed 0, canceled 1` — All tests passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01KomD6MV1kGKiMNcQQHavX4)_