### PR TITLE
refactor(compiler): extract parser source context

### DIFF
--- a/docs/refactoring/current-architecture.md
+++ b/docs/refactoring/current-architecture.md
@@ -49,9 +49,13 @@ under `target/`. `Parsing.scala` owns:
 - source reading and shebang removal;
 - JavaCC construction and recovery configuration;
 - conversion of collected and terminal parse errors;
-- source offset, line, and context extraction;
 - expected-token rendering;
 - localization and final parse-error assembly.
+
+`parser.SourceContext` owns the pure conversion from a 1-based parser position
+to the bounded lookahead context and complete source line consumed by syntax
+hints. Collected and terminal parse errors use the same helper and calculate
+both values once per error.
 
 `parser.SyntaxHintClassifier` owns the ordered regular-expression policy for
 more than thirty friendly syntax hints. It returns a message key and literal
@@ -113,11 +117,11 @@ Japanese parser hints. That coverage is a valuable refactoring oracle.
 
 ## Tests and CI
 
-- `testFull` currently executes 4,140 tests across 568 suites.
+- `testFull` currently executes 4,151 tests across 571 suites.
 - The default phase order and failure short-circuit are covered by
   `PipelineRunnerSpec`.
-- Parser hint behavior is covered by a direct pure classifier suite plus
-  focused end-to-end and localization suites.
+- Parser hint behavior is covered by direct pure source-context and classifier
+  suites plus focused end-to-end and localization suites.
 - `Test / parallelExecution := false` protects global output-capture behavior.
 - `.github/workflows/scala.yml` runs `sbt -v +test`, not the documented English
   and Japanese `testFull` quality gate.
@@ -131,8 +135,8 @@ Japanese parser hints. That coverage is a valuable refactoring oracle.
   tools, effects, Shapes, and typed boundaries shipped.
 - `docs/parser-refactoring.md` describes a desired parser/AST-builder split as
   if it were the complete current architecture; `Parsing.scala` still owns
-  source context, expected-token rendering, recovery, localization, and final
-  parse-error assembly.
+  expected-token rendering, recovery, localization, and final parse-error
+  assembly.
 - compiler architecture docs mention `StatementTyping.scala`, which no longer
   exists after expression-oriented block lowering.
 - contributor docs recommend `sbt test`, while the quality bar defines fresh

--- a/docs/refactoring/decision-log.md
+++ b/docs/refactoring/decision-log.md
@@ -89,3 +89,19 @@ Reason: these files record maintainer-facing measurements, sequencing, and
 temporary implementation status. The existing architecture and contributor
 documentation remains the stable public entry point, while the MkDocs coverage
 gate still verifies that the exclusion is intentional.
+
+## D009: represent parser hint source input as one pure value
+
+Decision: `parser.SourceContext.at` converts a 1-based parser position into the
+bounded context starting at the reported column and the complete reported
+source line. `Parsing` calculates this value once for each collected or
+terminal parse error.
+
+Reason: both parse-error paths previously repeated the same private offset and
+substring work. The calculation has no dependency on JavaCC state,
+localization, or diagnostic rendering, so a parser-local pure helper gives it a
+direct test seam without widening a compiler API.
+
+Invariant: coordinates stay 1-based, context remains capped at 200 characters
+and may cross line boundaries, the complete source line is not truncated, and
+a line beyond the source produces empty values.

--- a/docs/refactoring/onion-maintainability-roadmap.md
+++ b/docs/refactoring/onion-maintainability-roadmap.md
@@ -160,11 +160,11 @@ are not repository artifacts.
 
 Only start if the Phase 2 audit still ranks parser diagnostics as active debt.
 
-1. Split source-context calculation into a pure `SourceContext` helper.
-2. Split expected-token rendering into a pure helper.
-3. Group syntax hints by language-family mistake only if classifier tests keep
+1. [x] Split source-context calculation into a pure `SourceContext` helper.
+2. [ ] Split expected-token rendering into a pure helper.
+3. [ ] Group syntax hints by language-family mistake only if classifier tests keep
    priority visible across groups.
