### PR TITLE
fix(parser): add diagnostic hint for Rust/Scala/OCaml-style `match`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Rust/Scala/OCaml-style `match value { ... }` expression.**
+  `match` is not a keyword in Onion (which uses `select`), so it parses as a bare
+  identifier reference and the parser trips on whatever follows it, with a generic
+  expected-token dump that never mentions `select`. The diagnostic now recognizes
+  a leading `match` at the start of a statement, unparenthesized or parenthesized,
+  the same way the existing `switch`/`when` hints do.
+
 - **Parser hint for a JS/TS/PHP-style `function name(...) { ... }` declaration.**
   `function` is not a keyword in Onion (which uses `def`), so it parses as a bare
   identifier reference and the parser trips on the declaration name that follows,

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -106,6 +106,7 @@ error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
+error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style `match` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -106,6 +106,7 @@ error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉�
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
+error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風の `match` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -261,6 +261,17 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val LeadingWhenStatement = """^\s*when\b""".r
 
   /**
+   * A Rust/Scala/OCaml-style `match` expression at the start of a source line.
+   * `match` isn't a keyword in Onion -- it parses as a bare identifier-reference
+   * statement -- so the parser actually trips on whatever follows it (the
+   * scrutinee, or the `{` of a parenthesized scrutinee), never on `match`
+   * itself. Matching the *line*, not the token that triggered the error,
+   * catches `match x { ... }` and `match (x) { ... }` alike (mirroring the
+   * `switch` hint).
+   */
+  private val LeadingMatchStatement = """^\s*match\b""".r
+
+  /**
    * A JS/TS/Swift/Rust/Kotlin-style `let x = 1` variable declaration. Unlike
    * `const`, `let` is not a keyword at all in Onion -- it lexes as a plain
    * identifier -- so `let x = 1` at statement position is read as a bare
@@ -542,6 +553,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.switch_not_supported")
     case "when" if LeadingWhenStatement.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.when_not_supported")
+    case _ if LeadingMatchStatement.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.match_not_supported")
     case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.js_style_let")
     case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/tools/MatchStatementHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MatchStatementHintSpec.scala
@@ -1,0 +1,78 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no Rust/Scala/OCaml-style `match` expression -- `select` covers the
+ * same ground. `match` isn't a keyword in Onion, so it parses as a bare
+ * identifier reference and the parser actually trips on whatever follows it
+ * (the scrutinee, or the `{` of a parenthesized scrutinee), never mentioning
+ * `select`.
+ */
+class MatchStatementHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("match statement") {
+    it("hints at select for an unparenthesized match") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    match x {
+          |    case 1: IO::println("one")
+          |    else: IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("select"), s"expected a hint mentioning select, got: $msgs")
+      assert(msgs.contains("match"), s"expected the hint to name match, got: $msgs")
+    }
+
+    it("hints at select for a parenthesized match") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    match (x) {
+          |    case 1: IO::println("one")
+          |    else: IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("select"), s"expected a hint mentioning select, got: $msgs")
+      assert(msgs.contains("match"), s"expected the hint to name match, got: $msgs")
+    }
+
+    it("does not fire for an unrelated bare-identifier-statement typo") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foo bar
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("select"), s"hint should not fire without a leading `match`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Onion has no `match` expression (Rust/Scala/OCaml style) — `select` covers the same ground, but `match` is not a keyword, so it parses as a bare identifier reference and the parser trips on whatever follows it with a generic expected-token dump that never mentions `select`.
- Adds a diagnostic hint recognizing a leading `match` at the start of a statement (unparenthesized or parenthesized scrutinee), mirroring the existing `switch`/`when` hints.
- Bilingual message added to both `errorMessage.properties` and `errorMessage_ja.properties`.
- `CHANGELOG.md` updated under `[Unreleased]`.

Before:
```
match x {
      ^
Syntax error. Encountered "x", but expecting <EOF>, <EOL>, ";"
```

After: hint text naming `match` and pointing at `select value { case 1: ...; else: ... }`.

## Test plan

- [x] New spec `MatchStatementHintSpec` written first (TDD red), then implementation added (green)
- [x] Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4105 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated distribution smoke test unrelated to this change)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01FKtUDoLewBXtd6ufDrqSFW)_