### PR TITLE
fix(diagnostics): hint at val/var for a JS-style `let x = 1` declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a JS/TS/Swift/Rust/Kotlin-style `let x = 1` variable declaration.**
+  `let` is not a keyword at all in Onion -- it lexes as a plain identifier -- so
+  `let x = 1` at statement position is read as a bare identifier-reference statement
+  (`let`) immediately followed by another identifier (`x`), where only a statement
+  terminator is valid. The parser trips on the name one token past the actual mistake,
+  with an expected-token dump that never mentions `val`/`var`. The diagnostic now
+  recognizes a leading `let name` and points at the correct `val name: Type = value`
+  (or `var`, if it changes) form, the same way the existing `const` hint does.
+
 - **Parser hint for a reserved word used as an identifier, `val class = 5`.**
   A hard keyword token (`class`, `type`, `case`, ...) can never appear where `id()`
   (`<ID> | <QUOTED_ID>`) is expected, so the parser trips on the keyword itself with a

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -124,6 +124,7 @@ error.parsing.hint.java_style_implements=Hint: interfaces are named with `confor
 error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and can''t be used as an identifier directly — escape it with backticks, writing `{0}` (with backticks) instead.
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
+error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `let name = value`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -124,6 +124,7 @@ error.parsing.hint.java_style_implements=ヒント: インターフェースは 
 error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のため、そのままでは識別子として使えません — バッククォートでエスケープして `{0}`（バッククォート付き）と書いてください。
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
+error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `let name = value` ではなく `val name: Type = value` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -261,6 +261,20 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val LeadingWhenStatement = """^\s*when\b""".r
 
   /**
+   * A JS/TS/Swift/Rust/Kotlin-style `let x = 1` variable declaration. Unlike
+   * `const`, `let` is not a keyword at all in Onion -- it lexes as a plain
+   * identifier -- so `let x = 1` at statement position is read as a bare
+   * identifier-reference statement (`let`) immediately followed by another
+   * identifier (`x`), where only a statement terminator is valid. The parser
+   * trips on the name one token past the actual mistake, with an
+   * expected-token dump that never mentions `val`/`var`. Requiring a space
+   * before the following identifier (rather than `(` or `=`) keeps this from
+   * firing on a call to a function literally named `let` (`let(x)`) or a
+   * reassignment of a variable literally named `let` (`let = 1`).
+   */
+  private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
+
+  /**
    * A Kotlin (`fun`), Swift/Go (`func`), or Rust (`fn`) function/method
    * declaration. None of these are keywords in Onion (which uses `def`), so at
    * statement position the keyword parses as a bare identifier reference and the
@@ -528,6 +542,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.switch_not_supported")
     case "when" if LeadingWhenStatement.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.when_not_supported")
+    case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.js_style_let")
     case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       val m = FunExtensionDeclaration.findFirstMatchIn(sourceLine).get
       Message("error.parsing.hint.fun_extension_declaration", m.group(1), m.group(2))

--- a/src/test/scala/onion/compiler/JsStyleLetHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JsStyleLetHintI18nSpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The JS-style-`let` hint (`commonSyntaxHint`'s `LeadingLetDeclaration`
+ * case) must resolve through the bilingual `error.parsing.hint.*` bundle in
+ * both locales, like every other hint in that match -- see
+ * JsStyleConstHintI18nSpec for the same pattern.
+ */
+class JsStyleLetHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.js_style_let"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JS-style `let x: Int = 5` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |let x: Int = 5
+        |IO::println(x)
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("val name: Type = value"), s"expected the hint's `val name: Type = value` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/JsStyleLetHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JsStyleLetHintSpec.scala
@@ -1,0 +1,69 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A JS/TS/Swift/Rust/Kotlin-style `let x = 1` variable declaration. `let`
+ * is not a keyword at all in Onion -- it lexes as a plain identifier -- so
+ * `let x = 1` is read as a bare identifier-reference statement (`let`)
+ * immediately followed by another identifier (`x`), and the parser trips on
+ * the name one token past the actual mistake.
+ */
+class JsStyleLetHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("JS-style `let` declaration") {
+    it("hints at `val`/`var` for a top-level `let x: Int = 5`") {
+      val msgs = messages(
+        """
+          |let x: Int = 5
+          |IO::println(x)
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("val name: Type = value"), s"expected a hint mentioning `val name: Type = value`, got: $msgs")
+    }
+
+    it("hints at `val`/`var` for a `let` declaration inside a method body") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    let x: Int = 5
+          |    IO::println(x)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("val name: Type = value"), s"expected a hint mentioning `val name: Type = value`, got: $msgs")
+    }
+
+    it("does not fire for the correct `val` form") {
+      val msgs = messages(
+        """
+          |val x: Int = 5
+          |IO::println(x)
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `val` form, got: $msgs")
+    }
+
+    it("does not fire for a call to a function literally named `let`") {
+      val msgs = messages(
+        """
+          |def let(x: Int): Int = x
+          |IO::println(let(5))
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for a call to a function named `let`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `let` is not a keyword in Onion — it lexes as a plain identifier — so `let x = 1` at statement position is read as a bare identifier-reference statement (`let`) immediately followed by another identifier (`x`), where only a statement terminator is valid. The parser trips on the name one token past the actual mistake, with an expected-token dump that never mentions `val`/`var`.
- Adds a `commonSyntaxHint` case (mirroring the existing `const` hint) that recognizes a leading `let name` on the source line and points at the correct `val name: Type = value` (or `var`) form, in both English and Japanese message bundles.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] New tests written first (TDD): `src/test/scala/onion/compiler/tools/JsStyleLetHintSpec.scala`, `src/test/scala/onion/compiler/JsStyleLetHintI18nSpec.scala`
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.JsStyleLetHintSpec onion.compiler.JsStyleLetHintI18nSpec'` — 7/7 passed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4098 succeeded, 0 failed, 1 canceled (expected dist smoke test), 0 skipped


---
_Generated by [Claude Code](https://claude.ai/code/session_014nz5nXzqCCoiDC3fDZMV2d)_