### PR TITLE
test: assert the dedicated E0091 code in ClassUsedAsValueSpec

### DIFF
--- a/src/test/scala/onion/compiler/tools/ClassUsedAsValueSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ClassUsedAsValueSpec.scala
@@ -44,7 +44,7 @@ class ClassUsedAsValueSpec extends AbstractShellSpec {
         |""".stripMargin
     )
     assert(!codes.contains("E0002"), s"expected the dedicated hint, not the generic not-found error, got: $codes")
-    assert(codes.exists(c => c != "E0002"), s"expected some error to be reported, got: $codes")
+    assert(codes.contains("E0091"), s"expected the dedicated CLASS_USED_AS_VALUE code E0091, got: $codes")
   }
 
   it("names the :: fix in the message") {


### PR DESCRIPTION
## Summary
- `ClassUsedAsValueSpec`'s "reports a dedicated error code" case only asserted the reported code was *not* the generic `E0002` (`VARIABLE_NOT_FOUND`); it never checked that the code was actually the intended `E0091` (`CLASS_USED_AS_VALUE`). Strengthen the assertion to check for `E0091` directly, so a future regression that reports some *other* wrong dedicated code would still be caught.
- Found while auditing which of the ~89 `SemanticError` codes lack a test that asserts on the literal code string — `E0091` was the only one.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.ClassUsedAsValueSpec'` — 6/6 passed
- [x] `sbt -Duser.language=en testFull` — 4078 succeeded, 0 failed, 1 canceled, 0 aborted, all green

---
_Generated by [Claude Code](https://claude.ai/code/session_016kPUDMW1bwgdcdmuJdHLUa)_