### PR TITLE
fix(parser): handle stale EOL tokens between single-line if body and else

### DIFF
--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -211,6 +211,34 @@ public class JJOnionParser implements Parser {
   }
 
   /**
+   * Else-clause continuation: true when, skipping any EOLs after the current
+   * position, the next token is "else" AND it is followed by "{" or "if"
+   * (i.e. it is an if/else, not a select's "else:" clause). This is needed
+   * because when a block body fits on one line (e.g. `if cond { body }`), the
+   * IN_STATEMENT lexer mode activated by expression_element() can pre-tokenize
+   * the newline after `}` as an <EOL> before leaveSection() fires. That stale
+   * EOL persists in the token buffer even after the state reverts to DEFAULT,
+   * so a bare LOOKAHEAD(2) "else" would see <EOL> as token 1 and skip the else
+   * branch. By peeking past any EOLs we find the real next token regardless of
+   * how many newlines were buffered. We also exclude "else:" (select syntax) by
+   * requiring the token after "else" to be "{" or "if".
+   */
+  private boolean elseFollows() {
+    int i = 1;
+    while (getToken(i).kind == EOL) i++;
+    Token t = getToken(i);
+    if (t == null || !"else".equals(t.image)) return false;
+    // Skip any EOLs after "else" before checking what follows it
+    int j = i + 1;
+    while (getToken(j).kind == EOL) j++;
+    Token next = getToken(j);
+    if (next == null) return false;
+    // "else { ... }" or "else if ..." are valid if/else continuations.
+    // "else:" is the select-expression else clause — do NOT match that.
+    return "{".equals(next.image) || "if".equals(next.image);
+  }
+
+  /**
    * Desugars e |> rhs by injecting e as the first argument of the call on the
    * right-hand side: f -> f(e); f(a) -> f(e, a); obj.m -> obj.m(e);
    * obj.m(a) -> obj.m(e, a); C::m(a) -> C::m(e, a).
@@ -2277,7 +2305,7 @@ AST.Expression expression_element() :{AST.Expression e;}{
 
 AST.IfExpression if_expression() :{Token t; AST.Expression e; AST.BlockExpression b1, b2 = null; AST.IfExpression elif = null; ArrayBuffer<AST.BlockElement> elifElems = new ArrayBuffer<AST.BlockElement>();}{
   t="if" e=term() b1=block()
-  [ LOOKAHEAD(2) "else"
+  [ LOOKAHEAD({elseFollows()}) eols() "else"
     ( b2=block()
     | elif=if_expression() {
         // else-if chain: wrap the nested if in a synthetic block

--- a/src/test/scala/onion/compiler/tools/IfElseNewlineContinuationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IfElseNewlineContinuationSpec.scala
@@ -1,0 +1,134 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * Regression tests for the parser bug where `else` on the line after a
+ * single-line `if` body failed with a syntax error.
+ *
+ * When a block body fits on one line (`if cond { body }`), the IN_STATEMENT
+ * lexer mode entered by expression_element() pre-tokenizes the newline after
+ * `}` as an <EOL> token before leaveSection() fires. That stale EOL persists
+ * in the token buffer even after the state reverts to DEFAULT, so a bare
+ * LOOKAHEAD(2) "else" would see <EOL> as token 1 and skip the else branch,
+ * treating the `else` keyword as a syntax error.
+ *
+ * Fixed by changing the lookahead in if_expression() to use elseFollows()
+ * (which peeks past any buffered EOL tokens) and consuming them with eols()
+ * before matching "else".
+ */
+class IfElseNewlineContinuationSpec extends AbstractShellSpec {
+
+  describe("if/else with single-line body and else on next line") {
+    it("parses a two-branch if/else with compact bodies on separate lines") {
+      val result = shell.run(
+        """
+          |def abs(n: Int): Int = {
+          |  if n < 0 { n * -1 }
+          |  else { n }
+          |}
+          |def main(): void { println(abs(-5)) }
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(null) == result, s"expected successful run but got: $result")
+    }
+
+    it("parses a three-branch if/else-if/else chain with compact bodies") {
+      val result = shell.run(
+        """
+          |def clamp(n: Int, lo: Int, hi: Int): Int = {
+          |  if n < lo { lo }
+          |  else if n > hi { hi }
+          |  else { n }
+          |}
+          |def main(): void {
+          |  println(clamp(5, 0, 10))
+          |  println(clamp(-5, 0, 10))
+          |  println(clamp(15, 0, 10))
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(null) == result, s"expected successful run but got: $result")
+    }
+
+    it("parses else-if chain inside a method body") {
+      val result = shell.run(
+        """
+          |class Classifier {
+          |public:
+          |  static def classify(n: Int): String {
+          |    if n < 0 { return "negative" }
+          |    else if n == 0 { return "zero" }
+          |    else { return "positive" }
+          |  }
+          |  static def main(args: String[]): Int {
+          |    IO::println(classify(-1))
+          |    IO::println(classify(0))
+          |    IO::println(classify(1))
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(0) == result, s"expected 0 but got: $result")
+    }
+
+    it("parses else after single-line if body at top level") {
+      val result = shell.run(
+        """
+          |def sign(n: Int): Int = {
+          |  if n > 0 { 1 }
+          |  else if n < 0 { -1 }
+          |  else { 0 }
+          |}
+          |def main(): void {
+          |  println(sign(42))
+          |  println(sign(-7))
+          |  println(sign(0))
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(null) == result, s"expected successful run but got: $result")
+    }
+
+    it("existing multi-line if/else still works") {
+      val result = shell.run(
+        """
+          |def abs(n: Int): Int = {
+          |  if n < 0 {
+          |    n * -1
+          |  } else {
+          |    n
+          |  }
+          |}
+          |def main(): void { println(abs(-3)) }
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(null) == result, s"expected successful run but got: $result")
+    }
+
+    it("existing same-line if/else still works") {
+      val result = shell.run(
+        """
+          |def abs(n: Int): Int = {
+          |  if n < 0 { n * -1 } else { n }
+          |}
+          |def main(): void { println(abs(-8)) }
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(null) == result, s"expected successful run but got: $result")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes a parser bug where `else` on the line after a single-line `if` body caused a syntax error
- Adds `elseFollows()` semantic predicate that peeks past stale buffered `<EOL>` tokens to find the real next token
- Adds `eols()` before `"else"` in `if_expression()` to drain those stale tokens before matching
- Excludes the `select` expression's `else:` fallback clause from the predicate to avoid a regression

## Root Cause

When `expression_element()` calls `enterSection()` to switch the lexer into `IN_STATEMENT` mode, the closing `}` of a single-line `if` body triggers `eos_or_block_end()` → `leaveSection()`. But the newline *after* the `}` may already have been pre-tokenized as an `<EOL>` token before `leaveSection()` fires. That stale `<EOL>` persists in the JavaCC token buffer even after the lexer state reverts to `DEFAULT`.

A bare `LOOKAHEAD(2)` in `if_expression()` then sees `<EOL>` as token 1, treating the `else` keyword as a syntax error:

```
if n < 0 { n * -1 }
else { n }         ← parse error: unexpected token "else"
```

## Fix

Replace `LOOKAHEAD(2)` with `LOOKAHEAD({elseFollows()})` where `elseFollows()` skips over any buffered `<EOL>` tokens to find the real next image. Add `eols()` before consuming `"else"` to drain those tokens. The predicate also requires the token *after* `else` to be `{` or `if` — this excludes `else:` (the `select` expression's fallback clause) which would otherwise cause a spurious match.

## Tests

New spec: `IfElseNewlineContinuationSpec` (6 regression tests):
- Two-branch `if/else` with compact single-line bodies on separate lines
- Three-branch `if/else if/else` chain
- `else if` chain inside a class method body
- `else` after single-line body at top level
- Existing multi-line `if/else` still works
- Existing same-line `if/else` still works

All 21 targeted tests pass. `run/BrainFuck.on` (which uses `select … else:`) compiles and runs correctly — no regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T628nAgj8k7zBCbiWDFnbi)_