### PR TITLE
Refactor parser expected-token formatting

### DIFF
--- a/docs/refactoring/current-architecture.md
+++ b/docs/refactoring/current-architecture.md
@@ -49,13 +49,19 @@ under `target/`. `Parsing.scala` owns:
 - source reading and shebang removal;
 - JavaCC construction and recovery configuration;
 - conversion of collected and terminal parse errors;
-- expected-token rendering;
 - localization and final parse-error assembly.
 
 `parser.SourceContext` owns the pure conversion from a 1-based parser position
 to the bounded lookahead context and complete source line consumed by syntax
 hints. Collected and terminal parse errors use the same helper and calculate
 both values once per error.
+
+`parser.ExpectedTokenFormatter` owns the pure rendering of JavaCC
+`expectedTokenSequences` for terminal `ParseException` diagnostics. It keeps
+the first token from each sequence, deduplicates in encounter order, and
+preserves the existing separator and truncation behavior. The generated
+parser's `expectedSummary` method remains a separate recovery-path formatter;
+its punctuation and truncation contract are observably different.
 
 `parser.SyntaxHintClassifier` owns the ordered regular-expression policy for
 more than thirty friendly syntax hints. It returns a message key and literal
@@ -117,7 +123,7 @@ Japanese parser hints. That coverage is a valuable refactoring oracle.
 
 ## Tests and CI
 
-- `testFull` currently executes 4,151 tests across 571 suites.
+- `testFull` currently executes 4,155 tests across 572 suites.
 - The default phase order and failure short-circuit are covered by
   `PipelineRunnerSpec`.
 - Parser hint behavior is covered by direct pure source-context and classifier
@@ -135,8 +141,8 @@ Japanese parser hints. That coverage is a valuable refactoring oracle.
   tools, effects, Shapes, and typed boundaries shipped.
 - `docs/parser-refactoring.md` describes a desired parser/AST-builder split as
   if it were the complete current architecture; `Parsing.scala` still owns
-  expected-token rendering, recovery, localization, and final parse-error
-  assembly.
+  recovery orchestration, localization, and final parse-error assembly, while
+  the generated grammar retains recovery-specific expected-token summaries.
 - compiler architecture docs mention `StatementTyping.scala`, which no longer
   exists after expression-oriented block lowering.
 - contributor docs recommend `sbt test`, while the quality bar defines fresh

--- a/docs/refactoring/decision-log.md
+++ b/docs/refactoring/decision-log.md
@@ -105,3 +105,20 @@ direct test seam without widening a compiler API.
 Invariant: coordinates stay 1-based, context remains capped at 200 characters
 and may cross line boundaries, the complete source line is not truncated, and
 a line beyond the source produces empty values.
+
+## D010: keep terminal and recovery expected-token formatters separate
+
+Decision: `parser.ExpectedTokenFormatter` renders JavaCC expected-token
+metadata for terminal `ParseException` diagnostics. The generated grammar's
+`expectedSummary` method continues to render recovery-collected diagnostics.
+
+Reason: terminal rendering is deterministic and directly testable without
+parser or localization state. The recovery formatter runs inside generated
+JavaCC code and has different existing punctuation and truncation behavior;
+unifying the two would cross the generation boundary and change diagnostics,
+which is outside this refactoring slice.
+
+Invariant: terminal formatting keeps the null/empty fallback, considers only
+the first token of each sequence, deduplicates in encounter order, joins one to
+three tokens with the existing separators, and preserves the four-token
+truncation boundary exactly, including the existing `... (0 more)` result.

--- a/docs/refactoring/onion-maintainability-roadmap.md
+++ b/docs/refactoring/onion-maintainability-roadmap.md
@@ -161,10 +161,11 @@ are not repository artifacts.
 Only start if the Phase 2 audit still ranks parser diagnostics as active debt.
 
 1. [x] Split source-context calculation into a pure `SourceContext` helper.
-2. [ ] Split expected-token rendering into a pure helper.
+2. [x] Split terminal expected-token rendering into a pure
+   `ExpectedTokenFormatter` helper.
 3. [ ] Group syntax hints by language-family mistake only if classifier tests keep
    priority visible across groups.
