### PR TITLE
Fix: destructuring a generic record loses its type argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the actual mistake. The diagnostic now recognizes the Java-style
   `final Type name` shape and points at `val` instead, which is already
   immutable by default.
+- **Destructuring a generic record no longer loses its type argument.**
+  `case Wrap(v):` against a `Wrap[Int]` scrutinee bound `v` at the record's
+  bare type parameter `T` instead of the `Int` it was actually instantiated
+  with, so using `v` as an `Int` failed to typecheck (E0000: "type Int is
+  expected, but type T is used") even though `w.v()` on the same value
+  worked fine. The scrutinee's type argument is now recovered the same way
+  a root `is`-pattern already does for a sealed hierarchy (#311), and applies
+  through nested destructuring too (`Outer(Pair(a, b))` on an
+  `Outer[Int]`/`Pair[Int, String]` scrutinee binds `a: Int`, `b: String`).
 
 ## [0.26.0] - 2026-08-29
 

--- a/src/main/scala/onion/compiler/typing/DestructuringPatternProcessor.scala
+++ b/src/main/scala/onion/compiler/typing/DestructuringPatternProcessor.scala
@@ -77,6 +77,12 @@ private[typing] class DestructuringPatternProcessor(private val typing: Typing) 
           break(None)
         }
 
+        // `fieldType` is the enclosing field's type as seen from the outer
+        // scrutinee (already specialized if that field was itself generic),
+        // so it doubles as the scrutinee for recovering this nested record's
+        // own type arguments -- same trick as the top-level record below.
+        val nestedAppliedType = TypeSubst.specializeFromScrutinee(nestedType.asInstanceOf[ClassType], fieldType)
+
         // Build accessor for nested type check by following the access path
         def buildAccessorForCondition(base: Term, path: List[AccessStep]): Term = path match {
           case Nil => base
@@ -100,7 +106,8 @@ private[typing] class DestructuringPatternProcessor(private val typing: Typing) 
             break(None)
           }
           val nestedPath = currentPath :+ AccessStep(nestedType.asInstanceOf[ClassType], nestedGetter)
-          processNestedFieldPattern(nestedFieldPat, nestedField.`type`, nestedPath, bindingEntries, nestedConditions, nested)
+          val nestedFieldType = TypeSubst.withClassOnly(nestedField.`type`, nestedAppliedType)
+          processNestedFieldPattern(nestedFieldPat, nestedFieldType, nestedPath, bindingEntries, nestedConditions, nested)
         }
 
       case tp @ AST.TypePattern(_, bindingName, typeRef) =>
@@ -143,6 +150,13 @@ private[typing] class DestructuringPatternProcessor(private val typing: Typing) 
     val classDef = resolveRecordClass(dp, constructor)
     val recordType = classDef
 
+    // `constructor` names a raw record (`Wrap`, not `Wrap[Int]`), so a
+    // generic record's fields would otherwise stay typed at their bare type
+    // parameters. Recover the actual type arguments from the scrutinee being
+    // destructured (`bind`), same trick as a root `is`-pattern (#311), so
+    // e.g. matching `Wrap(v)` out of a `Wrap[Int]` binds `v: Int`.
+    val appliedRecordType = TypeSubst.specializeFromScrutinee(recordType.asInstanceOf[ClassType], bind.tp)
+
     // Get fields in order (records store fields in insertion order)
     val fields = classDef.fields
     val fieldCount = fields.length
@@ -166,7 +180,8 @@ private[typing] class DestructuringPatternProcessor(private val typing: Typing) 
         break(None)
       }
       val currentPath = List(AccessStep(recordType.asInstanceOf[ClassType], getter))
-      processNestedFieldPattern(fieldPattern, field.`type`, currentPath, bindingEntries, nestedConditions, dp)
+      val fieldType = TypeSubst.withClassOnly(field.`type`, appliedRecordType)
+      processNestedFieldPattern(fieldPattern, fieldType, currentPath, bindingEntries, nestedConditions, dp)
     }
 
     val bindingInfo = MultiBindings(recordType.asInstanceOf[ClassType], bindingEntries.toList, nestedConditions.toList)

