### PR TITLE
Add parser hint for Python-style `lambda x: expr` expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the actual replacement is Onion's Elvis operator, `?:`. The diagnostic now
   recognizes the doubled `??` and points at `a ?: b` instead.
 
+- **Parser hint for a Python-style `lambda x: expr` expression.** Writing
+  `lambda x: x + 1` — since `lambda` isn't a reserved word — parsed as a
+  bare identifier reference, so the statement `val f = lambda` was accepted
+  as complete and the actual mistake surfaced as an unrelated "unexpected
+  token" error on the parameter name that followed, with no diagnostic
+  connecting it back to `lambda`. The diagnostic now recognizes the
+  `lambda params: expr` shape and points at Onion's arrow-lambda syntax
+  (`(x) -> x + 1`) instead.
+
 ## [0.28.0] - 2026-08-30
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_conforms=Hint: interfaces are named with `conforms`, not 
 error.parsing.hint.trailing_lambda_parens=Hint: a trailing lambda''s parameters aren''t parenthesized — write `'{' {0} -> ... '}'`, not `'{' ({0}) -> ... '}'`.
 error.parsing.hint.old_trailing_arrow=Hint: the arrow in a trailing lambda is `->`, the same as everywhere else — write `{ x -> ... }`. (`=>` is no longer part of the language.)
 error.parsing.hint.old_lambda_arrow=Hint: the arrow in a lambda is `->`, the same as everywhere else — write `(x) -> ...` (or `x -> ...` for a single bare parameter). (`=>` is no longer part of the language.)
+error.parsing.hint.python_style_lambda=Hint: Onion has no `lambda` keyword — write an arrow lambda instead — write `({0}) -> {1}`, not `lambda {0}: {1}`.
 error.parsing.hint.old_super_init=Hint: arguments for the superclass constructor are written on the `extends` clause — `class Sub(x: Int) extends Base(x)` — and a `def this` in such a class delegates to it with `: this(...)`. The form `def this(x) : (x)` no longer exists.
 error.parsing.hint.python_style_return_arrow=Hint: a method''s return type follows a colon, not `->` — write `def {0}(...): {1} '{' ... '}'`, not `def {0}(...) -> {1} '{' ... '}'`.
 error.parsing.hint.dangling_return_type_colon=Hint: after `:` a method needs its return type on the same line -- write `def {0}(...): Void '{' ... '}'`, or drop the `:` entirely if you meant no declared return type: `def {0}(...) '{' ... '}'`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -101,6 +101,7 @@ error.parsing.hint.old_conforms=ヒント: インターフェースは `<:` で�
 error.parsing.hint.trailing_lambda_parens=ヒント: 末尾ラムダの引数は丸かっこで囲みません — `'{' ({0}) -> ... '}'` ではなく `'{' {0} -> ... '}'` と書いてください。
 error.parsing.hint.old_trailing_arrow=ヒント: 末尾ラムダの矢印は他と同じ `->` です — `{ x -> ... }` と書いてください。（`=>` は言語から無くなりました。）
 error.parsing.hint.old_lambda_arrow=ヒント: ラムダの矢印は他と同じ `->` です — `(x) -> ...`（単一の引数なら `x -> ...`）と書いてください。（`=>` は言語から無くなりました。）
