### PR TITLE
fix(diagnostics): hint at parentheses for a call written without them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a call written without parentheses.**
+  Onion always requires parentheses around a call's arguments; a Python
+  2-style `print "x"` or Ruby-style `puts x` habit (a bare name followed
+  directly by another token, with nothing between them) parsed as an
+  identifier-reference statement followed by a stray token, with a generic
+  expected-token dump that never mentioned the missing parentheses. The
+  diagnostic now recognizes a leading `name arg` statement at the exact
+  point a complete statement was expected and points at the correct
+  `name(arg)` form (or, if two separate statements were intended, that they
+  need a newline or `;` between them).
+
 ## [0.21.0] - 2026-08-27
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -148,6 +148,7 @@ error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `
 error.parsing.hint.csharp_style_using_import=Hint: Onion has no C#-style `using` import directive — imports are wrapped in braces — write `import '{' {0} '}'`, not `using {0};`.
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
 error.parsing.hint.dollar_sigil=Hint: Onion has no `$` sigil for variables or string interpolation — interpolate inside a string with `#{expr}` instead — write `"Hello, #{name}!"`, not `$"Hello, {name}!"` or `$name`.
+error.parsing.hint.missing_call_parens=Hint: a call''s arguments need parentheses — write `{0}(...)` instead of `{0} ...`. (Two separate statements go on separate lines, or joined with `;`.)
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -148,6 +148,7 @@ error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風�
 error.parsing.hint.csharp_style_using_import=ヒント: Onion に C# 風の `using` インポート指令はありません — import は波かっこで囲みます — `using {0};` ではなく `import '{' {0} '}'` と書いてください。
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
 error.parsing.hint.dollar_sigil=ヒント: Onion に変数や文字列補間のための `$` シジルはありません — 文字列内での補間は `#{expr}` を使ってください — `$"Hello, {name}!"` や `$name` ではなく `"Hello, #{name}!"` と書いてください。
