### PR TITLE
Add parser hint for Python-style `if cond:` / `while cond:` colon body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Python-style `if cond:` / `while cond:` colon body.**
+  Onion blocks use `{ ... }`, not a trailing `:`; writing `if cond:` or
+  `while cond:` (also `else if cond:`) hit only the generic "a block `{
+  ... }` is expected here" fallback with no mention of the actual mistake.
+  The diagnostic now recognizes the colon-terminated header and shows the
+  brace-based rewrite directly, e.g. `if args.length > 0 { ... }` instead
+  of `if args.length > 0:`.
 - **Parser hint for a Swift-style `guard let ... else` early exit.** Onion
   has no `guard`; `guard let x = expr else { ... }` parsed `guard` as a bare
   identifier-reference statement and then hit a generic `expecting <EOF>,

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -119,6 +119,7 @@ error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except`
 error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.
 error.parsing.hint.until_not_supported=Hint: Onion has no Ruby-style `until` loop. Negate the condition and use `while` instead: `while !condition { ... }`.
 error.parsing.hint.not_operator=Hint: Onion has no Python/Ruby-style `not` operator for boolean negation. Use `!` instead: `if !condition { ... }`, not `if not condition { ... }`.
+error.parsing.hint.python_style_colon_block=Hint: Onion blocks use '{' ... '}', not a trailing `:` — write `{0} {1} '{' ... '}'`, not `{0} {1}:`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.
 error.parsing.hint.block_expected=Hint: a block `{ ... }` is expected here.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -119,6 +119,7 @@ error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `exce
 error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。
 error.parsing.hint.until_not_supported=ヒント: Onion に Ruby 風の `until` ループはありません。条件を否定して `while` を使ってください: `while !condition { ... }`。
 error.parsing.hint.not_operator=ヒント: Onion に Python/Ruby 風の論理否定演算子 `not` はありません。代わりに `!` を使ってください: `if not condition { ... }` ではなく `if !condition { ... }` と書いてください。
