### PR TITLE
Recognize JS/TS/PHP-style `function name()` declarations in parser hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a JS/TS/PHP-style `function name(...) { ... }` declaration.**
+  `function` is not a keyword in Onion (which uses `def`), so it parses as a bare
+  identifier reference and the parser trips on the declaration name that follows,
+  with a generic expected-token dump that never mentions `def`. The existing
+  `fun`/`func`/`fn` hint now also recognizes `function`, including the
+  `function Type.method(...)` extension-method mistake.
+
 ## [0.18.0] - 2026-08-24
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -105,7 +105,7 @@ error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
-error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn` keyword. Write `def name(...): ReturnType { ... }`.
+error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -105,7 +105,7 @@ error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉�
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
-error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
+error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -275,28 +275,28 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
 
   /**
-   * A Kotlin (`fun`), Swift/Go (`func`), or Rust (`fn`) function/method
-   * declaration. None of these are keywords in Onion (which uses `def`), so at
-   * statement position the keyword parses as a bare identifier reference and the
-   * parser trips on the declaration name that follows, while inside a
-   * class/interface body it trips on the keyword itself -- neither mentions
-   * `def`. Matching the source line for `<kw> name(` catches both. A real call
-   * to a method named `fun`/`func`/`fn` is `fun(...)` with no name between the
-   * keyword and the paren, so it never matches; `fun name(` is not a valid Onion
-   * expression anyway.
+   * A Kotlin (`fun`), Swift/Go (`func`), Rust (`fn`), or JS/TS/PHP (`function`)
+   * function/method declaration. None of these are keywords in Onion (which uses
+   * `def`), so at statement position the keyword parses as a bare identifier
+   * reference and the parser trips on the declaration name that follows, while
+   * inside a class/interface body it trips on the keyword itself -- neither
+   * mentions `def`. Matching the source line for `<kw> name(` catches all four
+   * spellings. A real call to a method named `fun`/`func`/`fn`/`function` is
+   * `fun(...)` with no name between the keyword and the paren, so it never
+   * matches; `fun name(` is not a valid Onion expression anyway.
    */
-  private val FunDeclaration = """\b(?:fun|func|fn)\s+[A-Za-z_]\w*\s*\(""".r
+  private val FunDeclaration = """\b(?:fun|func|fn|function)\s+[A-Za-z_]\w*\s*\(""".r
 
   /**
    * A Kotlin-style extension-function declaration, `fun String.twice(): String { ... }`.
-   * This is a more specific form of the `fun`/`func`/`fn` mistake above: the receiver-dot
-   * syntax means [[FunDeclaration]]'s `<kw> name(` pattern never matches -- the identifier
-   * directly after the keyword is the *receiver type*, followed by `.`, not `(` -- so without
-   * its own case this would fall through to the generic parse error instead of naming Onion's
-   * `extension` block. Capturing the receiver type and method name lets the hint show the
-   * exact rewrite instead of just pointing at `def`.
+   * This is a more specific form of the `fun`/`func`/`fn`/`function` mistake above: the
+   * receiver-dot syntax means [[FunDeclaration]]'s `<kw> name(` pattern never matches -- the
+   * identifier directly after the keyword is the *receiver type*, followed by `.`, not `(` --
+   * so without its own case this would fall through to the generic parse error instead of
+   * naming Onion's `extension` block. Capturing the receiver type and method name lets the
+   * hint show the exact rewrite instead of just pointing at `def`.
    */
-  private val FunExtensionDeclaration = """\b(?:fun|func|fn)\s+([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\(""".r
+  private val FunExtensionDeclaration = """\b(?:fun|func|fn|function)\s+([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\(""".r
 
   /**
    * A Java-style parenthesized catch clause, `catch (e: Exception) { }`. `catch`

--- a/src/test/scala/onion/compiler/tools/FunDeclarationHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FunDeclarationHintSpec.scala
@@ -43,6 +43,17 @@ class FunDeclarationHintSpec extends AbstractShellSpec {
       assert(msgs.contains("def"), s"expected a hint mentioning def, got: $msgs")
     }
 
+    it("hints at def for a JS/TS/PHP-style function declaration") {
+      val msgs = messages("function greet(): void { IO::println(\"hi\") }\n")
+      assert(msgs.contains("def"), s"expected a hint mentioning def, got: $msgs")
+      assert(msgs.contains("function"), s"expected the hint to name function, got: $msgs")
+    }
+
+    it("does not fire for a call to a method literally named function") {
+      val msgs = messages("val x = function(1, 2)\n")
+      assert(!msgs.contains("declared with"), s"hint should not fire for a function(...) call, got: $msgs")
+    }
+
     it("does not fire for an unrelated bare-identifier-statement typo") {
       val msgs = messages("foo bar\n")
       assert(!msgs.contains("declared with"), s"hint should not fire without a leading fun/func/fn, got: $msgs")

--- a/src/test/scala/onion/compiler/tools/FunExtensionDeclarationHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FunExtensionDeclarationHintSpec.scala
@@ -34,6 +34,12 @@ class FunExtensionDeclarationHintSpec extends AbstractShellSpec {
       assert(msgs.contains("doubled"), s"expected the hint to name the method, got: $msgs")
     }
 
+    it("hints at an extension block for a function-spelled receiver method") {
+      val msgs = messages("function Int.doubled(): Int { return this * 2 }\n")
+      assert(msgs.contains("extension"), s"expected a hint mentioning extension, got: $msgs")
+      assert(msgs.contains("doubled"), s"expected the hint to name the method, got: $msgs")
+    }
+
     it("still hints at def (not extension) for a receiver-less fun declaration") {
       val msgs = messages("fun greet(): void { IO::println(\"hi\") }\n")
       assert(msgs.contains("def"), s"expected a hint mentioning def, got: $msgs")


### PR DESCRIPTION
## Summary
- `function` is not a keyword in Onion (which uses `def`), so `function foo(x: Int): Int { ... }` parses as a bare identifier reference and the parser trips on the declaration name that follows, with a generic expected-token dump that never mentions `def`:
  ```
  1:10: Syntax error. Encountered "foo", but expecting <EOF>, <EOL>, ";"
  ```
- Extends the existing `fun`/`func`/`fn` diagnostic hint (`FunDeclaration`/`FunExtensionDeclaration` in `Parsing.scala`) to also recognize the JS/TS/PHP `function` spelling, for both the plain declaration and the `function Type.method(...)` extension-method mistake.
- Updates both the English and Japanese `error.parsing.hint.fun_declaration` bundle strings.
- Adds test cases to `FunDeclarationHintSpec` and `FunExtensionDeclarationHintSpec`, plus a matching `[Unreleased]` CHANGELOG entry.

## Verification
- GitHub Actions CI (cold checkout, full `sbt +test`) on this commit: **success** — [run 2804](https://github.com/onion-lang/onion/actions/runs/32742971032) (push), [run 2805](https://github.com/onion-lang/onion/actions/runs/32743007511) (pull_request).
- Locally, the two targeted specs pass in both locales:
  ```
  $ sbt -Duser.language=en 'testOnly onion.compiler.tools.FunDeclarationHintSpec onion.compiler.tools.FunExtensionDeclarationHintSpec'
  Tests: succeeded 12, failed 0
  $ sbt -Duser.language=ja 'testOnly onion.compiler.tools.FunDeclarationHintSpec onion.compiler.tools.FunExtensionDeclarationHintSpec'
  Tests: succeeded 12, failed 0
  ```
- A local `sbt -Duser.language=en testFull` run stalled twice in this session's sandbox (GC-thrashing under a 4GB heap cap, unrelated to this change — memory freed back to ~14GB once killed); CI's cold, higher-memory run above supersedes that as the authoritative full-suite signal, per this repo's own note that CI always runs cold regardless of local `target/` state.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.FunDeclarationHintSpec onion.compiler.tools.FunExtensionDeclarationHintSpec'` — 12/12 passing
- [x] `sbt -Duser.language=ja 'testOnly onion.compiler.tools.FunDeclarationHintSpec onion.compiler.tools.FunExtensionDeclarationHintSpec'` — 12/12 passing
- [x] GitHub Actions CI — success

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaBmjabAe4qXqTRfRLd6TT)_
