### PR TITLE
Add parser hint for JS/TS/Kotlin-style `??` nullish-coalescing operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser hint for a JS/TS/Kotlin-style `??` nullish-coalescing operator.**
+  Writing `a ?? b` reused the `cond ? a : b` ternary hint on the first `?`,
+  pointing at an `if`/`else` rewrite that doesn't fit the mistake at all —
+  the actual replacement is Onion's Elvis operator, `?:`. The diagnostic now
+  recognizes the doubled `??` and points at `a ?: b` instead.
+
 ## [0.28.0] - 2026-08-30
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -105,6 +105,7 @@ error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor
 error.parsing.hint.python_style_return_arrow=Hint: a method''s return type follows a colon, not `->` — write `def {0}(...): {1} '{' ... '}'`, not `def {0}(...) -> {1} '{' ... '}'`.
 error.parsing.hint.dangling_return_type_colon=Hint: after `:` a method needs its return type on the same line -- write `def {0}(...): Void '{' ... '}'`, or drop the `:` entirely if you meant no declared return type: `def {0}(...) '{' ... '}'`.
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
+error.parsing.hint.nullish_coalescing=Hint: Onion has no `??` nullish-coalescing operator — use the Elvis operator instead — write `a ?: b`, not `a ?? b`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use `foreach x: Type in xs { ... }` (or a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`).
 error.parsing.hint.foreach_parens=Hint: `foreach` doesn''t parenthesize a single loop variable — write `foreach x: Type in xs { ... }`, not `foreach (x in xs) { ... }`. Parentheses are only for destructuring a map''s entries: `foreach (k, v) in map { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -105,6 +105,7 @@ error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラク�
 error.parsing.hint.python_style_return_arrow=ヒント: メソッドの戻り値の型は `->` ではなくコロンの後に書きます — `def {0}(...) -> {1} '{' ... '}'` ではなく `def {0}(...): {1} '{' ... '}'` と書いてください。
 error.parsing.hint.dangling_return_type_colon=ヒント: `:` の後には戻り値の型を同じ行に書く必要があります — `def {0}(...): Void '{' ... '}'` のように書くか、戻り値の型を宣言しないつもりなら `:` ごと削除してください: `def {0}(...) '{' ... '}'`。
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
+error.parsing.hint.nullish_coalescing=ヒント: Onion に `??` Null 合体演算子はありません — 代わりに Elvis 演算子を使ってください — `a ?? b` ではなく `a ?: b` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。`foreach x: Type in xs { ... }` を使ってください（または C スタイルのループ: `for var i = 0; i < xs.size(); i = i + 1 { ... }`）。
 error.parsing.hint.foreach_parens=ヒント: `foreach` は単一のループ変数を丸かっこで囲みません — `foreach (x in xs) { ... }` ではなく `foreach x: Type in xs { ... }` と書いてください。丸かっこはマップのエントリを分解する場合のみ使います: `foreach (k, v) in map { ... }`。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -129,6 +129,11 @@ private[compiler] object SyntaxHintClassifier {
   private val DanglingReturnTypeColon =
     """\bdef\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*\([^()]*\)\s*:\s*$""".r
   private val BareAdjacentTokens = """^\s*([A-Za-z_]\w*)\s+\S""".r
+  // `context` starts exactly at the found token, so a lone `?` found immediately
+  // followed by a second `?` is the two-token spelling of `??` -- distinguish it
+  // from the unrelated `cond ? a : b` ternary mistake below, which also matches
+  // on a bare `?` but has a differently-shaped fix (`?:`, not `if`/`else`).
+  private val NullishCoalescing = """\A\?\?""".r
 
   def classify(
     found: String,
@@ -284,6 +289,8 @@ private[compiler] object SyntaxHintClassifier {
       case ("\n" | "\r\n" | "\r") if DanglingReturnTypeColon.findFirstMatchIn(sourceLine).isDefined =>
         val matched = DanglingReturnTypeColon.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.dangling_return_type_colon", matched.group(1))
+      case "?" if NullishCoalescing.findFirstMatchIn(context).isDefined =>
+        hint("error.parsing.hint.nullish_coalescing")
       case "?" =>
         hint("error.parsing.hint.ternary")
       case "else" =>

--- a/src/test/scala/onion/compiler/NullishCoalescingHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/NullishCoalescingHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The `??` nullish-coalescing hint (`SyntaxHintClassifier`'s `"?"` case,
+ * ahead of the plain ternary fallback) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see TernaryHintI18nSpec for the same pattern.
+ */
+class NullishCoalescingHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.nullish_coalescing"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JS/TS/Kotlin-style `a ?? b` nullish-coalescing expression") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val a: Int? = null
+        |    val b: Int = a ?? 5
+        |    IO::println(b)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint text is identical in both bundles' example code, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("a ?: b"), s"expected the hint's Elvis-operator example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -469,6 +469,25 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("recognizes a JS/TS/Kotlin-style `??` nullish-coalescing operator") {
+      val hint = classify(
+        found = "?",
+        expected = "<EOF>, <EOL>, \";\"",
+        context = "?? 5",
+        sourceLine = "val b: Int = a ?? 5"
+      )
+      hint.messageKey shouldBe "error.parsing.hint.nullish_coalescing"
+    }
+
+    it("keeps the plain ternary hint for a lone `?` that isn't `??`") {
+      val hint = classify(
+        found = "?",
+        context = "? 1 : 2",
+        sourceLine = "val y = (x > 3) ? 1 : 0"
+      )
+      hint.messageKey shouldBe "error.parsing.hint.ternary"
+    }
+
     it("does not flag `not` when no block is expected next") {
       SyntaxHintClassifier.classify(
         found = "x",

--- a/src/test/scala/onion/compiler/tools/NullishCoalescingHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/NullishCoalescingHintSpec.scala
@@ -1,0 +1,39 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no JS/TS/Kotlin-style `??` nullish-coalescing operator. Without a
+ * dedicated hint, a lone `?` reuses the ternary-operator hint (`if`/`else`),
+ * which is the wrong fix here -- the actual replacement is the Elvis
+ * operator `?:`.
+ */
+class NullishCoalescingHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("nullish-coalescing operator") {
+    it("hints that Onion has no ?? operator, not the ternary hint") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val a: Int? = null
+          |    val b: Int = a ?? 5
+          |    return b
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("?:"), s"expected a hint mentioning the Elvis operator, got: $msgs")
+      assert(!msgs.contains("if cond"), s"expected the ternary hint not to fire instead, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Onion has no `??` nullish-coalescing operator, but a lone `?` was always classified as the `cond ? a : b` ternary mistake, so `a ?? b` produced a hint suggesting an `if`/`else` rewrite that doesn't fit the actual mistake at all.
- `SyntaxHintClassifier` now distinguishes a doubled `??` (found `"?"`, with `context` starting `??`) from a lone `?`, and points at Onion's actual replacement, the Elvis operator (`a ?: b`).
- Added the `error.parsing.hint.nullish_coalescing` message key to both the English and Japanese bundles.

## Test plan
- [x] New unit tests in `SyntaxHintClassifierSpec` (fires for `??`, still falls back to the ternary hint for a lone `?`)
- [x] New integration spec `NullishCoalescingHintSpec` (compiles a real `a ?? b` snippet and checks the hint text)
- [x] New bilingual spec `NullishCoalescingHintI18nSpec` (English/Japanese bundle resolution + end-to-end compile)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4490 succeeded, 0 failed, 1 canceled (pre-existing opt-in smoke test unrelated to this change)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4490 succeeded, 0 failed, 1 canceled (same)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Ucv8UQwWmytmJw454w2DFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ucv8UQwWmytmJw454w2DFA)_