### PR TITLE
Add parser hints for Java-style generic constructor calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `object Name { ... }` shape and points at Onion's actual equivalent: a
   class with only static members.
 
+- **Parser hints for Java-style generic constructor calls.** Writing
+  `new ArrayList<String>()` or the empty-diamond `new ArrayList<>()` parsed
+  `<` as a valid less-than operator, so `new ArrayList` and `<String>` were
+  read as a comparison chain and the real syntax error only surfaced later
+  in the line (typically at the trailing `(` or `)`), with no diagnostic
+  connecting it back to the angle brackets. The two shapes now get a
+  dedicated hint: the empty diamond points at dropping it entirely (type
+  arguments are inferred from the constructor's arguments), and an explicit
+  type argument points at Onion's square-bracket generics syntax.
+
 ## [0.27.0] - 2026-08-30
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -139,6 +139,8 @@ error.parsing.hint.missing_parameter_type=Hint: every parameter needs an explici
 error.parsing.hint.java_style_field=Hint: a field or local variable is declared with `val`/`var` before the name, not with the type before it — write `var {1}: {0}` (or `val {1}: {0}` if it never changes), not `{0} {1}`.
 error.parsing.hint.case_type_colon=Hint: a `select` type pattern uses `is`, not `:` — write `case s is String:`, not `case s: String:`.
 error.parsing.hint.java_style_generics=Hint: generics use square brackets, not angle brackets — write `{0}[{1}]`, not `{0}<{1}>`.
+error.parsing.hint.java_style_diamond_operator=Hint: Onion has no Java-style diamond operator `<>` — a constructor''s type arguments are inferred from its arguments (or the expected type), so just drop it: write `new {0}(...)`, not `new {0}<>(...)`.
+error.parsing.hint.java_style_generic_constructor_call=Hint: generics use square brackets, not angle brackets, in a constructor call too — write `new {0}[{1}](...)`, not `new {0}<{1}>(...)`.
 error.parsing.hint.primitive_dot_static=Hint: `{0}` names a type, not a value — static members are accessed with `::`, not `.` — write `{0}::{1}`, not `{0}.{1}`.
 error.parsing.hint.java_style_record_body=Hint: a record''s components are declared in parentheses after its name, not in a brace body — write `record {0}(x: Int, y: Int)`, not `record {0} '{' x; y '}'`. A record may still take a `'{' ... '}'` body after the parentheses, for extra methods.
 error.parsing.hint.java_style_try_resource=Hint: a try-with-resources declaration starts with `val` before the name, not with the type before it, and is always `val` (never `var`) — write `try (val {1}: {0} = ...)`, not `try ({0} {1} = ...)`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -139,6 +139,8 @@ error.parsing.hint.missing_parameter_type=ヒント: すべてのパラメータ
 error.parsing.hint.java_style_field=ヒント: フィールドやローカル変数は名前の前に型ではなく `val`/`var` を書いて宣言します — `{0} {1}` ではなく `var {1}: {0}`（値が変わらないなら `val {1}: {0}`）と書いてください。
 error.parsing.hint.case_type_colon=ヒント: `select` の型パターンは `:` ではなく `is` を使います — `case s: String:` ではなく `case s is String:` と書いてください。
 error.parsing.hint.java_style_generics=ヒント: ジェネリクスは山かっこではなく角かっこを使います — `{0}<{1}>` ではなく `{0}[{1}]` と書いてください。
+error.parsing.hint.java_style_diamond_operator=ヒント: Onion に Java 風のダイヤモンド演算子 `<>` はありません — コンストラクタの型引数は引数（または期待される型）から推論されるので、単に省略してください — `new {0}<>(...)` ではなく `new {0}(...)` と書いてください。
+error.parsing.hint.java_style_generic_constructor_call=ヒント: コンストラクタ呼び出しでも、ジェネリクスは山かっこではなく角かっこを使います — `new {0}<{1}>(...)` ではなく `new {0}[{1}](...)` と書いてください。
 error.parsing.hint.primitive_dot_static=ヒント: `{0}` は値ではなく型の名前です — 静的メンバーには `.` ではなく `::` を使います — `{0}.{1}` ではなく `{0}::{1}` と書いてください。
 error.parsing.hint.java_style_record_body=ヒント: レコードのコンポーネントは波かっこの本体ではなく、名前の直後の丸かっこで宣言します — `record {0} '{' x; y '}'` ではなく `record {0}(x: Int, y: Int)` と書いてください。丸かっこの後ろに追加のメソッド用の `'{' ... '}'` 本体を続けることもできます。
 error.parsing.hint.java_style_try_resource=ヒント: try-with-resources の宣言は名前の前に型ではなく `val` を書きます。常に `val`（`var` は不可）です — `try ({0} {1} = ...)` ではなく `try (val {1}: {0} = ...)` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -85,6 +85,16 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*case\s+[a-z_]\w*\s*:\s*[A-Z][\w.\[\]]*\??\s*:""".r
   private val JavaStyleGenericAngleBrackets =
     """\b([A-Z][A-Za-z0-9_]*)<([A-Za-z_][\w\s,\[\]?]*)>""".r
+  // A Java-style generic constructor call, e.g. `new ArrayList<String>()` or the
+  // empty-diamond `new ArrayList<>()`. Unlike JavaStyleGenericAngleBrackets above
+  // (a type-annotation position, where `<` is never valid and is itself the found
+  // token), `<` here parses as a valid less-than operator: `new ArrayList` reads as
+  // a value, then `<String>` as a comparison chain, so the real syntax error only
+  // surfaces later in the line (typically at the trailing `(` or `)`) with no token
+  // connecting it back to the angle brackets. Match on the source line directly,
+  // independent of the found token, to still catch it.
+  private val JavaStyleGenericConstructorCall =
+    """\bnew\s+([A-Za-z_][\w.]*)\s*<\s*([^<>]*?)\s*>\s*\(""".r
   private val PrimitiveTypeNames =
     Set("Int", "Long", "Double", "Float", "Boolean", "Byte", "Short", "Char")
   private val DotAfterPrimitiveTypeName = """\A[A-Za-z]+\s*\.\s*([A-Za-z_]\w*)""".r
@@ -147,6 +157,14 @@ private[compiler] object SyntaxHintClassifier {
       case "<" if JavaStyleGenericAngleBrackets.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleGenericAngleBrackets.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_generics", matched.group(1), matched.group(2).trim)
+      case _ if JavaStyleGenericConstructorCall.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = JavaStyleGenericConstructorCall.findFirstMatchIn(sourceLine).get
+        val className = matched.group(1)
+        val typeArgs = matched.group(2).trim
+        if (typeArgs.isEmpty)
+          hint("error.parsing.hint.java_style_diamond_operator", className)
+        else
+          hint("error.parsing.hint.java_style_generic_constructor_call", className, typeArgs)
       // A Python-style `class Foo:` header also lands here (the parser wants
       // `extends`/`{` right where the trailing `:` sits), but it's a missing-brace
       // mistake, not the old colon-extends syntax -- keep it ahead of that case.

--- a/src/test/scala/onion/compiler/JavaStyleGenericConstructorHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleGenericConstructorHintI18nSpec.scala
@@ -1,0 +1,83 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java-style generic-constructor-call hints (`SyntaxHintClassifier`'s
+ * `JavaStyleGenericConstructorCall` case, covering both the empty diamond `<>`
+ * and an explicit `<Type>` argument list) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in that
+ * match -- see ObjectDeclarationHintI18nSpec for the same pattern. Unlike the
+ * existing `java_style_generics` hint (a type-annotation position, e.g.
+ * `var xs: List<String>`), these fire for `new Foo<...>(...)`, where `<` parses
+ * as a valid operator and the real syntax error only surfaces later in the line.
+ */
+class JavaStyleGenericConstructorHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val diamondKey = "error.parsing.hint.java_style_diamond_operator"
+  private val genericCallKey = "error.parsing.hint.java_style_generic_constructor_call"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the diamond-operator hint in the English bundle") {
+    assert(en.getString(diamondKey).contains("Hint:"))
+  }
+
+  it("resolves the diamond-operator hint in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(diamondKey)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(diamondKey))
+  }
+
+  it("resolves the generic-constructor-call hint in the English bundle") {
+    assert(en.getString(genericCallKey).contains("Hint:"))
+  }
+
+  it("resolves the generic-constructor-call hint in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(genericCallKey)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(genericCallKey))
+  }
+
+  it("fires for a Java-style empty-diamond constructor call") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |import { java.util.* }
+        |class Main {
+        |  static def main(args: String[]): void {
+        |    val list = new ArrayList<>()
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted class name is literal source text, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("new ArrayList(...)"), s"expected the hint's `new ArrayList(...)` example, got: $msgs")
+  }
+
+  it("fires for a Java-style generic constructor call with an explicit type argument") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |import { java.util.* }
+        |class Main {
+        |  static def main(args: String[]): void {
+        |    val list = new ArrayList<String>()
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("ArrayList[String]"), s"expected the hint's `ArrayList[String]` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -595,6 +595,39 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("Foo")
     }
 
+    it("recognizes a Java-style diamond-operator constructor call") {
+      val hint = classify(
+        found = "<",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "val list = new ArrayList<>()"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.java_style_diamond_operator"
+      hint.arguments shouldBe Seq("ArrayList")
+    }
+
+    it("recognizes a Java-style generic constructor call with explicit type arguments") {
+      val hint = classify(
+        found = ")",
+        expected = "\"Boolean\", \"break\", \"Byte\"",
+        sourceLine = "val list = new ArrayList<String>()"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.java_style_generic_constructor_call"
+      hint.arguments shouldBe Seq("ArrayList", "String")
+    }
+
+    it("recognizes a Java-style generic constructor call with multiple type arguments") {
+      val hint = classify(
+        found = ")",
+        expected = "\"Boolean\", \"break\", \"Byte\"",
+        sourceLine = "val m = new HashMap<String, Int>()"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.java_style_generic_constructor_call"
+      hint.arguments shouldBe Seq("HashMap", "String, Int")
+    }
+
     it("recognizes a Java-style `final` local variable declaration") {
       val hint = classify(
         found = "final",


### PR DESCRIPTION
## Summary
- `new ArrayList<String>()` and the empty-diamond `new ArrayList<>()` are common Java constructor-call idioms with no Onion equivalent (generics use square brackets, and constructor type arguments are inferred). Previously these produced a confusing, unrelated syntax error: `<` parses as a valid less-than operator, so `new ArrayList` and `<String>` get read as a comparison chain, and the real error only surfaces later in the line (typically at the trailing `(` or `)`), with nothing connecting it back to the angle brackets.
- The existing `java_style_generics` hint only covers the type-annotation position (e.g. `var xs: List<String>`), where `<` is itself the unexpected token — it doesn't fire here.
- Adds two new dedicated hints in `SyntaxHintClassifier`, matched on the source line directly (independent of the actual found token, since it varies): the empty diamond suggests dropping the brackets entirely (`new ArrayList(...)`, since type arguments are inferred from the constructor's arguments or the expected type), and an explicit type argument points at Onion's square-bracket syntax (`new ArrayList[String](...)`).
- Bilingual (en/ja) messages added to both resource bundles.

## Test plan
- [x] Added failing tests first (direct classifier tests in `SyntaxHintClassifierSpec`, plus end-to-end bilingual `JavaStyleGenericConstructorHintI18nSpec`), confirmed red, then implemented and confirmed green.
- [x] `sbt shutdown && sbt -Duser.language=en testFull` — 4465 passed, 0 failed, 1 canceled (expected: distribution smoke test gated behind `-Donion.dist.path`).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Xgp3WwqcGsMx1b91rZvH)_