### PR TITLE
docs(test): fix stale SyntaxHintClassifier reference in UntilLoopHintI18nSpec

### DIFF
--- a/src/test/scala/onion/compiler/UntilLoopHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/UntilLoopHintI18nSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.funspec.AnyFunSpec
 import java.io.StringReader
 
 /**
- * The until hint (`SyntaxHintClassifier`'s `LeadingUntilStatement` case) must
+ * The until hint (`ControlFlowSyntaxHints`'s `LeadingUntilStatement` case) must
  * resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
  * like every other hint in that match -- see OldForInHintI18nSpec for the
  * motivating regression.


### PR DESCRIPTION
## Summary
- PR #913 relocated the until-loop hint's `LeadingUntilStatement` case from `SyntaxHintClassifier` into `ControlFlowSyntaxHints`, matching the control-flow family boundary established by #912's refactor.
- `UntilLoopHintI18nSpec`'s doc comment was left pointing at the old `SyntaxHintClassifier` location; this updates it to `ControlFlowSyntaxHints` to match the actual implementation.
- Comment-only change, no functional/behavioral change.

## Test plan
- [x] `sbt -Duser.language=en testFull` — 4229 tests passed, 0 failed, 1 canceled (pre-existing network-dependent test, unrelated to this change)
- [x] `sbt -Duser.language=ja testFull` — 4229 tests passed, 0 failed, 1 canceled (same)

---
_Generated by [Claude Code](https://claude.ai/code/session_016orL3UTMLyXLELSrJV6cYe)_