### PR TITLE
test: fix locale-dependent assertion in ForeachParensHintSpec

### DIFF
--- a/src/test/scala/onion/compiler/tools/ForeachParensHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ForeachParensHintSpec.scala
@@ -38,7 +38,7 @@ class ForeachParensHintSpec extends AbstractShellSpec {
           |""".stripMargin
       ).mkString("\n")
       assert(msgs.contains("foreach"), s"expected the hint to mention foreach, got: $msgs")
-      assert(!msgs.contains("C-style loop"), s"hint should not fall back to the for-in advice, got: $msgs")
+      assert(!msgs.contains("for var i"), s"hint should not fall back to the for-in advice, got: $msgs")
     }
 
     it("does not fire for the valid two-variable map-destructuring form") {
@@ -74,7 +74,7 @@ class ForeachParensHintSpec extends AbstractShellSpec {
           |}
           |""".stripMargin
       ).mkString("\n")
-      assert(msgs.contains("C-style loop"), s"expected the old for-in hint to still fire, got: $msgs")
+      assert(msgs.contains("for var i"), s"expected the old for-in hint to still fire, got: $msgs")
     }
   }
 }


### PR DESCRIPTION
## Summary

- `ForeachParensHintSpec`'s "still hints at a C-style loop for the unrelated old `for x in xs` mistake" case asserted on the English prose substring `"C-style loop"` to check that the `old_for_in` hint fired. That substring only exists in the English message bundle — under `-Duser.language=ja` the hint renders as Japanese prose (`C スタイルのループ`) and the assertion fails even though the correct hint fired correctly.
- This was a pre-existing latent bug (introduced with the spec in an earlier PR, #889) that had never been exercised against the `ja` locale bundle before.
- Fixed by asserting on `` "for var i" `` instead — the literal C-style-loop code example (`` `for var i = 0; i < xs.size(); i = i + 1 { ... }` ``) that's embedded verbatim, untranslated, in both locale bundles. This matches the locale-agnostic assertion style already used by the sibling specs `ForEachDestructureHintSpec` and `OldForInHintI18nSpec`.
- No production code changed — test-only fix.

## Test plan

- [x] Full suite green in both locales:
  `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4121 succeeded, 0 failed, 1 benign canceled (opt-in distribution smoke test).
  `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4121 succeeded, 0 failed, 1 benign canceled — previously **1 failed** (this spec) before the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYHUdeCfRH9WvRrHXBEHao)_