-4. Update stale parser architecture docs after code lands.
+4. [x] Update parser architecture docs for the source-context boundary.
 
 Each item uses RED/GREEN/refactor and is a separate commit.
 

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -6,7 +6,7 @@ import java.io.{IOException, Reader, StringReader}
 
 import _root_.onion.compiler.toolbox.Message
 import _root_.onion.compiler.exceptions.CompilationException
-import _root_.onion.compiler.parser.{JJOnionParser, ParseException, SyntaxHint, SyntaxHintClassifier}
+import _root_.onion.compiler.parser.{JJOnionParser, ParseException, SourceContext, SyntaxHint, SyntaxHintClassifier}
 
 /**
  * Parsing phase of the Onion compiler.
@@ -118,14 +118,15 @@ class Parsing(config: CompilerConfig) extends AnyRef
     val errors = parser.getCollectedErrors()
     for (i <- 0 until errors.size()) {
       val error = errors.get(i)
+      val sourceContext = SourceContext.at(sourceText, error.line, error.column)
       problems += CompileError(
         fileName,
         new Location(error.line, error.column),
         syntaxErrorMessage(
           error.found,
           error.expected,
-          contextAt(sourceText, error.line, error.column),
-          sourceLineAt(sourceText, error.line)
+          sourceContext.context,
+          sourceContext.sourceLine
         )
       )
     }
@@ -147,52 +148,18 @@ class Parsing(config: CompilerConfig) extends AnyRef
     } else {
       val error = e.currentToken.next
       val expected = formatExpectedTokens(e)
+      val sourceContext = SourceContext.at(sourceText, error.beginLine, error.beginColumn)
       problems += CompileError(
         fileName,
         new Location(error.beginLine, error.beginColumn),
         syntaxErrorMessage(
           error.image,
           expected,
-          contextAt(sourceText, error.beginLine, error.beginColumn),
-          sourceLineAt(sourceText, error.beginLine)
+          sourceContext.context,
+          sourceContext.sourceLine
         )
       )
     }
-  }
-
-  /**
-   * The source text starting at a 1-based (line, column), for hints that need
-   * to look past the offending token (bounded so a pathological file can't
-   * make the regex match slow).
-   */
-  private def lineStartOffset(sourceText: String, line: Int): Int = {
-    var offset = 0
-    var currentLine = 1
-    while (currentLine < line && offset >= 0 && offset < sourceText.length) {
-      val nl = sourceText.indexOf('\n', offset)
-      if (nl < 0) offset = sourceText.length else { offset = nl + 1; currentLine += 1 }
-    }
-    offset
-  }
-
-  private def contextAt(sourceText: String, line: Int, column: Int): String = {
-    val start = math.min(sourceText.length, lineStartOffset(sourceText, line) + column - 1)
-    sourceText.substring(start, math.min(sourceText.length, start + 200))
-  }
-
-  /**
-   * The full text of the 1-based source line containing (line, column), for
-   * hints that need to recognize a whole malformed statement (e.g. a leading
-   * `switch`) rather than just the token at the error position -- the error
-   * itself is often reported several tokens past the actual mistake.
-   */
-  private def sourceLineAt(sourceText: String, line: Int): String = {
-    val start = lineStartOffset(sourceText, line)
-    val end = sourceText.indexOf('\n', start) match {
-      case -1 => sourceText.length
-      case i => i
-    }
-    sourceText.substring(start, end)
   }
 
   /**

--- a/src/main/scala/onion/compiler/parser/SourceContext.scala
+++ b/src/main/scala/onion/compiler/parser/SourceContext.scala
@@ -1,0 +1,45 @@
+package onion.compiler.parser
+
+private[compiler] final case class SourceContext(context: String, sourceLine: String)
+
+private[compiler] object SourceContext {
+  private val ContextLimit = 200
+
+  /**
+   * Extract hint input from a 1-based source position.
+   *
+   * `context` starts at the reported column and may cross line boundaries, while
+   * `sourceLine` contains the entire reported line. Context is bounded so syntax
+   * hint matching stays predictable for pathological input.
+   */
+  def at(sourceText: String, line: Int, column: Int): SourceContext = {
+    val lineStart = lineStartOffset(sourceText, line)
+    val contextStart = math.min(sourceText.length, lineStart + column - 1)
+    val lineEnd = sourceText.indexOf('\n', lineStart) match {
+      case -1 => sourceText.length
+      case index => index
+    }
+
+    SourceContext(
+      context = sourceText.substring(
+        contextStart,
+        math.min(sourceText.length, contextStart + ContextLimit)
+      ),
+      sourceLine = sourceText.substring(lineStart, lineEnd)
+    )
+  }
+
+  private def lineStartOffset(sourceText: String, line: Int): Int = {
+    var offset = 0
+    var currentLine = 1
+    while (currentLine < line && offset >= 0 && offset < sourceText.length) {
+      val newline = sourceText.indexOf('\n', offset)
+      if (newline < 0) offset = sourceText.length
+      else {
+        offset = newline + 1
+        currentLine += 1
+      }
+    }
+    offset
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SourceContextSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SourceContextSpec.scala
@@ -1,0 +1,36 @@
+package onion.compiler.parser
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class SourceContextSpec extends AnyFunSpec with Matchers {
+  describe("SourceContext.at") {
+    it("extracts hint context and the full source line from a 1-based position") {
+      val source =
+        """first line
+          |  switch (value) {
+          |last line""".stripMargin
+
+      val result = SourceContext.at(source, line = 2, column = 3)
+
+      result.context shouldBe "switch (value) {\nlast line"
+      result.sourceLine shouldBe "  switch (value) {"
+    }
+
+    it("bounds hint context without truncating the source line") {
+      val longLine = "x" * 205
+
+      val result = SourceContext.at(s"header\n$longLine", line = 2, column = 1)
+
+      result.context shouldBe "x" * 200
+      result.sourceLine shouldBe longLine
+    }
+
+    it("returns empty text when the requested line is past the end of the source") {
+      val result = SourceContext.at("first\nsecond", line = 3, column = 1)
+
+      result.context shouldBe empty
+      result.sourceLine shouldBe empty
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- extract parser position-to-text calculation into package-private pure `parser.SourceContext`
- calculate bounded hint context and the complete source line once for both collected and terminal parse errors
- add direct source-context contract tests and update the maintainability architecture, roadmap, and decision log

## Behavior preservation

- coordinates remain 1-based
- hint context still starts at the reported column, may cross line boundaries, and is capped at 200 characters
- the complete reported source line remains untruncated; a line past EOF still yields empty values
- no grammar production, resource bundle, generated parser, diagnostic wording, public API, or recovery behavior changed
- `Parsing.scala` falls from 263 LOC / 39 branch proxies after the classifier extraction to 230 / 33; `SourceContext.scala` is 45 / 7

## TDD evidence

- the new direct suite first failed to compile because `SourceContext` did not exist
- changing the context limit from 200 to 199 made the boundary test fail
- focused parser/context/hint verification after rebasing onto current `develop`: 32 passed

## Verification

- `python3 scripts/maintainability/test_audit.py` — 1 passed
- `sbt --server -Duser.language=en testFull` — 4,151 passed, 0 failed, 1 expected opt-in distribution cancellation
- `sbt --server -Duser.language=ja testFull` — 4,151 passed, 0 failed, 1 expected opt-in distribution cancellation
- `mkdocs build --strict` — passed
- `git diff --check origin/develop..HEAD` — passed
- independent review and re-review: no Critical, Important, or Minor findings remain; Ready

## Rollback

Revert the two commits in this PR. The extraction has no grammar, bundle, generated-source, public-API, or data migration.