### PR TITLE
Fix misleading old-extends hint for a Python-style `class Foo:` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Python-style `class Foo:` header no longer says "superclass".**
+  A Python-style class header (`class Foo:` or `class Foo(x: Int):`, body indented
+  on the next line instead of `{ ... }`) hit the same generic colon-position error
+  as the *old* `class A : B` extends syntax and got that hint back verbatim — "a
+  superclass is named with `extends`, not `:`" — which makes no sense when there
+  is no superclass in sight. The diagnostic now tells the two mistakes apart by
+  whether anything follows the colon on the same line and, for the Python-style
+  case, points at the brace-based rewrite (`class Foo { ... }`) instead.
 - **Parser hint for a Java-style `final Type name = ...` local variable.**
   Onion has no grammar production for a `final`-qualified local declaration
   (`final` is only a class/method modifier), so writing one — e.g. `final

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -18,6 +18,11 @@ private[compiler] object SyntaxHintClassifier {
   private val NotOperatorCondition = """^\s*(?:if|while|else\s+if)\s+not\b""".r
   private val PythonStyleColonBlockHeader =
     """^\s*(if|while|else\s+if)\s+(.+?):\s*$""".r
+  // A Python-style `class Foo:` (or `class Foo(x: Int):`) header, where the colon
+  // terminates the whole line -- unlike the old `class Foo: Bar` extends-colon
+  // mistake below, where a superclass name follows the colon on the same line.
+  private val PythonStyleColonBlockClassHeader =
+    """^\s*class\s+(.+?):\s*$""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
   private val RustStyleMutDeclaration =
     """^\s*(val|var)\s+mut\s+([A-Za-z_]\w*)""".r
@@ -133,6 +138,12 @@ private[compiler] object SyntaxHintClassifier {
       case "<" if JavaStyleGenericAngleBrackets.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleGenericAngleBrackets.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_generics", matched.group(1), matched.group(2).trim)
+      // A Python-style `class Foo:` header also lands here (the parser wants
+      // `extends`/`{` right where the trailing `:` sits), but it's a missing-brace
+      // mistake, not the old colon-extends syntax -- keep it ahead of that case.
+      case ":" if expected.contains("extends") && PythonStyleColonBlockClassHeader.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = PythonStyleColonBlockClassHeader.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.python_style_colon_block", "class", matched.group(1).trim)
       case ":" if expected.contains("extends") =>
         hint("error.parsing.hint.old_extends")
       case "(" if expected.contains("\"this\"") && !expected.contains("<ID>") =>

--- a/src/test/scala/onion/compiler/PythonStyleColonBlockHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/PythonStyleColonBlockHintI18nSpec.scala
@@ -68,4 +68,19 @@ class PythonStyleColonBlockHintI18nSpec extends AnyFunSpec with Diagrams {
     }
     assert(msgs.contains("while args.length > 0"), s"expected the hint's rewritten header, got: $msgs")
   }
+
+  it("fires for a Python-style `class Foo:` header, not the old-extends hint") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Foo:
+        |  val x: Int = 1
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("class Foo"), s"expected the hint's rewritten header, got: $msgs")
+    assert(!msgs.contains("superclass") && !msgs.contains("親クラス"), s"expected the class-body hint, not the old-extends hint, got: $msgs")
+  }
 }

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -499,6 +499,38 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       ).map(_.messageKey) should not be Some("error.parsing.hint.python_style_colon_block")
     }
 
+    it("recognizes a Python-style `class Foo:` header with a trailing colon") {
+      val hint = classify(
+        found = ":",
+        expected = "<EOF>, \"extends\", \";\", \"{\"",
+        sourceLine = "class Foo:"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_colon_block"
+      hint.arguments shouldBe Seq("class", "Foo")
+    }
+
+    it("recognizes a Python-style `class Foo(x: Int):` header with a primary constructor") {
+      val hint = classify(
+        found = ":",
+        expected = "<EOF>, \"extends\", \";\", \"{\"",
+        sourceLine = "class Foo(x: Int):"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_colon_block"
+      hint.arguments shouldBe Seq("class", "Foo(x: Int)")
+    }
+
+    it("keeps the old-extends hint for a real `class Foo: Bar` superclass mistake") {
+      val hint = classify(
+        found = ":",
+        expected = "<EOF>, \"extends\", \";\", \"{\"",
+        sourceLine = "class Foo: Bar {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.old_extends"
+    }
+
     it("recognizes a Kotlin-style `data class` declaration") {
       val hint = classify(
         found = "class",


### PR DESCRIPTION
## Summary

- A Python-style class header (`class Foo:` or `class Foo(x: Int):`, body indented on the next line instead of `{ ... }`) hit the same colon-position parse error as the *old* `class A : B` extends syntax and reused that hint verbatim — "a superclass is named with `extends`, not `:`" — which makes no sense when there is no superclass anywhere on the line.
- `SyntaxHintClassifier` now distinguishes the two by checking whether anything follows the colon on the same source line: a trailing `class Foo:`/`class Foo(x: Int):` gets a hint pointing at the brace-based rewrite (reusing the existing `python_style_colon_block` message, e.g. `class Foo { ... }`), while `class Foo: Bar` still gets the original `extends` advice.
- Added unit coverage in `SyntaxHintClassifierSpec` (both header shapes, plus a regression case keeping the old-extends hint for a real superclass mistake) and an end-to-end case in `PythonStyleColonBlockHintI18nSpec` compiling a full `class Foo:` snippet.

## Test plan

- [x] `sbt -Duser.language=en testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.PythonStyleColonBlockHintI18nSpec` — green
- [x] `sbt shutdown && SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4428 tests / 597 suites, 0 failed, 1 canceled (the gated distribution smoke test)
- [x] Manual repro via `sbt runScript` confirming `class Foo:`, `class Foo(x: Int):`, and the real `class Foo: Bar {` mistake each get the correct hint

---
_Generated by [Claude Code](https://claude.ai/code/session_0116x6TGjpRqguSjKGp8s4Yp)_