### PR TITLE
Add parser hint for JavaScript/Python-style `yield` generator statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments are inferred from the constructor's arguments), and an explicit
   type argument points at Onion's square-bracket generics syntax.
 
+- **Parser hint for a JavaScript/Python-style `yield expr` generator statement.**
+  Writing `yield value` — the generator/coroutine idiom from JavaScript and
+  Python — parsed `yield` as a bare identifier statement and hit the generic
+  "a call's arguments need parentheses" fallback (suggesting the nonsensical
+  `yield(...)`), since the parser saw `yield` directly followed by another
+  expression with nothing in between. The diagnostic now recognizes the
+  `yield expr` shape and explains that Onion has no generator/coroutine
+  construct — a function returns one value, so build and return a `List` of
+  the results instead.
+
 ## [0.27.0] - 2026-08-30
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -120,6 +120,7 @@ error.parsing.hint.python_style_raise_construct=Hint: Onion has no Python-style 
 error.parsing.hint.python_style_raise=Hint: Onion has no Python-style `raise` statement — throw an exception with `throw` instead — write `throw {0}`, not `raise {0}`.
 error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.
 error.parsing.hint.await_not_supported=Hint: Onion has no JavaScript/Python-style prefix `await` — a `Future` is awaited postfix instead — write `{0}.await()`, not `await {0}`.
+error.parsing.hint.yield_not_supported=Hint: Onion has no JavaScript/Python-style `yield` for generators or coroutines. A function returns one value, so build and return a `List` of the results instead.
 error.parsing.hint.until_not_supported=Hint: Onion has no Ruby-style `until` loop. Negate the condition and use `while` instead: `while !condition { ... }`.
 error.parsing.hint.not_operator=Hint: Onion has no Python/Ruby-style `not` operator for boolean negation. Use `!` instead: `if !condition { ... }`, not `if not condition { ... }`.
 error.parsing.hint.python_style_colon_block=Hint: Onion blocks use '{' ... '}', not a trailing `:` — write `{0} {1} '{' ... '}'`, not `{0} {1}:`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -120,6 +120,7 @@ error.parsing.hint.python_style_raise_construct=ヒント: Onion に Python 風�
 error.parsing.hint.python_style_raise=ヒント: Onion に Python 風の `raise` 文はありません — 例外は `throw` で投げてください — `raise {0}` ではなく `throw {0}` と書いてください。
 error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。
 error.parsing.hint.await_not_supported=ヒント: Onion に JavaScript/Python 風の前置 `await` はありません — `Future` は後置で待ち合わせます — `await {0}` ではなく `{0}.await()` と書いてください。
+error.parsing.hint.yield_not_supported=ヒント: Onion にジェネレータやコルーチン用の JavaScript/Python 風 `yield` はありません。関数は値を1つ返すので、代わりに結果をまとめた `List` を構築して返してください。
 error.parsing.hint.until_not_supported=ヒント: Onion に Ruby 風の `until` ループはありません。条件を否定して `while` を使ってください: `while !condition { ... }`。
 error.parsing.hint.not_operator=ヒント: Onion に Python/Ruby 風の論理否定演算子 `not` はありません。代わりに `!` を使ってください: `if not condition { ... }` ではなく `if !condition { ... }` と書いてください。
 error.parsing.hint.python_style_colon_block=ヒント: Onion のブロックは末尾の `:` ではなく '{' ... '}' を使います — `{0} {1}:` ではなく `{0} {1} '{' ... '}'` と書いてください。

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -25,6 +25,12 @@ private[compiler] object ControlFlowSyntaxHints {
   // the generic missing-call-parens fallback (suggesting the nonsensical
   // `await(...)`); keep this ahead of that case.
   private val LeadingAwaitStatement = """^\s*await\s+(.+?)\s*$""".r
+  // A JavaScript/Python-style generator `yield expr` statement -- Onion has no
+  // generator/coroutine construct, so this reads as a bare `yield` identifier
+  // followed by another expression with nothing in between, which also matches
+  // the generic missing-call-parens fallback (suggesting the nonsensical
+  // `yield(...)`); keep this ahead of that case.
+  private val LeadingYieldStatement = """^\s*yield\s+(.+?)\s*$""".r
 
   def classify(found: String, sourceLine: String): Option[SyntaxHint] = {
     if (LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined) {
@@ -56,6 +62,8 @@ private[compiler] object ControlFlowSyntaxHints {
     } else if (LeadingAwaitStatement.findFirstMatchIn(sourceLine).isDefined) {
       val matched = LeadingAwaitStatement.findFirstMatchIn(sourceLine).get
       hint("error.parsing.hint.await_not_supported", matched.group(1).trim)
+    } else if (LeadingYieldStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.yield_not_supported")
     } else {
       None
     }

--- a/src/test/scala/onion/compiler/YieldStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/YieldStatementHintI18nSpec.scala
@@ -1,0 +1,52 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A JavaScript/Python-style prefix `yield expr` statement (`ControlFlowSyntaxHints`'s
+ * `LeadingYieldStatement` case) must resolve through the bilingual `error.parsing.hint.*`
+ * bundle in both locales, like every other hint in that family -- see
+ * AwaitStatementHintI18nSpec for the same pattern. Onion has no generator/coroutine
+ * `yield`, so the previous generic "missing call parens" fallback (suggesting the
+ * nonsensical `yield(...)`) was actively misleading.
+ */
+class YieldStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.yield_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JavaScript/Python-style prefix `yield expr` statement") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    yield 5
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint text is identical in both bundles' relevant markers, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("List"), s"expected the hint's `List` suggestion, got: $msgs")
+    assert(!msgs.contains("yield(...)"), s"the misleading missing-call-parens fallback should not fire, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- `yield value` (the generator/coroutine idiom from JavaScript and Python) parsed `yield` as a bare identifier statement and fell through to the generic "a call's arguments need parentheses" fallback, suggesting the nonsensical `yield(...)`.
- The diagnostic now recognizes the `yield expr` shape (`ControlFlowSyntaxHints.LeadingYieldStatement`, matching the same pattern as the existing `await`/`raise` prefix-statement hints) and explains that Onion has no generator/coroutine construct — a function returns one value, so build and return a `List` of the results instead.
- Added bilingual (en/ja) hint text in `errorMessage.properties`/`errorMessage_ja.properties`.
- Added `YieldStatementHintI18nSpec` (TDD: written first, confirmed red against the old fallback, then green after the fix), asserting on the resolved message content rather than locale-specific text.
- Recorded the change in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] New spec `YieldStatementHintI18nSpec` passes (`sbt "testOnly onion.compiler.YieldStatementHintI18nSpec"`)
- [x] Full suite green in English locale: `sbt shutdown && SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 4468 succeeded, 0 failed, 1 cancelled (distribution smoke test, expected)


---
_Generated by [Claude Code](https://claude.ai/code/session_015LZgE4EgRZXYK2vbALgPwE)_