### PR TITLE
fix(diagnostics): hint at a same-line return type for def name():

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `constructor(...) { ... }` method and points at the correct
   `def this(...) { ... }` form.
 
+- **Parser hint for a Python-style `def name():` with no return type.**
+  A method's `:` must be followed by its return type on the same line;
+  `def foo():` with nothing after the colon (the Python habit of ending a
+  `def` line with a bare `:` before an indented body) trips the parser at
+  the following newline, with a generic expected-token dump listing every
+  type keyword. The diagnostic now recognizes a dangling `def name(...):`
+  and suggests either adding the return type (`def name(...): Void { ... }`)
+  or dropping the `:` entirely (`def name(...) { ... }`).
+
 ## [0.20.0] - 2026-08-26
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -103,6 +103,7 @@ error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `-
 error.parsing.hint.old_lambda_arrow=Hint: the arrow in a lambda is `->`, the same as everywhere else — write `(x) -> ...` (or `x -> ...` for a single bare parameter). (`=>` is no longer part of the language.)
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
 error.parsing.hint.python_style_return_arrow=Hint: a method''s return type follows a colon, not `->` — write `def {0}(...): {1} '{' ... '}'`, not `def {0}(...) -> {1} '{' ... '}'`.
+error.parsing.hint.dangling_return_type_colon=Hint: after `:` a method needs its return type on the same line -- write `def {0}(...): Void '{' ... '}'`, or drop the `:` entirely if you meant no declared return type: `def {0}(...) '{' ... '}'`.
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use `foreach x: Type in xs { ... }` (or a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`).

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -103,6 +103,7 @@ error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他�
 error.parsing.hint.old_lambda_arrow=ヒント: ラムダの矢印は他と同じ `->` です — `(x) -> ...`（単一の引数なら `x -> ...`）と書いてください。（`=>` は言語から無くなりました。）
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
 error.parsing.hint.python_style_return_arrow=ヒント: メソッドの戻り値の型は `->` ではなくコロンの後に書きます — `def {0}(...) -> {1} '{' ... '}'` ではなく `def {0}(...): {1} '{' ... '}'` と書いてください。
+error.parsing.hint.dangling_return_type_colon=ヒント: `:` の後には戻り値の型を同じ行に書く必要があります — `def {0}(...): Void '{' ... '}'` のように書くか、戻り値の型を宣言しないつもりなら `:` ごと削除してください: `def {0}(...) '{' ... '}'`。
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。`foreach x: Type in xs { ... }` を使ってください（または C スタイルのループ: `for var i = 0; i < xs.size(); i = i + 1 { ... }`）。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -83,6 +83,8 @@ private[compiler] object SyntaxHintClassifier {
     """\(\s*([A-Z][\w.\[\]]*\??)\s*\)\s*[A-Za-z_$(]""".r
   private val PythonStyleReturnArrow =
     """\bdef\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*\([^()]*\)\s*->\s*([A-Za-z_][\w.\[\]?]*)""".r
+  private val DanglingReturnTypeColon =
+    """\bdef\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*\([^()]*\)\s*:\s*$""".r
 
   def classify(
     found: String,
@@ -196,6 +198,9 @@ private[compiler] object SyntaxHintClassifier {
       case "->" if PythonStyleReturnArrow.findFirstMatchIn(sourceLine).isDefined =>
         val matched = PythonStyleReturnArrow.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.python_style_return_arrow", matched.group(1), matched.group(2))
+      case ("\n" | "\r\n" | "\r") if DanglingReturnTypeColon.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = DanglingReturnTypeColon.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.dangling_return_type_colon", matched.group(1))
       case "?" =>
         hint("error.parsing.hint.ternary")
       case "else" =>

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -171,6 +171,26 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("bar", "Int")
     }
 
+    it("recognizes a Python-style `def name():` with no return type before the block") {
+      val hint = classify(
+        found = "\n",
+        expected = "\"Boolean\", \"Byte\", \"Char\", \"Double\", ... (11 more)",
+        sourceLine = "  def foo():"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.dangling_return_type_colon"
+      hint.arguments shouldBe Seq("foo")
+    }
+
+    it("does not flag a method colon that already has a same-line return type") {
+      SyntaxHintClassifier.classify(
+        found = "\n",
+        expected = "\"Boolean\", \"Byte\", \"Char\", \"Double\", ... (11 more)",
+        context = "",
+        sourceLine = "  def foo(): Int {"
+      ) shouldBe None
+    }
+
     it("does not confuse the real `(expr as Type)` cast with a C-style cast") {
       SyntaxHintClassifier.classify(
         found = "as",


### PR DESCRIPTION
## Summary
- Onion requires a method's return type immediately after `:`, on the same line — there is no Python-style `def name():` header followed by an indented body.
- That form currently trips the parser at the following newline with a generic expected-token dump listing every type keyword (`Boolean`, `Byte`, `Char`, ...), never mentioning that the return type belongs right after the colon.
- Adds a `SyntaxHintClassifier` rule that recognizes a dangling `def name(...):` and suggests either adding the return type (`def name(...): Void { ... }`) or dropping the `:` entirely (`def name(...) { ... }`).
- Bilingual message (en/ja) added to both `errorMessage.properties` files.
- `CHANGELOG.md` `[Unreleased]` updated.

## Test plan
- [x] Added a failing test first (`SyntaxHintClassifierSpec`), confirmed red, then implemented and confirmed green.
- [x] Added a negative test confirming a correctly-typed `def foo(): Int {` does not fire the hint.
- [x] Manually verified end-to-end via `sbt runScript` in both `en` and `ja` locales.
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4201 tests, 0 failed, 1 canceled (opt-in distribution smoke test, expected).
- [x] Same in `-Duser.language=ja` — 4201 tests, 0 failed, 1 canceled.

---
_Generated by [Claude Code](https://claude.ai/code/session_017h5sXfzBD1GWAoiPeCz5hZ)_