### PR TITLE
Add parser hint for Java-style `final` local variable declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a Java-style `final Type name = ...` local variable.**
+  Onion has no grammar production for a `final`-qualified local declaration
+  (`final` is only a class/method modifier), so writing one — e.g. `final
+  Int x = 5` inside a method body — previously fell straight through to the
+  generic "encountered `final`, but expecting `}`" fallback with no mention
+  of the actual mistake. The diagnostic now recognizes the Java-style
+  `final Type name` shape and points at `val` instead, which is already
+  immutable by default.
+
 ## [0.26.0] - 2026-08-29
 
 ### Added

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -156,6 +156,7 @@ error.parsing.hint.python_style_from_import=Hint: Onion has no Python-style `fro
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
 error.parsing.hint.dollar_sigil=Hint: Onion has no `$` sigil for variables or string interpolation — interpolate inside a string with `#{expr}` instead — write `"Hello, #{name}!"`, not `$"Hello, {name}!"` or `$name`.
 error.parsing.hint.missing_call_parens=Hint: a call''s arguments need parentheses — write `{0}(...)` instead of `{0} ...`. (Two separate statements go on separate lines, or joined with `;`.)
+error.parsing.hint.java_style_final_local=Hint: Onion has no Java-style `final` local variable — every `val` is already immutable, so declare it with `val` instead — write `val {1}: {0} = ...`, not `final {0} {1} = ...`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -156,6 +156,7 @@ error.parsing.hint.python_style_from_import=ヒント: Onion に Python 風の `
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
 error.parsing.hint.dollar_sigil=ヒント: Onion に変数や文字列補間のための `$` シジルはありません — 文字列内での補間は `#{expr}` を使ってください — `$"Hello, {name}!"` や `$name` ではなく `"Hello, #{name}!"` と書いてください。
 error.parsing.hint.missing_call_parens=ヒント: 呼び出しの引数にはかっこが必要です — `{0} ...` ではなく `{0}(...)` と書いてください。（2つの別々の文のつもりなら、改行するか `;` で区切ってください。）
+error.parsing.hint.java_style_final_local=ヒント: Onion に Java 風の `final` ローカル変数はありません — `val` はもともと不変なので、代わりに `val` で宣言してください — `final {0} {1} = ...` ではなく `val {1}: {0} = ...` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -65,6 +65,13 @@ private[compiler] object SyntaxHintClassifier {
     """\bdef\s+[A-Za-z_]\w*(?:\[[^\]]*\])?\s*\(\s*(?:(?:val|var)\s+)?([A-Za-z_]\w*)\s*[,)]""".r
   private val JavaStyleFieldDeclaration =
     """^\s*(?:public|private|protected)?\s*([A-Z][A-Za-z0-9_]*(?:\[[^\]]*\])?\??)\s+([A-Za-z_]\w*)\s*(?:=|;|$)""".r
+  // `final` is itself a valid Onion modifier (for classes/methods, via `modifiers()`
+  // in the grammar), so this must require a capitalized type name right after it --
+  // that shape never appears for a legitimate `final class ...`/`final def ...`/
+  // `final override ...` (all lowercase keywords), only for the Java mistake of a
+  // `final`-qualified local variable, which Onion has no grammar production for at all.
+  private val JavaStyleFinalLocalDeclaration =
+    """^\s*final\s+([A-Z][A-Za-z0-9_]*(?:\[[^\]]*\])?\??)\s+([A-Za-z_]\w*)\s*(?:=|;|$)""".r
   private val JavaStyleTypeCase =
     """^\s*case\s+[a-z_]\w*\s*:\s*[A-Z][\w.\[\]]*\??\s*:""".r
   private val JavaStyleGenericAngleBrackets =
@@ -207,6 +214,9 @@ private[compiler] object SyntaxHintClassifier {
       case (")" | ",") if expected == "\":\"" && MissingParameterType.findFirstMatchIn(sourceLine).isDefined =>
         val matched = MissingParameterType.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.missing_parameter_type", matched.group(1))
+      case _ if JavaStyleFinalLocalDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = JavaStyleFinalLocalDeclaration.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.java_style_final_local", matched.group(1), matched.group(2))
       case _ if JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleFieldDeclaration.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_field", matched.group(1), matched.group(2))

--- a/src/test/scala/onion/compiler/JavaStyleFinalLocalHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleFinalLocalHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style `final Type name = ...` local-variable-declaration hint
+ * (`SyntaxHintClassifier`'s `JavaStyleFinalLocalDeclaration` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that match -- see RustStyleMutDeclarationHintI18nSpec
+ * for the same pattern.
+ */
+class JavaStyleFinalLocalHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_final_local"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `final Int x = 5` local declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    final Int x = 5
+        |    IO::println(x)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted type and name are literal source text, identical in
+    // both bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("val x: Int = ..."), s"expected the hint's `val x: Int = ...` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -510,6 +510,37 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("Point", "x: Int, y: Int")
     }
 
+    it("recognizes a Java-style `final` local variable declaration") {
+      val hint = classify(
+        found = "final",
+        expected = "\"}\"",
+        sourceLine = "final Int x = 5"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.java_style_final_local"
+      hint.arguments shouldBe Seq("Int", "x")
+    }
+
+    it("recognizes a Java-style `final` local variable declaration with no initializer") {
+      val hint = classify(
+        found = "final",
+        expected = "\"}\"",
+        sourceLine = "final String name;"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.java_style_final_local"
+      hint.arguments shouldBe Seq("String", "name")
+    }
+
+    it("does not flag a `final class` declaration as a final-local mistake") {
+      SyntaxHintClassifier.classify(
+        found = "class",
+        expected = "<ID>",
+        context = "",
+        sourceLine = "final class Point {"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.java_style_final_local")
+    }
+
     it("recognizes a JS/TS-style `constructor(...)` method") {
       val hint = classify(
         found = "constructor",


### PR DESCRIPTION
## Summary

- Onion has no grammar production for a Java-style `final Type name = ...` local variable declaration (`final` is only a class/method modifier via `modifiers()` in the grammar), so writing one — e.g. `final Int x = 5` inside a method body — previously fell through to the generic `"Encountered \"final\", but expecting \"}\""` fallback with no mention of the actual mistake.
- Adds a `SyntaxHintClassifier` rule (`JavaStyleFinalLocalDeclaration`) that recognizes the `final <CapitalizedType> <name>` shape and points at `val` instead, which is already immutable by default.
- The rule requires a capitalized type name immediately after `final`, so it never fires for the legitimate Onion uses of `final` (`final class Foo`, `final def bar()`, `final override ...`, etc. — all lowercase keywords), only for the unsupported local-declaration mistake.
- Adds bilingual (EN/JA) message-bundle entries, a unit test in `SyntaxHintClassifierSpec` (including a negative case for `final class Point {`), and an end-to-end bilingual integration spec (`JavaStyleFinalLocalHintI18nSpec`), plus a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] Added failing tests first (TDD), confirmed red before the implementation
- [x] `sbt "testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.JavaStyleFinalLocalHintI18nSpec"` — all green
- [x] Manually verified via `sbt runScript` that `final Int x = 5` now produces the new hint, and that a legitimate `final class Point { ... }` still parses (reaches semantic analysis, not a parse error)
- [x] Full suite: `sbt shutdown && sbt -Duser.language=en testFull` — **4424 tests, 597 suites, 0 failed, 1 canceled** (the distribution smoke test, gated behind `-Donion.dist.path` as documented)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JfF9APkPGK6opct58Q6ocm)_