### PR TITLE
Exempt `_` from unused-variable/-parameter warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`_` no longer triggers "unused variable"/"unused parameter" warnings.**
+  `_` is the conventional "I'm intentionally discarding this binding" name
+  (Scala, Rust, Go, and Onion's own `run/` examples all use it, e.g.
+  `foreach (k, _) in map { ... }` to keep only one half of a destructured
+  pair). The unused-variable checker (W0001/W0006) previously flagged it
+  like any other name, which meant the one identifier whose entire point is
+  "unused" produced a warning — noise that trained users to ignore the
+  checker instead of acting on it. `_` is now exempt.
+
 - **Parser hint for a JavaScript/Python-style `typeof` operator.** Writing
   `if typeof x == "string" { ... }` — the runtime type-check idiom from
   JavaScript and Python — parsed `typeof` as a bare identifier expression and

--- a/src/main/scala/onion/compiler/VariableUsageTracker.scala
+++ b/src/main/scala/onion/compiler/VariableUsageTracker.scala
@@ -39,9 +39,13 @@ class VariableUsageTracker {
 
   /**
    * Returns all unused variables (declared but never used).
+   *
+   * `_` is excluded: it's the conventional "I'm intentionally discarding
+   * this binding" name (e.g. `foreach (k, _) in map`), so warning on it
+   * would flag the one name whose entire point is being unused.
    */
   def unusedVariables: Seq[VariableDecl] = {
-    declarations.values.filter(d => !usages.contains(d.name)).toSeq
+    declarations.values.filter(d => d.name != "_" && !usages.contains(d.name)).toSeq
   }
 
   /**

--- a/src/test/scala/onion/compiler/tools/UnderscoreUnusedWarningSpec.scala
+++ b/src/test/scala/onion/compiler/tools/UnderscoreUnusedWarningSpec.scala
@@ -1,0 +1,75 @@
+package onion.compiler.tools
+
+import onion.compiler.{CompilerConfig, OnionCompiler, StreamInputSource, WarningLevel}
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * `_` is the conventional "I'm intentionally discarding this binding" name
+ * (Scala, Rust, Go, and Onion's own `run/` examples all rely on it, e.g.
+ * `foreach (k, _) in map { ... }` to keep only one half of a destructured
+ * pair). W0001/W0006 (unused variable/parameter) must not fire for it --
+ * flagging the one name whose entire point is "unused" is a false positive
+ * that trains users to ignore the warning instead of acting on it.
+ */
+class UnderscoreUnusedWarningSpec extends AnyFunSpec {
+
+  private def compileWarnings(source: String) = {
+    val config = CompilerConfig(Seq("."), null, "UTF-8", "", 10, warningLevel = WarningLevel.On)
+    new OnionCompiler(config)
+      .compileDetailed(Seq(new StreamInputSource(() => new StringReader(source), "U.on")))
+  }
+
+  describe("unused-variable/parameter warnings for `_`") {
+    it("does not warn for a foreach-destructured `_` component") {
+      val result = compileWarnings(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val m = ["a": 1, "b": 2]
+          |    var total = args.length
+          |    foreach (_, v) in m { total = total + v }
+          |    return total
+          |  }
+          |}
+          |""".stripMargin)
+      assert(!result.hasErrors, s"unexpected errors: ${result.allErrors.map(_.message)}")
+      val unused = result.diagnostics.warnings.filter(w => w.category.code == "W0001" || w.category.code == "W0006")
+      assert(unused.isEmpty, s"expected no unused-variable warnings, got: ${result.diagnostics.warnings.map(_.message)}")
+    }
+
+    it("does not warn for an unused `_` parameter") {
+      val result = compileWarnings(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val f = (_: Int, y: Int) -> y
+          |    return f(1, 2) + args.length
+          |  }
+          |}
+          |""".stripMargin)
+      assert(!result.hasErrors)
+      val unused = result.diagnostics.warnings.filter(w => w.category.code == "W0001" || w.category.code == "W0006")
+      assert(unused.isEmpty, s"expected no unused-variable warnings, got: ${result.diagnostics.warnings.map(_.message)}")
+    }
+
+    it("still warns for a genuinely unused, normally-named local variable") {
+      val result = compileWarnings(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val unused = 42
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin)
+      assert(!result.hasErrors)
+      val w1 = result.diagnostics.warnings.filter(_.category.code == "W0001")
+      assert(w1.length == 1, s"expected 1 W0001, got: ${result.diagnostics.warnings.map(_.message)}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `_` is the conventional "I'm intentionally discarding this binding" name (Scala, Rust, Go, and Onion's own `run/` examples all rely on it, e.g. `foreach (k, _) in map { ... }` to keep only one half of a destructured pair).
- Found while spot-checking newer `run/` examples: `run/TimeSeries.on` triggers two spurious W0001 ("unused variable '_'") warnings for exactly this pattern.
- W0001/W0006 (unused variable/parameter) now exempt bindings named `_`; everything else is still flagged as before.

## Test plan
- [x] Added `UnderscoreUnusedWarningSpec` (TDD: confirmed red before the fix, green after) covering a foreach-destructured `_`, an unused `_` lambda parameter, and a regression check that a normal unused local still warns.
- [x] `sbt -Duser.language=en testFull` — 4484 tests, 0 failed.
- [x] `sbt -Duser.language=ja testFull` — 4484 tests, 0 failed.
- [x] Rebuilt the jar and re-ran `run/TimeSeries.on`: the two spurious warnings are gone.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_018imwJwzjUkwJ71pVUifCrc)_