--- a/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
@@ -307,7 +307,10 @@ final class SelectExpressionTyping(
 
             val bindingStmts = varBinds.zip(bindings).map { case (varBind, BindingEntry(_, _, accessPath)) =>
               val accessor = buildAccessor(new RefLocal(bind), accessPath)
-              new ExpressionActionStatement(new SetLocal(varBind, accessor))
+              // The getter's raw return type may still be an unsubstituted type
+              // variable (e.g. T) while varBind was declared at the type argument
+              // recovered from the scrutinee (e.g. Int) -- narrow/unbox to match.
+              new ExpressionActionStatement(new SetLocal(varBind, TypeSubst.withCast(accessor, varBind.tp)))
             }
             new StatementBlock(caseNodes(caseIndex).location, (setCast +: bindingStmts :+ innerBody)*)
 
@@ -445,7 +448,7 @@ final class SelectExpressionTyping(
         // The *binding* can be more precise than the check: matching a
         // `Some` out of an `Opt[String]` binds `Some[String]`, recovered from
         // the scrutinee's type arguments (#311).
-        bindingInfo = SingleBinding(name, specializeFromScrutinee(mappedType, conditionType))
+        bindingInfo = SingleBinding(name, TypeSubst.specializeFromScrutinee(mappedType, conditionType))
 
         instanceOfCheck
 
@@ -625,50 +628,6 @@ final class SelectExpressionTyping(
       case None =>
         typeBlockExpression(thenBlock, context, expected)
     }
-  }
-
-  /**
-   * Recover the matched case's type arguments from the scrutinee's.
-   *
-   * `case x is Some` names a class, not a parameterization, so the pattern
-   * alone binds the raw `Some` and its components come back as bare type
-   * variables. When the scrutinee is a parameterization the arguments are
-   * already known: matching `Some` out of an `Opt[String]` must bind
-   * `Some[String]`, so `x.value()` is a `String` rather than `T` (#311).
-   *
-   * The case's own view of the scrutinee's class (`Some[T] <: Opt[T]`) is
-   * unified against the scrutinee (`Opt[String]`), which solves the case's
-   * parameters. Anything not solved that way -- no generics involved, an
-   * unparameterized scrutinee, a variable left free -- keeps the raw type, so
-   * this only ever adds precision.
-   */
-  private def specializeFromScrutinee(matched: Type, scrutinee: Type): Type = (matched, scrutinee) match {
-    case (raw: ClassType, applied: AppliedClassType)
-      if !raw.isInstanceOf[AppliedClassType] && raw.typeParameters.nonEmpty =>
-      val solved = scala.collection.mutable.HashMap[String, Type]()
-      val paramNames = raw.typeParameters.map(_.name).toSet
-
-      def unify(formal: Type, actual: Type): Unit = formal match {
-        case tv: TypeVariableType if paramNames.contains(tv.name) =>
-          if (!solved.contains(tv.name)) solved += tv.name -> actual
-        case fa: AppliedClassType =>
-          actual match {
-            case aa: AppliedClassType
-              if TypeRelations.sameClass(fa.raw, aa.raw) && fa.typeArguments.length == aa.typeArguments.length =>
-              fa.typeArguments.zip(aa.typeArguments).foreach((f, a) => unify(f, a))
-            case _ =>
-          }
-        case _ =>
-      }
-
-      AppliedTypeViews.collectAppliedViewsFrom(raw)
-        .collectFirst { case (viewRaw, view) if TypeRelations.sameClass(viewRaw, applied.raw) => view }
-        .foreach(view => unify(view, applied))
-
-      if (raw.typeParameters.forall(tp => solved.contains(tp.name)))
-        AppliedClassType(raw, raw.typeParameters.map(tp => solved(tp.name)).toList)
-      else matched
-    case _ => matched
   }
 
   private def ensureBoolean(node: AST.Node, term: Term): Term =

--- a/src/main/scala/onion/compiler/typing/TypeSubstHelpers.scala
+++ b/src/main/scala/onion/compiler/typing/TypeSubstHelpers.scala
@@ -1,7 +1,7 @@
 package onion.compiler.typing
 
 import onion.compiler.TypedAST
-import onion.compiler.TypedAST.{AsInstanceOf, Method, Term, Type}
+import onion.compiler.TypedAST.{AppliedClassType, AsInstanceOf, ClassType, Method, Term, Type, TypeVariableType}
 
 import scala.collection.immutable.Map
 
@@ -54,4 +54,53 @@ private[typing] object TypeSubst {
   /** Option-returning version of withCast */
   def withCastOpt(term: Term, targetType: Type): Option[Term] =
     Some(withCast(term, targetType))
+
+  /**
+   * Recovers type arguments for a raw (unapplied) class from a scrutinee it
+   * was matched out of: matching `Some` out of an `Opt[String]` scrutinee
+   * specializes to `Some[String]` by unifying `Some`'s applied view of `Opt`
+   * against the scrutinee's actual type arguments (#311). Anything not
+   * solved that way -- no generics involved, an unparameterized scrutinee, a
+   * variable left free -- keeps the raw type, so this only ever adds
+   * precision.
+   */
+  def specializeFromScrutinee(matched: Type, scrutinee: Type): Type = (matched, scrutinee) match {
+    // The common case: the matched class *is* the scrutinee's own class (e.g.
+    // destructuring `Wrap(v)` straight out of a `Wrap[Int]` scrutinee, no
+    // sealed-hierarchy narrowing involved). The scrutinee's type arguments
+    // already line up 1:1 with `raw`'s own type parameters, so this can skip
+    // the ancestor-view unification below entirely -- which only ever
+    // produces an empty-argument self view (AppliedTypeViews's traversal
+    // starting point, not a real parameterization) and would fail to unify.
+    case (raw: ClassType, applied: AppliedClassType)
+      if !raw.isInstanceOf[AppliedClassType] && raw.typeParameters.nonEmpty &&
+        TypeRelations.sameClass(raw, applied.raw) =>
+      AppliedClassType(raw, applied.typeArguments.toList)
+    case (raw: ClassType, applied: AppliedClassType)
+      if !raw.isInstanceOf[AppliedClassType] && raw.typeParameters.nonEmpty =>
+      val solved = scala.collection.mutable.HashMap[String, Type]()
+      val paramNames = raw.typeParameters.map(_.name).toSet
+
+      def unify(formal: Type, actual: Type): Unit = formal match {
+        case tv: TypeVariableType if paramNames.contains(tv.name) =>
+          if (!solved.contains(tv.name)) solved += tv.name -> actual
+        case fa: AppliedClassType =>
+          actual match {
+            case aa: AppliedClassType
+              if TypeRelations.sameClass(fa.raw, aa.raw) && fa.typeArguments.length == aa.typeArguments.length =>
+              fa.typeArguments.zip(aa.typeArguments).foreach((f, a) => unify(f, a))
+            case _ =>
+          }
+        case _ =>
+      }
+
+      AppliedTypeViews.collectAppliedViewsFrom(raw)
+        .collectFirst { case (viewRaw, view) if TypeRelations.sameClass(viewRaw, applied.raw) => view }
+        .foreach(view => unify(view, applied))
+
+      if (raw.typeParameters.forall(tp => solved.contains(tp.name)))
+        AppliedClassType(raw, raw.typeParameters.map(tp => solved(tp.name)).toList)
+      else matched
+    case _ => matched
+  }
 }

--- a/src/test/scala/onion/compiler/tools/DestructuringPatternSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DestructuringPatternSpec.scala
@@ -92,6 +92,53 @@ class DestructuringPatternSpec extends AbstractShellSpec {
       assert(Shell.Success("error: oops") == result)
     }
 
+    it("binds a generic record's field at its instantiated type argument, not the raw type parameter") {
+      // Regression test: `case Wrap(v):` on a `Wrap[Int]` scrutinee used to bind
+      // `v` at the record's bare type parameter `T` instead of the `Int` it was
+      // actually instantiated with, so using `v` as an `Int` failed to typecheck
+      // (E0000: "type Int is expected, but type T is used").
+      val result = shell.run(
+        """
+          |record Wrap[T](v: T);
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val w = new Wrap[Int](5);
+          |    return select w {
+          |      case Wrap(v): v + 1
+          |      else: -1
+          |    };
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(6) == result)
+    }
+
+    it("binds a nested generic record's field at its instantiated type argument") {
+      val result = shell.run(
+        """
+          |record Pair[A, B](first: A, second: B);
+          |record Outer[T](inner: Pair[T, String]);
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val o = new Outer[Int](new Pair[Int, String](5, "x"));
+          |    return select o {
+          |      case Outer(Pair(a, b)): a + b.length
+          |      else: -1
+          |    };
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success(6) == result)
+    }
+
     it("reports error for wrong binding count") {
       val result = shell.run(
         """


### PR DESCRIPTION
## Summary

- `case Wrap(v):` matched against a `Wrap[Int]` scrutinee bound `v` at the record's bare type parameter `T` instead of the `Int` it was actually instantiated with, so using `v` as an `Int` failed to typecheck (`E0000: type Int is expected, but type T is used`) — even though `w.v()` on the same value worked correctly.
- Root cause: `DestructuringPatternProcessor` resolves the record class by name only (`typing.load("Wrap")`, which carries no type arguments) and used each field's declared type unsubstituted.
- Fix: recover the scrutinee's type argument the same way a root `is`-pattern already does for a sealed hierarchy (issue #311's `specializeFromScrutinee`, now shared via `TypeSubst` instead of living only in `SelectExpressionTyping`). Added a fast path for the common case where the matched record *is* the scrutinee's own class (the existing ancestor-view unification only handled matching a narrower subtype out of a wider scrutinee, e.g. `Some` out of `Opt[String]`, and has no type arguments to unify against for a same-class self-view). The recovered type flows down through nested destructuring too, and the accessor's runtime value gets an `AsInstanceOf` cast where that differs from the raw getter's return type, mirroring the existing `copy()` accessor in `InstanceMethodCallSupport`.

## Test plan

- [x] New regression tests in `DestructuringPatternSpec` (confirmed red on the old code via `git stash`, green after the fix): top-level generic record destructuring, and nested generic record destructuring.
- [x] Manually verified no regression in the existing generic-ADT type-pattern recovery (`case s is Some:` on `Opt[String]`, issue #311) and in plain non-generic record destructuring.
- [x] Full suite green: `sbt -Duser.language=en testFull` — 4430 tests, 597 suites, 0 failed, 1 cancelled (matches the documented baseline).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoAoE6nFgQf75PYgjWGxAT)_