-4. [x] Update parser architecture docs for the source-context boundary.
+4. [x] Update parser architecture docs for each extracted diagnostic boundary.
 
 Each item uses RED/GREEN/refactor and is a separate commit.
 

--- a/docs/refactoring/target-architecture.md
+++ b/docs/refactoring/target-architecture.md
@@ -42,15 +42,18 @@ Each phase should converge on this shape:
 ParsingPhase
   -> Parsing (reader lifecycle and JavaCC recovery)
      -> ParseDiagnosticBuilder
+        -> SourceContext (pure source slicing)
+        -> ExpectedTokenFormatter (pure terminal-token rendering)
         -> SyntaxHintClassifier (pure classification)
         -> localized Message rendering
 ```
 
-The first slice extracts `SyntaxHintClassifier` as a package-local pure service.
-It returns a message key and literal arguments rather than localized text.
-`Parsing` remains responsible for localization and exact final message
-assembly. Later slices may separate source context and expected-token rendering,
-but only if measurements still justify them.
+The landed parser slices extract `SyntaxHintClassifier`, `SourceContext`, and
+`ExpectedTokenFormatter` as package-local pure services. The classifier returns
+a message key and literal arguments rather than localized text. `Parsing`
+remains responsible for localization and exact final message assembly. The
+JavaCC grammar retains its recovery-specific expected-token summary because its
+existing output contract differs from terminal parse errors.
 
 ## Rewriting target
 

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -6,7 +6,14 @@ import java.io.{IOException, Reader, StringReader}
 
 import _root_.onion.compiler.toolbox.Message
 import _root_.onion.compiler.exceptions.CompilationException
-import _root_.onion.compiler.parser.{JJOnionParser, ParseException, SourceContext, SyntaxHint, SyntaxHintClassifier}
+import _root_.onion.compiler.parser.{
+  ExpectedTokenFormatter,
+  JJOnionParser,
+  ParseException,
+  SourceContext,
+  SyntaxHint,
+  SyntaxHintClassifier
+}
 
 /**
  * Parsing phase of the Onion compiler.
@@ -147,7 +154,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
       problems += CompileError(fileName, new Location(1, 1), e.getMessage)
     } else {
       val error = e.currentToken.next
-      val expected = formatExpectedTokens(e)
+      val expected = ExpectedTokenFormatter.format(e.expectedTokenSequences, e.tokenImage)
       val sourceContext = SourceContext.at(sourceText, error.beginLine, error.beginColumn)
       problems += CompileError(
         fileName,
@@ -194,37 +201,4 @@ class Parsing(config: CompilerConfig) extends AnyRef
     if (image == null || image.isEmpty) "<EOF>"
     else image.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
 
-  /**
-   * Format expected tokens from a ParseException for better error messages.
-   *
-   * When multiple tokens are expected, this creates a more readable message
-   * like "';' or 'newline'" instead of just showing the first one.
-   */
-  private def formatExpectedTokens(e: ParseException): String = {
-    val sequences = e.expectedTokenSequences
-    if (sequences == null || sequences.isEmpty) {
-      return "valid token"
-    }
-
-    // Collect unique expected tokens
-    val expectedSet = scala.collection.mutable.LinkedHashSet[String]()
-    for (seq <- sequences) {
-      if (seq != null && seq.nonEmpty) {
-        expectedSet += e.tokenImage(seq(0))
-      }
-    }
-
-    val expected = expectedSet.toSeq
-    if (expected.isEmpty) {
-      "valid token"
-    } else if (expected.size == 1) {
-      expected.head
-    } else if (expected.size <= 3) {
-      // Show all expected tokens if 3 or fewer
-      expected.init.mkString(", ") + " or " + expected.last
-    } else {
-      val shown = expected.take(4)
-      shown.mkString(", ") + s", ... (${expected.size - shown.size} more)"
-    }
-  }
 }

--- a/src/main/scala/onion/compiler/parser/ExpectedTokenFormatter.scala
+++ b/src/main/scala/onion/compiler/parser/ExpectedTokenFormatter.scala
@@ -1,0 +1,33 @@
+package onion.compiler.parser
+
+import scala.collection.mutable.LinkedHashSet
+
+private[compiler] object ExpectedTokenFormatter {
+  private val Fallback = "valid token"
+
+  /** Render the first token of each JavaCC expected-token sequence. */
+  def format(expectedTokenSequences: Array[Array[Int]], tokenImages: Array[String]): String = {
+    if (expectedTokenSequences == null || expectedTokenSequences.isEmpty) {
+      return Fallback
+    }
+
+    val expectedSet = LinkedHashSet[String]()
+    for (sequence <- expectedTokenSequences) {
+      if (sequence != null && sequence.nonEmpty) {
+        expectedSet += tokenImages(sequence(0))
+      }
+    }
+
+    val expected = expectedSet.toSeq
+    if (expected.isEmpty) {
+      Fallback
+    } else if (expected.size == 1) {
+      expected.head
+    } else if (expected.size <= 3) {
+      expected.init.mkString(", ") + " or " + expected.last
+    } else {
+      val shown = expected.take(4)
+      shown.mkString(", ") + s", ... (${expected.size - shown.size} more)"
+    }
+  }
+}

--- a/src/test/scala/onion/compiler/parser/ExpectedTokenFormatterSpec.scala
+++ b/src/test/scala/onion/compiler/parser/ExpectedTokenFormatterSpec.scala
@@ -1,0 +1,52 @@
+package onion.compiler.parser
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ExpectedTokenFormatterSpec extends AnyFunSpec with Matchers {
+  describe("ExpectedTokenFormatter.format") {
+    it("falls back when no usable expected-token sequence is available") {
+      ExpectedTokenFormatter.format(null, Array.empty) shouldBe "valid token"
+      ExpectedTokenFormatter.format(Array.empty, Array.empty) shouldBe "valid token"
+      ExpectedTokenFormatter.format(
+        Array(null, Array.empty[Int]),
+        Array("unused")
+      ) shouldBe "valid token"
+    }
+
+    it("uses the first token of each sequence once and in encounter order") {
+      val rendered = ExpectedTokenFormatter.format(
+        Array(Array(2, 3), Array(1), Array(2), null, Array.empty[Int]),
+        Array("<EOF>", "\"class\"", "\"interface\"", "\"record\"")
+      )
+
+      rendered shouldBe "\"interface\" or \"class\""
+    }
+
+    it("joins one to three expected tokens with the existing separators") {
+      val tokenImages = Array("<EOF>", "a", "b", "c")
+      val cases = Seq(
+        Array(Array(1)) -> "a",
+        Array(Array(1), Array(2)) -> "a or b",
+        Array(Array(1), Array(2), Array(3)) -> "a, b or c"
+      )
+
+      cases.foreach { case (sequences, expected) =>
+        ExpectedTokenFormatter.format(sequences, tokenImages) shouldBe expected
+      }
+    }
+
+    it("keeps the existing four-token boundary and truncates after four") {
+      val tokenImages = Array("<EOF>", "a", "b", "c", "d", "e", "f")
+
+      ExpectedTokenFormatter.format(
+        Array(Array(1), Array(2), Array(3), Array(4)),
+        tokenImages
+      ) shouldBe "a, b, c, d, ... (0 more)"
+      ExpectedTokenFormatter.format(
+        Array(Array(1), Array(2), Array(3), Array(4), Array(5), Array(6)),
+        tokenImages
+      ) shouldBe "a, b, c, d, ... (2 more)"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract terminal JavaCC expected-token rendering into a package-private pure helper
- preserve the existing ordering, separators, fallback, and four-token truncation boundary exactly
- document why grammar recovery keeps its separate formatter

## Verification
- RED: new formatter spec initially failed because the helper did not exist
- mutation: changing the four-token boundary made the exact-boundary test fail
- focused parser suites: 34 passed
- English testFull: 4,155 passed across 572 suites, 0 failed
- Japanese testFull: 4,155 passed across 572 suites, 0 failed
- mkdocs build --strict
- maintainability audit test and audit
- git diff --check

## Review
- independent read-only review: no Critical, Important, or Minor findings; ready to merge