### PR TITLE
Add parser hint for JavaScript/Python-style `typeof` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a JavaScript/Python-style `typeof` operator.** Writing
+  `if typeof x == "string" { ... }` — the runtime type-check idiom from
+  JavaScript and Python — parsed `typeof` as a bare identifier expression and
+  hit the generic "a block is expected here" fallback on the operand that
+  followed it, which pointed nowhere near the actual mistake. The diagnostic
+  now recognizes the `typeof expr` shape in an `if`/`while`/`else if`
+  condition and points at Onion's actual type check, the `is` operator
+  (`expr is Type`).
+
 - **Parser hint for a Kotlin/Scala-style singleton `object` declaration.**
   Writing `object Registry { ... }` — the singleton idiom from Kotlin and
   Scala — parsed `object` as a bare identifier statement and hit the generic

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -123,6 +123,7 @@ error.parsing.hint.await_not_supported=Hint: Onion has no JavaScript/Python-styl
 error.parsing.hint.yield_not_supported=Hint: Onion has no JavaScript/Python-style `yield` for generators or coroutines. A function returns one value, so build and return a `List` of the results instead.
 error.parsing.hint.until_not_supported=Hint: Onion has no Ruby-style `until` loop. Negate the condition and use `while` instead: `while !condition { ... }`.
 error.parsing.hint.not_operator=Hint: Onion has no Python/Ruby-style `not` operator for boolean negation. Use `!` instead: `if !condition { ... }`, not `if not condition { ... }`.
