### PR TITLE
fix(diagnostics): hint at `:` for a Python/Rust/TS-style `-> Type` return arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   array/nullable type spellings) and points at the correct
   `(expr as Type)` form.
 
+- **Parser hint for a Python/Rust/TypeScript-style return-type arrow, `def name(...) -> Type { ... }`.**
+  Onion writes a method's return type after a colon, not `->`; the arrow form
+  parses as a complete parameterless-return-type declaration followed by a
+  stray `->` token, with a generic expected-token dump that never mentions the
+  colon. The diagnostic now recognizes `def name(...) -> Type` and points at
+  the correct `def name(...): Type { ... }` form.
+
 ## [0.19.0] - 2026-08-25
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_conforms=Hint: interfaces are named with `conforms`, not 
 error.parsing.hint.trailing_lambda_parens=Hint: a trailing lambda''s parameters aren''t parenthesized — write `'{' {0} -> ... '}'`, not `'{' ({0}) -> ... '}'`.
 error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `->`, the same as everywhere else — write `{ x -> ... }`. (`=>` is no longer part of the language.)
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
+error.parsing.hint.python_style_return_arrow=Hint: a method''s return type follows a colon, not `->` — write `def {0}(...): {1} '{' ... '}'`, not `def {0}(...) -> {1} '{' ... '}'`.
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use `foreach x: Type in xs { ... }` (or a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`).

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_conforms=ヒント: インターフェースは `<:` で�
 error.parsing.hint.trailing_lambda_parens=ヒント: 末尾ラムダの引数は丸かっこで囲みません — `'{' ({0}) -> ... '}'` ではなく `'{' {0} -> ... '}'` と書いてください。
 error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他と同じ `->` です — `{ x -> ... }` と書いてください。（`=>` は言語から無くなりました。）
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
+error.parsing.hint.python_style_return_arrow=ヒント: メソッドの戻り値の型は `->` ではなくコロンの後に書きます — `def {0}(...) -> {1} '{' ... '}'` ではなく `def {0}(...): {1} '{' ... '}'` と書いてください。
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。`foreach x: Type in xs { ... }` を使ってください（または C スタイルのループ: `for var i = 0; i < xs.size(); i = i + 1 { ... }`）。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -68,6 +68,8 @@ private[compiler] object SyntaxHintClassifier {
     """:\s*([A-Za-z_][\w.\[\]]*)\s*\|\s*null\b""".r
   private val CStyleCast =
     """\(\s*([A-Z][\w.\[\]]*\??)\s*\)\s*[A-Za-z_$(]""".r
+  private val PythonStyleReturnArrow =
+    """\bdef\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*\([^()]*\)\s*->\s*([A-Za-z_][\w.\[\]?]*)""".r
 
   def classify(
     found: String,
@@ -155,6 +157,9 @@ private[compiler] object SyntaxHintClassifier {
       case _ if CStyleCast.findFirstMatchIn(sourceLine).isDefined =>
         val matched = CStyleCast.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.c_style_cast", matched.group(1))
+      case "->" if PythonStyleReturnArrow.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = PythonStyleReturnArrow.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.python_style_return_arrow", matched.group(1), matched.group(2))
       case "?" =>
         hint("error.parsing.hint.ternary")
       case "else" =>

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -108,6 +108,17 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("List[String]")
     }
 
+    it("recognizes a Python/Rust/TypeScript-style `-> Type` return type arrow") {
+      val hint = classify(
+        found = "->",
+        expected = "\"=\"",
+        sourceLine = "  def bar(x: Int) -> Int {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_return_arrow"
+      hint.arguments shouldBe Seq("bar", "Int")
+    }
+
     it("does not confuse the real `(expr as Type)` cast with a C-style cast") {
       SyntaxHintClassifier.classify(
         found = "as",

--- a/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HintMessageFormatSpec.scala
@@ -91,4 +91,26 @@ class HintMessageFormatSpec extends AbstractShellSpec {
       assert(msgs.contains("`}`"), s"expected a literal closing brace in the hint, got: $msgs")
     }
   }
+
+  describe("hints resolved via the args-taking Message lookup") {
+    it("renders the python-style-return-arrow hint without crashing on the apostrophe in the pattern text") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  def bar(x: Int) -> Int {
+          |    ret x
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      // Locale-independent only: the hint text itself is translated (ja), but the
+      // MessageFormat pattern escaping (and the apostrophe bug it must not regress to)
+      // is shared by both bundles, and the quoted code snippet is never translated.
+      assert(!msgs.contains("I0000"), s"hint crashed MessageFormat: $msgs")
+      assert(!msgs.contains("'{'") && !msgs.contains("'}'"), s"hint leaked MessageFormat quoting: $msgs")
+      assert(!msgs.contains("''"), s"hint leaked an unresolved doubled-quote escape: $msgs")
+      assert(msgs.contains("def bar(...): Int { ... }"), s"expected substituted literal braces in the hint, got: $msgs")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Onion writes a method's return type after a colon (`def name(...): Type`), not `->`. Writing the Python/Rust/TypeScript-style `def name(...) -> Type { ... }` previously produced a generic expected-token dump that never mentioned the colon. `SyntaxHintClassifier` now recognizes this pattern and points at the correct form.
- Along the way, found and fixed an unescaped apostrophe in the new English hint text (`method's`) that broke `MessageFormat`'s brace-quoting and crashed the compiler with an `I0000` internal error at the call site — a regression test (`HintMessageFormatSpec`) now covers this class of bug end-to-end.

## Test plan

- [x] Added a red→green unit test in `SyntaxHintClassifierSpec` for the new hint rule
- [x] Added an end-to-end regression test in `HintMessageFormatSpec` that exercises the full compile pipeline and would have caught the `I0000` crash
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Full suite green under `-Duser.language=en` (4157 succeeded, 0 failed, 1 canceled — pre-existing)
- [x] Full suite green under `-Duser.language=ja` (same counts)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014XT77QTfCvxNUcSpuXFWgE)_