### PR TITLE
fix(diagnostics): hint at correct foreach syntax for parenthesized foreach (x in xs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java/Kotlin/JS-style parenthesized `foreach (x in xs) { ... }` loop.**
+  `foreach` only takes parentheses for the two-variable map-destructuring form,
+  `foreach (k, v) in map { ... }` -- a single loop variable is never parenthesized
+  (`foreach x: Type in xs { ... }`). Writing `foreach (x in xs)` made the parser take
+  the map-destructuring branch, consume `x` as the key, and trip on `in` expecting a
+  `,`, which surfaced the unrelated "Onion does not support `for x in xs`, use a
+  C-style loop" hint -- confusing advice, since `foreach` is already the right
+  construct and the only mistake is the stray parentheses. The diagnostic now
+  recognizes a parenthesized `foreach` head and points at both correct forms.
+
 - **Parser hint for a Rust/Scala/OCaml-style `match value { ... }` expression.**
   `match` is not a keyword in Onion (which uses `select`), so it parses as a bare
   identifier reference and the parser trips on whatever follows it, with a generic

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -104,6 +104,7 @@ error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
+error.parsing.hint.foreach_parens=Hint: `foreach` doesn''t parenthesize a single loop variable — write `foreach x: Type in xs { ... }`, not `foreach (x in xs) { ... }`. Parentheses are only for destructuring a map''s entries: `foreach (k, v) in map { ... }`.
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
 error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style `match` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -104,6 +104,7 @@ error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラク�
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
+error.parsing.hint.foreach_parens=ヒント: `foreach` は単一のループ変数を丸かっこで囲みません — `foreach (x in xs) { ... }` ではなく `foreach x: Type in xs { ... }` と書いてください。丸かっこはマップのエントリを分解する場合のみ使います: `foreach (k, v) in map { ... }`。
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
 error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風の `match` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -341,6 +341,16 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val CStyleForLoop = """^\s*for\s*\(""".r
 
   /**
+   * A `foreach` with a parenthesized loop head, `foreach (x in xs) { }`. `foreach`
+   * itself only takes parentheses for the two-variable map-destructuring form
+   * (`foreach (k, v) in map { }`); a single variable is never parenthesized. `foreach`
+   * cannot appear as an identifier (it is reserved), so a `foreach\s*\(` earlier on the
+   * line -- checked once the parser has already tripped on `in` expecting a `,` -- can
+   * only be the single-variable form written with stray parens.
+   */
+  private val ForeachParenMistake = """\bforeach\s*\(""".r
+
+  /**
    * A Java/C#-style unbraced `import java.util.List;` (or wildcard/no-semicolon variant).
    * Onion's `import` decl always wraps its targets in braces -- `import { java.util.List }`
    * -- so the parser consumes the `import` keyword and then trips on the identifier that
@@ -559,6 +569,16 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.old_super_init")
     case "(" if expected.contains("<ID>") && ParenthesizedCatchClause.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.catch_parens")
+    // `foreach` only takes parentheses for the two-variable map-destructuring form,
+    // `foreach (k, v) in map { ... }` -- a single loop variable is never parenthesized
+    // (`foreach x: Type in xs { ... }`). Writing the Java/Kotlin/JS-style
+    // `foreach (x in xs) { ... }` makes the parser take the map-destructuring branch,
+    // consume `x` as the key, and then trip on `in` expecting a `,`. Without this case
+    // that falls through to the generic `old_for_in` hint below, which tells the writer
+    // to abandon `foreach` for a C-style loop -- the wrong advice when they already
+    // reached for the right construct and just added stray parentheses.
+    case "in" if ForeachParenMistake.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.foreach_parens")
     case "in" =>
       Message("error.parsing.hint.old_for_in")
     case _ if LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/ForeachParensHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/ForeachParensHintI18nSpec.scala
@@ -1,0 +1,53 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The foreach-parens hint (`commonSyntaxHint`'s `ForeachParenMistake` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that match -- see OldForInHintI18nSpec for the
+ * motivating regression.
+ */
+class ForeachParensHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.foreach_parens"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java/Kotlin/JS-style `foreach (x in xs)` clause") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val xs = [1, 2, 3]
+        |    foreach (x in xs) {
+        |      IO::println(x)
+        |    }
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("foreach x: Type in xs"), s"expected the hint's foreach example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/tools/ForeachParensHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ForeachParensHintSpec.scala
@@ -1,0 +1,80 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * `foreach` never parentheses a single loop variable -- `foreach x: Type in xs { ... }` --
+ * parentheses are reserved for the two-variable map-destructuring form,
+ * `foreach (k, v) in map { ... }`. Writing the Java/Kotlin/JS-style
+ * `foreach (x in xs) { ... }` makes the parser take the map-destructuring
+ * branch, consume `x` as the key, and then trip on `in` expecting a `,` --
+ * which used to surface the unrelated `old_for_in` ("use a C-style loop")
+ * hint, even though the fix here is simply to use `foreach` correctly.
+ */
+class ForeachParensHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("foreach with parenthesized single variable") {
+    it("hints at the correct foreach forms instead of the old-style for-in hint") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs = [1, 2, 3]
+          |    foreach (x in xs) {
+          |      IO::println(x)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("foreach"), s"expected the hint to mention foreach, got: $msgs")
+      assert(!msgs.contains("C-style loop"), s"hint should not fall back to the for-in advice, got: $msgs")
+    }
+
+    it("does not fire for the valid two-variable map-destructuring form") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val m = ["a": 1, "b": 2]
+          |    foreach (k, v) in m {
+          |      IO::println(k)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for valid foreach, got: $msgs")
+    }
+
+    it("still hints at a C-style loop for the unrelated old `for x in xs` mistake") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs = [1, 2, 3]
+          |    for x in xs {
+          |      IO::println(x)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("C-style loop"), s"expected the old for-in hint to still fire, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `foreach` only takes parentheses for the two-variable map-destructuring form, `foreach (k, v) in map { ... }` — a single loop variable is never parenthesized (`foreach x: Type in xs { ... }`).
- Writing the Java/Kotlin/JS-style `foreach (x in xs) { ... }` makes the parser take the map-destructuring branch, consume `x` as the key, and trip on `in` expecting a `,`. That previously surfaced the unrelated `old_for_in` hint ("Onion does not support `for x in xs`, use a C-style loop") — confusing advice, since `foreach` is already the right construct and the only mistake is the stray parentheses.
- Adds a dedicated `foreach_parens` hint (bilingual, en/ja) that points at both correct forms, and updates `CHANGELOG.md` under `[Unreleased]`.

## Test plan

- [x] Added `ForeachParensHintSpec` (fires for the mistake, does not fire for valid `foreach (k, v) in map`, and the old `for x in xs` hint still fires unchanged) and `ForeachParensHintI18nSpec` (bilingual bundle resolution) — `sbt testOnly` on the new specs: 9/9 passed.
- [x] CI (`test` job, en + ja locale) — both green: https://github.com/onion-lang/onion/actions/runs/32803005474 and https://github.com/onion-lang/onion/actions/runs/32802986448
