### PR TITLE
docs(changelog): add [Unreleased] entry for run/TextTransformPipeline.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `distinct`, `any`) driving conflict detection, free-slot finding, and an
   auto-scheduler.
 
+- **`run/TextTransformPipeline.on`, a 352-line composable text-transformation
+  pipeline simulator.** An ADT `case` enum `Transform` (10 cases: Upper,
+  Lower, TrimSpaces, Truncate, Repeat, Reverse, Replace, AddPrefix,
+  AddSuffix, CollapseSpaces) with `apply`/`category`/`label` methods, a
+  data-carrying `Category` enum, records with methods (`StepResult`,
+  `RunResult`), a `Pipeline` class conforming to a `Reportable` interface,
+  extension methods on `String`/`Int`, and collection pipelines (`filter`,
+  `map`, `fold`, `sortedBy`, `groupBy`, `distinct`, `find`, `partition`,
+  `any`, `count`, `zip`) run five named pipelines over five sample inputs
+  with aggregate analytics.
+
 ### Fixed
 
 - **Parser hint for a Rust-style `val mut`/`var mut` declaration.** Onion has


### PR DESCRIPTION
## Summary

- `run/TextTransformPipeline.on` (merged in #957) was missing a `CHANGELOG.md` entry. This adds one under `[Unreleased] / Added`, following the same format as the other recent `run/*.on` sample entries.

## Test plan

- Docs-only change (no source/test files touched); no test run needed.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01TdbMQzZdzotszN3HoELvU1)_