### PR TITLE
docs(changelog): add [Unreleased] entry for run/LibraryCatalog.on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`run/LibraryCatalog.on`, a 361-line library catalog and loan tracking
+  sample.** A public-library book catalog and loan management system:
+  records with `example` clauses (`Book`, `Member`, `Loan`), a data-carrying
+  ADT `enum LoanStatus` (`Active(dueDay)`, `Returned(returnedDay, onTime)`,
+  `Overdue(dueDay, daysLate)`) matched exhaustively via `select`, a plain
+  `enum Genre`, extension methods on `Int` and `String`, a mutable `Library`
+  class, nullable `Int?` handling, collection pipelines (`any`/`count`/
+  `filter`/`groupBy`/`sortedBy`/`sortedByDescending`/`take`), `foreach (k, v)
+  in map` for genre/author breakdowns, and `try`/`catch` for validation
+  errors.
+
 - **`run/SymbolicMath.on`, a 283-line symbolic expression rewriting and
   calculus engine.** An ADT `enum Term` (Num, Var, Add, Sub, Mul, Div, Neg,
   Pow) with nested `select`/destructuring, fixpoint simplification


### PR DESCRIPTION
## Summary

PR #941 merged the 361-line `run/LibraryCatalog.on` rewrite (a public-library book catalog and loan management sample) without a corresponding `[Unreleased]` line in `CHANGELOG.md`. This adds it.

## Why draft

This session was unable to complete a full local `sbt -Duser.language=en testFull` run before submitting — the local sandbox (15GB RAM total) hit sustained heavy GC pressure and stalled deep into the suite even at `-Xmx10G` (matching CI's configured heap), most likely from local resource constraints rather than a project-wide regression, since CI has been passing consistently on other recent PRs. Per the repo's testing policy (never merge without a locally-confirmed green run), this is left as a **draft** pending CI's own result rather than merged on unconfirmed footing.

This is a changelog-only, prose-only change with no code or test-asserted content, so the risk of this specific diff being wrong is low — but the policy is followed regardless.

## Test plan

- [ ] CI green on this branch
- No local full-suite confirmation (see above)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReZnWRQdvmPiLGBx7huGDP)_