### PR TITLE
fix(diagnostics): stop the for-each-destructure hint leaking a stray paren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `for (vars in coll)` destructuring-mistake hint leaked a stray `)` into
+  its suggested fix.** Writing the whole `for (key, value in entries) { ... }`
+  clause wrapped in one outer paren pair (mimicking the also-supported
+  `for (key, value) in entries { ... }` mistake) produced a hint reading
+  `foreach (key, value) in entries) { ... }` -- the wrapper's own closing
+  paren was captured as part of the collection expression, because the
+  classifier's regex only accounted for an optional close paren right after
+  the variable list, not one belonging to an outer wrap. A dedicated pattern
+  now recognizes the whole-clause-wrapped form before falling back to the
+  general one, so the suggested fix has balanced parens again; collection
+  expressions that are themselves calls (`getEntries()`) are unaffected.
+
 - **E0091 (`ClassName` used as a value) didn't mention the `is` pattern fix.**
   Writing a bare class name as a `select` case pattern (`case Nothing:`,
   meaning to match a singleton ADT enum case or any other type by name)

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -39,6 +39,13 @@ private[compiler] object SyntaxHintClassifier {
   private val CStyleForLoop = """^\s*for\s*\(""".r
   private val ForEachDestructureMistake =
     """^\s*for\s*\(?\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)+)\s*\)?\s*in\s+([^{]+?)\s*\{?\s*$""".r
+  // The whole `for (vars in coll)` clause wrapped in one outer paren pair: unlike
+  // ForEachDestructureMistake's optional parens around the vars alone, the closing
+  // paren here belongs to the wrapper, not to the collection expression, so it must
+  // be matched explicitly -- otherwise it leaks into the captured collection text
+  // (e.g. "entries)" instead of "entries").
+  private val ForEachDestructureWrappedMistake =
+    """^\s*for\s*\(\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)+)\s*in\s+([^{]+?)\)\s*\{?\s*$""".r
   private val JavaStyleEnhancedForLoop =
     """^\s*for\s*\(\s*(?:final\s+)?([A-Za-z_][\w.\[\],\s]*\??)\s+([A-Za-z_]\w*)\s*:\s*(.+?)\s*\)\s*\{?\s*$""".r
   private val ForeachParenMistake = """\bforeach\s*\(""".r
@@ -167,6 +174,12 @@ private[compiler] object SyntaxHintClassifier {
         val member = DotAfterPrimitiveTypeName.findFirstMatchIn(context).get.group(1)
         hint("error.parsing.hint.primitive_dot_static", name, member)
       // The parenthesized form also matches CStyleForLoop, so keep this first.
+      // Try the whole-clause-wrapped form first: ForEachDestructureMistake's optional
+      // parens around the vars alone would otherwise also match it, but leak the
+      // wrapper's closing paren into the collection capture (see its comment above).
+      case _ if ForEachDestructureWrappedMistake.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = ForEachDestructureWrappedMistake.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.for_each_destructure", matched.group(1), matched.group(2).trim)
       case _ if ForEachDestructureMistake.findFirstMatchIn(sourceLine).isDefined =>
         val matched = ForEachDestructureMistake.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.for_each_destructure", matched.group(1), matched.group(2).trim)

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -46,6 +46,36 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("key, value", "entries")
     }
 
+    it("strips the outer paren when the whole `for (vars in coll)` clause is wrapped") {
+      val hint = classify(
+        found = ",",
+        sourceLine = "for (key, value in entries) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.for_each_destructure"
+      hint.arguments shouldBe Seq("key, value", "entries")
+    }
+
+    it("keeps a call's own parens when the collection is a function call") {
+      val hint = classify(
+        found = ",",
+        sourceLine = "for (key, value) in getEntries() {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.for_each_destructure"
+      hint.arguments shouldBe Seq("key, value", "getEntries()")
+    }
+
+    it("keeps a call's own parens when the whole wrapped clause's collection is a call") {
+      val hint = classify(
+        found = ",",
+        sourceLine = "for (key, value in getEntries()) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.for_each_destructure"
+      hint.arguments shouldBe Seq("key, value", "getEntries()")
+    }
+
     it("prefers enhanced-for advice over generic C-style-for advice") {
       val hint = classify(
         found = "s",


### PR DESCRIPTION
## Summary
- Writing the whole `for (key, value in entries) { ... }` mistake — the entire clause wrapped in one outer paren pair, as opposed to `for (key, value) in entries { ... }` (paren around just the vars) — produced a suggested-fix hint reading `foreach (key, value) in entries) { ... }`, with an unbalanced trailing `)`. The classifier's regex only accounted for a closing paren right after the variable list, not one belonging to an outer wrap, so the wrapper's own `)` leaked into the captured collection text.
- Added a dedicated `ForEachDestructureWrappedMistake` pattern for the whole-clause-wrapped form, tried before the general `ForEachDestructureMistake` pattern, so the captured collection excludes the wrapper's closing paren. The error code and all other classifier behavior are unchanged.
- Added regression-guard tests confirming collection expressions that are themselves calls (`getEntries()`) are unaffected in both the vars-only-wrapped and whole-clause-wrapped forms.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec'` — 55/55 pass (2 new cases + 2 regression-guard cases added)
- [x] `sbt -Duser.language=en testFull` (full suite) — 4385 succeeded, 0 failed, 1 cancelled (expected: the dist smoke test gated behind `-Donion.dist.path`)
- [x] Manual end-to-end check with `onionc`/`onion` on `for (i, j in list) { ... }`: hint now reads `foreach (i, j) in list { ... }` (balanced parens) instead of `foreach (i, j) in list) { ... }`


---
_Generated by [Claude Code](https://claude.ai/code/session_0148g2c3zuVjkLpxtiSXxALC)_