### PR TITLE
fix(diagnostics): correct missing-parameter-type misclassified as Java-style method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   colon. The diagnostic now recognizes `def name(...) -> Type` and points at
   the correct `def name(...): Type { ... }` form.
 
+- **Missing-parameter-type diagnostic misclassified as a Java-style method hint.**
+  `def foo(x): Int { ... }` -- a parameter without a type annotation -- was
+  matched by `SyntaxHintClassifier`'s Java-style-method pattern (it excluded
+  a leading `public`/`private`/`protected` but not `def`), producing a hint
+  telling the user to write `def` on a line that already starts with `def`.
+  The classifier now excludes `def` from that pattern and reports a dedicated
+  hint naming the untyped parameter instead.
+
 ## [0.19.0] - 2026-08-25
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -122,6 +122,7 @@ error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — wri
 error.parsing.hint.java_style_import_alias=Hint: an import''s alias is named with `as`, not `=` — write `{0} as {1}`, not `{1} = {0}`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
 error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
+error.parsing.hint.missing_parameter_type=Hint: every parameter needs an explicit type after its name — write `{0}: Type`, not a bare `{0}`.
 error.parsing.hint.java_style_field=Hint: a field or local variable is declared with `val`/`var` before the name, not with the type before it — write `var {1}: {0}` (or `val {1}: {0}` if it never changes), not `{0} {1}`.
 error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not `:` — write `case s is String:`, not `case s: String:`.
 error.parsing.hint.java_style_generics=Hint: generics use square brackets, not angle brackets — write `{0}[{1}]`, not `{0}<{1}>`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -122,6 +122,7 @@ error.parsing.hint.java_style_import=ヒント: import は波かっこで囲み�
 error.parsing.hint.java_style_import_alias=ヒント: import のエイリアスは `=` ではなく `as` で指定します — `{1} = {0}` ではなく `{0} as {1}` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
 error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
+error.parsing.hint.missing_parameter_type=ヒント: すべてのパラメータには名前の後に明示的な型が必要です — 裸の `{0}` ではなく `{0}: Type` と書いてください。
 error.parsing.hint.java_style_field=ヒント: フィールドやローカル変数は名前の前に型ではなく `val`/`var` を書いて宣言します — `{0} {1}` ではなく `var {1}: {0}`（値が変わらないなら `val {1}: {0}`）と書いてください。
 error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:` ではなく `is` を使います — `case s: String:` ではなく `case s is String:` と書いてください。
 error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっこではなく角かっこを使います — `{0}<{1}>` ではなく `{0}[{1}]` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -36,7 +36,9 @@ private[compiler] object SyntaxHintClassifier {
   private val JavaStyleConstructor =
     """^\s*(?:public|private|protected)?\s*[A-Z][A-Za-z0-9_]*\s*\(""".r
   private val JavaStyleMethodDeclaration =
-    """^\s*(?:public|private|protected)?\s*(?!public\b|private\b|protected\b)[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
+    """^\s*(?:public|private|protected)?\s*(?!public\b|private\b|protected\b|def\b)[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
+  private val MissingParameterType =
+    """\bdef\s+[A-Za-z_]\w*(?:\[[^\]]*\])?\s*\(\s*(?:(?:val|var)\s+)?([A-Za-z_]\w*)\s*[,)]""".r
   private val JavaStyleFieldDeclaration =
     """^\s*(?:public|private|protected)?\s*([A-Z][A-Za-z0-9_]*(?:\[[^\]]*\])?\??)\s+([A-Za-z_]\w*)\s*(?:=|;|$)""".r
   private val JavaStyleTypeCase =
@@ -142,6 +144,9 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.java_style_method")
       case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleConstructor.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.java_style_constructor")
+      case (")" | ",") if expected == "\":\"" && MissingParameterType.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = MissingParameterType.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.missing_parameter_type", matched.group(1))
       case _ if JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_field", matched.group(1), matched.group(2))

--- a/src/test/scala/onion/compiler/MissingParameterTypeHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/MissingParameterTypeHintI18nSpec.scala
@@ -1,0 +1,54 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A parameter without an explicit type (Python/JS/TS style, where types are
+ * optional or inferred) used to be misclassified by `SyntaxHintClassifier` as
+ * a Java-style method declaration (`JavaStyleMethodDeclaration` also matches
+ * `def name(` since the pattern only excludes a leading `public`/`private`/
+ * `protected`, not `def`), producing a nonsensical hint that told the user to
+ * write `def`, which the line already did. This hint -- and the fix that
+ * excludes `def` from that other pattern -- must resolve through the
+ * bilingual `error.parsing.hint.*` bundle in both locales, like every other
+ * hint in that match -- see OldForInHintI18nSpec for the motivating
+ * regression.
+ */
+class MissingParameterTypeHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.missing_parameter_type"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  private def messages(src: String): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("hints at a missing parameter type, not a Java-style method, for `def foo(x): Int`") {
+    val msgs = messages("def foo(x): Int { ret x }\n")
+    assert(msgs.contains("x"), s"expected the hint to name the untyped parameter, got: $msgs")
+    assert(!msgs.contains("public void method"), s"should not fire the Java-style-method hint, got: $msgs")
+  }
+
+  it("does not fire when every parameter already has a type") {
+    val msgs = messages("def foo(x: Int): Int { ret x }\n")
+    assert(!msgs.contains("needs an explicit type"), s"hint should not fire for a fully-typed parameter list, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -128,6 +128,26 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       ) shouldBe None
     }
 
+    it("recognizes a parameter missing its type annotation, not a Java-style method") {
+      val hint = classify(
+        found = ")",
+        expected = "\":\"",
+        sourceLine = "def foo(x): Int {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.missing_parameter_type"
+      hint.arguments shouldBe Seq("x")
+    }
+
+    it("does not confuse a fully-typed parameter list with a missing-type parameter") {
+      SyntaxHintClassifier.classify(
+        found = ":",
+        expected = "\"def\"",
+        context = "",
+        sourceLine = "  void foo(x: Int) {"
+      ).map(_.messageKey) shouldBe Some("error.parsing.hint.java_style_method")
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",


### PR DESCRIPTION
## Summary
- `def foo(x): Int { ... }` with an untyped parameter `x` was misclassified by `SyntaxHintClassifier`'s `JavaStyleMethodDeclaration` pattern (it only excluded a leading `public`/`private`/`protected`, not `def`), producing a hint telling the user to write `def` — which the line already did.
- Excludes `def` from that pattern and adds a dedicated `missing_parameter_type` hint that names the untyped parameter instead, in both locale bundles (en/ja).
- Adds regression coverage in `SyntaxHintClassifierSpec` and a new bilingual `MissingParameterTypeHintI18nSpec`.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.MissingParameterTypeHintI18nSpec onion.compiler.JavaStyleMethodHintI18nSpec onion.compiler.tools.FunDeclarationHintSpec'` — all 28 tests pass
- [x] Full suite, English locale (`sbt -Duser.language=en testFull`) — 4163 tests, 0 failed, 1 canceled, all green
- [x] Full suite, Japanese locale (`sbt -Duser.language=ja testFull`) — 4163 tests, 0 failed, 1 canceled, all green

Both full-suite runs confirmed green — ready to merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1Yq99sUhJcbLdNzh7BjRx)_