### PR TITLE
Refactor unsupported control-flow syntax hints

### DIFF
--- a/docs/refactoring/current-architecture.md
+++ b/docs/refactoring/current-architecture.md
@@ -63,11 +63,16 @@ preserves the existing separator and truncation behavior. The generated
 parser's `expectedSummary` method remains a separate recovery-path formatter;
 its punctuation and truncation contract are observably different.
 
-`parser.SyntaxHintClassifier` owns the ordered regular-expression policy for
-more than thirty friendly syntax hints. It returns a message key and literal
-arguments without consulting parser or locale state. `Parsing` renders that
-result through `Message`. Direct priority tests and the existing end-to-end
-English/Japanese suites protect this boundary.
+`parser.SyntaxHintClassifier` owns the global priority policy for 51 friendly
+syntax hints and the rules that have not yet earned a cohesive family boundary.
+`parser.ControlFlowSyntaxHints` owns the seven unsupported control-flow forms
+for `switch`, `when`, `match`, `default`, `elif`, `unless`, and `except`.
+The classifier evaluates that family at the same position as the former inline
+branches, before declarations and the generic missing-block fallback. Both
+components return message keys and literal arguments without consulting parser
+or locale state; `Parsing` renders the result through `Message`. Direct family
+and cross-family priority tests plus the existing end-to-end English/Japanese
+suites protect this boundary.
 
 ## Rewriting
 
@@ -123,7 +128,7 @@ Japanese parser hints. That coverage is a valuable refactoring oracle.
 
 ## Tests and CI
 
-- `testFull` currently executes 4,155 tests across 572 suites.
+- `testFull` currently executes 4,225 tests across 585 suites.
 - The default phase order and failure short-circuit are covered by
   `PipelineRunnerSpec`.
 - Parser hint behavior is covered by direct pure source-context and classifier

--- a/docs/refactoring/decision-log.md
+++ b/docs/refactoring/decision-log.md
@@ -122,3 +122,23 @@ Invariant: terminal formatting keeps the null/empty fallback, considers only
 the first token of each sequence, deduplicates in encounter order, joins one to
 three tokens with the existing separators, and preserves the four-token
 truncation boundary exactly, including the existing `... (0 more)` result.
+
+## D011: begin hint grouping with one contiguous control-flow family
+
+Decision: move the seven contiguous unsupported control-flow rules for
+`switch`, `when`, `match`, `default`, `elif`, `unless`, and `except` into the
+package-private pure `parser.ControlFlowSyntaxHints` object. Keep its single
+delegation point in the exact former position of the global classifier chain.
+
+Reason: after the original classifier extraction, the file reached 240 LOC,
+113 branch proxies, 16 commits, and 242 lines of churn in the audit window;
+most of that activity was new hint work. These seven rules form a closed,
+contiguous priority interval and share the same unsupported-control-flow
+responsibility. Extracting them localizes future changes without introducing a
+registry, one-rule files, or a speculative rule interface.
+
+Invariant: the seven internal rules retain their order, the family remains
+after the removed `for ... in` cases and before declaration rules, and it stays
+ahead of the generic missing-block fallback. Message keys, arguments, regular
+expressions, localization, source locations, and no-match behavior do not
+change.

--- a/docs/refactoring/feature-recipes.md
+++ b/docs/refactoring/feature-recipes.md
@@ -6,15 +6,19 @@ unavailable; ordinary environments may use `sbt` directly.
 
 ## Add a friendly parser hint
 
