### PR TITLE
ci: disable sbt 2.x disk-cache to fix silent test-suite skipping

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - name: Install sbt
       uses: sbt/setup-sbt@v1
+      with:
+        disk-cache: false
     - name: Checkout
       uses: actions/checkout@v4
     - name: Setup JDK


### PR DESCRIPTION
## Summary
- Fixes #981: CI's `sbt -v +test` job was silently skipping suites (e.g. `QualityBarSpec`) because `sbt/setup-sbt@v1`'s `disk-cache` (on by default) persists sbt 2's build-server task cache across unrelated CI runs, keyed only by toolchain+date rather than commit SHA — combined with sbt 2's `test` delegating to `testQuick` incremental semantics, CI could serve stale "already passed" results instead of re-running suites.
- This is the scoped fix candidate identified in [the issue's root-cause comment](https://github.com/onion-lang/onion/issues/981#issuecomment-5462107336): pass `disk-cache: false` to `sbt/setup-sbt@v1`. It does **not** change the `test` invocation or the job's 25-minute timeout — it only stops that build-server cache from being restored across runs, so a fresh checkout actually re-executes every suite.

## Verification
- **CI on this PR** (with the fix applied): `Total number of tests run: 4442`, `Suites: completed 599, aborted 0`, `Tests: succeeded 4442, failed 0, canceled 1` — the full suite actually ran, and the job log no longer shows a stale "sbt 2.x disk cache" hit.
- **Local** `sbt -Duser.language=en testFull`: identical counts (4442 tests / 599 suites / 0 failed / 1 canceled) — matches CI exactly.
- CI job runtime was ~2 minutes, well within the existing 25-minute timeout — no budget change needed.

## Test plan
- [x] Local `sbt -Duser.language=en testFull` green
- [x] CI on this PR runs the full suite (test/suite counts match local `testFull`)
- [x] No CI runtime regression threatening the 25-minute job timeout