+error.parsing.hint.typeof_not_supported=Hint: Onion has no JavaScript/Python-style `typeof` operator — check a value''s type with the `is` operator instead — write `{0} is Type`, not `typeof {0}`.
 error.parsing.hint.python_style_colon_block=Hint: Onion blocks use '{' ... '}', not a trailing `:` — write `{0} {1} '{' ... '}'`, not `{0} {1}:`.
 error.parsing.hint.fun_declaration=Hint: functions and methods are declared with `def` — Onion has no `fun`/`func`/`fn`/`function` keyword. Write `def name(...): ReturnType { ... }`.
 error.parsing.hint.fun_extension_declaration=Hint: Onion has no `fun Type.method(...)` receiver syntax for extension methods — write an extension block instead: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`, not `fun {0}.{1}(...) '{' ... '}'`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -123,6 +123,7 @@ error.parsing.hint.await_not_supported=ヒント: Onion に JavaScript/Python �
 error.parsing.hint.yield_not_supported=ヒント: Onion にジェネレータやコルーチン用の JavaScript/Python 風 `yield` はありません。関数は値を1つ返すので、代わりに結果をまとめた `List` を構築して返してください。
 error.parsing.hint.until_not_supported=ヒント: Onion に Ruby 風の `until` ループはありません。条件を否定して `while` を使ってください: `while !condition { ... }`。
 error.parsing.hint.not_operator=ヒント: Onion に Python/Ruby 風の論理否定演算子 `not` はありません。代わりに `!` を使ってください: `if not condition { ... }` ではなく `if !condition { ... }` と書いてください。
+error.parsing.hint.typeof_not_supported=ヒント: Onion に JavaScript/Python 風の `typeof` 演算子はありません — 代わりに型検査演算子 `is` を使って値の型を調べてください — `typeof {0}` ではなく `{0} is Type` と書いてください。
 error.parsing.hint.python_style_colon_block=ヒント: Onion のブロックは末尾の `:` ではなく '{' ... '}' を使います — `{0} {1}:` ではなく `{0} {1} '{' ... '}'` と書いてください。
 error.parsing.hint.fun_declaration=ヒント: 関数やメソッドは `def` で宣言します — Onion に `fun`/`func`/`fn`/`function` キーワードはありません。`def name(...): ReturnType { ... }` と書いてください。
 error.parsing.hint.fun_extension_declaration=ヒント: Onion に `fun Type.method(...)` というレシーバ構文はありません — 代わりに extension ブロックを使ってください: `extension {0} '{' def {1}(...): ReturnType '{' ... '}' '}'`（`fun {0}.{1}(...) '{' ... '}'` ではなく）。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -16,6 +16,8 @@ private[compiler] object SyntaxHintClassifier {
   private val ParenthesizedTrailingLambdaHead = """\A\{\s*\(([^()]*)\)\s*->""".r
   private val OldArrowTrailingLambdaHead = """\A\{\s*(?:\(?[^(){}=]*\)?)\s*=>""".r
   private val NotOperatorCondition = """^\s*(?:if|while|else\s+if)\s+not\b""".r
+  private val TypeofCondition =
+    """^\s*(?:if|while|else\s+if)\s+typeof\s+([A-Za-z_][\w.]*)""".r
   private val PythonStyleColonBlockHeader =
     """^\s*(if|while|else\s+if)\s+(.+?):\s*$""".r
   // A Python-style `class Foo:` (or `class Foo(x: Int):`) header, where the colon
@@ -302,6 +304,9 @@ private[compiler] object SyntaxHintClassifier {
         hint("error.parsing.hint.reserved_word_identifier", word)
       case _ if expected.contains("{") && NotOperatorCondition.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.not_operator")
+      case _ if expected.contains("{") && TypeofCondition.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = TypeofCondition.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.typeof_not_supported", matched.group(1))
       // A Rust-Option-style `if let Some(x) = ...` pattern also matches the
       // plain-identifier alternative below it, so keep this ahead of the
       // generic block-expected fallback.

--- a/src/test/scala/onion/compiler/TypeofHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/TypeofHintI18nSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A JavaScript/Python-style `typeof expr` runtime type check
+ * (`SyntaxHintClassifier`'s `TypeofCondition` case) must resolve through the
+ * bilingual `error.parsing.hint.*` bundle in both locales, like every other
+ * hint in that family -- see InstanceofHintI18nSpec for the same pattern.
+ * `typeof` isn't a keyword in Onion, so it parses as a bare identifier and
+ * the parser trips on whatever follows it, never on `typeof` itself; the
+ * generic "a block is expected here" fallback pointed nowhere near the
+ * actual mistake. Onion's type check is the `is` operator (`expr is Type`).
+ */
+class TypeofHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.typeof_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JS/Python-style `typeof expr` condition") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val x: Object = "hi"
+        |    if typeof x == "string" {
+        |      IO::println("yes")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted expression is literal source text, identical in both
+    // bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("x is"), s"expected the hint's `is` rewrite, got: $msgs")
+    assert(msgs.contains("typeof x"), s"expected the hint to echo the mistake, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -478,6 +478,48 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       ) shouldBe None
     }
 
+    it("recognizes a JS/Python-style `typeof` operator in an `if` condition") {
+      val hint = classify(
+        found = "x",
+        expected = "\"{\"",
+        sourceLine = "if typeof x == \"Int\" {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.typeof_not_supported"
+      hint.arguments shouldBe Seq("x")
+    }
+
+    it("recognizes a JS/Python-style `typeof` operator in a `while` condition") {
+      val hint = classify(
+        found = "y",
+        expected = "\"{\"",
+        sourceLine = "while typeof y == \"String\" {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.typeof_not_supported"
+      hint.arguments shouldBe Seq("y")
+    }
+
+    it("recognizes a JS/Python-style `typeof` operator in an `else if` condition") {
+      val hint = classify(
+        found = "z",
+        expected = "\"{\"",
+        sourceLine = "else if typeof z == \"Boolean\" {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.typeof_not_supported"
+      hint.arguments shouldBe Seq("z")
+    }
+
+    it("does not flag `typeof` when no block is expected next") {
+      SyntaxHintClassifier.classify(
+        found = "x",
+        expected = "\";\"",
+        context = "",
+        sourceLine = "if typeof x"
+      ) shouldBe None
+    }
+
     it("recognizes a Python-style `if cond:` header with a trailing colon") {
       val hint = classify(
         found = ":",


### PR DESCRIPTION
## Summary
- Onion has no `typeof` operator; writing `if typeof x == "string" { ... }` (a common JS/Python habit) parsed `typeof` as a bare identifier expression and hit the generic "a block is expected here" fallback on whatever followed it, pointing nowhere near the actual mistake.
- Adds a dedicated `SyntaxHintClassifier` rule (`TypeofCondition`) that recognizes `typeof expr` in an `if`/`while`/`else if` condition and points at Onion's real type-check operator, `is` (`expr is Type`).
- New bilingual message key `error.parsing.hint.typeof_not_supported` (en/ja).
- Adds classifier unit tests (`SyntaxHintClassifierSpec`) and an end-to-end bilingual spec (`TypeofHintI18nSpec`), following the same pattern as the existing `instanceof`/`not`-operator hints.
- `CHANGELOG.md` `[Unreleased]` updated.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.TypeofHintI18nSpec'` — all green (87/87).
- [ ] Full suite (`SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en test`) — **could not be confirmed green**. Two independent attempts in this session reproducibly stalled/thrashed under GC pressure at the exact same point (right after `ConfigSpec`, ~4.00GB/4.00GB heap used, 90-99% time in GC) until killed after 8-10 minutes of zero progress. This reproduced on a fresh `sbt shutdown` + fresh JVM as well, so it does not look transient. It appears unrelated to this change (a 2-line regex/message addition, nowhere near `Config`/`Math` specs) and more likely an environment/heap-sizing issue, possibly aggravated by the large batch of `run/*.on` example programs added recently. Flagging this as a separate concern worth investigating (e.g. bumping `-Xmx` or splitting the suite) rather than blocking this PR indefinitely.

Opened as **draft** per this repo's release-routine policy: never merge without a confirmed-green full run. Marking ready for review once the full suite can be confirmed green (by a human, or a future automated run with more heap headroom).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBWpajGahNXv3dynMWhAiy)_