+error.parsing.hint.python_style_colon_block=ヒント: Onion のブロックは末尾の `:` ではなく '{' ... '}' を使います — `{0} {1}:` ではなく `{0} {1} '{' ... '}'` と書いてください。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。
 error.parsing.hint.block_expected=ヒント: ここにはブロック `{ ... }` が必要です。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -16,6 +16,8 @@ private[compiler] object SyntaxHintClassifier {
   private val ParenthesizedTrailingLambdaHead = """\A\{\s*\(([^()]*)\)\s*->""".r
   private val OldArrowTrailingLambdaHead = """\A\{\s*(?:\(?[^(){}=]*\)?)\s*=>""".r
   private val NotOperatorCondition = """^\s*(?:if|while|else\s+if)\s+not\b""".r
+  private val PythonStyleColonBlockHeader =
+    """^\s*(if|while|else\s+if)\s+(.+?):\s*$""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
   private val RustStyleMutDeclaration =
     """^\s*(val|var)\s+mut\s+([A-Za-z_]\w*)""".r
@@ -253,6 +255,11 @@ private[compiler] object SyntaxHintClassifier {
         val matched = IfWhileLetBinding.findFirstMatchIn(sourceLine).get
         val name = Option(matched.group(2)).getOrElse(matched.group(3))
         hint("error.parsing.hint.if_let_binding", matched.group(1), name, matched.group(4).trim)
+      // A Python-style `if cond:` / `while cond:` header also matches the generic
+      // block-expected fallback below, so keep this ahead of it.
+      case ":" if expected.contains("{") && PythonStyleColonBlockHeader.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = PythonStyleColonBlockHeader.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.python_style_colon_block", matched.group(1), matched.group(2).trim)
       case _ if expected.contains("{") && !Set(";", "<EOL>", "<EOF>").exists(expected.contains) =>
         hint("error.parsing.hint.block_expected")
       // A Swift-style `guard let x = expr else { ... }` early exit reads as a bare

--- a/src/test/scala/onion/compiler/PythonStyleColonBlockHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/PythonStyleColonBlockHintI18nSpec.scala
@@ -1,0 +1,71 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Python-style-colon-block hint (`SyntaxHintClassifier`'s `PythonStyleColonBlockHeader`
+ * case) must resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that match -- see OldForInHintI18nSpec for the motivating
+ * regression.
+ */
+class PythonStyleColonBlockHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.python_style_colon_block"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Python-style `if cond:` header") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    if args.length > 0:
+        |      IO::println("hi")
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The rewritten header shown in the hint is literal code, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("if args.length > 0"), s"expected the hint's rewritten header, got: $msgs")
+  }
+
+  it("fires for a Python-style `while cond:` header") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    while args.length > 0:
+        |      IO::println("hi")
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("while args.length > 0"), s"expected the hint's rewritten header, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -447,6 +447,58 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       ) shouldBe None
     }
 
+    it("recognizes a Python-style `if cond:` header with a trailing colon") {
+      val hint = classify(
+        found = ":",
+        expected = "\"{\"",
+        sourceLine = "    if args.length > 0:"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_colon_block"
+      hint.arguments shouldBe Seq("if", "args.length > 0")
+    }
+
+    it("recognizes a Python-style `while cond:` header with a trailing colon") {
+      val hint = classify(
+        found = ":",
+        expected = "\"{\"",
+        sourceLine = "while x > 0:"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_colon_block"
+      hint.arguments shouldBe Seq("while", "x > 0")
+    }
+
+    it("recognizes a Python-style `else if cond:` header with a trailing colon") {
+      val hint = classify(
+        found = ":",
+        expected = "\"{\"",
+        sourceLine = "else if x > 0:"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_colon_block"
+      hint.arguments shouldBe Seq("else if", "x > 0")
+    }
+
+    it("prefers the `not`-operator hint over the colon-block hint when both apply") {
+      val hint = classify(
+        found = ":",
+        expected = "\"{\"",
+        sourceLine = "if not done:"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.not_operator"
+    }
+
+    it("keeps the colon-block hint out of a case type pattern") {
+      SyntaxHintClassifier.classify(
+        found = ":",
+        expected = "\"{\"",
+        context = "",
+        sourceLine = "case s: String:"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.python_style_colon_block")
+    }
+
     it("recognizes a Kotlin-style `data class` declaration") {
       val hint = classify(
         found = "class",


### PR DESCRIPTION
## Summary

- Onion blocks use `{ ... }`, not a trailing `:`. Writing `if cond:`,
  `while cond:`, or `else if cond:` (a natural Python habit) previously hit
  only the generic "a block `{ ... }` is expected here" fallback, with no
  mention of the actual mistake or a concrete rewrite.
- Adds a diagnostic hint (`SyntaxHintClassifier`'s new
  `PythonStyleColonBlockHeader` case, `error.parsing.hint.python_style_colon_block`
  key in both `errorMessage.properties` / `errorMessage_ja.properties`) that
  recognizes the colon-terminated `if`/`while`/`else if` header and shows the
  brace-based rewrite directly, e.g. `if args.length > 0 { ... }` instead of
  `if args.length > 0:`.
- The new case sits ahead of the generic `block_expected` fallback but behind
  the existing Python/Ruby-style `not`-operator hint (`if not done:` still
  reports the more specific `not_operator` hint first).
- TDD: added unit cases to `SyntaxHintClassifierSpec` (including two negative
  cases: it doesn't fire when `not` also applies, and it doesn't misfire on a
  `select` type-pattern's `case s: String:`) and an end-to-end bilingual
  resolution spec, `PythonStyleColonBlockHintI18nSpec`, following the existing
  pattern for these hints (e.g. `PythonStyleFromImportHintI18nSpec`).
- `CHANGELOG.md` `[Unreleased]` updated.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.PythonStyleColonBlockHintI18nSpec'` — all green
- [x] Manual repro via `sbt runScript` confirms the hint fires on real `if cond:` / `while cond:` source, in both English and Japanese locales
- [x] Full suite (`sbt -Duser.language=en testFull`): 4418 succeeded, 0 failed, 1 canceled (the environment-dependent distribution smoke test, pre-existing/unrelated)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkjpqPf2T9c2DLnDoUYcvV)_