### PR TITLE
fix(diagnostics): stop hinting a C-style for-loop for `for (a, b) in xs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for the `for (a, b) in xs` / `for a, b in xs` destructuring mistake
+  no longer recommends the wrong rewrite.** `for` never destructures or iterates a
+  collection in Onion (that's `foreach`'s job), but the comma right after `for` made
+  this fall through to the generic C-style-`for` hint, which told the reader to
+  rewrite it as a numeric-index loop -- an unhelpful, unrelated suggestion. It now
+  recognizes both the parenthesized and unparenthesized forms and points at the
+  correct `foreach (a, b) in xs { ... }` instead. The related `for x in xs` hint's
+  wording was also updated to mention `foreach x: Type in xs { ... }` -- the actual
+  idiomatic form -- instead of only suggesting a C-style loop.
+
 - **Parser hint for a Rust/Scala/OCaml-style `match value { ... }` expression.**
   `match` is not a keyword in Onion (which uses `select`), so it parses as a bare
   identifier reference and the parser trips on whatever follows it, with a generic

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -103,7 +103,7 @@ error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `-
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
-error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`.
+error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use `foreach x: Type in xs { ... }` (or a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`).
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
 error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style `match` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
@@ -113,6 +113,7 @@ error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
+error.parsing.hint.for_each_destructure=Hint: `for` doesn''t destructure or iterate a collection — that''s `foreach`''s job — write `foreach ({0}) in {1} '{' ... '}'`, not `for ({0}) in {1}`.
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.parsing.hint.java_style_import_alias=Hint: an import''s alias is named with `as`, not `=` — write `{0} as {1}`, not `{1} = {0}`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -103,7 +103,7 @@ error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他�
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
-error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。C スタイルのループを使ってください: `for var i = 0; i < xs.size(); i = i + 1 { ... }`。
+error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。`foreach x: Type in xs { ... }` を使ってください（または C スタイルのループ: `for var i = 0; i < xs.size(); i = i + 1 { ... }`）。
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
 error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風の `match` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