+error.parsing.hint.python_style_lambda=ヒント: Onion に `lambda` キーワードはありません — 代わりにアロー式のラムダを使ってください — `lambda {0}: {1}` ではなく `({0}) -> {1}` と書いてください。
 error.parsing.hint.old_super_init=ヒント: 親クラスのコンストラクタ引数は `extends` 節に書きます — `class Sub(x: Int) extends Base(x)`。そのクラスの `def this` は `: this(...)` でプライマリコンストラクタに委譲してください。`def this(x) : (x)` という形はもうありません。
 error.parsing.hint.python_style_return_arrow=ヒント: メソッドの戻り値の型は `->` ではなくコロンの後に書きます — `def {0}(...) -> {1} '{' ... '}'` ではなく `def {0}(...): {1} '{' ... '}'` と書いてください。
 error.parsing.hint.dangling_return_type_colon=ヒント: `:` の後には戻り値の型を同じ行に書く必要があります — `def {0}(...): Void '{' ... '}'` のように書くか、戻り値の型を宣言しないつもりなら `:` ごと削除してください: `def {0}(...) '{' ... '}'`。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -42,6 +42,15 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*from\s+([A-Za-z_][\w.]*)\s+import\s+(.+?)\s*;?\s*$""".r
   private val DataClassDeclaration =
     """^\s*data\s+class\s+([A-Za-z_]\w*)\s*\(([^)]*)\)""".r
+  // A Python-style `lambda x: expr` (or `lambda x, y: expr`) expression --
+  // `lambda` isn't a reserved word, so it parses as a bare identifier and the
+  // rest reads as a stray second statement with nothing connecting it back to
+  // the actual mistake. The `\s+` before the parameter list requires at least
+  // one space, which a real Onion identifier named `lambda` followed by its
+  // own type annotation (`lambda: Int`, no space before the colon) never has,
+  // so this can't misfire on that.
+  private val PythonStyleLambdaExpression =
+    """\blambda\s+([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*:\s*(.+?)\s*$""".r
   private val RustStyleStructDeclaration =
     """^\s*struct\s+([A-Za-z_]\w*)\b""".r
   private val KotlinScalaStyleObjectDeclaration =
@@ -203,6 +212,9 @@ private[compiler] object SyntaxHintClassifier {
           ValVarParamPrefix.replaceFirstIn(p.trim, "")
         }.mkString(", ")
         hint("error.parsing.hint.data_class_declaration", matched.group(1), params)
+      case _ if PythonStyleLambdaExpression.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = PythonStyleLambdaExpression.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.python_style_lambda", matched.group(1).trim, matched.group(2).trim)
       case _ if RustStyleStructDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         val matched = RustStyleStructDeclaration.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.struct_declaration", matched.group(1))

--- a/src/test/scala/onion/compiler/PythonStyleLambdaHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/PythonStyleLambdaHintI18nSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Python-style `lambda x: expr` hint (`SyntaxHintClassifier`'s
+ * `PythonStyleLambdaExpression` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see NullishCoalescingHintI18nSpec for the same pattern.
+ */
+class PythonStyleLambdaHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.python_style_lambda"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Python-style `lambda x: expr` expression") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val f = lambda x: x + 1
+        |    IO::println(f)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint text is identical in both bundles' example code, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("(x) -> x + 1"), s"expected the hint's arrow-lambda example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -623,6 +623,28 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.messageKey shouldBe "error.parsing.hint.old_extends"
     }
 
+    it("recognizes a Python-style `lambda x: expr` expression") {
+      val hint = classify(
+        found = "x",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "val f = lambda x: x + 1"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_lambda"
+      hint.arguments shouldBe Seq("x", "x + 1")
+    }
+
+    it("recognizes a Python-style multi-parameter `lambda x, y: expr` expression") {
+      val hint = classify(
+        found = "x",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "val f = lambda x, y: x + y"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.python_style_lambda"
+      hint.arguments shouldBe Seq("x, y", "x + y")
+    }
+
     it("recognizes a Kotlin-style `data class` declaration") {
       val hint = classify(
         found = "class",


### PR DESCRIPTION
## Summary
- `lambda` isn't a reserved word in Onion, so `val f = lambda x: x + 1` parsed `lambda` as a bare identifier reference; the actual mistake surfaced as an unrelated "unexpected token" error on the parameter name (`x`), with no diagnostic connecting it back to `lambda`.
- Recognizes the `lambda params: expr` shape (single or multiple params) in `SyntaxHintClassifier` and points at Onion's actual arrow-lambda syntax, e.g. `(x) -> x + 1` instead of `lambda x: x + 1`.
- Adds bilingual (en/ja) hint text in `errorMessage.properties` / `errorMessage_ja.properties`, following the same pattern as the other foreign-syntax hints (`typeof`, `instanceof`, `??`, etc).

## Test plan
- [x] TDD: added `SyntaxHintClassifierSpec` unit tests and a `PythonStyleLambdaHintI18nSpec` i18n integration spec; confirmed both failed before the fix and pass after.
- [x] Manually verified the improved diagnostic via `sbt runScript` on a `lambda x: x + 1` snippet.
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4495/4495 passed.
- [x] Full suite green in Japanese locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4495/4495 passed.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyGk4gHR7XQ7sEkhF1QojS)_