### PR TITLE
fix(diagnostics): hint at -> for a standalone lambda still using the old => arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The classifier now excludes `def` from that pattern and reports a dedicated
   hint naming the untyped parameter instead.
 
+- **Parser hint for a standalone lambda still using the old `=>` arrow,
+  `(x) => expr` or `x => expr`.** `OldTrailingArrowHintI18nSpec`'s
+  `{ x => ... }` case was already covered, but that rule only fires when the
+  parser trips on the lambda's opening `{`; a non-trailing lambda (assigned
+  to a `val`, or passed as a plain call argument) trips on the `=` of `=>`
+  instead, with a generic expected-token dump that never mentions `->`. The
+  diagnostic now recognizes this case and points at the correct `(x) -> ...`
+  form, while still deferring to the existing `:`-expecting reading for a
+  Ruby-style `key => value` map-literal mistake on the same token.
+
 ## [0.19.0] - 2026-08-25
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -100,6 +100,7 @@ error.parsing.hint.old_extends=Hint: a superclass is named with `extends`, not `
 error.parsing.hint.old_conforms=Hint: interfaces are named with `conforms`, not `<:` — write `class A conforms I` (and `class A extends B conforms I`).
 error.parsing.hint.trailing_lambda_parens=Hint: a trailing lambda''s parameters aren''t parenthesized — write `'{' {0} -> ... '}'`, not `'{' ({0}) -> ... '}'`.
 error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `->`, the same as everywhere else — write `{ x -> ... }`. (`=>` is no longer part of the language.)
+error.parsing.hint.old_lambda_arrow=Hint: the arrow in a lambda is `->`, the same as everywhere else — write `(x) -> ...` (or `x -> ...` for a single bare parameter). (`=>` is no longer part of the language.)
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
 error.parsing.hint.python_style_return_arrow=Hint: a method''s return type follows a colon, not `->` — write `def {0}(...): {1} '{' ... '}'`, not `def {0}(...) -> {1} '{' ... '}'`.
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -100,6 +100,7 @@ error.parsing.hint.old_extends=ヒント: 親クラスは `:` ではなく `exte
 error.parsing.hint.old_conforms=ヒント: インターフェースは `<:` ではなく `conforms` で指定します — `class A conforms I`（親クラスと併用する場合は `class A extends B conforms I`）と書いてください。
 error.parsing.hint.trailing_lambda_parens=ヒント: 末尾ラムダの引数は丸かっこで囲みません — `'{' ({0}) -> ... '}'` ではなく `'{' {0} -> ... '}'` と書いてください。
 error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他と同じ `->` です — `{ x -> ... }` と書いてください。（`=>` は言語から無くなりました。）
