### PR TITLE
fix(diagnostics): hint at `?` for a TypeScript-style `String | null` nullable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a TypeScript/Kotlin-style union nullable type, `String | null`.**
+  Onion writes a nullable type with a trailing `?` (`String?`) -- `|` is never valid inside
+  a type, so the parser accepts the base type and then trips right on the `|`, with an
+  expected-token dump that never mentions `?`. The diagnostic now recognizes `Type | null`
+  in any type position (a `val`/`var` declaration, a parameter, a return type) and points
+  at the correct `Type?` form, naming the captured type.
+
 - **Parser hint for a JS/TS-style `const x = 1` variable declaration.**
   `const` is a reserved keyword token (`K_CONST`) that no grammar production ever
   references -- Onion declares variables with `val` (immutable) or `var` (mutable) --

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -122,6 +122,7 @@ error.parsing.hint.java_style_record_body=Hint: a record''s components are decla
 error.parsing.hint.java_style_try_resource=Hint: a try-with-resources declaration starts with `val` before the name, not with the type before it, and is always `val` (never `var`) — write `try (val {1}: {0} = ...)`, not `try ({0} {1} = ...)`.
 error.parsing.hint.java_style_implements=Hint: interfaces are named with `conforms`, not Java''s `implements` — write `class {0} conforms {1}`, not `class {0} implements {1}`.
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
+error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -122,6 +122,7 @@ error.parsing.hint.java_style_record_body=ヒント: レコードのコンポー
 error.parsing.hint.java_style_try_resource=ヒント: try-with-resources の宣言は名前の前に型ではなく `val` を書きます。常に `val`（`var` は不可）です — `try ({0} {1} = ...)` ではなく `try (val {1}: {0} = ...)` と書いてください。
 error.parsing.hint.java_style_implements=ヒント: インターフェースは Java の `implements` ではなく `conforms` で指定します — `class {0} implements {1}` ではなく `class {0} conforms {1}` と書いてください。
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
+error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -457,6 +457,19 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val JavaStyleImplements =
     """^\s*class\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*(?:extends\s+[A-Za-z_][\w.\[\]]*(?:\([^)]*\))?\s*)?implements\s+([A-Za-z_][\w.\[\], ]*?)\s*\{?\s*$""".r
 
+  /**
+   * A TypeScript/Kotlin-style union nullable type, `String | null`, in a type
+   * position (a `val`/`var` declaration, a parameter, a return type). Onion
+   * writes a nullable type with a trailing `?` (`String?`) -- `|` is never
+   * valid inside a type, so the parser accepts the base type and then trips
+   * right on the `|`, with an expected-token dump that never mentions `?`.
+   * Requiring a preceding `:` (the start of any type position) directly
+   * followed by a type name, `|`, and `null` keeps this from firing on an
+   * ordinary bitwise-or expression, whose right-hand side is essentially
+   * never the literal `null`.
+   */
+  private val NullableUnionType = """:\s*([A-Za-z_][\w.\[\]]*)\s*\|\s*null\b""".r
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -528,6 +541,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
     case "(" if expected.contains("{") && JavaStyleTryResource.findFirstMatchIn(sourceLine).isDefined =>
       val m = JavaStyleTryResource.findFirstMatchIn(sourceLine).get
       Message("error.parsing.hint.java_style_try_resource", m.group(1), m.group(2))
+    case "|" if NullableUnionType.findFirstMatchIn(sourceLine).isDefined =>
+      val m = NullableUnionType.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.nullable_union_type", m.group(1))
     // There is no `cond ? a : b` ternary operator -- `if`/`else` covers the same
     // ground as an expression, so unlike the hints above this isn't a token swap;
     // name the rewrite so the reader isn't left guessing what "unsupported" means here.

--- a/src/test/scala/onion/compiler/NullableUnionTypeHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/NullableUnionTypeHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The nullable-union-type hint (`commonSyntaxHint`'s `NullableUnionType` case)
+ * must resolve through the bilingual `error.parsing.hint.*` bundle in both
+ * locales, like every other hint in that match -- see
+ * JavaStyleImplementsHintI18nSpec for the same pattern.
+ */
+class NullableUnionTypeHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.nullable_union_type"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a TypeScript-style `String | null` nullable type") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Test {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val x: String | null = "a"
+        |    IO::println(x)
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("String?"), s"expected the hint's `String?` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/NullableUnionTypeHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NullableUnionTypeHintSpec.scala
@@ -1,0 +1,67 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A TypeScript/Kotlin-style union nullable type, `String | null`. Onion writes
+ * a nullable type with a trailing `?` (`String?`) -- `|` never appears in a
+ * type position, so the parser accepts the base type and then trips right on
+ * the `|`, with an expected-token dump that never mentions `?`.
+ */
+class NullableUnionTypeHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("TypeScript-style `T | null` nullable type") {
+    it("hints at `?` for a `val` declaration's type") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: String | null = "a"
+          |    IO::println(x)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("String?"), s"expected a hint mentioning `String?`, got: $msgs")
+    }
+
+    it("hints at `?` for a parameter's type") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def f(x: String | null): Int { return 0 }
+          |  static def main(args: String[]): Int { return 0 }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("String?"), s"expected a hint mentioning `String?`, got: $msgs")
+    }
+
+    it("does not fire for the correct `String?` nullable form") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x: String? = "a"
+          |    IO::println(x)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `String?` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion writes a nullable type with a trailing `?` (`String?`) — `|` is never valid inside a type, so `val x: String | null = ...` parses the base type and then trips right on the `|`, with an expected-token dump (`<EOF>`, `<EOL>`, `=`, `;`, ...) that never mentions `?`.
- `commonSyntaxHint` now recognizes `Type | null` in any type position (a `val`/`var` declaration, a parameter, a return type) via a new `NullableUnionType` regex anchored on a preceding `:`, and points at the correct `Type?` form, naming the captured type.
- Added the bilingual `error.parsing.hint.nullable_union_type` message key (en/ja).
- CHANGELOG `[Unreleased]` updated.

## Test plan
- [x] New tests (TDD, confirmed red before the fix): `NullableUnionTypeHintI18nSpec` (bilingual bundle resolution) and `tools/NullableUnionTypeHintSpec` (fires for `val`/parameter type position, does not fire for the correct `String?` form)
- [x] Full suite green in English locale: `sbt -Duser.language=en testFull` — 4084 succeeded, 0 failed (1 pre-existing environment-gated cancel, unrelated)
- [x] Full suite green in Japanese locale: `sbt -Duser.language=ja testFull` — 4084 succeeded, 0 failed (same pre-existing cancel)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VgWdU8N74M1qFU4T7xB29Q)_