### PR TITLE
fix(diagnostics): hint at else if for a Python-style elif clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pointing at `def main(args: String[]): void { ... }` or adding executable
   top-level statements.
 
+- **Parser hint for a Python-style `elif` clause.**
+  `elif` is not a keyword in Onion (which chains with `else if`), so it parses
+  as a bare identifier reference and the parser trips on whatever follows it
+  (the condition), with a generic expected-token dump that never mentions
+  `else if`. Unlike the `switch`/`when`/`match` hints, `elif` almost never
+  starts a source line -- it typically follows the closing `}` of the
+  preceding branch on the same line (`} elif b { ... }`) -- so the diagnostic
+  matches the keyword anywhere on the line instead of anchoring at the start.
+
 ## [0.18.0] - 2026-08-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,7 @@ These are frequently confused with other languages. **Always check these:**
 | `if (condition) { }` | `if condition { }` - no parentheses around condition |
 | `while (condition) { }` | `while condition { }` - no parentheses |
 | `else if condition { }` | ✓ correct - `else if` chains are supported (also as expressions) |
+| `elif condition { }` (Python) | `else if condition { }` - no `elif` keyword, chain with `else if` |
 | `switch value { case 1: }` | `select value { case 1: }` - use `select` not `switch` |
 | `case s: String:` (Java/Scala pattern) | `case s is String:` - type patterns use `is`; sealed exhaustiveness (E0042) applies |
 | `case Add(l, n is Num):` nested type pattern? | ✓ correct - type patterns nest inside destructuring, and the binding is usable at the narrowed type; also works for a non-record component (`case Wrap(s is String)`) |

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -107,6 +107,7 @@ error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a 
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
 error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style `match` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
+error.parsing.hint.elif_not_supported=Hint: Onion has no Python-style `elif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -107,6 +107,7 @@ error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポート
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
 error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風の `match` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
+error.parsing.hint.elif_not_supported=ヒント: Onion に Python 風の `elif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -272,6 +272,18 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val LeadingMatchStatement = """^\s*match\b""".r
 
   /**
+   * A Python-style `elif` clause chaining an `if`. `elif` isn't a keyword in
+   * Onion (which chains with `else if`), so it parses as a bare
+   * identifier-reference statement and the parser trips on whatever follows
+   * it (the condition), never on `elif` itself. Unlike the `switch`/`when`/
+   * `match` hints above, `elif` almost never starts a source line -- it
+   * follows the closing `}` of the preceding branch on the same line, e.g.
+   * `} elif b { ... }` -- so this matches the keyword anywhere on the line
+   * rather than anchoring at the start.
+   */
+  private val ElifStatement = """\belif\b""".r
+
+  /**
    * A JS/TS/Swift/Rust/Kotlin-style `let x = 1` variable declaration. Unlike
    * `const`, `let` is not a keyword at all in Onion -- it lexes as a plain
    * identifier -- so `let x = 1` at statement position is read as a bare
@@ -555,6 +567,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.when_not_supported")
     case _ if LeadingMatchStatement.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.match_not_supported")
+    case _ if ElifStatement.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.elif_not_supported")
     case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.js_style_let")
     case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/ElifStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/ElifStatementHintI18nSpec.scala
@@ -1,0 +1,55 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The elif hint (`commonSyntaxHint`'s `ElifStatement` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that match -- see OldForInHintI18nSpec for the
+ * motivating regression.
+ */
+class ElifStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.elif_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Python-style `elif` clause") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val x = 1
+        |    if x == 1 {
+        |      IO::println("one")
+        |    } elif x == 2 {
+        |      IO::println("two")
+        |    }
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("else if"), s"expected the hint's `else if` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/ElifStatementHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ElifStatementHintSpec.scala
@@ -1,0 +1,82 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no Python-style `elif` clause -- `else if` covers the same
+ * ground. `elif` isn't a keyword in Onion, so it parses as a bare
+ * identifier-reference statement and the parser actually trips on whatever
+ * follows it (the condition), never on `elif` itself.
+ */
+class ElifStatementHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("elif clause") {
+    it("hints at else if for a Python-style elif chained onto the closing brace") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    if x == 1 {
+          |      IO::println("one")
+          |    } elif x == 2 {
+          |      IO::println("two")
+          |    } else {
+          |      IO::println("other")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("else if"), s"expected a hint mentioning else if, got: $msgs")
+      assert(msgs.contains("elif"), s"expected the hint to name elif, got: $msgs")
+    }
+
+    it("hints at else if for a leading elif on its own line") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 1
+          |    if x == 1 {
+          |      IO::println("one")
+          |    }
+          |    elif x == 2 {
+          |      IO::println("two")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("else if"), s"expected a hint mentioning else if, got: $msgs")
+      assert(msgs.contains("elif"), s"expected the hint to name elif, got: $msgs")
+    }
+
+    it("does not fire for an unrelated bare-identifier-statement typo") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foo bar
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("else if"), s"hint should not fire without an `elif`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `elif` is not a keyword in Onion (which chains with `else if`), so it parses as a bare identifier-reference statement and the parser trips on whatever follows it (the condition), with a generic expected-token dump that never mentions `else if`.
- Adds a `commonSyntaxHint` case recognizing `elif` anywhere on the source line (not anchored at line-start like the `switch`/`when`/`match` hints, since `elif` typically follows the closing `}` of the preceding branch on the same line: `} elif b { ... }`).
- Bilingual hint message (en/ja), `CLAUDE.md` mistakes table entry, and `CHANGELOG.md` `[Unreleased]` entry.

## Test plan
- [x] New `ElifStatementHintSpec` (3 cases: trailing `} elif ... {`, leading-line `elif`, and a negative case) — pass.
- [x] New `ElifStatementHintI18nSpec` (en/ja bundle resolution + fires-for-elif) — pass.
- [x] GitHub Actions CI (`sbt +test`, English locale, fresh/uncached) — green: https://github.com/onion-lang/onion/actions/runs/32783711442
- [x] Full `sbt -Duser.language=ja testFull` locally (bumped heap to `-Xmx10G`, this sandbox's default `-Xmx4G` was insufficient to complete the full suite without OOM, unrelated to this change) — 4111 succeeded, 0 failed, 1 pre-existing conditional cancellation (`ProjectDistributionSpec`'s dist smoke test, gated on `-Donion.dist.path`).