+error.parsing.hint.old_lambda_arrow=ヒント: ラムダの矢印は他と同じ `->` です — `(x) -> ...`（単一の引数なら `x -> ...`）と書いてください。（`=>` は言語から無くなりました。）
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
 error.parsing.hint.python_style_return_arrow=ヒント: メソッドの戻り値の型は `->` ではなくコロンの後に書きます — `def {0}(...) -> {1} '{' ... '}'` ではなく `def {0}(...): {1} '{' ... '}'` と書いてください。
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -172,6 +172,12 @@ private[compiler] object SyntaxHintClassifier {
       // The parentheses rule below recognizes only the current `->` arrow.
       case "{" if OldArrowTrailingLambdaHead.findFirstMatchIn(context).isDefined =>
         hint("error.parsing.hint.old_trailing_arrow")
+      // A standalone (non-trailing) lambda with the old `=>` arrow: `found` lands on
+      // the `=` and `context` (which starts exactly there) sees the rest, `=> ...`.
+      // A map/array literal's Ruby-style `key => value` mistake hits the same token,
+      // but the parser still wants `:` there, so let that reading win instead.
+      case "=" if context.startsWith("=>") && !expected.contains("\":\"") =>
+        hint("error.parsing.hint.old_lambda_arrow")
       case "{" if ParenthesizedTrailingLambdaHead.findFirstMatchIn(context).isDefined =>
         val params = ParenthesizedTrailingLambdaHead.findFirstMatchIn(context).get.group(1).trim
         hint("error.parsing.hint.trailing_lambda_parens", params)

--- a/src/test/scala/onion/compiler/OldLambdaArrowHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/OldLambdaArrowHintI18nSpec.scala
@@ -1,0 +1,87 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A standalone (non-trailing) lambda still using the old `=>` arrow --
+ * `val f = (x) => x * 2` -- is the same mistake as `OldTrailingArrowHintI18nSpec`
+ * covers for trailing lambdas, but it trips the parser on a different token
+ * (`=`, not `{`), so `SyntaxHintClassifier` needs its own case
+ * (`old_lambda_arrow`). The message must also resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales; see OldForInHintI18nSpec for
+ * the motivating regression.
+ */
+class OldLambdaArrowHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.old_lambda_arrow"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  private def compile(src: String): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  it("fires for a standalone lambda still using the old `=>`") {
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val f = (x) => x * 2
+        |    return f(1)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = compile(src)
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("(x) -> ..."), s"expected the hint's `(x) -> ...` example, got: $msgs")
+  }
+
+  it("fires for a bare-parameter lambda still using the old `=>`") {
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val f: Int -> Int = x => x * 2
+        |    return f(1)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = compile(src)
+    assert(msgs.contains("(x) -> ..."), s"expected the hint's `(x) -> ...` example, got: $msgs")
+  }
+
+  it("does not fire for a Ruby-style `key => value` map-literal mistake") {
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val m = ["a" => 1]
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = compile(src)
+    assert(!msgs.contains("(x) -> ..."), s"lambda-arrow hint should not fire on a map literal, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -76,6 +76,38 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("recognizes an old arrow in a standalone (non-trailing) lambda") {
+      val hint = classify(
+        found = "=",
+        expected = "<EOF>, <EOL>, \";\"",
+        context = "=> x * 2",
+        sourceLine = "val f = (x) => x * 2"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.old_lambda_arrow"
+      hint.arguments shouldBe empty
+    }
+
+    it("recognizes an old arrow in a bare-parameter standalone lambda") {
+      val hint = classify(
+        found = "=",
+        expected = "<EOF>, <EOL>, \";\"",
+        context = "=> x * 2",
+        sourceLine = "val f = x => x * 2"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.old_lambda_arrow"
+    }
+
+    it("prefers the Ruby-style map-arrow reading when a `:` is expected next") {
+      SyntaxHintClassifier.classify(
+        found = "=",
+        expected = "<EOL>, \":\", \",\", \"]\"",
+        context = "=> 1]",
+        sourceLine = "val m = [\"a\" => 1]"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.old_lambda_arrow")
+    }
+
     it("keeps the reserved-word and missing-block fallbacks") {
       val reserved = classify(found = "class", expected = "<ID>")
       val block = classify(found = ")", expected = "\"{\"")


### PR DESCRIPTION
## Summary

- `OldTrailingArrowHintI18nSpec`'s `{ x => ... }` hint only fires when the parser trips on a *trailing* lambda's opening `{`. A **standalone** (non-trailing) lambda using the old `=>` arrow — `val f = (x) => x * 2`, or `x => x * 2` passed as a plain call argument — trips on the `=` of `=>` instead, and previously got a generic expected-token dump that never mentioned `->`.
- `SyntaxHintClassifier` now recognizes this case (`found == "="` with `context` starting `"=>"`) and points at the correct `(x) -> ...` form.
- The same token also fires for a Ruby-style `key => value` map-literal mistake (e.g. `["a" => 1]`, where the parser still expects `:`); the new rule defers to that reading via `!expected.contains("\":\"")` so it doesn't misfire with lambda advice there.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.OldLambdaArrowHintI18nSpec'`
- [x] Verified red→green: added the classifier case only after the new unit tests failed against the unmodified classifier
- [x] Mutation check: temporarily pointed the new branch at `old_trailing_arrow`'s message key and confirmed both the classifier spec and the i18n spec caught it, then reverted
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4171 succeeded, 0 failed, 1 canceled (pre-existing opt-in distribution smoke test, unrelated)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4171 succeeded, 0 failed, 1 canceled (same)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bo3gPHJMS6weUHVqNhBqCn)_