### PR TITLE
fix(diagnostics): hint at try-with-resources for a C#/Python-style using statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a C#/Python-style `using` resource statement.**
+  Onion has no `using` keyword; `using r = new Res() { ... }` parses as a bare
+  identifier-reference statement followed by a stray `r`, with a generic
+  expected-token dump that never mentions `try`. The diagnostic now recognizes
+  a leading `using name = expr` line and points at the correct
+  `try (val name = expr) { ... }` form.
+
 - **Parser hint for a Java/JavaScript-style `default:` case inside a `select` block.**
   Onion's `select` has no `default` label -- the catch-all arm is `else` -- so
   `default:` parses as a bare identifier-reference statement and the parser

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -137,6 +137,7 @@ error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and c
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
 error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `let name = value`.
+error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `using` resource statement — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `using {0} = {1} '{' ... '}'`.
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -137,6 +137,7 @@ error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のた�
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
 error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `let name = value` ではなく `val name: Type = value` と書いてください。
+error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風の `using` リソース文はありません — 代わりに try-with-resources ブロックを使ってください: `using {0} = {1} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -22,6 +22,8 @@ private[compiler] object SyntaxHintClassifier {
   private val ElifStatement = """\belif\b""".r
   private val ExceptClause = """\bexcept\b""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
+  private val UsingResourceStatement =
+    """^\s*using\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*\{?\s*$""".r
   private val FunDeclaration = """\b(?:fun|func|fn|function)\s+[A-Za-z_]\w*\s*\(""".r
   private val FunExtensionDeclaration =
     """\b(?:fun|func|fn|function)\s+([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\(""".r
@@ -122,6 +124,9 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.except_not_supported")
       case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.js_style_let")
+      case _ if UsingResourceStatement.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = UsingResourceStatement.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.using_resource_statement", matched.group(1), matched.group(2).trim)
       // Also resembles `Int.member`; extension-declaration advice is more useful.
       case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         val matched = FunExtensionDeclaration.findFirstMatchIn(sourceLine).get

--- a/src/test/scala/onion/compiler/UsingResourceStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/UsingResourceStatementHintI18nSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The `using`-resource-statement hint (`SyntaxHintClassifier`'s
+ * `UsingResourceStatement` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see JsStyleLetHintI18nSpec for the same pattern.
+ */
+class UsingResourceStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.using_resource_statement"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a C#/Python-style `using r = new Res() { ... }` statement") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Res {
+        |public:
+        |  def this { }
+        |  def close: void { }
+        |}
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    using r = new Res() {
+        |      IO::println("using")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted variable name and expression are literal source text,
+    // identical in both bundles, so this assertion holds regardless of the
+    // JVM's default locale.
+    assert(msgs.contains("try (val r = new Res())"), s"expected the hint's `try (val r = new Res())` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -200,6 +200,16 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       ).map(_.messageKey) shouldBe Some("error.parsing.hint.java_style_method")
     }
 
+    it("recognizes a C#/Python-style `using` resource statement") {
+      val hint = classify(
+        found = "r",
+        sourceLine = "using r = new Res() {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.using_resource_statement"
+      hint.arguments shouldBe Seq("r", "new Res()")
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",

--- a/src/test/scala/onion/compiler/tools/UsingResourceStatementHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/UsingResourceStatementHintSpec.scala
@@ -1,0 +1,66 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A C#/Python-style `using` resource statement, `using r = new Res() { ... }`.
+ * Onion has no `using` keyword, so it parses as a bare identifier-reference
+ * statement followed by a stray `r`, and the raw expected-token dump never
+ * mentions `try`. The diagnostic now recognizes a leading `using name = expr`
+ * line and points at the correct `try (val name = expr) { ... }` form.
+ */
+class UsingResourceStatementHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("C#/Python-style `using` resource statement") {
+    it("hints at `try (val ...)` for `using r = new Res() { ... }`") {
+      val msgs = messages(
+        """
+          |class Res {
+          |public:
+          |  def this { }
+          |  def close: void { }
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): void {
+          |    using r = new Res() {
+          |      IO::println("using")
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("try (val r = new Res())"), s"expected a hint mentioning `try (val r = new Res())`, got: $msgs")
+    }
+
+    it("does not fire for the correct `try (val r = ...) { ... }` form") {
+      val msgs = messages(
+        """
+          |import { java.lang.AutoCloseable }
+          |class Res conforms AutoCloseable {
+          |public:
+          |  def this { }
+          |  def close: void { }
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): void {
+          |    try (val r = new Res()) {
+          |      IO::println("using")
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `try (val r = ...)` form, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion has no `using` keyword. A C#/Python-style resource statement like `using r = new Res() { ... }` currently parses as a bare identifier-reference statement followed by a stray identifier, producing a generic expected-token dump that never mentions `try`.
- `SyntaxHintClassifier` now recognizes a leading `using name = expr` line and hints at the correct `try (val name = expr) { ... }` form, following the existing pattern of other foreign-syntax hints in that file.
- Adds bilingual (en/ja) message resources, a classifier-level unit test, an integration test (positive + negative case), and an i18n test, plus a CHANGELOG entry.

## Status
Opened as **draft**: the repo-wide `sbt -Duser.language=en testFull` run was still executing in this session (an earlier attempt with the CLAUDE.md-prescribed `-Xmx4G` heap hit an actual `OutOfMemoryError` given the current size of the test suite; retried with a larger heap). Per this repo's release process, this PR should only be marked ready and merged once that full run is confirmed green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFqwUJik7BkFgPsvdBMpgL)_