### PR TITLE
fix(diagnostics): hint at `as` for a C-style prefix type cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   case label and points at the correct `select value { case 1: ...; else: ... }`
   form.
 
+- **Parser hint for a C/Java/C#-style prefix type cast, `(Type) expr`.**
+  Onion casts are written postfix with `as` (`expr as Type`); the C-style
+  prefix form parses as a parenthesized expression followed by a stray
+  second expression, and the raw expected-token dump never mentions `as`.
+  The diagnostic now recognizes `(Type) expr` (including generic and
+  array/nullable type spellings) and points at the correct
+  `(expr as Type)` form.
+
 ## [0.19.0] - 2026-08-25
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -133,6 +133,7 @@ error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and c
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
 error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `let name = value`.
+error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -133,6 +133,7 @@ error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のた�
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
 error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `let name = value` ではなく `val name: Type = value` と書いてください。
+error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -66,6 +66,8 @@ private[compiler] object SyntaxHintClassifier {
   )
   private val NullableUnionType =
     """:\s*([A-Za-z_][\w.\[\]]*)\s*\|\s*null\b""".r
+  private val CStyleCast =
+    """\(\s*([A-Z][\w.\[\]]*\??)\s*\)\s*[A-Za-z_$(]""".r
 
   def classify(
     found: String,
@@ -150,6 +152,9 @@ private[compiler] object SyntaxHintClassifier {
       case "|" if NullableUnionType.findFirstMatchIn(sourceLine).isDefined =>
         val matched = NullableUnionType.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.nullable_union_type", matched.group(1))
+      case _ if CStyleCast.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = CStyleCast.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.c_style_cast", matched.group(1))
       case "?" =>
         hint("error.parsing.hint.ternary")
       case "else" =>

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -86,6 +86,37 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       block.arguments shouldBe empty
     }
 
+    it("recognizes a C-style cast") {
+      val hint = classify(
+        found = "o",
+        expected = "<EOL>",
+        sourceLine = "    val s: String = (String) o"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.c_style_cast"
+      hint.arguments shouldBe Seq("String")
+    }
+
+    it("recognizes a C-style cast of a generic type") {
+      val hint = classify(
+        found = "coll",
+        expected = "<EOL>",
+        sourceLine = "val xs = (List[String]) coll"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.c_style_cast"
+      hint.arguments shouldBe Seq("List[String]")
+    }
+
+    it("does not confuse the real `(expr as Type)` cast with a C-style cast") {
+      SyntaxHintClassifier.classify(
+        found = "as",
+        expected = "\")\"",
+        context = "",
+        sourceLine = "val s: String = (o as String)"
+      ) shouldBe None
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",

--- a/src/test/scala/onion/compiler/tools/CStyleCastHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CStyleCastHintSpec.scala
@@ -1,0 +1,56 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+
+/**
+ * A C/Java/C#-style prefix cast, `(Type) expr`, parses as a parenthesized
+ * expression followed by a stray second expression -- the raw expected-token
+ * dump never mentions Onion's postfix `as` cast. See CLAUDE.md's syntax
+ * mistakes table: `(expr as Type)` is correct, `(Type) expr` is not.
+ */
+class CStyleCastHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new java.io.StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("C-style cast used in place of `as`") {
+    it("hints at `as` for a simple type") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val o: Object = "hi"
+          |    val s: String = (String) o
+          |    IO::println(s)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("as"), s"expected a hint mentioning `as`, got: $msgs")
+      assert(msgs.contains("expr as String"), s"expected the hint to show the correct form, got: $msgs")
+    }
+
+    it("does not fire for the correct `(expr as Type)` form") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val o: Object = "hi"
+          |    val s: String = (o as String)
+          |    IO::println(s)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `as` cast form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- A C/Java/C#-style prefix cast, `(Type) expr`, parses as a parenthesized expression followed by a stray second expression. The raw expected-token dump never mentions Onion's postfix `as` cast, so the diagnostic didn't help newcomers from those languages find the right form.
- `SyntaxHintClassifier` now recognizes `(Type) expr` (including generic and array/nullable type spellings, e.g. `(List[String]) coll`) and points at the correct `(expr as Type)` form, following the same pattern as the other foreign-syntax hints in that file.
- Added bilingual (en/ja) message text and a CHANGELOG entry.

## Test plan
- [x] New unit tests in `SyntaxHintClassifierSpec` (matches the cast pattern, a generic-type variant, and confirms the real `(expr as Type)` form is not misclassified)
- [x] New integration test `CStyleCastHintSpec` (compiles a `(String) o` cast and asserts the hint text appears; confirms the correct `(o as String)` form still compiles clean)
- [x] Full suite green in English locale: `sbt -Duser.language=en testFull` — 4148 succeeded, 0 failed
- [x] Full suite green in Japanese locale: `sbt -Duser.language=ja testFull` — 4148 succeeded, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxL3hSDNNMSR2Ej42mFqjr)_