### PR TITLE
fix(diagnostics): hint at record for a Kotlin-style data class declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Kotlin-style `data class` declaration.**
+  Onion has no `data class`; a data-carrying type is a `record`, and a
+  `data class Name(val x: Int, val y: Int)` line parses as a bare
+  identifier-reference statement followed by a stray `class`, with a generic
+  expected-token dump that never mentions `record`. The diagnostic now
+  recognizes a leading `data class Name(...)` declaration and points at the
+  correct `record Name(...)` form, stripping the `val`/`var` prefixes that
+  Onion's record component list does not use.
+
 - **Parser hint for a Go-style `:=` short variable declaration.**
   Onion has no `:=` operator; assignment is `=` and a type annotation is a
   separate `:`, so `x := 5` parses as a bare identifier-reference statement

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,7 @@ These are frequently confused with other languages. **Always check these:**
 | Wrong (Java style) | Correct (Onion) |
 |--------------------|-----------------|
 | `record Point { int x; int y; }` | `record Point(x: Int, y: Int)` - constructor-style |
+| `data class Point(val x: Int, val y: Int)` (Kotlin) | `record Point(x: Int, y: Int)` - no `val`/`var` in the component list |
 | `point.x` for record field | `point.x()` - record fields are methods (need parens) |
 | `point.copy(y=9)` unsupported? | ✓ correct - named partial copy, `copy()` clone, positional all work |
 | record with methods? | `record Fraction(num: Int, den: Int) { public: def plus(o: Fraction): Fraction = ...; static def of(...) ... }` - a record may carry a `{ access-section* }` body (instance/static/operator methods, private helpers); methods see the generated accessors. Also works on a generic record implementing a generic interface (`record Foo[T](v: T) conforms Bar[T]`) |

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -137,6 +137,7 @@ error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and c
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
 error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `let name = value`.
+error.parsing.hint.data_class_declaration=Hint: Onion has no `data class` — a data-carrying type is a `record`, whose component list has no `val`/`var` prefix. Write `record {0}({1})`, not `data class {0}(...)`.
 error.parsing.hint.go_style_short_var_decl=Hint: Onion has no Go-style `:=` short variable declaration — declare it with `val` (immutable) or `var` (mutable) instead — write `val {0} = {1}`, not `{0} := {1}`.
 error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `using` resource statement — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `using {0} = {1} '{' ... '}'`.
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -137,6 +137,7 @@ error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のた�
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
 error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `let name = value` ではなく `val name: Type = value` と書いてください。
+error.parsing.hint.data_class_declaration=ヒント: Onion に `data class` はありません — データを保持する型は `record` で、コンポーネント列に `val`/`var` は付けません。`data class {0}(...)` ではなく `record {0}({1})` と書いてください。
 error.parsing.hint.go_style_short_var_decl=ヒント: Onion に Go 風の `:=` 短縮変数宣言はありません — 変数は `val`（不変）または `var`（可変）で宣言します — `{0} := {1}` ではなく `val {0} = {1}` と書いてください。
 error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風の `using` リソース文はありません — 代わりに try-with-resources ブロックを使ってください: `using {0} = {1} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -26,6 +26,9 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*([A-Za-z_]\w*)\s*:=\s*(.+?)\s*$""".r
   private val UsingResourceStatement =
     """^\s*using\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*\{?\s*$""".r
+  private val DataClassDeclaration =
+    """^\s*data\s+class\s+([A-Za-z_]\w*)\s*\(([^)]*)\)""".r
+  private val ValVarParamPrefix = """^(?:val|var)\s+""".r
   private val FunDeclaration = """\b(?:fun|func|fn|function)\s+[A-Za-z_]\w*\s*\(""".r
   private val FunExtensionDeclaration =
     """\b(?:fun|func|fn|function)\s+([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\(""".r
@@ -126,6 +129,12 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.except_not_supported")
       case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.js_style_let")
+      case _ if DataClassDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = DataClassDeclaration.findFirstMatchIn(sourceLine).get
+        val params = matched.group(2).split(",").map { p =>
+          ValVarParamPrefix.replaceFirstIn(p.trim, "")
+        }.mkString(", ")
+        hint("error.parsing.hint.data_class_declaration", matched.group(1), params)
       case _ if GoStyleShortVarDecl.findFirstMatchIn(sourceLine).isDefined =>
         val matched = GoStyleShortVarDecl.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.go_style_short_var_decl", matched.group(1), matched.group(2).trim)

--- a/src/test/scala/onion/compiler/DataClassDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/DataClassDeclarationHintI18nSpec.scala
@@ -1,0 +1,45 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Kotlin-style `data class` declaration hint (`SyntaxHintClassifier`'s
+ * `DataClassDeclaration` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see JsStyleLetHintI18nSpec for the same pattern.
+ */
+class DataClassDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.data_class_declaration"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Kotlin-style `data class` declaration and drops val/var from the record hint") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |data class Point(val x: Int, val y: Int)
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted name and component list are literal source text (with
+    // `val`/`var` stripped), identical in both bundles, so this assertion
+    // holds regardless of the JVM's default locale.
+    assert(msgs.contains("record Point(x: Int, y: Int)"), s"expected the hint's `record Point(x: Int, y: Int)` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -221,6 +221,17 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("x", "5")
     }
 
+    it("recognizes a Kotlin-style `data class` declaration") {
+      val hint = classify(
+        found = "class",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "data class Point(val x: Int, val y: Int)"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.data_class_declaration"
+      hint.arguments shouldBe Seq("Point", "x: Int, y: Int")
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",


### PR DESCRIPTION
## Summary
- Onion has no `data class`; a data-carrying type is a `record`. `data class Name(val x: Int, val y: Int)` currently parses as a bare identifier-reference statement followed by a stray `class`, producing a generic expected-token dump that never mentions `record`.
- `SyntaxHintClassifier` now recognizes a leading `data class Name(...)` line and points at the correct `record Name(...)` form, stripping the `val`/`var` prefixes that Onion's record component list does not use.
- Adds the bilingual (en/ja) hint message, a `SyntaxHintClassifierSpec` unit case, and a `DataClassDeclarationHintI18nSpec` integration case following the existing per-hint i18n test pattern.
- Syncs `CLAUDE.md`'s common-mistakes table and `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- `SyntaxHintClassifierSpec` (targeted, local) — 22/22 green
- `DataClassDeclarationHintI18nSpec` (targeted, local) — 3/3 green
- Manual `runScript` against `data class Point(x: Int, y: Int)` and `data class Point(val x: Int, val y: Int)` — hint fires correctly in both cases
- `sbt -Duser.language=en testFull` hung under GC pressure in this session's local sandbox and could not be completed there, so this was opened as a draft. GitHub Actions CI (both `test` checks) subsequently ran the full suite on this commit and **passed** — promoting out of draft on the strength of that CI result.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTvE8eGAVD1a5EfchMtdMs)_
