### PR TITLE
fix(diagnostics): hint at backtick-escaping for a reserved word used as an identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a reserved word used as an identifier, `val class = 5`.**
+  A hard keyword token (`class`, `type`, `case`, ...) can never appear where `id()`
+  (`<ID> | <QUOTED_ID>`) is expected, so the parser trips on the keyword itself with a
+  generic `expecting <ID>, <QUOTED_ID>` dump that never mentions that Onion lets a
+  reserved word be used as an identifier by escaping it with backticks (`` `class` ``).
+  The diagnostic now recognizes any of the grammar's hard keyword tokens in that
+  position and points at the backtick-escaped form, naming the captured word. A *soft*
+  keyword like `conforms`/`from`/`shape` -- which lexes as a plain `<ID>` and is
+  already a legal identifier on its own -- is unaffected.
+
 - **Parser hint for a JS/TS-style `const x = 1` variable declaration.**
   `const` is a reserved keyword token (`K_CONST`) that no grammar production ever
   references -- Onion declares variables with `val` (immutable) or `var` (mutable) --

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -121,6 +121,7 @@ error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value �
 error.parsing.hint.java_style_record_body=Hint: a record''s components are declared in parentheses after its name, not in a brace body — write `record {0}(x: Int, y: Int)`, not `record {0} '{' x; y '}'`. A record may still take a `'{' ... '}'` body after the parentheses, for extra methods.
 error.parsing.hint.java_style_try_resource=Hint: a try-with-resources declaration starts with `val` before the name, not with the type before it, and is always `val` (never `var`) — write `try (val {1}: {0} = ...)`, not `try ({0} {1} = ...)`.
 error.parsing.hint.java_style_implements=Hint: interfaces are named with `conforms`, not Java''s `implements` — write `class {0} conforms {1}`, not `class {0} implements {1}`.
+error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and can''t be used as an identifier directly — escape it with backticks, writing `{0}` (with backticks) instead.
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -121,6 +121,7 @@ error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型�
 error.parsing.hint.java_style_record_body=ヒント: レコードのコンポーネントは波かっこの本体ではなく、名前の直後の丸かっこで宣言します — `record {0} '{' x; y '}'` ではなく `record {0}(x: Int, y: Int)` と書いてください。丸かっこの後ろに追加のメソッド用の `'{' ... '}'` 本体を続けることもできます。
 error.parsing.hint.java_style_try_resource=ヒント: try-with-resources の宣言は名前の前に型ではなく `val` を書きます。常に `val`（`var` は不可）です — `try ({0} {1} = ...)` ではなく `try (val {1}: {0} = ...)` と書いてください。
 error.parsing.hint.java_style_implements=ヒント: インターフェースは Java の `implements` ではなく `conforms` で指定します — `class {0} implements {1}` ではなく `class {0} conforms {1}` と書いてください。
+error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のため、そのままでは識別子として使えません — バッククォートでエスケープして `{0}`（バッククォート付き）と書いてください。
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -457,6 +457,28 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val JavaStyleImplements =
     """^\s*class\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*(?:extends\s+[A-Za-z_][\w.\[\]]*(?:\([^)]*\))?\s*)?implements\s+([A-Za-z_][\w.\[\], ]*?)\s*\{?\s*$""".r
 
