### PR TITLE
fix(diagnostics): hint at #{expr} for a $-sigil variable/interpolation mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a `$` variable/interpolation sigil.**
+  Onion has no `$` sigil; string interpolation is `#{expr}` inside a string
+  literal, so a C#-style `$"Hello, {name}!"` interpolated string or a
+  PHP/Bash-style `$name` variable reference trips the parser right at `$`,
+  with a generic expected-token dump listing over 40 alternatives that never
+  mentions `#{}`. The diagnostic now recognizes a leading `$` token and
+  points at the correct `"Hello, #{name}!"` interpolation form.
+
 - **Parser hint for a Python/Ruby-style `not` boolean negation.**
   Onion has no `not` operator; boolean negation is `!`, so `if not done { ... }`
   or `while not empty { ... }` parses `not` as a bare identifier-reference

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -145,6 +145,7 @@ error.parsing.hint.data_class_declaration=Hint: Onion has no `data class` — a 
 error.parsing.hint.go_style_short_var_decl=Hint: Onion has no Go-style `:=` short variable declaration — declare it with `val` (immutable) or `var` (mutable) instead — write `val {0} = {1}`, not `{0} := {1}`.
 error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `using` resource statement — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `using {0} = {1} '{' ... '}'`.
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
+error.parsing.hint.dollar_sigil=Hint: Onion has no `$` sigil for variables or string interpolation — interpolate inside a string with `#{expr}` instead — write `"Hello, #{name}!"`, not `$"Hello, {name}!"` or `$name`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -145,6 +145,7 @@ error.parsing.hint.data_class_declaration=ヒント: Onion に `data class` は�
 error.parsing.hint.go_style_short_var_decl=ヒント: Onion に Go 風の `:=` 短縮変数宣言はありません — 変数は `val`（不変）または `var`（可変）で宣言します — `{0} := {1}` ではなく `val {0} = {1}` と書いてください。
 error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風の `using` リソース文はありません — 代わりに try-with-resources ブロックを使ってください: `using {0} = {1} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
+error.parsing.hint.dollar_sigil=ヒント: Onion に変数や文字列補間のための `$` シジルはありません — 文字列内での補間は `#{expr}` を使ってください — `$"Hello, {name}!"` や `$name` ではなく `"Hello, #{name}!"` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -98,6 +98,8 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.old_conforms")
       case "const" =>
         hint("error.parsing.hint.js_style_const")
+      case "$" =>
+        hint("error.parsing.hint.dollar_sigil")
       case _ if JavaStyleImplements.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleImplements.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_implements", matched.group(1), matched.group(2).trim)

--- a/src/test/scala/onion/compiler/DollarSigilHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/DollarSigilHintI18nSpec.scala
@@ -1,0 +1,69 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The `$`-sigil hint (`SyntaxHintClassifier`'s `"$"` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that match -- see JsStyleConstHintI18nSpec for the
+ * same pattern.
+ */
+class DollarSigilHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.dollar_sigil"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a C#-style `$\"Hello, {name}!\"` interpolated string") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val name = "world"
+        |    IO::println($"Hello, {name}!")
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("#{expr}"), s"expected the hint's `#{expr}` example, got: $msgs")
+  }
+
+  it("fires for a PHP/Bash-style `$name` variable sigil") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val greeting = $name
+        |    IO::println(greeting)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("#{expr}"), s"expected the hint's `#{expr}` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -316,6 +316,28 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("recognizes a C#-style `$\"...\"` interpolated string prefix") {
+      val hint = classify(
+        found = "$",
+        expected = "<EOL>, \"Boolean\", \"break\", ... (44 more)",
+        sourceLine = "IO::println($\"Hello, {name}!\")"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.dollar_sigil"
+      hint.arguments shouldBe empty
+    }
+
+    it("recognizes a PHP/Bash-style `$name` variable sigil") {
+      val hint = classify(
+        found = "$",
+        expected = "<EOL>, \"Boolean\", \"break\", ... (44 more)",
+        sourceLine = "val greeting = \"Hi \" + $name"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.dollar_sigil"
+      hint.arguments shouldBe empty
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",


### PR DESCRIPTION
## Summary
- Onion has no `$` sigil; string interpolation is `#{expr}` inside a string literal, so a C#-style `$"Hello, {name}!"` interpolated string or a PHP/Bash-style `$name` variable reference currently trips the parser right at `$` with a generic expected-token dump (40+ alternatives) that never mentions `#{}`.
- `SyntaxHintClassifier` now recognizes a leading `$` token and points at the correct `"Hello, #{name}!"` interpolation form, in both English and Japanese bundles.
- Added `error.parsing.hint.dollar_sigil` to both `errorMessage.properties` and `errorMessage_ja.properties`.

## Test plan
- [x] `SyntaxHintClassifierSpec` — direct unit coverage for both the `$"..."` and bare `$name` forms
- [x] `DollarSigilHintI18nSpec` — end-to-end bilingual bundle resolution + real parse-error assertions
- [x] Full suite, English locale (`sbt -Duser.language=en testFull`): 4214 tests, all passed
- [x] Full suite, Japanese locale (`sbt -Duser.language=ja testFull`): 4214 tests, all passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3hJZWUdjWaspv8w6YrZan)_