### PR TITLE
fix(diagnostics): hint at val/var for a Go-style := short variable declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Go-style `:=` short variable declaration.**
+  Onion has no `:=` operator; assignment is `=` and a type annotation is a
+  separate `:`, so `x := 5` parses as a bare identifier-reference statement
+  followed by a stray `:`, with a generic expected-token dump that never
+  mentions `val`/`var`. The diagnostic now recognizes a leading
+  `name := expr` line and points at the correct `val name = expr` (or
+  `var name = expr` for a mutable binding) form.
+
 - **Parser hint for a C#/Python-style `using` resource statement.**
   Onion has no `using` keyword; `using r = new Res() { ... }` parses as a bare
   identifier-reference statement followed by a stray `r`, with a generic

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -137,6 +137,7 @@ error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and c
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
 error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `let name = value`.
+error.parsing.hint.go_style_short_var_decl=Hint: Onion has no Go-style `:=` short variable declaration — declare it with `val` (immutable) or `var` (mutable) instead — write `val {0} = {1}`, not `{0} := {1}`.
 error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `using` resource statement — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `using {0} = {1} '{' ... '}'`.
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -137,6 +137,7 @@ error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のた�
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
 error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `let name = value` ではなく `val name: Type = value` と書いてください。
+error.parsing.hint.go_style_short_var_decl=ヒント: Onion に Go 風の `:=` 短縮変数宣言はありません — 変数は `val`（不変）または `var`（可変）で宣言します — `{0} := {1}` ではなく `val {0} = {1}` と書いてください。
 error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風の `using` リソース文はありません — 代わりに try-with-resources ブロックを使ってください: `using {0} = {1} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -22,6 +22,8 @@ private[compiler] object SyntaxHintClassifier {
   private val ElifStatement = """\belif\b""".r
   private val ExceptClause = """\bexcept\b""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
+  private val GoStyleShortVarDecl =
+    """^\s*([A-Za-z_]\w*)\s*:=\s*(.+?)\s*$""".r
   private val UsingResourceStatement =
     """^\s*using\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*\{?\s*$""".r
   private val FunDeclaration = """\b(?:fun|func|fn|function)\s+[A-Za-z_]\w*\s*\(""".r
@@ -124,6 +126,9 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.except_not_supported")
       case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.js_style_let")
+      case _ if GoStyleShortVarDecl.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = GoStyleShortVarDecl.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.go_style_short_var_decl", matched.group(1), matched.group(2).trim)
       case _ if UsingResourceStatement.findFirstMatchIn(sourceLine).isDefined =>
         val matched = UsingResourceStatement.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.using_resource_statement", matched.group(1), matched.group(2).trim)

--- a/src/test/scala/onion/compiler/GoStyleShortVarDeclHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/GoStyleShortVarDeclHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Go-style `:=` short-variable-declaration hint (`SyntaxHintClassifier`'s
+ * `GoStyleShortVarDecl` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see JsStyleLetHintI18nSpec for the same pattern.
+ */
+class GoStyleShortVarDeclHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.go_style_short_var_decl"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Go-style `x := 5` short variable declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    x := 5
+        |    IO::println(x)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted name and expression are literal source text, identical
+    // in both bundles, so this assertion holds regardless of the JVM's
+    // default locale.
+    assert(msgs.contains("val x = 5"), s"expected the hint's `val x = 5` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -210,6 +210,17 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("r", "new Res()")
     }
 
+    it("recognizes a Go-style `:=` short variable declaration") {
+      val hint = classify(
+        found = ":",
+        expected = "<EOL>, \";\", <EOF>",
+        sourceLine = "x := 5"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.go_style_short_var_decl"
+      hint.arguments shouldBe Seq("x", "5")
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",


### PR DESCRIPTION
## Summary
- Onion has no `:=` operator; assignment is `=` and a type annotation is a separate `:`, so `x := 5` parsed as a bare identifier-reference statement followed by a stray `:`, with a generic expected-token dump that never mentioned `val`/`var`.
- `SyntaxHintClassifier` now recognizes a leading `name := expr` line and points at the correct `val name = expr` (or `var name = expr` for a mutable binding) form, matching the existing `let`/`const` hints.
- Added the bilingual (en/ja) message bundle entries and a `CHANGELOG.md` entry.

## Test plan
- [x] `SyntaxHintClassifierSpec` — new unit test for the classifier rule (TDD: confirmed red before the implementation, green after)
- [x] `GoStyleShortVarDeclHintI18nSpec` — new end-to-end test asserting the hint resolves in both locale bundles and fires through the real compiler
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4183 tests, all passed
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4183 tests, all passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1gY3HuhWTdocj71usMDH4)_