### PR TITLE
Add parser hint for Java/JS/PHP-style `instanceof` type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Java/JavaScript/PHP-style `expr instanceof Type` check.**
+  Writing `if x instanceof String { ... }` — the runtime type-check idiom from
+  Java, JavaScript, and PHP — parsed `x` as the whole `if` condition and then
+  hit the generic "a block is expected here" fallback on `instanceof`, which
+  pointed nowhere near the actual mistake. The diagnostic now recognizes the
+  `expr instanceof Type` shape and points at Onion's `is` type-check operator
+  (`x is String`, also usable as `case x is Type:` in `select`).
+
 - **Parser hint for a JavaScript/Python-style prefix `await expr` statement.**
   Writing `await asyncOp()` — the idiom every JavaScript/Python programmer
   reaches for to wait on an async result — parsed `await` as a bare identifier

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -161,6 +161,7 @@ error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-sty
 error.parsing.hint.dollar_sigil=Hint: Onion has no `$` sigil for variables or string interpolation — interpolate inside a string with `#{expr}` instead — write `"Hello, #{name}!"`, not `$"Hello, {name}!"` or `$name`.
 error.parsing.hint.missing_call_parens=Hint: a call''s arguments need parentheses — write `{0}(...)` instead of `{0} ...`. (Two separate statements go on separate lines, or joined with `;`.)
 error.parsing.hint.java_style_final_local=Hint: Onion has no Java-style `final` local variable — every `val` is already immutable, so declare it with `val` instead — write `val {1}: {0} = ...`, not `final {0} {1} = ...`.
+error.parsing.hint.instanceof_not_supported=Hint: Onion has no Java-style `instanceof` operator — use the `is` type-check operator instead (also usable as `case x is Type:` in `select`) — write `{0} is {1}`, not `{0} instanceof {1}`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -161,6 +161,7 @@ error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく�
 error.parsing.hint.dollar_sigil=ヒント: Onion に変数や文字列補間のための `$` シジルはありません — 文字列内での補間は `#{expr}` を使ってください — `$"Hello, {name}!"` や `$name` ではなく `"Hello, #{name}!"` と書いてください。
 error.parsing.hint.missing_call_parens=ヒント: 呼び出しの引数にはかっこが必要です — `{0} ...` ではなく `{0}(...)` と書いてください。（2つの別々の文のつもりなら、改行するか `;` で区切ってください。）
 error.parsing.hint.java_style_final_local=ヒント: Onion に Java 風の `final` ローカル変数はありません — `val` はもともと不変なので、代わりに `val` で宣言してください — `final {0} {1} = ...` ではなく `val {1}: {0} = ...` と書いてください。
+error.parsing.hint.instanceof_not_supported=ヒント: Onion に Java 風の `instanceof` 演算子はありません — 代わりに型検査演算子 `is` を使ってください（`select` の中では `case x is Type:` としても使えます）— `{0} instanceof {1}` ではなく `{0} is {1}` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -108,6 +108,8 @@ private[compiler] object SyntaxHintClassifier {
     """:\s*([A-Za-z_][\w.\[\]]*)\s*\|\s*null\b""".r
   private val CStyleCast =
     """\(\s*([A-Z][\w.\[\]]*\??)\s*\)\s*[A-Za-z_$(]""".r
+  private val InstanceofExpression =
+    """\b([A-Za-z_][\w.]*(?:\([^()]*\))?)\s+instanceof\s+([A-Za-z_][\w.\[\]]*)""".r
   private val PythonStyleReturnArrow =
     """\bdef\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*\([^()]*\)\s*->\s*([A-Za-z_][\w.\[\]?]*)""".r
   private val DanglingReturnTypeColon =
@@ -129,6 +131,9 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.js_style_const")
       case "$" =>
         hint("error.parsing.hint.dollar_sigil")
+      case "instanceof" if InstanceofExpression.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = InstanceofExpression.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.instanceof_not_supported", matched.group(1), matched.group(2))
       case _ if JavaStyleImplements.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleImplements.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_implements", matched.group(1), matched.group(2).trim)

--- a/src/test/scala/onion/compiler/InstanceofHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/InstanceofHintI18nSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A Java/JavaScript/PHP-style `expr instanceof Type` runtime type check
+ * (`SyntaxHintClassifier`'s `InstanceofExpression` case) must resolve through
+ * the bilingual `error.parsing.hint.*` bundle in both locales, like every
+ * other hint in that family -- see PythonStyleRaiseHintI18nSpec for the same
+ * pattern. Onion's type check is the `is` operator (`expr is Type`, also
+ * usable as `case x is Type:` in `select`), so `instanceof` previously fell
+ * through to the generic "a block is expected here" fallback, which pointed
+ * nowhere near the actual mistake.
+ */
+class InstanceofHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.instanceof_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java-style `expr instanceof Type` condition") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val x: Object = "hi"
+        |    if x instanceof String {
+        |      IO::println("yes")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted expression/type are literal source text, identical in
+    // both bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("x is String"), s"expected the hint's `is` rewrite, got: $msgs")
+    assert(msgs.contains("x instanceof String"), s"expected the hint to echo the mistake, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -199,6 +199,37 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("List[String]")
     }
 
+    it("recognizes a Java-style `instanceof` type check") {
+      val hint = classify(
+        found = "instanceof",
+        expected = "\"{\"",
+        sourceLine = "    if x instanceof String {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.instanceof_not_supported"
+      hint.arguments shouldBe Seq("x", "String")
+    }
+
+    it("recognizes an `instanceof` check on a method call result") {
+      val hint = classify(
+        found = "instanceof",
+        expected = "\"{\"",
+        sourceLine = "    if get() instanceof Foo {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.instanceof_not_supported"
+      hint.arguments shouldBe Seq("get()", "Foo")
+    }
+
+    it("does not flag `instanceof` used as an ordinary identifier") {
+      SyntaxHintClassifier.classify(
+        found = "instanceof",
+        expected = "\"=\"",
+        context = "",
+        sourceLine = "val instanceof: Int"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.instanceof_not_supported")
+    }
+
     it("recognizes a Python/Rust/TypeScript-style `-> Type` return type arrow") {
       val hint = classify(
         found = "->",


### PR DESCRIPTION
## Summary
- Writing `if x instanceof String { ... }` — the runtime type-check idiom from Java, JavaScript, and PHP — parsed `x` as the whole `if` condition and then hit the generic "a block is expected here" fallback on `instanceof`, which pointed nowhere near the actual mistake.
- The diagnostic now recognizes the `expr instanceof Type` shape and points at Onion's `is` type-check operator (`x is String`, also usable as `case x is Type:` in `select`).
- Bilingual (en/ja) hint message added, following the existing `error.parsing.hint.*` family conventions.

## Test plan
- [x] New `InstanceofHintI18nSpec` (bundle resolution in both locales + end-to-end compile reproduction)
- [x] New `SyntaxHintClassifierSpec` cases (identifier form, method-call-result form, and a negative case ensuring `instanceof` used as an ordinary identifier is not misflagged)
- [x] Full suite green in English locale: `sbt -Duser.language=en testFull` → 4452 succeeded, 0 failed, 1 canceled (pre-existing environment-dependent distribution smoke test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gd2naJxVAmyLLu3V4o2FrW)_