### PR TITLE
docs(changelog): record PropCheck.on and PersonalFinance.on additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `any`, `count`, `zip`) run five named pipelines over five sample inputs
   with aggregate analytics.
 
+- **`run/PropCheck.on`, a 416-line mini property-based testing framework**
+  modelled on QuickCheck. An ADT `case` enum (`Outcome`: `Pass`/`Fail`/
+  `GaveUp`) with sealed exhaustive `select` matching, records (`PropSpec`,
+  `Cex`), static-method classes, function-type parameters, closures over
+  captured PRNG state, an integer shrinker (bisection) and a string
+  shrinker (suffix trim), and a conditional property runner with
+  precondition and give-up threshold. Twelve properties are checked
+  end-to-end (commutativity, distributivity, `reverse(reverse(s)) == s`,
+  a deliberately-falsified property, and more).
+
+- **`run/PersonalFinance.on`, a 458-line personal finance tracker.** A
+  plain enum (`Category`), an ADT enum (`TransactionType` with
+  Credit/Debit/Transfer cases carrying fields), records with methods
+  (`Money`, `Transaction`, `BudgetLine`, `MonthlyReport`), classes with
+  `public:`/`private:` sections (`Account`, `BudgetManager`,
+  `FinanceEngine`, `ReportPrinter`), and collection pipelines drive budget
+  tracking, monthly income/expense/savings-rate reporting, top-expense
+  ranking, and a savings-goal projection over two months of transactions.
+
 ### Fixed
 
 - **Parser hint for a Rust-style `val mut`/`var mut` declaration.** Onion has


### PR DESCRIPTION
## Summary

- Backfills `CHANGELOG.md`'s `[Unreleased]` → `Added` section with entries for `run/PropCheck.on` (#959) and `run/PersonalFinance.on` (#960), both merged to `develop` without a changelog entry.
- Documentation-only change, no code touched.

## Why draft

This session's sandbox repeatedly restarted mid-run (twice) before `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` could finish, so I could not confirm a green full-suite run with a real command this session. Per repo policy, an unverified change is never merged — leaving this as a draft rather than merging. A future session (or a maintainer) should run the full English-locale suite and, if green, mark ready and merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_018KR9q2hQCPV3hNqiFHV4Qx)_