### PR TITLE
parser: add diagnostic hint for PHP-style `elseif` clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a PHP-style `elseif` clause.** Onion has no `elseif`;
+  `if`/`else if` chains cover the same ground, so `if a { ... } elseif b {
+  ... }` parsed `elseif` as a bare identifier-reference statement and then
+  hit a generic `expecting <EOF>, <EOL>, ";"` error on the next token, with
+  no mention of `else if`. The diagnostic now recognizes a line containing
+  `elseif` and points at the correct `else if` form (matching the existing
+  Python-style `elif` and Ruby-style `elsif` hints).
 - **Parser hint for a Ruby-style `elsif` clause.** Onion has no `elsif`;
   `if`/`else if` chains cover the same ground, so `if a { ... } elsif b {
   ... }` parsed `elsif` as a bare identifier-reference statement and then

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -114,6 +114,7 @@ error.parsing.hint.match_not_supported=Hint: Onion has no Rust/Scala/OCaml-style
 error.parsing.hint.default_case_not_supported=Hint: Onion's `select` has no Java/JavaScript-style `default` case. Use `else` instead: `select value { case 1: ...; else: ... }`.
 error.parsing.hint.elif_not_supported=Hint: Onion has no Python-style `elif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.elsif_not_supported=Hint: Onion has no Ruby-style `elsif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
+error.parsing.hint.elseif_not_supported=Hint: Onion has no PHP-style `elseif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except` clause. Catch exceptions with `catch` instead: `try { ... } catch e: Exception { ... }`.
 error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.
 error.parsing.hint.until_not_supported=Hint: Onion has no Ruby-style `until` loop. Negate the condition and use `while` instead: `while !condition { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -114,6 +114,7 @@ error.parsing.hint.match_not_supported=ヒント: Onion に Rust/Scala/OCaml 風
 error.parsing.hint.default_case_not_supported=ヒント: Onion の `select` に Java/JavaScript 風の `default` 節はありません。代わりに `else` を使ってください: `select value { case 1: ...; else: ... }`。
 error.parsing.hint.elif_not_supported=ヒント: Onion に Python 風の `elif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.elsif_not_supported=ヒント: Onion に Ruby 風の `elsif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
+error.parsing.hint.elseif_not_supported=ヒント: Onion に PHP 風の `elseif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `except` 節はありません。代わりに `catch` で例外を捕捉してください: `try { ... } catch e: Exception { ... }`。
 error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。
 error.parsing.hint.until_not_supported=ヒント: Onion に Ruby 風の `until` ループはありません。条件を否定して `while` を使ってください: `while !condition { ... }`。

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -8,6 +8,7 @@ private[compiler] object ControlFlowSyntaxHints {
   private val DefaultCaseLabel = """^\s*default\s*:""".r
   private val ElifStatement = """\belif\b""".r
   private val ElsifStatement = """\belsif\b""".r
+  private val ElseifStatement = """\belseif\b""".r
   private val LeadingUnlessStatement = """^\s*unless\b""".r
   private val LeadingUntilStatement = """^\s*until\b""".r
   private val ExceptClause = """\bexcept\b""".r
@@ -25,6 +26,8 @@ private[compiler] object ControlFlowSyntaxHints {
       hint("error.parsing.hint.elif_not_supported")
     } else if (ElsifStatement.findFirstMatchIn(sourceLine).isDefined) {
       hint("error.parsing.hint.elsif_not_supported")
+    } else if (ElseifStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.elseif_not_supported")
     } else if (LeadingUnlessStatement.findFirstMatchIn(sourceLine).isDefined) {
       hint("error.parsing.hint.unless_not_supported")
     } else if (LeadingUntilStatement.findFirstMatchIn(sourceLine).isDefined) {

--- a/src/test/scala/onion/compiler/PhpStyleElseifHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/PhpStyleElseifHintI18nSpec.scala
@@ -1,0 +1,55 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The elseif hint (`ControlFlowSyntaxHints`'s `PhpStyleElseif` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both
+ * locales, like every other hint in that match -- see OldForInHintI18nSpec
+ * for the motivating regression.
+ */
+class PhpStyleElseifHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.elseif_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a PHP-style `elseif` clause") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    val x = 1
+        |    if x == 1 {
+        |      IO::println("one")
+        |    } elseif x == 2 {
+        |      IO::println("two")
+        |    }
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("else if"), s"expected the hint's `else if` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -384,6 +384,17 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("recognizes a PHP-style `elseif` clause") {
+      val hint = classify(
+        found = "x",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "} elseif x == 2 {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.elseif_not_supported"
+      hint.arguments shouldBe empty
+    }
+
     it("keeps unsupported control-flow advice ahead of the generic block fallback") {
       val hint = classify(
         found = ")",


### PR DESCRIPTION
## Summary
- Onion has no `elseif`; only `else if` chains cover the same ground. A PHP-style `if a { ... } elseif b { ... }` previously parsed `elseif` as a bare identifier-reference statement and hit a generic `expecting <EOF>, <EOL>, ";"` error with no mention of `else if`.
- Adds a bilingual (EN/JA) parser hint for this case in `ControlFlowSyntaxHints`, mirroring the existing Python-style `elif` and Ruby-style `elsif` hints.
- Adds a unit test to `SyntaxHintClassifierSpec` and a new `PhpStyleElseifHintI18nSpec` (following `RubyStyleElsifHintI18nSpec`'s pattern) to guard both bundles resolve and the hint actually fires end-to-end.
- Adds a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.PhpStyleElseifHintI18nSpec onion.compiler.RubyStyleElsifHintI18nSpec'` — 63/63 passed
- [x] `sbt -Duser.language=en testFull` (full suite) — 4399 succeeded, 0 failed, 1 canceled, 0 ignored — all tests passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvGq7CCPnc6U9x5ZfzVbqX)_