### PR TITLE
fix(diagnostics): hint at property access for arr.length()/arr.size()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnostic hint for calling an array's `length`/`size` as a method.**
+  An array only exposes `length`/`size` as the paren-less property form
+  (`arr.length`); calling it with parentheses (`arr.length()`, a Java/JS
+  habit) previously reported a bare "method ... is not found" with no
+  guidance, since arrays have no user-visible fields or same-name methods
+  for the existing hint machinery to key off of. The diagnostic now adds
+  the same "is a field/property, not a method; access it without
+  parentheses" hint already used for record component accessor mix-ups.
+
 - **Parser hint for a Ruby-style `until` loop.**
   Onion has no `until` loop; the negated-condition idiom is `while !condition`,
   so `until done { ... }` parses as a bare identifier-reference statement

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -504,7 +504,8 @@ class SemanticErrorReporter(threshold: Int) {
   private def reportMethodNotFound(position: Location, items: Array[AnyRef]): Unit = {
     val targetType = items(0).asInstanceOf[TypedAST.Type]
     val name = asString(items(1))
-    val args = typeNames(asTypeArray(items(2)))
+    val argTypes = asTypeArray(items(2))
+    val args = typeNames(argTypes)
     val baseMessage = format(message("error.semantic.methodNotFound"), Seq(typeName(targetType), name, args))
     // A method with that exact name exists: show its signatures instead of
     // a (possibly misleading) name-similarity suggestion
@@ -517,6 +518,13 @@ class SemanticErrorReporter(threshold: Int) {
           s"${m.name}(${m.arguments.map(typeName).mkString(", ")})"
         }
         Some(format(message("error.suggestion.candidates"), Seq(signatures.mkString(", "))))
+      } else if (targetType.isArrayType && argTypes.isEmpty && (name == "length" || name == "size")) {
+        // Arrays expose `length`/`size` only as the paren-less pseudo-property
+        // handled in member-selection typing (`arr.length`), never as a real
+        // method, so an array has no same-name method and no user-visible
+        // field either -- without this case `arr.length()` falls through to
+        // an unhelpful bare "not found".
+        Some(format(message("suggestion.fieldNotMethod"), Seq(name)))
       } else if (fieldNamed(targetType, name)) {
         // `p.name()` where `name` is a field, not a method -- a common mix-up
         // with record component accessors (which really are methods). A

--- a/src/test/scala/onion/compiler/tools/DiagnosticHintsSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DiagnosticHintsSpec.scala
@@ -69,4 +69,58 @@ class DiagnosticHintsSpec extends AnyFunSpec {
       assert(errors.exists(_.contains("userName")), s"expected did-you-mean hint, got: $errors")
     }
   }
+
+  describe("METHOD_NOT_FOUND array property hint") {
+    it("hints that Int[].length() is a property, not a method") {
+      val errors = compile(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs = new Int[3]
+          |    return xs.length()
+          |  }
+          |}
+        """.stripMargin
+      )
+      val msg = errors.mkString("\n")
+      // The hint restates "length" in its own parenthetical, so a fixed
+      // string appearing twice is a locale-independent signal that the hint
+      // fired (translated wording around it differs per locale).
+      assert(msg.indexOf("length") != msg.lastIndexOf("length"), s"expected a property-not-method hint, got: $errors")
+    }
+
+    it("hints that Int[].size() is a property, not a method") {
+      val errors = compile(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs = new Int[3]
+          |    return xs.size()
+          |  }
+          |}
+        """.stripMargin
+      )
+      val msg = errors.mkString("\n")
+      assert(msg.indexOf("size") != msg.lastIndexOf("size"), s"expected a property-not-method hint, got: $errors")
+    }
+
+    it("does not add the hint for an unrelated missing array method") {
+      val errors = compile(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs = new Int[3]
+          |    return xs.bogusMethod()
+          |  }
+          |}
+        """.stripMargin
+      )
+      val msg = errors.mkString("\n")
+      assert(errors.nonEmpty, "expected a method-not-found error")
+      assert(msg.indexOf("bogusMethod") == msg.lastIndexOf("bogusMethod"), s"did not expect a doubled hint, got: $errors")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Arrays expose `length`/`size` only as the paren-less property form (`arr.length`). Calling it with parentheses — a Java/JS habit (`arr.length()`) — fell through every existing `METHOD_NOT_FOUND` suggestion branch, since arrays have no user-visible fields or same-name methods for the existing hint machinery to key off of, so it reported a bare "method ... is not found" with no guidance.
- Reuse the existing `suggestion.fieldNotMethod` hint (already used for record component accessor mix-ups) for this case, in `SemanticErrorReporter.reportMethodNotFound`.
- Added regression tests to `DiagnosticHintsSpec` covering `Int[].length()`, `Int[].size()`, and a negative case (unrelated missing array method does not get a spurious hint). Assertions use a locale-independent signal (the hinted name appearing twice in the message) per this repo's bilingual-message testing convention.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `sbt -Duser.language=en testFull` — 4232 tests, 0 failed, 1 canceled (pre-existing/unrelated), all passed
- [x] `sbt -Duser.language=ja testFull` — 4232 tests, 0 failed, 1 canceled (pre-existing/unrelated), all passed
- [x] Targeted `testOnly onion.compiler.tools.DiagnosticHintsSpec` confirmed red before the fix, green after


---
_Generated by [Claude Code](https://claude.ai/code/session_01LXzFrCFkaFu5brVn1zxwBV)_