### PR TITLE
fix(diagnostics): hint at if !condition for a Ruby-style unless statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a Ruby-style `unless` statement.**
+  Onion has no `unless` statement; `unless condition { ... }` parses as a bare
+  identifier-reference statement followed by a stray condition expression,
+  with a generic expected-token dump that never mentions `if`. The diagnostic
+  now recognizes a leading `unless condition { ... }` statement and points at
+  the correct negated-condition form, `if !condition { ... }`.
+
 ## [0.20.0] - 2026-08-26
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -113,6 +113,7 @@ error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style
 error.parsing.hint.default_case_not_supported=Hint: Onion's `select` has no Java/JavaScript-style `default` case. Use `else` instead: `select value { case 1: ...; else: ... }`.
 error.parsing.hint.elif_not_supported=Hint: Onion has no Python-style `elif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except` clause. Catch exceptions with `catch` instead: `try { ... } catch e: Exception { ... }`.
+error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -113,6 +113,7 @@ error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風
 error.parsing.hint.default_case_not_supported=ヒント: Onion の `select` に Java/JavaScript 風の `default` 節はありません。代わりに `else` を使ってください: `select value { case 1: ...; else: ... }`。
 error.parsing.hint.elif_not_supported=ヒント: Onion に Python 風の `elif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `except` 節はありません。代わりに `catch` で例外を捕捉してください: `try { ... } catch e: Exception { ... }`。
+error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -20,6 +20,7 @@ private[compiler] object SyntaxHintClassifier {
   private val LeadingMatchStatement = """^\s*match\b""".r
   private val DefaultCaseLabel = """^\s*default\s*:""".r
   private val ElifStatement = """\belif\b""".r
+  private val LeadingUnlessStatement = """^\s*unless\b""".r
   private val ExceptClause = """\bexcept\b""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
   private val GoStyleShortVarDecl =
@@ -125,6 +126,8 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.default_case_not_supported")
       case _ if ElifStatement.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.elif_not_supported")
+      case _ if LeadingUnlessStatement.findFirstMatchIn(sourceLine).isDefined =>
+        hint("error.parsing.hint.unless_not_supported")
       case _ if ExceptClause.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.except_not_supported")
       case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/UnlessStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/UnlessStatementHintI18nSpec.scala
@@ -1,0 +1,53 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The unless hint (`SyntaxHintClassifier`'s `LeadingUnlessStatement` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that match -- see OldForInHintI18nSpec for the
+ * motivating regression.
+ */
+class UnlessStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.unless_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Ruby-style `unless` statement") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val done = false
+        |    unless done {
+        |      IO::println("not done")
+        |    }
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("if !"), s"expected the hint's `if !` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -221,6 +221,17 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("x", "5")
     }
 
+    it("recognizes a Ruby-style `unless` statement") {
+      val hint = classify(
+        found = "unless",
+        expected = "<ID>",
+        sourceLine = "unless done {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.unless_not_supported"
+      hint.arguments shouldBe empty
+    }
+
     it("recognizes a Kotlin-style `data class` declaration") {
       val hint = classify(
         found = "class",


### PR DESCRIPTION
## Summary
- Onion has no `unless` statement; `unless condition { ... }` currently parses as a bare identifier-reference statement followed by a stray condition expression, producing a generic expected-token dump that never mentions `if`.
- `SyntaxHintClassifier` now recognizes a leading `unless condition { ... }` line and points at the correct negated-condition form: `if !condition { ... }`.
- Adds the bilingual (en/ja) `error.parsing.hint.unless_not_supported` message, following the same shape as the existing `elif`/`except`/`switch`/`when`/`match` hints.
- `[Unreleased]` in CHANGELOG.md updated.

## Test plan
- [x] `SyntaxHintClassifierSpec`: new unit test for the `unless` classification case
- [x] `UnlessStatementHintI18nSpec`: bundle resolution in both locales + an end-to-end compile of a real `unless` snippet asserting on the hint's literal example text (locale-agnostic)
- [x] Full suite green, English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 4191 succeeded, 0 failed (1 canceled, pre-existing/unrelated `ProjectDistributionSpec` environment skip)
- [x] Full suite green, Japanese locale: same command with `-Duser.language=ja` → 4191 succeeded, 0 failed (same canceled test)


---
_Generated by [Claude Code](https://claude.ai/code/session_012BVZd9TKSc2HfyL5nhCWpf)_