+error.parsing.hint.missing_call_parens=ヒント: 呼び出しの引数にはかっこが必要です — `{0} ...` ではなく `{0}(...)` と書いてください。（2つの別々の文のつもりなら、改行するか `;` で区切ってください。）
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -81,6 +81,7 @@ private[compiler] object SyntaxHintClassifier {
     """\bdef\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*\([^()]*\)\s*->\s*([A-Za-z_][\w.\[\]?]*)""".r
   private val DanglingReturnTypeColon =
     """\bdef\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*\([^()]*\)\s*:\s*$""".r
+  private val BareAdjacentTokens = """^\s*([A-Za-z_]\w*)\s+\S""".r
 
   def classify(
     found: String,
@@ -215,6 +216,14 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.not_operator")
       case _ if expected.contains("{") && !Set(";", "<EOL>", "<EOF>").exists(expected.contains) =>
         hint("error.parsing.hint.block_expected")
+      // A complete statement was expected right where a second bare token follows its
+      // leading identifier with nothing in between -- most often a call whose arguments
+      // were written without parentheses (a Python 2 `print "x"` or Ruby `puts x` habit).
+      case _
+          if expected.contains("<EOL>") && expected.contains(";") && expected.contains("<EOF>") &&
+            BareAdjacentTokens.findFirstMatchIn(sourceLine).exists(m => !ReservedWords.contains(m.group(1))) =>
+        val name = BareAdjacentTokens.findFirstMatchIn(sourceLine).get.group(1)
+        hint("error.parsing.hint.missing_call_parens", name)
       case _ =>
         None
     }

--- a/src/test/scala/onion/compiler/MissingCallParensHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/MissingCallParensHintI18nSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The missing-call-parentheses hint (`SyntaxHintClassifier`'s bottom-of-chain
+ * bare-adjacent-tokens case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see DollarSigilHintI18nSpec for the same pattern.
+ */
+class MissingCallParensHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.missing_call_parens"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a call written without parentheses") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    foo bar
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("foo(...)"), s"expected the hint's foo(...) example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -386,6 +386,54 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("recognizes a function call missing its parentheses") {
+      val hint = classify(
+        found = "bar",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "foo bar"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.missing_call_parens"
+      hint.arguments shouldBe Seq("foo")
+    }
+
+    it("recognizes a Python2-style `print` statement missing its parentheses") {
+      val hint = classify(
+        found = "\"Hello\"",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "println \"Hello\""
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.missing_call_parens"
+      hint.arguments shouldBe Seq("println")
+    }
+
+    it("does not flag a bare identifier when a block is expected next, not end-of-statement") {
+      SyntaxHintClassifier.classify(
+        found = "bar",
+        expected = "\"{\"",
+        context = "",
+        sourceLine = "foo bar {"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.missing_call_parens")
+    }
+
+    it("does not flag a leading reserved word as a missing-parens call") {
+      SyntaxHintClassifier.classify(
+        found = "5",
+        expected = "<EOF>, <EOL>, \";\"",
+        context = "",
+        sourceLine = "val x 5"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.missing_call_parens")
+    }
+
+    it("keeps the Ruby-style `unless` advice ahead of the missing-call-parens fallback") {
+      classify(
+        found = "unless",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "unless done {"
+      ).messageKey shouldBe "error.parsing.hint.unless_not_supported"
+    }
+
     it("returns no hint when no classification rule matches") {
       SyntaxHintClassifier.classify(
         found = ")",

--- a/src/test/scala/onion/compiler/tools/MissingCallParensHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MissingCallParensHintSpec.scala
@@ -1,0 +1,67 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * A call whose arguments are written without parentheses (a Python 2
+ * `print "x"` or Ruby `puts x` habit) parses as a bare identifier-reference
+ * statement followed by a stray token, with a generic expected-token dump
+ * that never mentions the missing parentheses.
+ */
+class MissingCallParensHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("missing call parentheses") {
+    it("hints at parentheses for a call written without them") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foo bar
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("foo(...)"), s"expected a hint mentioning foo(...), got: $msgs")
+    }
+
+    it("hints at parentheses for a Python2-style `print` statement") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    println "Hello"
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("println(...)"), s"expected a hint mentioning println(...), got: $msgs")
+    }
+
+    it("does not fire when the leading token is a keyword, not a call name") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val x = 5
+          |    return x
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("(...)"), s"hint should not fire for a well-formed val, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Onion always requires parentheses around a call's arguments. A Python 2-style `print "x"` or Ruby-style `puts x` habit (a bare name followed directly by another token, with nothing between them) parsed as an identifier-reference statement followed by a stray token, with a generic expected-token dump that never mentioned the missing parentheses.
- `SyntaxHintClassifier` now recognizes the exact point a complete statement was expected (the parser's `<EOF>`/`<EOL>`/`;` triple) followed immediately by a second bare token on the same line, and points at the correct `name(arg)` form — or, if two separate statements were intended, that they need a newline or `;` between them.
- The new rule sits at the bottom of the classifier's priority chain (after every more specific rule, including the existing `unless`/`until`/`not` control-flow hints, which also see this same expected-token signature) and excludes any leading reserved word, so it only fires as a genuine fallback.

## Test plan

- [x] `sbt 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec'` — new focused priority/fallback cases, TDD red before the classifier change, green after.
- [x] New `onion.compiler.tools.MissingCallParensHintSpec` and `onion.compiler.MissingCallParensHintI18nSpec` (bilingual bundle resolution + end-to-end compiler firing).
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4246 tests, 0 failed, 1 canceled (matches the existing baseline opt-in-distribution cancellation).
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4246 tests, 0 failed, 1 canceled (same baseline).
- `CHANGELOG.md`'s `[Unreleased]` section updated.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WW9Ds4rpS4sn9fDkM6MP9k

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW9Ds4rpS4sn9fDkM6MP9k)_