### PR TITLE
Add I18n end-to-end spec for the switch-statement parser hint

### DIFF
--- a/src/test/scala/onion/compiler/SwitchStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/SwitchStatementHintI18nSpec.scala
@@ -1,0 +1,55 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A Java/C/JavaScript-style `switch` statement (`ControlFlowSyntaxHints`'s
+ * `LeadingSwitchStatement` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that family -- see YieldStatementHintI18nSpec for the same pattern. Onion
+ * has no `switch` statement; `select` covers the same ground, so a bare
+ * `switch value { ... }` previously had no dedicated diagnostic pointing at it.
+ */
+class SwitchStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.switch_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java/C/JavaScript-style `switch` statement") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val x: Int = 1
+        |    switch x {
+        |      case 1:
+        |        IO::println("one")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint text is identical in both bundles' relevant markers, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("select"), s"expected the hint's `select` suggestion, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- `SyntaxHintClassifierSpec`/`ControlFlowSyntaxHintsSpec` already cover the regex-level classification for a Java/C/JavaScript-style `switch` statement, but unlike most other hints in the `error.parsing.hint.*` family (see `InstanceofHintI18nSpec`, `YieldStatementHintI18nSpec`, etc.), it had no end-to-end spec asserting the `switch_not_supported` message key resolves to real, distinct text in both locale bundles.
- Adds `SwitchStatementHintI18nSpec`, mirroring the existing pattern: resolves in English (`Hint:` marker), resolves in Japanese with actual Japanese text (no English leak, distinct from the English string), and fires end-to-end through the compiler for a `switch value { case 1: ... }` snippet, asserting the `select` suggestion appears in the message.

Test-only change; no behavior or public API changes.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4471 succeeded, 0 failed, 1 canceled (pre-existing, opt-in `ProjectDistributionSpec` smoke test gated behind `-Donion.dist.path`, unrelated to this change)
- [x] `sbt -Duser.language=ja "testOnly onion.compiler.SwitchStatementHintI18nSpec"` — 3/3 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01UfaFMJmhc7Trm6aR2o8obz)_