+  /**
+   * Every hard keyword token in the grammar (the `K_*` productions in the lexer
+   * section) -- as opposed to a *soft* keyword like `conforms`/`from`/`shape`, which
+   * lexes as a plain `<ID>` and is only special-cased by a lookahead on its image, so
+   * it's always free to use as an identifier. A hard keyword can never appear where
+   * `id()` (`<ID> | <QUOTED_ID>`) is expected -- e.g. `val class = 5` or a `for`-loop
+   * naming a variable `type` -- so the parser trips on the keyword itself, with an
+   * expected-token dump of `<ID>, <QUOTED_ID>` that never mentions that a reserved
+   * word can still be used as an identifier by escaping it with backticks. `void` has
+   * two spellings, both reserved.
+   */
+  private val ReservedWords = Set(
+    "abstract", "and", "as", "Boolean", "break", "Byte", "case", "catch", "Char", "class",
+    "const", "continue", "def", "do", "Double", "else", "enum", "extends", "extension",
+    "false", "final", "finally", "Float", "for", "foreach", "forward", "goto", "if",
+    "import", "instance", "interface", "internal", "Int", "is", "Long", "module", "new",
+    "null", "or", "override", "private", "protected", "public", "record", "ret", "return",
+    "select", "self", "Short", "static", "super", "sealed", "synchronized", "this", "throw",
+    "throws", "trait", "true", "try", "type", "Unit", "val", "var", "void", "volatile",
+    "when", "while"
+  )
+
   private def commonSyntaxHint(found: String, expected: String, context: String, sourceLine: String): String = found match {
     // The symbolic spellings of inheritance, replaced by `extends` and `conforms`.
     // `<:` no longer appears in any production, so meeting one can only be old source.
@@ -542,6 +564,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
     case "{" if ParenthesizedTrailingLambdaHead.findFirstMatchIn(context).isDefined =>
       val params = ParenthesizedTrailingLambdaHead.findFirstMatchIn(context).get.group(1).trim
       Message("error.parsing.hint.trailing_lambda_parens", params)
+    case word if ReservedWords.contains(word) && (expected.contains("<ID>") || expected.contains("<QUOTED_ID>")) =>
+      Message("error.parsing.hint.reserved_word_identifier", word)
     case _ if expected.contains("{") && !Set(";", "<EOL>", "<EOF>").exists(expected.contains) =>
       Message("error.parsing.hint.block_expected")
     case _ =>

--- a/src/test/scala/onion/compiler/ReservedWordIdentifierHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/ReservedWordIdentifierHintI18nSpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The reserved-word-as-identifier hint (`commonSyntaxHint`'s `ReservedWords`
+ * case) must resolve through the bilingual `error.parsing.hint.*` bundle in
+ * both locales, like every other hint in that match -- see
+ * JavaStyleImplementsHintI18nSpec for the same pattern.
+ */
+class ReservedWordIdentifierHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.reserved_word_identifier"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for `val class = 5`, naming the reserved word") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |val class = 5
+        |IO::println(class)
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The backtick-escaped word is literal, identical in both bundles, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("`class`"), s"expected the hint's backtick-escaped `class`, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/ReservedWordIdentifierHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ReservedWordIdentifierHintSpec.scala
@@ -1,0 +1,70 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A hard keyword token (`class`, `type`, `case`, ...) used where an identifier is
+ * expected, e.g. `val class = 5`. Onion lets a reserved word be used as an
+ * identifier by escaping it with backticks (`` `class` ``), but the raw
+ * expected-token dump (`<ID>, <QUOTED_ID>`) never mentions that. A *soft* keyword
+ * like `conforms`/`from`/`shape` lexes as a plain `<ID>` and is already a legal
+ * identifier on its own, so it must not trigger this hint.
+ */
+class ReservedWordIdentifierHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("reserved word used as an identifier") {
+    it("hints at backtick-escaping for `val class = 5` at top level") {
+      val msgs = messages(
+        """
+          |val class = 5
+          |IO::println(class)
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("`class`"), s"expected a hint mentioning backtick-escaped `class`, got: $msgs")
+    }
+
+    it("hints at backtick-escaping for a `type` local inside a method body") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val type = 5
+          |    IO::println(type)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("`type`"), s"expected a hint mentioning backtick-escaped `type`, got: $msgs")
+    }
+
+    it("does not fire for the correct backtick-escaped form") {
+      val msgs = messages(
+        """
+          |val `class` = 5
+          |IO::println(`class`)
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct backtick-escaped form, got: $msgs")
+    }
+
+    it("does not fire for the soft keyword `conforms` used as a plain identifier") {
+      val msgs = messages(
+        """
+          |val conforms = 5
+          |IO::println(conforms)
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the soft keyword `conforms` used as an identifier, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `val class = 5` (or any hard keyword in identifier position, e.g. `type`, `case`, `new`) trips the parser with a generic `expecting <ID>, <QUOTED_ID>` dump that never mentions that Onion lets a reserved word be used as an identifier by escaping it with backticks (`` `class` ``).
- Recognizes any of the grammar's hard `K_*` keyword tokens appearing where `id()` (`<ID> | <QUOTED_ID>`) is expected and points at the backtick-escaped form, naming the captured word.
- A *soft* keyword like `conforms`/`from`/`shape` — which lexes as a plain `<ID>` and is already a legal identifier on its own — is unaffected (covered by a regression test).
- Bilingual (en/ja) hint message added, following the existing `error.parsing.hint.*` pattern.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Test plan

- [x] New TDD spec `ReservedWordIdentifierHintSpec` (fires for `val class`, fires for a `type` local inside a method, does not fire for the correct backtick-escaped form, does not fire for the soft keyword `conforms` used as a plain identifier)
- [x] New bilingual coverage spec `ReservedWordIdentifierHintI18nSpec` (resolves in both locales, Japanese text differs from English, message content is locale-agnostic)
- [x] Full suite green in English locale: `sbt -Duser.language=en testFull` → 4085 succeeded, 0 failed
- [x] Full suite green in Japanese locale: `sbt -Duser.language=ja testFull` → 4085 succeeded, 0 failed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn5C73hB6fZqHpqf6DwkzG)_