### PR TITLE
fix(diagnostics): hint at def this for a JS/TS-style constructor method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now recognizes a leading `unless condition { ... }` statement and points at
   the correct negated-condition form, `if !condition { ... }`.
 
+- **Parser hint for a JS/TS-style `constructor(...)` method.**
+  Onion has no special `constructor` method name; `constructor` is an ordinary
+  identifier (not a reserved word), so `constructor(x: Int) { ... }` trips the
+  parser right at `constructor`, with a generic expected-token dump that never
+  mentions `def this`. The diagnostic now recognizes a leading
+  `constructor(...) { ... }` method and points at the correct
+  `def this(...) { ... }` form.
+
 ## [0.20.0] - 2026-08-26
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -124,6 +124,7 @@ error.parsing.hint.java_style_enhanced_for=Hint: Onion''s enhanced-for is `forea
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.parsing.hint.java_style_import_alias=Hint: an import''s alias is named with `as`, not `=` — write `{0} as {1}`, not `{1} = {0}`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.
+error.parsing.hint.js_style_constructor=Hint: Onion has no JS/TS-style `constructor` method name — a constructor is declared with `def this` — write `def this(...) { ... }`, not `constructor(...) { ... }`.
 error.parsing.hint.java_style_method=Hint: a method's return type comes after its name, not before it, and needs `def` — write `public:` on its own line, then `def method(): void { ... }`, not `public void method() { ... }`.
 error.parsing.hint.missing_parameter_type=Hint: every parameter needs an explicit type after its name — write `{0}: Type`, not a bare `{0}`.
 error.parsing.hint.java_style_field=Hint: a field or local variable is declared with `val`/`var` before the name, not with the type before it — write `var {1}: {0}` (or `val {1}: {0}` if it never changes), not `{0} {1}`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -124,6 +124,7 @@ error.parsing.hint.java_style_enhanced_for=ヒント: Onion の拡張for文は `
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.parsing.hint.java_style_import_alias=ヒント: import のエイリアスは `=` ではなく `as` で指定します — `{1} = {0}` ではなく `{0} as {1}` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
+error.parsing.hint.js_style_constructor=ヒント: Onion に JS/TS スタイルの `constructor` という名前のメソッドはありません — コンストラクタは `def this` で宣言します — `constructor(...) { ... }` ではなく `def this(...) { ... }` と書いてください。
 error.parsing.hint.java_style_method=ヒント: メソッドの戻り値の型は名前の前ではなく後ろに `:` を挟んで書き、`def` が必要です — `public void method() { ... }` ではなく、`public:` を独立した行に書いた上で `def method(): void { ... }` としてください。
 error.parsing.hint.missing_parameter_type=ヒント: すべてのパラメータには名前の後に明示的な型が必要です — 裸の `{0}` ではなく `{0}: Type` と書いてください。
 error.parsing.hint.java_style_field=ヒント: フィールドやローカル変数は名前の前に型ではなく `val`/`var` を書いて宣言します — `{0} {1}` ではなく `var {1}: {0}`（値が変わらないなら `val {1}: {0}`）と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -45,6 +45,7 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\.\*)?)\s*;?\s*$""".r
   private val JavaStyleConstructor =
     """^\s*(?:public|private|protected)?\s*[A-Z][A-Za-z0-9_]*\s*\(""".r
+  private val JsStyleConstructorDeclaration = """^\s*constructor\s*\(""".r
   private val JavaStyleMethodDeclaration =
     """^\s*(?:public|private|protected)?\s*(?!public\b|private\b|protected\b|def\b)[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
   private val MissingParameterType =
@@ -170,6 +171,8 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.java_style_import_alias", matched.group(2), matched.group(1))
       case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleMethodDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.java_style_method")
+      case "constructor" if expected.contains("\"def\"") && JsStyleConstructorDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+        hint("error.parsing.hint.js_style_constructor")
       case _ if (expected == "\":\"" || expected.contains("\"def\"")) && JavaStyleConstructor.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.java_style_constructor")
       case (")" | ",") if expected == "\":\"" && MissingParameterType.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/JsStyleConstructorHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JsStyleConstructorHintI18nSpec.scala
@@ -1,0 +1,49 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The JS/TS-style-`constructor`-method hint (`SyntaxHintClassifier`'s `JsStyleConstructorDeclaration`
+ * case) must resolve through the bilingual `error.parsing.hint.*` bundle in both locales, like every
+ * other hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class JsStyleConstructorHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.js_style_constructor"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JS/TS-style `constructor(...) { }` method") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Point {
+        |  val x: Int
+        |public:
+        |  constructor(x: Int) {
+        |    this.x = x
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("def this"), s"expected the hint's `def this` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -243,6 +243,17 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("Point", "x: Int, y: Int")
     }
 
+    it("recognizes a JS/TS-style `constructor(...)` method") {
+      val hint = classify(
+        found = "constructor",
+        expected = "\"abstract\", \"def\", \"final\", \"forward\", ... (13 more)",
+        sourceLine = "constructor(x: Int, y: Int) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.js_style_constructor"
+      hint.arguments shouldBe empty
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",

--- a/src/test/scala/onion/compiler/tools/JsStyleConstructorHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JsStyleConstructorHintSpec.scala
@@ -1,0 +1,84 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A JS/TS-style `constructor(...) { }` method, named after the JavaScript/TypeScript
+ * convention instead of using `def this`. `constructor` is an ordinary identifier in
+ * Onion (not a reserved word), so the parser trips right at it, expecting a member
+ * declarator (`def`, `val`, `var`, ...) -- the generic dump never mentions `def this`.
+ */
+class JsStyleConstructorHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("JS/TS-style constructor method") {
+    it("hints at `def this` for `constructor(...) { }`") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |  val y: Int
+          |public:
+          |  constructor(x: Int, y: Int) {
+          |    this.x = x
+          |    this.y = y
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def this"), s"expected a hint mentioning `def this`, got: $msgs")
+    }
+
+    it("hints at `def this` for a no-arg `constructor() { }`") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |private:
+          |  constructor() {
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("def this"), s"expected a hint mentioning `def this`, got: $msgs")
+    }
+
+    it("does not fire for the correct `def this` form") {
+      val msgs = messages(
+        """
+          |class Point {
+          |  val x: Int
+          |  val y: Int
+          |public:
+          |  def this(x: Int, y: Int) {
+          |    this.x = x
+          |    this.y = y
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.isEmpty, s"expected no errors for the correct `def this` form, got: $msgs")
+    }
+
+    it("does not fire for a method that merely calls something named `constructor`") {
+      val msgs = messages(
+        """
+          |class Point {
+          |public:
+          |  def this() {
+          |    val constructor = 1
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("def this(...) { ... }`, not `constructor"), s"unexpected constructor hint, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `constructor` is an ordinary identifier in Onion, not a reserved word, so a JS/TS-style `constructor(x: Int) { ... }` method inside a class body trips the parser right at `constructor` (expecting a member declarator such as `def`/`val`/`var`), with a generic expected-token dump that never mentions `def this`.
- `SyntaxHintClassifier` now recognizes a leading `constructor(...) { ... }` declaration (guarded on the parser expecting `def` next) and points at the correct `def this(...) { ... }` form, in both English and Japanese bundles.
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] New unit case in `SyntaxHintClassifierSpec`
- [x] New end-to-end specs: `JsStyleConstructorHintSpec` (tools) and `JsStyleConstructorHintI18nSpec` (bilingual bundle + compile-through-OnionCompiler)
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4199 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated dist smoke test)
- [x] Same suite under `-Duser.language=ja` — identical result

---
_Generated by [Claude Code](https://claude.ai/code/session_015iJSUe1xToUF8LGwKtSTXP)_