### PR TITLE
fix(diagnostics): hint that arr.length()/arr.size() is a property, not a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `name(arg)` form (or, if two separate statements were intended, that they
   need a newline or `;` between them).
 
+- **No hint for `arr.length()`/`arr.size()`, unlike the same mix-up on a
+  record field.** Array length is a property (`arr.length`, no
+  parentheses), not a method, so calling it with parentheses raised a bare
+  "method ... is not found" with no suggestion — the parallel
+  `p.name()`-on-a-record-field mix-up already got a "field, not a method"
+  hint, but arrays carry no real `length` field entry in the type table for
+  that check to match. `arr.length()`/`arr.size()` now gets the same hint.
+
 ## [0.21.0] - 2026-08-27
 
 ### Fixed

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -517,11 +517,14 @@ class SemanticErrorReporter(threshold: Int) {
           s"${m.name}(${m.arguments.map(typeName).mkString(", ")})"
         }
         Some(format(message("error.suggestion.candidates"), Seq(signatures.mkString(", "))))
-      } else if (fieldNamed(targetType, name)) {
+      } else if (fieldNamed(targetType, name) || isArrayLengthProperty(targetType, name)) {
         // `p.name()` where `name` is a field, not a method -- a common mix-up
         // with record component accessors (which really are methods). A
         // name-similarity hint would uselessly suggest the same spelling, so
-        // point at the parentheses instead.
+        // point at the parentheses instead. `arr.length()`/`arr.size()` hits
+        // the same mix-up, but arrays carry no real `length` field entry for
+        // fieldNamed to match (their length is resolved specially, not as a
+        // TypedAST field), so it needs its own check.
         Some(format(message("suggestion.fieldNotMethod"), Seq(name)))
       } else {
         val candidates = targetType match
@@ -537,6 +540,9 @@ class SemanticErrorReporter(threshold: Int) {
     targetType match
       case obj: TypedAST.ObjectType => obj.fields.exists(_.name == name)
       case _ => false
+
+  private def isArrayLengthProperty(targetType: TypedAST.Type, name: String): Boolean =
+    targetType.isArrayType && (name == "length" || name == "size")
 
   private def reportFieldNotFound(position: Location, items: Array[AnyRef]): Unit = {
     val targetType = items(0).asInstanceOf[TypedAST.Type]

--- a/src/test/scala/onion/compiler/tools/DidYouMeanSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DidYouMeanSpec.scala
@@ -189,6 +189,44 @@ class DidYouMeanSpec extends AbstractShellSpec {
       }
     }
 
+    describe("for array length") {
+      // `arr.length()` / `arr.size()` -- array length is a property (`arr.length`,
+      // no parentheses), not a method, so there is no real `length` field entry
+      // on ArrayType to match the record/getter fieldNotMethod hint on. The base
+      // message alone repeats "length" as part of the call signature
+      // ("Int[].length() is not found"), so assert on the hint's distinguishing
+      // "(length)" parenthetical rather than on "length" alone.
+      it("hints that length is a property, not a method") {
+        failsWithSuggestion(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int {
+            |    val arr: Int[] = new Int[3];
+            |    return arr.length();
+            |  }
+            |}
+            |""".stripMargin,
+          "E0005", "(length)"
+        )
+      }
+
+      it("hints that size is a property, not a method") {
+        failsWithSuggestion(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): Int {
+            |    val arr: Int[] = new Int[3];
+            |    return arr.size();
+            |  }
+            |}
+            |""".stripMargin,
+          "E0005", "(size)"
+        )
+      }
+    }
+
     describe("for named-argument names") {
       // The typo ("kount") shares no substring with the real name ("count"),
       // so matching on "count" in the output can only be the suggestion --


### PR DESCRIPTION
## Summary

- Array length is accessed as a property (`arr.length`, no parentheses), not a method. Calling it with parentheses (`arr.length()`) raised a bare `[E0005] method applicable for Int[].length() is not found. Check spelling and argument types.` with **no suggestion at all**.
- The parallel mistake on a record field — `p.name()` where `name` is a field — already gets a `hint: name is a field, not a method; access it without parentheses (name)` suggestion via `SemanticErrorReporter.fieldNamed`. But arrays carry no real `length` field entry in the `TypedAST` type table (array length is resolved specially in `MemberSelectionResolutionSupport`, not as a `FieldRef`), so `fieldNamed` never matched and the candidate-suggestion fallback found nothing to suggest either (`ArrayType` has no real fields/methods to search).
- `SemanticErrorReporter.reportMethodNotFound` now also recognizes `arr.length()`/`arr.size()` on an `ArrayType` and reuses the same "field, not a method" hint.

## Test plan

- [x] TDD: added `DidYouMeanSpec`'s "for array length" cases first (both `.length()` and `.size()`), confirmed red (`(length)`/`(size)` missing from output), then implemented the fix and confirmed green.
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.DidYouMeanSpec'` and `-Duser.language=ja` — both green.
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4248 tests, 0 failed, 1 canceled (matches the existing baseline opt-in-distribution cancellation).
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4248 tests, 0 failed, 1 canceled (same baseline).
- [x] `CHANGELOG.md`'s `[Unreleased]` section updated.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KSYVrPcKQQiZSfiHf8NnxN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSYVrPcKQQiZSfiHf8NnxN)_