### PR TITLE
Hint Rust-style val mut/var mut declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a Rust-style `val mut`/`var mut` declaration.** Onion has
+  no `mut` keyword; mutability is chosen directly by `val` (immutable) or
+  `var` (mutable). Writing `let mut x = 5` translated naively as
+  `val mut x = 5` parsed `mut` as the declared identifier and then hit a
+  generic `expecting "=", ":"` error on the next token, with no mention of
+  `val`/`var`. The diagnostic now recognizes the `val mut name` / `var mut
+  name` pattern and points at the correct `var name = ...` form.
+
 ## [0.23.0] - 2026-08-28
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -142,6 +142,7 @@ error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and c
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
 error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `let name = value`.
+error.parsing.hint.rust_style_mut=Hint: Onion has no `mut` keyword — mutability is chosen by `val` (immutable) or `var` (mutable) directly, so drop `mut` — write `var {1} = ...`, not `{0} mut {1} = ...`.
 error.parsing.hint.data_class_declaration=Hint: Onion has no `data class` — a data-carrying type is a `record`, whose component list has no `val`/`var` prefix. Write `record {0}({1})`, not `data class {0}(...)`.
 error.parsing.hint.go_style_short_var_decl=Hint: Onion has no Go-style `:=` short variable declaration — declare it with `val` (immutable) or `var` (mutable) instead — write `val {0} = {1}`, not `{0} := {1}`.
 error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `using` resource statement — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `using {0} = {1} '{' ... '}'`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -142,6 +142,7 @@ error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のた�
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
 error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `let name = value` ではなく `val name: Type = value` と書いてください。
+error.parsing.hint.rust_style_mut=ヒント: Onion に `mut` キーワードはありません — 可変かどうかは `val`（不変）か `var`（可変）で直接指定するので、`mut` は取り除いてください — `{0} mut {1} = ...` ではなく `var {1} = ...` と書いてください。
 error.parsing.hint.data_class_declaration=ヒント: Onion に `data class` はありません — データを保持する型は `record` で、コンポーネント列に `val`/`var` は付けません。`data class {0}(...)` ではなく `record {0}({1})` と書いてください。
 error.parsing.hint.go_style_short_var_decl=ヒント: Onion に Go 風の `:=` 短縮変数宣言はありません — 変数は `val`（不変）または `var`（可変）で宣言します — `{0} := {1}` ではなく `val {0} = {1}` と書いてください。
 error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風の `using` リソース文はありません — 代わりに try-with-resources ブロックを使ってください: `using {0} = {1} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -17,6 +17,8 @@ private[compiler] object SyntaxHintClassifier {
   private val OldArrowTrailingLambdaHead = """\A\{\s*(?:\(?[^(){}=]*\)?)\s*=>""".r
   private val NotOperatorCondition = """^\s*(?:if|while|else\s+if)\s+not\b""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
+  private val RustStyleMutDeclaration =
+    """^\s*(val|var)\s+mut\s+([A-Za-z_]\w*)""".r
   private val GoStyleShortVarDecl =
     """^\s*([A-Za-z_]\w*)\s*:=\s*(.+?)\s*$""".r
   private val UsingResourceStatement =
@@ -127,6 +129,9 @@ private[compiler] object SyntaxHintClassifier {
         controlFlowHint
       case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.js_style_let")
+      case _ if RustStyleMutDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = RustStyleMutDeclaration.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.rust_style_mut", matched.group(1), matched.group(2))
       case _ if DataClassDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         val matched = DataClassDeclaration.findFirstMatchIn(sourceLine).get
         val params = matched.group(2).split(",").map { p =>

--- a/src/test/scala/onion/compiler/RustStyleMutDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/RustStyleMutDeclarationHintI18nSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Rust-style `val mut`/`var mut` declaration hint (`SyntaxHintClassifier`'s
+ * `RustStyleMutDeclaration` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see GoStyleShortVarDeclHintI18nSpec for the same pattern.
+ */
+class RustStyleMutDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.rust_style_mut"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Rust-style `val mut x = 5` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val mut x = 5
+        |    IO::println(x)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted keyword and name are literal source text, identical in
+    // both bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("var x = ..."), s"expected the hint's `var x = ...` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -299,6 +299,28 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("x", "5")
     }
 
+    it("recognizes a Rust-style `val mut` declaration") {
+      val hint = classify(
+        found = "x",
+        expected = "\"=\", \":\"",
+        sourceLine = "val mut x = 5"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.rust_style_mut"
+      hint.arguments shouldBe Seq("val", "x")
+    }
+
+    it("recognizes a Rust-style `var mut` declaration") {
+      val hint = classify(
+        found = "count",
+        expected = "\"=\", \":\"",
+        sourceLine = "var mut count = 0"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.rust_style_mut"
+      hint.arguments shouldBe Seq("var", "count")
+    }
+
     it("recognizes a Ruby-style `unless` statement") {
       val hint = classify(
         found = "unless",


### PR DESCRIPTION
## Summary
- A Rust-flavored `let mut x = 5` translated naively to `val mut x = 5` (or `var mut x = 5`) previously hit a generic `Encountered "x", but expecting "=", ":"` parse error with no hint.
- Onion has no `mut` keyword — mutability is already chosen by `val` (immutable) vs `var` (mutable) — so this adds a `SyntaxHintClassifier` rule (`RustStyleMutDeclaration`) that recognizes the pattern and points the user at `var name = ...`, following the same convention as the existing `let`/`:=`/`const` hints.
- New bilingual (en/ja) message key `error.parsing.hint.rust_style_mut` in both `errorMessage*.properties` bundles.

## Test plan
- [x] Added unit tests in `SyntaxHintClassifierSpec` for both `val mut` and `var mut`.
- [x] Added `RustStyleMutDeclarationHintI18nSpec` (end-to-end compile + bilingual bundle resolution), mirroring `GoStyleShortVarDeclHintI18nSpec`.
- [x] `sbt -Duser.language=en testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.RustStyleMutDeclarationHintI18nSpec` — all green.
- [ ] Full `sbt -Duser.language=en testFull` suite — still running locally (this repo's suite is large; two attempts hit a 40min/90min wrapper timeout before finishing). Opening as **draft** until a full green run is confirmed; will convert to ready and request the merge once that lands, or update here if it turns something up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ru3FbihNY23H2TyW2h6evK)_