### PR TITLE
fix(diagnostics): hint at import { ... } for a C#-style using directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a C#-style `using` namespace-import directive.**
+  Onion has no `using Namespace;` import directive; imports are wrapped in
+  braces, so `using System.Collections.Generic;` at the top of a file parses
+  `using` as a bare identifier-reference statement followed by a stray
+  identifier, with a generic expected-token dump that never mentions
+  `import { ... }`. The diagnostic now recognizes a leading
+  `using Some.Dotted.Path;` statement and points at the correct
+  `import { Some.Dotted.Path }` form. This is distinct from the existing hint
+  for C#/Python-style `using r = expr { ... }` resource statements.
+
 - **Parser hint for a `$` variable/interpolation sigil.**
   Onion has no `$` sigil; string interpolation is `#{expr}` inside a string
   literal, so a C#-style `$"Hello, {name}!"` interpolated string or a

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -144,6 +144,7 @@ error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a v
 error.parsing.hint.data_class_declaration=Hint: Onion has no `data class` — a data-carrying type is a `record`, whose component list has no `val`/`var` prefix. Write `record {0}({1})`, not `data class {0}(...)`.
 error.parsing.hint.go_style_short_var_decl=Hint: Onion has no Go-style `:=` short variable declaration — declare it with `val` (immutable) or `var` (mutable) instead — write `val {0} = {1}`, not `{0} := {1}`.
 error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `using` resource statement — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `using {0} = {1} '{' ... '}'`.
+error.parsing.hint.csharp_style_using_import=Hint: Onion has no C#-style `using` import directive — imports are wrapped in braces — write `import '{' {0} '}'`, not `using {0};`.
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
 error.parsing.hint.dollar_sigil=Hint: Onion has no `$` sigil for variables or string interpolation — interpolate inside a string with `#{expr}` instead — write `"Hello, #{name}!"`, not `$"Hello, {name}!"` or `$name`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -144,6 +144,7 @@ error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはあ
 error.parsing.hint.data_class_declaration=ヒント: Onion に `data class` はありません — データを保持する型は `record` で、コンポーネント列に `val`/`var` は付けません。`data class {0}(...)` ではなく `record {0}({1})` と書いてください。
 error.parsing.hint.go_style_short_var_decl=ヒント: Onion に Go 風の `:=` 短縮変数宣言はありません — 変数は `val`（不変）または `var`（可変）で宣言します — `{0} := {1}` ではなく `val {0} = {1}` と書いてください。
 error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風の `using` リソース文はありません — 代わりに try-with-resources ブロックを使ってください: `using {0} = {1} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
+error.parsing.hint.csharp_style_using_import=ヒント: Onion に C# 風の `using` インポート指令はありません — import は波かっこで囲みます — `using {0};` ではなく `import '{' {0} '}'` と書いてください。
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
 error.parsing.hint.dollar_sigil=ヒント: Onion に変数や文字列補間のための `$` シジルはありません — 文字列内での補間は `#{expr}` を使ってください — `$"Hello, {name}!"` や `$name` ではなく `"Hello, #{name}!"` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -28,6 +28,8 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*([A-Za-z_]\w*)\s*:=\s*(.+?)\s*$""".r
   private val UsingResourceStatement =
     """^\s*using\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*\{?\s*$""".r
+  private val CSharpStyleUsingImport =
+    """^\s*using\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*;\s*$""".r
   private val DataClassDeclaration =
     """^\s*data\s+class\s+([A-Za-z_]\w*)\s*\(([^)]*)\)""".r
   private val ValVarParamPrefix = """^(?:val|var)\s+""".r
@@ -150,6 +152,9 @@ private[compiler] object SyntaxHintClassifier {
       case _ if UsingResourceStatement.findFirstMatchIn(sourceLine).isDefined =>
         val matched = UsingResourceStatement.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.using_resource_statement", matched.group(1), matched.group(2).trim)
+      case _ if CSharpStyleUsingImport.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = CSharpStyleUsingImport.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.csharp_style_using_import", matched.group(1))
       // Also resembles `Int.member`; extension-declaration advice is more useful.
       case _ if FunExtensionDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         val matched = FunExtensionDeclaration.findFirstMatchIn(sourceLine).get

--- a/src/test/scala/onion/compiler/CSharpStyleUsingImportHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/CSharpStyleUsingImportHintI18nSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The C#-style-using-import hint (`SyntaxHintClassifier`'s `CSharpStyleUsingImport` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both locales, like every other
+ * hint in that match -- see OldForInHintI18nSpec for the motivating regression.
+ */
+class CSharpStyleUsingImportHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.csharp_style_using_import"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a C#-style `using` namespace-import directive") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |using System.Collections.Generic;
+        |
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example import shown in the hint is literal code, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("import { System.Collections.Generic }"), s"expected the hint's example import, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -230,6 +230,24 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("r", "new Res()")
     }
 
+    it("recognizes a C#-style `using` namespace-import directive") {
+      val hint = classify(
+        found = "System",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "using System.Collections.Generic;"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.csharp_style_using_import"
+      hint.arguments shouldBe Seq("System.Collections.Generic")
+    }
+
+    it("does not confuse a C#-style resource `using` statement with the import-directive form") {
+      classify(
+        found = "r",
+        sourceLine = "using r = new Res() {"
+      ).messageKey shouldBe "error.parsing.hint.using_resource_statement"
+    }
+
     it("recognizes a Go-style `:=` short variable declaration") {
       val hint = classify(
         found = ":",


### PR DESCRIPTION
## Summary
- Onion has no `using Namespace;` import directive; imports are wrapped in braces (`import { ... }`).
- `using System.Collections.Generic;` at the top of a file previously trips the parser at the second identifier with a generic expected-token dump that never mentions `import { ... }`.
- Adds a `SyntaxHintClassifier` rule that recognizes a leading `using Some.Dotted.Path;` statement and points at the correct `import { Some.Dotted.Path }` form, in both English and Japanese bundles.
- This is distinct from the existing hint for C#/Python-style `using r = expr { ... }` resource statements (`error.parsing.hint.using_resource_statement`), which requires an `=`.

## Test plan
- [x] New unit tests in `SyntaxHintClassifierSpec` (fires for the import-directive form; does not shadow the resource-statement form)
- [x] New bilingual integration spec `CSharpStyleUsingImportHintI18nSpec` (English/Japanese bundle resolution + end-to-end compile message)
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4219 succeeded, 0 failed, 1 canceled (pre-existing, opt-in dist smoke test gated behind a system property, unrelated to this change)
- [x] Same suite with `-Duser.language=ja` — identical result

CHANGELOG `[Unreleased]` updated with a new entry.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GsXFuTyKveGhPVDWqzUwMP)_