### PR TITLE
Add parser hint for JavaScript/Python-style prefix `await` statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a JavaScript/Python-style prefix `await expr` statement.**
+  Writing `await asyncOp()` — the idiom every JavaScript/Python programmer
+  reaches for to wait on an async result — parsed `await` as a bare identifier
+  statement and hit the generic "a call's arguments need parentheses" fallback
+  (suggesting the nonsensical `await(...)`), since the parser saw `await`
+  directly followed by another expression with nothing in between. The
+  diagnostic now recognizes the `await expr` shape and points at Onion's
+  actual equivalent, postfix `expr.await()` on a `Future`.
+
 ### Added
 
 - **`run/GraphAlgorithms.on` extended into a property-graph showcase**

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -119,6 +119,7 @@ error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except`
 error.parsing.hint.python_style_raise_construct=Hint: Onion has no Python-style `raise` statement — throw an exception with `throw new` instead — write `throw new {0}({1})`, not `raise {0}({1})`.
 error.parsing.hint.python_style_raise=Hint: Onion has no Python-style `raise` statement — throw an exception with `throw` instead — write `throw {0}`, not `raise {0}`.
 error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.
+error.parsing.hint.await_not_supported=Hint: Onion has no JavaScript/Python-style prefix `await` — a `Future` is awaited postfix instead — write `{0}.await()`, not `await {0}`.
 error.parsing.hint.until_not_supported=Hint: Onion has no Ruby-style `until` loop. Negate the condition and use `while` instead: `while !condition { ... }`.
 error.parsing.hint.not_operator=Hint: Onion has no Python/Ruby-style `not` operator for boolean negation. Use `!` instead: `if !condition { ... }`, not `if not condition { ... }`.
 error.parsing.hint.python_style_colon_block=Hint: Onion blocks use '{' ... '}', not a trailing `:` — write `{0} {1} '{' ... '}'`, not `{0} {1}:`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -119,6 +119,7 @@ error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `exce
 error.parsing.hint.python_style_raise_construct=ヒント: Onion に Python 風の `raise` 文はありません — 例外は `throw new` で投げてください — `raise {0}({1})` ではなく `throw new {0}({1})` と書いてください。
 error.parsing.hint.python_style_raise=ヒント: Onion に Python 風の `raise` 文はありません — 例外は `throw` で投げてください — `raise {0}` ではなく `throw {0}` と書いてください。
 error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。
