### PR TITLE
fix(diagnostics): hint at foreach for a Java-style enhanced for-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The classifier now excludes `def` from that pattern and reports a dedicated
   hint naming the untyped parameter instead.
 
+- **Parser hint for a Java-style enhanced for-loop, `for (Type name : expr) { ... }`.**
+  Onion's collection loop is `foreach`, not `for`; the enhanced-for form parses
+  as a parenthesized `for` clause and previously fell through to the generic
+  C-style-for advice (`for var i: Int = 0; i < 10; i++ { ... }`), which is the
+  wrong fix for a collection loop. The diagnostic now recognizes
+  `for (Type name : expr)` ahead of that fallback and points at the correct
+  `foreach name: Type in expr { ... }` form. Fixing this also uncovered and
+  fixed an internal-compiler-error crash (arity-3+ syntax hints were
+  unsupported by the renderer).
+
 ## [0.19.0] - 2026-08-25
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -118,6 +118,7 @@ error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.
 error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthesized — write `catch e: Exception { ... }`, not `catch (e: Exception) { ... }`.
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
 error.parsing.hint.for_each_destructure=Hint: `for` doesn''t destructure or iterate a collection — that''s `foreach`''s job — write `foreach ({0}) in {1} '{' ... '}'`, not `for ({0}) in {1}`.
+error.parsing.hint.java_style_enhanced_for=Hint: Onion''s enhanced-for is `foreach` — write `foreach {0}: {1} in {2} '{' ... '}'`, not `for ({1} {0} : {2}) '{' ... '}'`.
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.parsing.hint.java_style_import_alias=Hint: an import''s alias is named with `as`, not `=` — write `{0} as {1}`, not `{1} = {0}`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -118,6 +118,7 @@ error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` 
 error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこで囲みません — `catch (e: Exception) { ... }` ではなく `catch e: Exception { ... }` と書いてください。
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
 error.parsing.hint.for_each_destructure=ヒント: `for` はコレクションを分配・反復できません — それは `foreach` の役目です — `for ({0}) in {1}` ではなく `foreach ({0}) in {1} '{' ... '}'` と書いてください。
+error.parsing.hint.java_style_enhanced_for=ヒント: Onion の拡張for文は `foreach` です — `for ({1} {0} : {2}) '{' ... '}'` ではなく `foreach {0}: {1} in {2} '{' ... '}'` と書いてください。
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.parsing.hint.java_style_import_alias=ヒント: import のエイリアスは `=` ではなく `as` で指定します — `{1} = {0}` ではなく `{0} as {1}` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -193,7 +193,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
       case Seq() => Message(hint.messageKey)
       case Seq(argument) => Message(hint.messageKey, argument)
       case Seq(first, second) => Message(hint.messageKey, first, second)
-      case _ => throw new IllegalArgumentException(s"Unsupported syntax-hint arity: ${hint.arguments.size}")
+      case more => Message(hint.messageKey, more.toArray[Any])
     }
 
   /** Make control characters and EOF visible in error messages. */

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -29,6 +29,8 @@ private[compiler] object SyntaxHintClassifier {
   private val CStyleForLoop = """^\s*for\s*\(""".r
   private val ForEachDestructureMistake =
     """^\s*for\s*\(?\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)+)\s*\)?\s*in\s+([^{]+?)\s*\{?\s*$""".r
+  private val JavaStyleEnhancedForLoop =
+    """^\s*for\s*\(\s*(?:final\s+)?([A-Za-z_][\w.\[\],\s]*\??)\s+([A-Za-z_]\w*)\s*:\s*(.+?)\s*\)\s*\{?\s*$""".r
   private val ForeachParenMistake = """\bforeach\s*\(""".r
   private val JavaStyleImport = """^\s*import\s+(?!\{)\S""".r
   private val JavaStyleImportAlias =
@@ -133,6 +135,10 @@ private[compiler] object SyntaxHintClassifier {
       case _ if ForEachDestructureMistake.findFirstMatchIn(sourceLine).isDefined =>
         val matched = ForEachDestructureMistake.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.for_each_destructure", matched.group(1), matched.group(2).trim)
+      // A Java enhanced-for (`for (Type name : expr)`) also matches CStyleForLoop, so keep this first.
+      case _ if JavaStyleEnhancedForLoop.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = JavaStyleEnhancedForLoop.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.java_style_enhanced_for", matched.group(2), matched.group(1).trim, matched.group(3).trim)
       case _ if CStyleForLoop.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.c_style_for")
       case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -37,6 +37,26 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("key, value", "entries")
     }
 
+    it("prefers enhanced-for advice over generic C-style-for advice") {
+      val hint = classify(
+        found = "s",
+        sourceLine = "for (String s : list) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.java_style_enhanced_for"
+      hint.arguments shouldBe Seq("s", "String", "list")
+    }
+
+    it("recognizes an enhanced-for loop over a qualified/generic element type") {
+      val hint = classify(
+        found = "entry",
+        sourceLine = "for (Map.Entry[String, Int] entry : map.entrySet()) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.java_style_enhanced_for"
+      hint.arguments shouldBe Seq("entry", "Map.Entry[String, Int]", "map.entrySet()")
+    }
+
     it("captures Java-style import alias arguments in Onion order") {
       val hint = classify(
         found = "=",


### PR DESCRIPTION
## Summary

- `for (Type name : expr) { ... }` (Java's enhanced for-loop) previously fell through to the generic C-style-for advice (`for var i: Int = 0; i < 10; i++ { ... }`), which is the wrong fix for a collection loop. Added a `SyntaxHintClassifier` rule that recognizes the enhanced-for shape ahead of that fallback and points at the correct `foreach name: Type in expr { ... }` form, with matching English/Japanese message strings.
- While verifying this end-to-end, found that the new hint (which needs 3 message arguments) crashed the compiler with an internal `I0000` error: `Parsing.renderSyntaxHint` only handled 0–2 argument hints and threw `IllegalArgumentException` for anything larger. Fixed it to render any arity via `Message`'s existing `Array[Any]` overload instead of hard-coding a cap — this was a real latent crash bug independent of the new rule.

## Test plan

- [x] Added `SyntaxHintClassifierSpec` cases (simple enhanced-for, and a qualified/generic element type like `Map.Entry[String, Int]`) — confirmed red before the fix, green after.
- [x] Manually verified end-to-end via `runScript` in both `en` and `ja` locales that the hint renders correctly and no longer crashes.
- [x] Confirmed the pre-existing genuine C-style for-loop (`for (int i = 0; i < 10; i++)`) still gets the original hint (no regression).
- [x] Full suite: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4165 tests, 0 failed, 1 canceled (pre-existing, environment-conditional distribution test unrelated to this change).
- [x] Same in `-Duser.language=ja` — 4165 tests, 0 failed, 1 canceled.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_015FUubgyZCYuUQGfh3gpUAq)_