-1. Add a failing literal case to
-   `onion.compiler.parser.SyntaxHintClassifierSpec`.
-2. State which broader rule the new case must precede.
-3. Add the message key to both `errorMessage.properties` bundles.
-4. Add or update one end-to-end `*HintSpec` for the real malformed source.
-5. Add an i18n test when the hint has new text or arguments.
-6. Implement the smallest classifier pattern and ordered branch.
-7. Mutate its key or priority locally and confirm the focused test fails.
-8. Run focused tests and both locale `testFull` suites.
+1. Identify the owning family. Unsupported `switch` / `when` / `match` /
+   `default` / `elif` / `unless` / `except` forms belong to
+   `ControlFlowSyntaxHints`; other rules remain in `SyntaxHintClassifier` until
+   a cohesive family boundary is justified.
+2. Add a failing literal case to the owning direct spec. Add a
+   `SyntaxHintClassifierSpec` case when the rule can collide across families.
+3. State which broader rule or family the new case must precede.
+4. Add the message key to both `errorMessage.properties` bundles.
+5. Add or update one end-to-end `*HintSpec` for the real malformed source.
+6. Add an i18n test when the hint has new text or arguments.
+7. Implement the smallest pattern and ordered branch in the owning family.
+8. Mutate its key or priority locally and confirm the focused test fails.
+9. Run focused tests and both locale `testFull` suites.
 
 Do not edit generated JavaCC sources. Change
 `grammar/JJOnionParser.jj` only when accepted syntax changes; a hint for rejected

--- a/docs/refactoring/onion-maintainability-roadmap.md
+++ b/docs/refactoring/onion-maintainability-roadmap.md
@@ -165,6 +165,10 @@ Only start if the Phase 2 audit still ranks parser diagnostics as active debt.
    `ExpectedTokenFormatter` helper.
 3. [ ] Group syntax hints by language-family mistake only if classifier tests keep
    priority visible across groups.
+   - [x] Re-audit after active hint development and extract the contiguous
+     unsupported control-flow family into `ControlFlowSyntaxHints`.
+   - [ ] Extract another family only when churn and a closed priority interval
+     justify it; do not create one-rule files or reorder the global chain.
 4. [x] Update parser architecture docs for each extracted diagnostic boundary.
 
 Each item uses RED/GREEN/refactor and is a separate commit.

--- a/docs/refactoring/target-architecture.md
+++ b/docs/refactoring/target-architecture.md
@@ -45,15 +45,19 @@ ParsingPhase
         -> SourceContext (pure source slicing)
         -> ExpectedTokenFormatter (pure terminal-token rendering)
         -> SyntaxHintClassifier (pure classification)
