### PR TITLE
fix(diagnostics): hint at `else` for a Java/JS-style `default:` case in select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a Java/JavaScript-style `default:` case inside a `select` block.**
+  Onion's `select` has no `default` label -- the catch-all arm is `else` -- so
+  `default:` parses as a bare identifier-reference statement and the parser
+  trips on the colon that follows it, with a generic expected-token dump that
+  never mentions `else`. The diagnostic now recognizes a leading `default:`
+  case label and points at the correct `select value { case 1: ...; else: ... }`
+  form.
+
 ## [0.19.0] - 2026-08-25
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -108,6 +108,7 @@ error.parsing.hint.foreach_parens=Hint: `foreach` doesn''t parenthesize a single
 error.parsing.hint.switch_not_supported=Hint: Onion has no `switch` statement. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
 error.parsing.hint.when_not_supported=Hint: Onion has no Kotlin-style `when` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`. (`when` is reserved in Onion only as the case-guard keyword, `case p when guard: ...`.)
 error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style `match` expression. `select` covers the same ground, so write `select value { case 1: ...; else: ... }`.
+error.parsing.hint.default_case_not_supported=Hint: Onion's `select` has no Java/JavaScript-style `default` case. Use `else` instead: `select value { case 1: ...; else: ... }`.
 error.parsing.hint.elif_not_supported=Hint: Onion has no Python-style `elif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except` clause. Catch exceptions with `catch` instead: `try { ... } catch e: Exception { ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -108,6 +108,7 @@ error.parsing.hint.foreach_parens=ヒント: `foreach` は単一のループ変�
 error.parsing.hint.switch_not_supported=ヒント: Onion に `switch` 文はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
 error.parsing.hint.when_not_supported=ヒント: Onion に Kotlin 風の `when` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください（`when` は `case p when guard: ...` というガード節のキーワードとしてのみ予約されています）。
 error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風の `match` 式はありません。`select` が同じ役割を持つので、`select value { case 1: ...; else: ... }` と書いてください。
+error.parsing.hint.default_case_not_supported=ヒント: Onion の `select` に Java/JavaScript 風の `default` 節はありません。代わりに `else` を使ってください: `select value { case 1: ...; else: ... }`。
 error.parsing.hint.elif_not_supported=ヒント: Onion に Python 風の `elif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `except` 節はありません。代わりに `catch` で例外を捕捉してください: `try { ... } catch e: Exception { ... }`。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -18,6 +18,7 @@ private[compiler] object SyntaxHintClassifier {
   private val LeadingSwitchStatement = """^\s*switch\b""".r
   private val LeadingWhenStatement = """^\s*when\b""".r
   private val LeadingMatchStatement = """^\s*match\b""".r
+  private val DefaultCaseLabel = """^\s*default\s*:""".r
   private val ElifStatement = """\belif\b""".r
   private val ExceptClause = """\bexcept\b""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
@@ -105,6 +106,8 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.when_not_supported")
       case _ if LeadingMatchStatement.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.match_not_supported")
+      case _ if DefaultCaseLabel.findFirstMatchIn(sourceLine).isDefined =>
+        hint("error.parsing.hint.default_case_not_supported")
       case _ if ElifStatement.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.elif_not_supported")
       case _ if ExceptClause.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/DefaultCaseNotSupportedHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/DefaultCaseNotSupportedHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The default-case hint (`SyntaxHintClassifier`'s `DefaultCaseLabel` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that match -- see JavaStyleAnnotatedMethodHintI18nSpec
+ * for the same pattern.
+ */
+class DefaultCaseNotSupportedHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.default_case_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java/JS-style `default:` case inside a `select` block") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    select 1 {
+        |    case 1: IO::println("one")
+        |    default: IO::println("other")
+        |    }
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("else"), s"expected the hint to mention `else`, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- Onion's `select` has no `default` label — the catch-all arm is `else` — so `default:` inside a `select` block previously parsed as a bare identifier-reference statement, and the parser tripped on the colon that follows it with a generic expected-token dump that never mentioned `else`.
- `SyntaxHintClassifier` now recognizes a leading `default:` case label and points at the correct `select value { case 1: ...; else: ... }` form, matching the existing `switch`/`when`/`match` "not supported" hints.
- Added bilingual (en/ja) message-bundle entries and an end-to-end `DefaultCaseNotSupportedHintI18nSpec` test, plus a `CHANGELOG.md [Unreleased]` entry.

## Test plan
- [x] `sbt -Duser.language=en testFull` — 4143 pass / 0 fail / 1 cancelled
- [x] `sbt -Duser.language=ja testFull` — 4143 pass / 0 fail / 1 cancelled
- [x] New spec `onion.compiler.DefaultCaseNotSupportedHintI18nSpec` covers bundle resolution in both locales and an end-to-end compile firing the hint


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgTd7VosTYawbChBk2g7g9)_