### PR TITLE
diag: mention `is ClassName` select-pattern fix in E0091

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **E0091 (`ClassName` used as a value) didn't mention the `is` pattern fix.**
+  Writing a bare class name as a `select` case pattern (`case Nothing:`,
+  meaning to match a singleton ADT enum case or any other type by name)
+  hits E0091, but the message only suggested `::` for static-member
+  access -- correct for the `System.currentTimeMillis()` habit the error
+  was designed for, but not what fixes a pattern. The message now also
+  names the `is` fix (`case x is ClassName:`); the error code and all
+  other behavior are unchanged.
+
 - **Parser rejected `else` on the line after a single-line `if` body.**
   `if n < 0 { n * -1 }` followed by `else { n }` on the next line raised a
   syntax error at `else`: the closing `}` of the single-line body could

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -71,7 +71,7 @@ error.suggestion.availableConstructors=available constructors:
 error.semantic.typeParameterMayBeNull=value of type parameter {0} may be null and cannot be dereferenced directly. Use ?. / ?: / a null check (if x != null), or declare a non-null bound ([{0} extends SomeType]).
 error.semantic.nullableMemberAccess=value of type {0} may be null and cannot be dereferenced directly. Use ?. to access it safely, ?: to provide a default, !! to assert non-null, or check for null first (if x != null).
 error.semantic.staticCallOnInstance={0} is a variable, not a type. Use . to call an instance method ({0}.method()); :: is only for static members of a type.
-error.semantic.classUsedAsValue={0} is a class, not a variable. Use :: to access a static member ({0}::member); a bare class name is never a value.
+error.semantic.classUsedAsValue={0} is a class, not a variable. Use :: to access a static member ({0}::member), or `is {0}` in a select pattern to match its type; a bare class name is never a value.
 error.semantic.abstractMethodWithBody=abstract method {0} cannot have a body (the body would be silently ignored). Remove `abstract` to make it a concrete method, or remove the body to leave it abstract.
 error.semantic.staticMethodWithoutBody=static method {0} must have a body. A static method cannot be abstract; add a body (`'{' ... '}'` or `= expr`), or remove `static` to declare an abstract instance method.
 error.semantic.mapNotDirectlyIterable=a Map ({0}) cannot be iterated directly by foreach. Use `foreach (k, v) in ...` to walk its entries, or iterate `.keySet()` / `.values()` / `.entrySet()`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -70,7 +70,7 @@ error.suggestion.availableConstructors=\u5229\u7528\u53ef\u80fd\u306a\u30b3\u30f
 error.semantic.typeParameterMayBeNull=型パラメータ {0} の値はnullの可能性があるため、直接参照できません。?. / ?: / nullチェック（if x != null）を使うか、非nullの境界（[{0} extends SomeType]）を宣言してください。
 error.semantic.nullableMemberAccess=型 {0} の値はnullの可能性があるため、直接参照できません。安全に参照するには ?.、デフォルト値を与えるには ?:、非nullを断言するには !!、または先にnullチェック（if x != null）を行ってください。
 error.semantic.staticCallOnInstance={0} は変数であり、型ではありません。インスタンスメソッドの呼び出しには . を使ってください（{0}.method()）。:: は型の静的メンバー専用です。
-error.semantic.classUsedAsValue={0} は変数ではなくクラスです。静的メンバーには :: を使ってください（{0}::member）。クラス名単独では値になりません。
+error.semantic.classUsedAsValue={0} は変数ではなくクラスです。静的メンバーには :: を使ってください（{0}::member）。select パターンで型に一致させるには `is {0}` を使ってください。クラス名単独では値になりません。
 error.semantic.abstractMethodWithBody=abstractメソッド {0} は本体を持てません（本体は静かに無視されます）。具象メソッドにするには `abstract` を外し、abstractのままにするには本体を削除してください。
 error.semantic.staticMethodWithoutBody=staticメソッド {0} には本体が必要です。staticメソッドをabstractにはできません。本体（`'{' ... '}'` または `= 式`）を追加するか、`static` を外してabstractインスタンスメソッドにしてください。
 error.semantic.mapNotDirectlyIterable=Map（{0}）は foreach で直接反復できません。エントリを回すには `foreach (k, v) in ...` を使うか、`.keySet()` / `.values()` / `.entrySet()` を反復してください。

--- a/src/test/scala/onion/compiler/tools/ClassUsedAsValueSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ClassUsedAsValueSpec.scala
@@ -95,4 +95,45 @@ class ClassUsedAsValueSpec extends AbstractShellSpec {
         |""".stripMargin
     ).contains("E0002"))
   }
+
+  it("also fires for a bare class name used as a select-case pattern") {
+    val codes = errorCodes(
+      """
+        |class Animal {}
+        |class Test {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val a: Animal = new Animal()
+        |    select a {
+        |    case Animal: IO::println("no")
+        |    else: IO::println("yes")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    )
+    assert(codes.contains("E0091"), s"expected E0091 for a bare class name as a case pattern, got: $codes")
+  }
+
+  it("names the `is` pattern fix too, for the select-case scenario") {
+    val msgs = new OnionCompiler(new CompilerConfig(List("."), null, "UTF-8", "", 10))
+      .compile(Seq(new StreamInputSource(() => new StringReader(
+        """
+          |class Animal {}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): void {
+          |    val a: Animal = new Animal()
+          |    select a {
+          |    case Animal: IO::println("no")
+          |    else: IO::println("yes")
+          |    }
+          |  }
+          |}
+          |""".stripMargin), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("is Animal"), s"expected the message to also name the `is Animal` pattern fix, got: $msgs")
+  }
 }


### PR DESCRIPTION
## Summary
- Writing a bare class name as a `select` case pattern (`case Nothing:`, meaning to match a singleton ADT enum case or any other type by name) hits E0091 (`CLASS_USED_AS_VALUE`), but the message only suggested the `::` static-member fix — correct for the `System.currentTimeMillis()` habit the error was designed for, but not what actually fixes a pattern (`case x is ClassName:`).
- The message (EN + JA) now names both fixes. Error code and all other resolution behavior are unchanged.
- Added regression tests in `ClassUsedAsValueSpec` covering the select-pattern scenario, asserting on the error code and on message content per the repo's locale-independence convention.

## Test plan
- [x] `sbt -Duser.language=en testFull` — 4358 succeeded, 0 failed, 1 cancelled (expected dist smoke test gate)
- [x] `sbt -Duser.language=ja testFull` (fresh server) — 4358 succeeded, 0 failed, 1 cancelled
- [x] New tests confirmed red before the message change, green after


---
_Generated by [Claude Code](https://claude.ai/code/session_01Akt5AwvQVyFvQ2TTBLriW6)_