+           -> ControlFlowSyntaxHints (pure family rules)
         -> localized Message rendering
 ```
 
 The landed parser slices extract `SyntaxHintClassifier`, `SourceContext`, and
 `ExpectedTokenFormatter` as package-local pure services. The classifier returns
-a message key and literal arguments rather than localized text. `Parsing`
-remains responsible for localization and exact final message assembly. The
-JavaCC grammar retains its recovery-specific expected-token summary because its
-existing output contract differs from terminal parse errors.
+a message key and literal arguments rather than localized text and delegates
+only cohesive, evidence-backed rule families; `ControlFlowSyntaxHints` is the
+first such family. Global family priority remains visible in the classifier.
+`Parsing` remains responsible for localization and exact final message
+assembly. The JavaCC grammar retains its recovery-specific expected-token
+summary because its existing output contract differs from terminal parse
+errors.
 
 ## Rewriting target
 

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -1,0 +1,35 @@
+package onion.compiler.parser
+
+/** Classifies unsupported control-flow forms that have direct Onion alternatives. */
+private[compiler] object ControlFlowSyntaxHints {
+  private val LeadingSwitchStatement = """^\s*switch\b""".r
+  private val LeadingWhenStatement = """^\s*when\b""".r
+  private val LeadingMatchStatement = """^\s*match\b""".r
+  private val DefaultCaseLabel = """^\s*default\s*:""".r
+  private val ElifStatement = """\belif\b""".r
+  private val LeadingUnlessStatement = """^\s*unless\b""".r
+  private val ExceptClause = """\bexcept\b""".r
+
+  def classify(found: String, sourceLine: String): Option[SyntaxHint] = {
+    if (LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.switch_not_supported")
+    } else if (found == "when" && LeadingWhenStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.when_not_supported")
+    } else if (LeadingMatchStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.match_not_supported")
+    } else if (DefaultCaseLabel.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.default_case_not_supported")
+    } else if (ElifStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.elif_not_supported")
+    } else if (LeadingUnlessStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.unless_not_supported")
+    } else if (ExceptClause.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.except_not_supported")
+    } else {
+      None
+    }
+  }
+
+  private def hint(messageKey: String): Option[SyntaxHint] =
+    Some(SyntaxHint(messageKey))
+}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -15,14 +15,7 @@ private[compiler] final case class SyntaxHint(
 private[compiler] object SyntaxHintClassifier {
   private val ParenthesizedTrailingLambdaHead = """\A\{\s*\(([^()]*)\)\s*->""".r
   private val OldArrowTrailingLambdaHead = """\A\{\s*(?:\(?[^(){}=]*\)?)\s*=>""".r
-  private val LeadingSwitchStatement = """^\s*switch\b""".r
-  private val LeadingWhenStatement = """^\s*when\b""".r
-  private val LeadingMatchStatement = """^\s*match\b""".r
-  private val DefaultCaseLabel = """^\s*default\s*:""".r
-  private val ElifStatement = """\belif\b""".r
-  private val LeadingUnlessStatement = """^\s*unless\b""".r
   private val NotOperatorCondition = """^\s*(?:if|while|else\s+if)\s+not\b""".r
-  private val ExceptClause = """\bexcept\b""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
   private val GoStyleShortVarDecl =
     """^\s*([A-Za-z_]\w*)\s*:=\s*(.+?)\s*$""".r
@@ -94,7 +87,9 @@ private[compiler] object SyntaxHintClassifier {
     expected: String,
     context: String,
     sourceLine: String
-  ): Option[SyntaxHint] =
+  ): Option[SyntaxHint] = {
+    lazy val controlFlowHint = ControlFlowSyntaxHints.classify(found, sourceLine)
+
     found match {
       case "<:" =>
         hint("error.parsing.hint.old_conforms")
@@ -124,20 +119,9 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.foreach_parens")
       case "in" =>
         hint("error.parsing.hint.old_for_in")
-      case _ if LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined =>
-        hint("error.parsing.hint.switch_not_supported")
-      case "when" if LeadingWhenStatement.findFirstMatchIn(sourceLine).isDefined =>
-        hint("error.parsing.hint.when_not_supported")
-      case _ if LeadingMatchStatement.findFirstMatchIn(sourceLine).isDefined =>
-        hint("error.parsing.hint.match_not_supported")
-      case _ if DefaultCaseLabel.findFirstMatchIn(sourceLine).isDefined =>
-        hint("error.parsing.hint.default_case_not_supported")
-      case _ if ElifStatement.findFirstMatchIn(sourceLine).isDefined =>
-        hint("error.parsing.hint.elif_not_supported")
-      case _ if LeadingUnlessStatement.findFirstMatchIn(sourceLine).isDefined =>
-        hint("error.parsing.hint.unless_not_supported")
-      case _ if ExceptClause.findFirstMatchIn(sourceLine).isDefined =>
-        hint("error.parsing.hint.except_not_supported")
+      // Keep this family before declarations and the generic missing-block fallback.
+      case _ if controlFlowHint.isDefined =>
+        controlFlowHint
       case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.js_style_let")
       case _ if DataClassDeclaration.findFirstMatchIn(sourceLine).isDefined =>
@@ -234,6 +218,7 @@ private[compiler] object SyntaxHintClassifier {
       case _ =>
         None
     }
+  }
 
   private def hint(messageKey: String, arguments: String*): Option[SyntaxHint] =
     Some(SyntaxHint(messageKey, arguments))

--- a/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
+++ b/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
@@ -1,0 +1,44 @@
+package onion.compiler.parser
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ControlFlowSyntaxHintsSpec extends AnyFunSpec with Matchers {
+  describe("ControlFlowSyntaxHints.classify") {
+    it("classifies each unsupported control-flow family member") {
+      val cases = Seq(
+        ("value", "switch value {", "error.parsing.hint.switch_not_supported"),
+        ("when", "when value {", "error.parsing.hint.when_not_supported"),
+        ("value", "match value {", "error.parsing.hint.match_not_supported"),
+        (":", "default:", "error.parsing.hint.default_case_not_supported"),
+        ("condition", "} elif condition {", "error.parsing.hint.elif_not_supported"),
+        ("unless", "unless done {", "error.parsing.hint.unless_not_supported"),
+        ("error", "} except error: Exception {", "error.parsing.hint.except_not_supported")
+      )
+
+      cases.foreach { case (found, sourceLine, expectedKey) =>
+        ControlFlowSyntaxHints.classify(found, sourceLine).map(_.messageKey) shouldBe Some(expectedKey)
+      }
+    }
+
+    it("preserves rule order inside the family") {
+      ControlFlowSyntaxHints
+        .classify(found = "value", sourceLine = "switch elif {")
+        .map(_.messageKey) shouldBe Some("error.parsing.hint.switch_not_supported")
+    }
+
+    it("requires the parser to fail on the when keyword itself") {
+      ControlFlowSyntaxHints.classify(
+        found = "guard",
+        sourceLine = "when value {"
+      ) shouldBe None
+    }
+
+    it("returns no hint when the family does not match") {
+      ControlFlowSyntaxHints.classify(
+        found = "value",
+        sourceLine = "if value {"
+      ) shouldBe None
+    }
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -27,6 +27,15 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("keeps generic old-for-in advice ahead of the control-flow family") {
+      val hint = classify(
+        found = "in",
+        sourceLine = "switch item in items {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.old_for_in"
+    }
+
     it("prefers destructuring-foreach advice over generic C-style-for advice") {
       val hint = classify(
         found = ",",
@@ -268,6 +277,16 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
 
       hint.messageKey shouldBe "error.parsing.hint.unless_not_supported"
       hint.arguments shouldBe empty
+    }
+
+    it("keeps unsupported control-flow advice ahead of the generic block fallback") {
+      val hint = classify(
+        found = ")",
+        expected = "\"{\"",
+        sourceLine = "switch (value) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.switch_not_supported"
     }
 
     it("recognizes a Python-style `not` boolean negation in an `if` condition") {


### PR DESCRIPTION
## Summary
- extract the contiguous switch, when, match, default, elif, unless, and except hint rules into a package-private pure family
- keep the family at the exact former global-priority position between old for-in advice and declaration/block fallbacks
- update parser architecture, roadmap, decision log, and the syntax-hint feature recipe

## Evidence
- pre-slice audit: SyntaxHintClassifier 240 LOC, 113 branch proxies, 16 commits, 242 churn
- post-slice classifier: 225 LOC, 101 branch proxies; ControlFlowSyntaxHints is a focused 35 LOC boundary
- RED: direct family spec initially failed because ControlFlowSyntaxHints did not exist
- mutation: moving the family after generic block fallback changed switch_not_supported to block_expected and failed the boundary test
- mutation: moving the family before old_for_in changed old_for_in to switch_not_supported and failed the boundary test
- focused direct, end-to-end, and i18n suites: 63 passed before the final boundary addition; final direct suites: 40 passed
- English testFull: 4,225 passed across 585 suites, 0 failed
- Japanese testFull: 4,225 passed across 585 suites, 0 failed
- mkdocs build --strict
- maintainability audit test and audit
- git diff --check

## Review
- independent read-only review and follow-up review: no Critical, Important, or Minor findings; Ready to merge: Yes