### PR TITLE
docs(changelog): note IntervalCalendar.on example addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`run/IntervalCalendar.on`, a 456-line interval-based calendar system.**
+  A realistic scheduler exercising ADT enums (`Priority`, `Recurrence`) and a
+  plain enum (`Weekday`), records with methods (`TimeSlot`, `Event`,
+  `Conflict`, `ScheduleStats`), an observer interface (`CalendarObserver` /
+  `LogObserver`), a mutable `Calendar` class with `public:`/`private:`
+  sections, extension methods on `Int`/`String`, and collection pipelines
+  (`filter`, `map`, `fold`, `sortedBy`, `groupBy`, `partition`, `count`,
+  `distinct`, `any`) driving conflict detection, free-slot finding, and an
+  auto-scheduler.
+
 ### Fixed
 
 - **Parser hint for a Rust-style `val mut`/`var mut` declaration.** Onion has


### PR DESCRIPTION
## Summary
- PR #949 added `run/IntervalCalendar.on` (456 lines) but merged without a `CHANGELOG.md` entry, breaking the established convention of listing each new `run/` example under `[Unreleased]`.
- This adds the missing entry, matching the style of the other example entries already in `[Unreleased]`/`[0.23.0]`.

## Test plan
- Docs-only change (`CHANGELOG.md` only); no code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYYY1nfLzm9GbTdLvBpero)_