@@ -113,6 +113,7 @@ error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.meth
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
+error.parsing.hint.for_each_destructure=ヒント: `for` はコレクションを分配・反復できません — それは `foreach` の役目です — `for ({0}) in {1}` ではなく `foreach ({0}) in {1} '{' ... '}'` と書いてください。
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.parsing.hint.java_style_import_alias=ヒント: import のエイリアスは `=` ではなく `as` で指定します — `{1} = {0}` ではなく `{0} as {1}` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -341,6 +341,22 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val CStyleForLoop = """^\s*for\s*\(""".r
 
   /**
+   * A Java/Python/JS-style `for (a, b) in xs { ... }` (or unparenthesized
+   * `for a, b in xs { ... }`) loop, meant to destructure map entries or walk
+   * a collection with `for` instead of `foreach`. The comma right after `for`
+   * (optionally inside parens) is what the parser trips on -- either as an
+   * unexpected token inside a would-be C-style init clause (parenthesized
+   * form) or as an unexpected token where only a statement terminator is
+   * valid (unparenthesized form) -- so without a dedicated check this falls
+   * through to the generic C-style-`for` hint above, which recommends a
+   * numeric-index rewrite that has nothing to do with the actual mistake.
+   * Checked *before* [[CStyleForLoop]], whose broader `for\s*\(` pattern
+   * would otherwise shadow the parenthesized form of this one.
+   */
+  private val ForEachDestructureMistake =
+    """^\s*for\s*\(?\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)+)\s*\)?\s*in\s+([^{]+?)\s*\{?\s*$""".r
+
+  /**
    * A Java/C#-style unbraced `import java.util.List;` (or wildcard/no-semicolon variant).
    * Onion's `import` decl always wraps its targets in braces -- `import { java.util.List }`
    * -- so the parser consumes the `import` keyword and then trips on the identifier that
@@ -583,6 +599,9 @@ class Parsing(config: CompilerConfig) extends AnyRef
     case name if PrimitiveTypeNames.contains(name) && DotAfterPrimitiveTypeName.findFirstMatchIn(context).isDefined =>
       val member = DotAfterPrimitiveTypeName.findFirstMatchIn(context).get.group(1)
       Message("error.parsing.hint.primitive_dot_static", name, member)
+    case _ if ForEachDestructureMistake.findFirstMatchIn(sourceLine).isDefined =>
+      val m = ForEachDestructureMistake.findFirstMatchIn(sourceLine).get
+      Message("error.parsing.hint.for_each_destructure", m.group(1), m.group(2).trim)
     case _ if CStyleForLoop.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.c_style_for")
     case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/tools/ForEachDestructureHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ForEachDestructureHintSpec.scala
@@ -1,0 +1,97 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A Java/Python/JS-style `for (a, b) in xs { ... }` (or unparenthesized
+ * `for a, b in xs { ... }`) loop, meant to destructure map entries or iterate
+ * a collection. Onion's `for` never destructures or iterates directly -- that
+ * is `foreach`'s job -- but the comma inside the parens makes the parser trip
+ * on it while still trying to read a C-style `for (init; cond; step)` clause,
+ * so without a dedicated hint the line falls through to the generic
+ * C-style-`for` hint, which recommends a numeric-index rewrite that has
+ * nothing to do with the actual mistake.
+ */
+class ForEachDestructureHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("`for (a, b) in xs` destructuring mistake") {
+    it("hints at `foreach (k, v) in m` for the parenthesized form") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val m = ["a": 1, "b": 2]
+          |    for (k, v) in m {
+          |      IO::println(k)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("foreach (k, v) in m"), s"expected a hint mentioning `foreach (k, v) in m`, got: $msgs")
+    }
+
+    it("hints at `foreach (k, v) in m` for the unparenthesized form") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val m = ["a": 1, "b": 2]
+          |    for k, v in m {
+          |      IO::println(k)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("foreach (k, v) in m"), s"expected a hint mentioning `foreach (k, v) in m`, got: $msgs")
+    }
+
+    it("does not fire for the correct `foreach (k, v) in m` form") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val m = ["a": 1, "b": 2]
+          |    foreach (k, v) in m {
+          |      IO::println(k)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `foreach` form, got: $msgs")
+    }
+
+    it("still hints at the C-style rewrite for a real `for (init; cond; step)` loop") {
+      val msgs = messages(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    for (int i = 0; i < 10; i++) {
+          |      IO::println(i)
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("for var i"), s"expected the C-style `for` hint to still fire, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `for` never destructures or iterates a collection in Onion — that's `foreach`'s job — but writing `for (k, v) in m { ... }` (or the unparenthesized `for k, v in m { ... }`) tripped the parser on the comma while it was still trying to read a C-style `for (init; cond; step)` clause. Without a dedicated check, this fell through to the generic C-style-`for` hint, which recommends a numeric-index rewrite that has nothing to do with the actual mistake.
- Added a dedicated `for_each_destructure` hint that recognizes both the parenthesized and unparenthesized forms and points at the correct `foreach (k, v) in m { ... }` instead. It's checked before the broader C-style-`for` pattern so it takes precedence only for this specific shape.
- Also updated the existing `for x in xs` hint (`old_for_in`) to mention `foreach x: Type in xs { ... }` — the actual idiomatic form — instead of only suggesting a clunky C-style loop rewrite.
- Both English and Japanese message resource files updated.

## Test plan

- [x] New `ForEachDestructureHintSpec` (TDD: written first, confirmed red against the old behavior) covers: parenthesized form, unparenthesized form, the correct `foreach` form does not fire, and the real C-style `for (init; cond; step)` hint still fires.
- [x] Manually verified rendered output in both `en` and `ja` locales (MessageFormat argument substitution with escaped literal braces).
- [x] Full suite green in both locales: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` and `=ja testFull` — 4115 succeeded, 0 failed, 1 benign canceled (an opt-in distribution smoke test gated behind a system property, unrelated to this change) in both runs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9fkRdpZprBSE2gX6J2M9o)_