### PR TITLE
fix(diagnostics): hint at catch for a Python-style except clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Python-style `except` clause on a `try` block.**
+  `except` is not a keyword in Onion (which catches with `catch`), so it parses
+  as a bare identifier-reference statement and the parser trips on whatever
+  follows it (the exception type or bound name), with a generic expected-token
+  dump that never mentions `catch`. The diagnostic now recognizes both
+  `except Type as name { ... }` and `except name: Type { ... }` spellings and
+  points at the correct `catch name: Type { ... }` form.
+
 - **Parser hint for the `for (a, b) in xs` / `for a, b in xs` destructuring mistake
   no longer recommends the wrong rewrite.** `for` never destructures or iterates a
   collection in Onion (that's `foreach`'s job), but the comma right after `for` made

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -109,6 +109,7 @@ error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `
 error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
 error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style `match` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.elif_not_supported=Hint: Onion has no Python-style `elif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
+error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except` clause. Catch exceptions with `catch` instead: `try { ... } catch e: Exception { ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -109,6 +109,7 @@ error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はあ�
 error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
 error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風の `match` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.elif_not_supported=ヒント: Onion に Python 風の `elif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
+error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `except` 節はありません。代わりに `catch` で例外を捕捉してください: `try { ... } catch e: Exception { ... }`。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -284,6 +284,18 @@ class Parsing(config: CompilerConfig) extends AnyRef
   private val ElifStatement = """\belif\b""".r
 
   /**
+   * A Python-style `except` clause on a `try` block, `except Type as name { }`
+   * or `except name: Type { }`. `except` isn't a keyword in Onion (which
+   * catches with `catch`), so it parses as a bare identifier-reference
+   * statement and the parser trips on whatever follows it (the type or bound
+   * name), never on `except` itself. Like `elif`, `except` almost never starts
+   * a source line -- it typically follows the closing `}` of the `try` block
+   * on the same line (`} except Exception as e { ... }`) -- so this matches
+   * the keyword anywhere on the line rather than anchoring at the start.
+   */
+  private val ExceptClause = """\bexcept\b""".r
+
+  /**
    * A JS/TS/Swift/Rust/Kotlin-style `let x = 1` variable declaration. Unlike
    * `const`, `let` is not a keyword at all in Onion -- it lexes as a plain
    * identifier -- so `let x = 1` at statement position is read as a bare
@@ -605,6 +617,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
       Message("error.parsing.hint.match_not_supported")
     case _ if ElifStatement.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.elif_not_supported")
+    case _ if ExceptClause.findFirstMatchIn(sourceLine).isDefined =>
+      Message("error.parsing.hint.except_not_supported")
     case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
       Message("error.parsing.hint.js_style_let")
     case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/tools/ExceptClauseHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ExceptClauseHintSpec.scala
@@ -1,0 +1,78 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no Python-style `except` clause on a `try` block -- exceptions
+ * are caught with `catch`. `except` isn't a keyword in Onion, so it parses
+ * as a bare identifier-reference statement and the parser actually trips on
+ * whatever follows it (the exception type or bound name), never on `except`
+ * itself.
+ */
+class ExceptClauseHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("except clause") {
+    it("hints at catch for a Python-style except chained onto the closing brace") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    try {
+          |      IO::println("risky")
+          |    } except e: Exception {
+          |      IO::println("caught")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("catch"), s"expected a hint mentioning catch, got: $msgs")
+      assert(msgs.contains("except"), s"expected the hint to name except, got: $msgs")
+    }
+
+    it("hints at catch for a Python `except Type as name:` clause") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    try {
+          |      IO::println("risky")
+          |    } except Exception as e {
+          |      IO::println("caught")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("catch"), s"expected a hint mentioning catch, got: $msgs")
+      assert(msgs.contains("except"), s"expected the hint to name except, got: $msgs")
+    }
+
+    it("does not fire for an unrelated bare-identifier-statement typo") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foo bar
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("except"), s"hint should not fire without an `except`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `except` is not a keyword in Onion (which catches with `catch`), so a Python-style `except Type as name { ... }` / `except name: Type { ... }` clause on a `try` block parsed as a bare identifier-reference statement, and the parser tripped on whatever followed it (the type or bound name) with a generic expected-token dump that never mentioned `catch`.
- Adds a diagnostic hint (mirroring the existing `elif`/`match`/`switch` hints) that recognizes both spellings and points at the correct `catch name: Type { ... }` form, in both English and Japanese message bundles.
- Adds `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.ExceptClauseHintSpec"` — 3/3 passed locally
- [x] CI full suite (en + ja locale matrix) — both green: https://github.com/onion-lang/onion/actions/runs/32820891635, https://github.com/onion-lang/onion/actions/runs/32820869270

(Originally opened as draft because the local sandbox this session ran in couldn't complete a full `sbt test` run — hit environment resource/hang issues twice. CI's clean run supersedes that; marking ready and merging.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xxn2wR2rfZCmXCG8ZeNvgc)_
