### PR TITLE
docs(changelog): add Unreleased entry for run/LambdaCalc.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`run/LambdaCalc.on`, a 306-line untyped lambda calculus interpreter.**
+  An ADT `enum Expr` (`Var`/`Abs`/`App`) drives capture-avoiding
+  substitution and beta reduction to normal form, with Church numeral
+  encodings exercising `succ`, `+`, and `*` end-to-end. Uses nullable
+  types, `select`/`case` pattern matching (including an `else:`
+  catch-all), extension methods on `String`, and `filter`/`fold`/`find`
+  pipelines over `List[String]`.
+
 ### Fixed
 
 - **E0091 (`ClassName` used as a value) didn't mention the `is` pattern fix.**


### PR DESCRIPTION
## Summary

- Adds a `[Unreleased]` CHANGELOG entry documenting `run/LambdaCalc.on` (merged in #964), matching the existing style for other `run/` example additions.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172FWPQ8yXYZNWdGz3PYnA9)_