### PR TITLE
docs: move elsif hint CHANGELOG entry from 0.24.0 to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Ruby-style `elsif` clause.** Onion has no `elsif`;
+  `if`/`else if` chains cover the same ground, so `if a { ... } elsif b {
+  ... }` parsed `elsif` as a bare identifier-reference statement and then
+  hit a generic `expecting <EOF>, <EOL>, ";"` error on the next token, with
+  no mention of `else if`. The diagnostic now recognizes a line containing
+  `elsif` and points at the correct `else if` form (matching the existing
+  Python-style `elif` hint).
 - **Diagnostics: `docs/quality-bar.md` / `docs/ja/quality-bar.md` figures
   synced** after the `EpidemiologySim.on` corpus addition (245 samples, 185
   large programs, 4388 recorded tests).
@@ -168,14 +175,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with aggregate analytics.
 
 ### Fixed
-
-- **Parser hint for a Ruby-style `elsif` clause.** Onion has no `elsif`;
-  `if`/`else if` chains cover the same ground, so `if a { ... } elsif b {
-  ... }` parsed `elsif` as a bare identifier-reference statement and then
-  hit a generic `expecting <EOF>, <EOL>, ";"` error on the next token, with
-  no mention of `else if`. The diagnostic now recognizes a line containing
-  `elsif` and points at the correct `else if` form (matching the existing
-  Python-style `elif` hint).
 
 - **Parser hint for a Rust-style `val mut`/`var mut` declaration.** Onion has
   no `mut` keyword; mutability is chosen directly by `val` (immutable) or


### PR DESCRIPTION
## Summary

- PR #979 (merged just now) added the "Parser hint for a Ruby-style `elsif`
  clause" CHANGELOG entry into the already-released `[0.24.0]` section
  instead of `[Unreleased]`.
- The code implementing that hint (`ControlFlowSyntaxHints.scala`'s
  `ElsifStatement` case) did not exist at the `v0.24.0` tag — confirmed via
  `git show v0.24.0:src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala`,
  no `elsif` match. It only landed with #979 today, after `v0.25.0` was
  already tagged. The `[0.24.0]` entry was documenting a feature as shipped
  before the code actually existed.
- Moves the entry into `[Unreleased]`'s `### Fixed` section, where the code
  that implements it actually lives right now.
- Docs-only change; no code touched.

## Test plan

- [x] `sbt shutdown && sbt -Duser.language=en testFull` — full English-locale
  suite run to confirm nothing else regressed (docs-only diff, run for
  policy compliance)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q2D2Qwmjr8c2VZMF97Mo9)_