+error.parsing.hint.await_not_supported=ヒント: Onion に JavaScript/Python 風の前置 `await` はありません — `Future` は後置で待ち合わせます — `await {0}` ではなく `{0}.await()` と書いてください。
 error.parsing.hint.until_not_supported=ヒント: Onion に Ruby 風の `until` ループはありません。条件を否定して `while` を使ってください: `while !condition { ... }`。
 error.parsing.hint.not_operator=ヒント: Onion に Python/Ruby 風の論理否定演算子 `not` はありません。代わりに `!` を使ってください: `if not condition { ... }` ではなく `if !condition { ... }` と書いてください。
 error.parsing.hint.python_style_colon_block=ヒント: Onion のブロックは末尾の `:` ではなく '{' ... '}' を使います — `{0} {1}:` ではなく `{0} {1} '{' ... '}'` と書いてください。

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -19,6 +19,12 @@ private[compiler] object ControlFlowSyntaxHints {
   private val LeadingRaiseConstructorCall =
     """^\s*raise\s+([A-Za-z_][\w.]*)\s*\(([^()]*)\)\s*$""".r
   private val LeadingRaiseStatement = """^\s*raise\s+(.+?)\s*$""".r
+  // A JavaScript/Python-style prefix `await expr` statement -- Onion's `Future`
+  // is awaited postfix (`f.await()`), so this reads as a bare `await` identifier
+  // followed by another expression with nothing in between, which also matches
+  // the generic missing-call-parens fallback (suggesting the nonsensical
+  // `await(...)`); keep this ahead of that case.
+  private val LeadingAwaitStatement = """^\s*await\s+(.+?)\s*$""".r
 
   def classify(found: String, sourceLine: String): Option[SyntaxHint] = {
     if (LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined) {
@@ -47,6 +53,9 @@ private[compiler] object ControlFlowSyntaxHints {
     } else if (LeadingRaiseStatement.findFirstMatchIn(sourceLine).isDefined) {
       val matched = LeadingRaiseStatement.findFirstMatchIn(sourceLine).get
       hint("error.parsing.hint.python_style_raise", matched.group(1))
+    } else if (LeadingAwaitStatement.findFirstMatchIn(sourceLine).isDefined) {
+      val matched = LeadingAwaitStatement.findFirstMatchIn(sourceLine).get
+      hint("error.parsing.hint.await_not_supported", matched.group(1).trim)
     } else {
       None
     }

--- a/src/test/scala/onion/compiler/AwaitStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/AwaitStatementHintI18nSpec.scala
@@ -1,0 +1,52 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A JavaScript/Python-style prefix `await expr` statement (`ControlFlowSyntaxHints`'s
+ * `LeadingAwaitStatement` case) must resolve through the bilingual `error.parsing.hint.*`
+ * bundle in both locales, like every other hint in that family -- see
+ * PythonStyleRaiseHintI18nSpec for the same pattern. Onion's `Future` is awaited
+ * postfix (`f.await()`), so the previous generic "missing call parens" fallback
+ * (suggesting the nonsensical `await(...)`) was actively misleading.
+ */
+class AwaitStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.await_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JavaScript/Python-style prefix `await expr` statement") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    await foo()
+        |  }
+        |  static def foo(): Int = 1
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted expression is literal source text, identical in both
+    // bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("foo().await()"), s"expected the hint's postfix `.await()` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
+++ b/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
@@ -16,7 +16,8 @@ class ControlFlowSyntaxHintsSpec extends AnyFunSpec with Matchers {
         ("until", "until done {", "error.parsing.hint.until_not_supported"),
         ("error", "} except error: Exception {", "error.parsing.hint.except_not_supported"),
         ("Exception", "raise Exception(\"boom\")", "error.parsing.hint.python_style_raise_construct"),
-        ("e", "raise e", "error.parsing.hint.python_style_raise")
+        ("e", "raise e", "error.parsing.hint.python_style_raise"),
+        ("foo", "await foo()", "error.parsing.hint.await_not_supported")
       )
 
       cases.foreach { case (found, sourceLine, expectedKey) =>
@@ -40,6 +41,15 @@ class ControlFlowSyntaxHintsSpec extends AnyFunSpec with Matchers {
 
       hint.messageKey shouldBe "error.parsing.hint.python_style_raise"
       hint.arguments shouldBe Seq("e")
+    }
+
+    it("captures the awaited expression from a prefix `await expr` statement") {
+      val hint = ControlFlowSyntaxHints
+        .classify(found = "foo", sourceLine = "await foo()")
+        .getOrElse(fail("expected a syntax hint"))
+
+      hint.messageKey shouldBe "error.parsing.hint.await_not_supported"
+      hint.arguments shouldBe Seq("foo()")
     }
 
     it("preserves rule order inside the family") {


### PR DESCRIPTION
## Summary
- Writing `await asyncOp()` (the JS/Python prefix idiom) parsed `await` as a bare identifier statement and fell through to the generic "a call's arguments need parentheses" fallback, misleadingly suggesting `await(...)` — there is no such function in Onion.
- Onion's `Future` is awaited postfix (`f.await()`), so the diagnostic now recognizes the `await expr` shape and points at that instead.
- Added `error.parsing.hint.await_not_supported` to both the English and Japanese bundles.

## Test plan
- [x] New TDD spec `AwaitStatementHintI18nSpec` (bundle resolution in both locales + end-to-end compiler message) — confirmed red before the fix, green after.
- [x] Added a case + a dedicated unit test to `ControlFlowSyntaxHintsSpec` for the new classifier rule.
- [x] Full suite green: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 4446 succeeded, 0 failed, 1 canceled (pre-existing, environment-conditional distribution smoke test, unrelated to this change).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NPWhynWHs3z4dFjBNXvWo)_