### PR TITLE
fix(diagnostics): hint at ! for a Python/Ruby-style not operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Python/Ruby-style `not` boolean negation.**
+  Onion has no `not` operator; boolean negation is `!`, so `if not done { ... }`
+  or `while not empty { ... }` parses `not` as a bare identifier-reference
+  expression followed by a stray token, with a generic "a block is expected
+  here" hint that never mentions `!`. The diagnostic now recognizes a leading
+  `if`/`while`/`else if not ...` condition and points at the correct
+  `if !condition { ... }` form.
+
 - **Parser hint for a Ruby-style `unless` statement.**
   Onion has no `unless` statement; `unless condition { ... }` parses as a bare
   identifier-reference statement followed by a stray condition expression,

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -115,6 +115,7 @@ error.parsing.hint.default_case_not_supported=Hint: Onion's `select` has no Java
 error.parsing.hint.elif_not_supported=Hint: Onion has no Python-style `elif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except` clause. Catch exceptions with `catch` instead: `try { ... } catch e: Exception { ... }`.
 error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.
+error.parsing.hint.not_operator=Hint: Onion has no Python/Ruby-style `not` operator for boolean negation. Use `!` instead: `if !condition { ... }`, not `if not condition { ... }`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -115,6 +115,7 @@ error.parsing.hint.default_case_not_supported=ヒント: Onion の `select` に 
 error.parsing.hint.elif_not_supported=ヒント: Onion に Python 風の `elif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `except` 節はありません。代わりに `catch` で例外を捕捉してください: `try { ... } catch e: Exception { ... }`。
 error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。
+error.parsing.hint.not_operator=ヒント: Onion に Python/Ruby 風の論理否定演算子 `not` はありません。代わりに `!` を使ってください: `if not condition { ... }` ではなく `if !condition { ... }` と書いてください。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -21,6 +21,7 @@ private[compiler] object SyntaxHintClassifier {
   private val DefaultCaseLabel = """^\s*default\s*:""".r
   private val ElifStatement = """\belif\b""".r
   private val LeadingUnlessStatement = """^\s*unless\b""".r
+  private val NotOperatorCondition = """^\s*(?:if|while|else\s+if)\s+not\b""".r
   private val ExceptClause = """\bexcept\b""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
   private val GoStyleShortVarDecl =
@@ -219,6 +220,8 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.trailing_lambda_parens", params)
       case word if ReservedWords.contains(word) && (expected.contains("<ID>") || expected.contains("<QUOTED_ID>")) =>
         hint("error.parsing.hint.reserved_word_identifier", word)
+      case _ if expected.contains("{") && NotOperatorCondition.findFirstMatchIn(sourceLine).isDefined =>
+        hint("error.parsing.hint.not_operator")
       case _ if expected.contains("{") && !Set(";", "<EOL>", "<EOF>").exists(expected.contains) =>
         hint("error.parsing.hint.block_expected")
       case _ =>

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -252,6 +252,48 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("recognizes a Python-style `not` boolean negation in an `if` condition") {
+      val hint = classify(
+        found = "done",
+        expected = "\"{\"",
+        sourceLine = "if not done {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.not_operator"
+      hint.arguments shouldBe empty
+    }
+
+    it("recognizes a Python-style `not` boolean negation in a `while` condition") {
+      val hint = classify(
+        found = "empty",
+        expected = "\"{\"",
+        sourceLine = "while not empty {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.not_operator"
+      hint.arguments shouldBe empty
+    }
+
+    it("recognizes a Python-style `not` boolean negation in an `else if` condition") {
+      val hint = classify(
+        found = "ready",
+        expected = "\"{\"",
+        sourceLine = "else if not ready {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.not_operator"
+      hint.arguments shouldBe empty
+    }
+
+    it("does not flag `not` when no block is expected next") {
+      SyntaxHintClassifier.classify(
+        found = "x",
+        expected = "\";\"",
+        context = "",
+        sourceLine = "if not x"
+      ) shouldBe None
+    }
+
     it("recognizes a Kotlin-style `data class` declaration") {
       val hint = classify(
         found = "class",

--- a/src/test/scala/onion/compiler/tools/NotOperatorHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NotOperatorHintSpec.scala
@@ -1,0 +1,75 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no Python/Ruby-style `not` operator for boolean negation --
+ * conditions are negated with `!`. `not` isn't a keyword in Onion, so it
+ * parses as a bare identifier-reference expression and the parser actually
+ * trips on whatever follows it, never on `not` itself.
+ */
+class NotOperatorHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("not operator") {
+    it("hints at ! for a Python-style `not` in an if condition") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val done = false
+          |    if not done {
+          |      IO::println("not done")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("!"), s"expected a hint mentioning !, got: $msgs")
+      assert(msgs.contains("not"), s"expected the hint to name not, got: $msgs")
+    }
+
+    it("hints at ! for a Python-style `not` in a while condition") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val empty = true
+          |    while not empty {
+          |      IO::println("looping")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("!"), s"expected a hint mentioning !, got: $msgs")
+      assert(msgs.contains("not"), s"expected the hint to name not, got: $msgs")
+    }
+
+    it("does not fire for an unrelated bare-identifier-statement typo") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foo bar
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("not"), s"hint should not fire without a `not`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion has no `not` keyword for boolean negation; `if not done { ... }` or `while not empty { ... }` currently parses `not` as a bare identifier-reference expression followed by a stray token, producing a generic "a block is expected here" hint that never mentions `!`.
- Recognizes a leading `if`/`while`/`else if not ...` condition in the parser's syntax-hint classifier and points at the correct `if !condition { ... }` form (bilingual en/ja message).
- Adds unit tests to `SyntaxHintClassifierSpec` and an end-to-end `NotOperatorHintSpec`, plus a `CHANGELOG.md [Unreleased]` entry.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.tools.NotOperatorHintSpec onion.compiler.tools.HintMessageFormatSpec'` — pass
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.*Hint* onion.compiler.parser.*'` — 170/170 pass
- [x] CI `test` check — green (a local full-suite run timed out after 40 min without flushing output; CI completed the full suite successfully in ~3 minutes, so that concern is resolved)