### PR TITLE
docs(changelog): add [Unreleased] entry for run/MaxFlow.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`run/MaxFlow.on`, a 370-line maximum-flow and minimum s-t cut demo.**
+  Edmonds-Karp (BFS-based Ford-Fulkerson, O(VE²)) over a `class`/`record`
+  graph model, residual-graph min-cut derivation via reachability from the
+  source, and bipartite maximum matching as a unit-capacity max-flow
+  reduction. Five worked examples (CLRS Figure 26.1, a supply-chain network,
+  a 5-router packet mesh, bipartite worker/job matching, and degenerate
+  disconnected/parallel/diamond cases) exercise ADT `case`-enums, `HashMap`
+  Java interop, generic `List[T]`, `extension Int`, closures, and collection
+  pipelines.
+
 - **`run/IntervalCalendar.on`, a 456-line interval-based calendar system.**
   A realistic scheduler exercising ADT enums (`Priority`, `Recurrence`) and a
   plain enum (`Weekday`), records with methods (`TimeSlot`, `Event`,


### PR DESCRIPTION
## Summary

- PR #954 merged `run/MaxFlow.on` (a 370-line Edmonds-Karp max-flow / min-cut demo) directly to `develop` without a `CHANGELOG.md` entry.
- This adds the missing `[Unreleased]` entry, matching the format of the other corpus-addition entries already there.

## Why draft

The scheduled maintenance session that authored this change could not get a green full-suite run (`SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull`) before its time budget ran out: the JVM entered a GC death-spiral (heap pinned near 0 free of 4G, 97%+ time in GC) partway through the suite and made no further progress for 25+ minutes, so the run was killed rather than left to hang indefinitely. This is a documentation-only change (`CHANGELOG.md`, no source/test changes), but per this repo's release-automation policy nothing merges without a confirmed green run, so this is left as a draft for a future session (or a maintainer) to re-run the suite and merge once green.

## Test plan

- [ ] Re-run `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` to a clean completion (consider a larger `-Xmx` if the GC pressure recurs — the container had ~10G available).
- [ ] Repeat with `-Duser.language=ja`.
- [ ] Merge once green.

---
_Generated by [Claude Code](https://claude.ai/code/session_015z4yLv5VJv5L5Fqz2uY443)_