### PR TITLE
Add diagnostic hint for JS/TS-style backtick template literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnostic hint for a JS/TS-style backtick template literal used as a
+  string.** Writing `` `Hello ${name}` `` — Onion uses backticks only to
+  escape a reserved word into an identifier, not for template literals — made
+  the whole `${name}` text parse as the literal name of a local variable
+  reference. Since that variable is never declared, the mistake surfaced as a
+  `local variable Hello ${name} is not found` (E0002) error that repeated the
+  entire template text back at the user with nothing connecting it to the
+  actual mistake. The diagnostic now recognizes the `${...}` shape in the
+  unresolved name and points at Onion's actual string interpolation syntax,
+  `"text #{expr}"`, instead.
+
 - **Parser hint for a Swift-style bare `guard <condition> else { ... }` early
   exit.** The `guard let x = ... else { ... }` binding form already had a
   dedicated hint, but the bare form with no `let` binding fell through to

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -65,6 +65,7 @@ error.semantic.duplicateTypeAlias=duplicate type alias: {0}
 suggestion.didYouMean=did you mean: {0}
 suggestion.nullableToNonNull=hint: the value is nullable; use `!!` to assert non-null, `?:` to provide a default, or check for null first
 suggestion.fieldNotMethod=hint: {0} is a field, not a method; access it without parentheses ({0})
+suggestion.jsTemplateLiteral=hint: Onion has no JS/TS-style backtick template literals; a backtick only escapes a reserved word into an identifier. Use string interpolation instead: write "text #{expr}", not `text ${expr}`.
 error.parsing.unterminated_string=unterminated string literal: missing closing quote.
 error.suggestion.candidates=available: {0}
 error.suggestion.availableConstructors=available constructors:

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -64,6 +64,7 @@ error.semantic.duplicateTypeAlias=\u578B\u30A8\u30A4\u30EA\u30A2\u30B9\u304C\u91
 suggestion.didYouMean=\u3082\u3057\u304B\u3057\u3066: {0}
 suggestion.nullableToNonNull=\u30D2\u30F3\u30C8: \u5024\u306F null \u8A31\u5BB9\u3067\u3059; \u975E null \u3092\u65AD\u8A00\u3059\u308B\u306B\u306F `!!`\u3001\u30C7\u30D5\u30A9\u30EB\u30C8\u5024\u3092\u4E0E\u3048\u308B\u306B\u306F `?:`\u3001\u307E\u305F\u306F\u5148\u306B null \u30C1\u30A7\u30C3\u30AF\u3092\u884C\u3063\u3066\u304F\u3060\u3055\u3044\u3002
 suggestion.fieldNotMethod=ヒント: {0} はメソッドではなくフィールドです。括弧なしでアクセスしてください ({0})。
+suggestion.jsTemplateLiteral=ヒント: Onion に JS/TS 風のバッククォートテンプレートリテラルはありません。バッククォートは予約語を識別子にエスケープするだけです。文字列補間を使ってください: `text ${expr}` ではなく "text #{expr}" と書きます。
 error.parsing.unterminated_string=\u6587\u5b57\u5217\u30ea\u30c6\u30e9\u30eb\u304c\u9589\u3058\u3089\u308c\u3066\u3044\u307e\u305b\u3093\u3002\u9589\u3058\u5f15\u7528\u7b26 " \u3092\u8ffd\u52a0\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 error.suggestion.candidates=\u5019\u88dc: {0}
 error.suggestion.availableConstructors=\u5229\u7528\u53ef\u80fd\u306a\u30b3\u30f3\u30b9\u30c8\u30e9\u30af\u30bf:

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -481,6 +481,14 @@ class SemanticErrorReporter(threshold: Int) {
 
   // ========== Special case handlers ==========
 
+  // A JS/TS-style backtick template literal (`` `Hello ${name}` ``) isn't a string in
+  // Onion -- backticks only escape a reserved word into an identifier, so the whole
+  // `${...}` text becomes the literal name of a local variable reference, and the
+  // mistake surfaces as a VARIABLE_NOT_FOUND whose message repeats the entire template
+  // text back as if it were an identifier. Detect that shape in the unresolved name
+  // and point at Onion's actual interpolation syntax instead of a name-similarity guess.
+  private val TemplateLiteralInName = """\$\{.*\}""".r
+
   /**
    * Handles VARIABLE_NOT_FOUND with optional suggestions.
    */
@@ -491,7 +499,9 @@ class SemanticErrorReporter(threshold: Int) {
     // A third item is an explicit qualified-form hint (e.g. "this.x" / "C::x")
     // for a name that is actually a field; prefer it over name-similarity.
     val suggestion =
-      if (items.length > 2 && items(2) != null) {
+      if (TemplateLiteralInName.findFirstIn(name).isDefined) {
+        Some(message("suggestion.jsTemplateLiteral"))
+      } else if (items.length > 2 && items(2) != null) {
         Some(format(message("suggestion.didYouMean"), Seq(asString(items(2)))))
       } else if (items.length > 1) {
         val candidates = items(1).asInstanceOf[Array[String]]

--- a/src/test/scala/onion/compiler/JsTemplateLiteralHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JsTemplateLiteralHintI18nSpec.scala
@@ -1,0 +1,72 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A JS/TS-style backtick template literal (`` `Hello ${name}` ``) is not a string
+ * in Onion -- backticks only escape a reserved word into an identifier (see
+ * `` `class` `` in CLAUDE.md), so the whole ``${name}`` text becomes the literal
+ * name of a local variable reference. That variable is never declared, so the
+ * mistake surfaces as a VARIABLE_NOT_FOUND (E0002) whose message repeats the
+ * entire template text as if it were an identifier, with nothing connecting it
+ * back to the actual mistake. `SemanticErrorReporter.reportVariableNotFound`
+ * recognizes the `${...}` shape in the unresolved name and points at Onion's
+ * actual string interpolation syntax, `"text #{expr}"`, instead.
+ */
+class JsTemplateLiteralHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "suggestion.jsTemplateLiteral"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("#{"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("#{"), s"expected the interpolation example, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JS/TS-style backtick template literal used as a string") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val name = "world"
+        |    IO::println(`Hello ${name}`)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint's interpolation example is identical in both bundles, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("#{"), s"expected the JS-template-literal hint, got: $msgs")
+  }
+
+  it("does not fire for an ordinary unresolved variable name") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    IO::println(doesNotExist)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(!msgs.contains("#{"), s"did not expect the JS-template-literal hint, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- Backticks in Onion only escape a reserved word into an identifier (see `` `class` `` in CLAUDE.md) — they are not a string-literal delimiter. So writing a JS/TS-style template literal like `` `Hello ${name}` `` parses the whole `${name}` text as the literal *name* of a local variable reference.
- Since no variable named `Hello ${name}` exists, the mistake surfaced as a `local variable Hello ${name} is not found` (E0002) error that repeats the entire template text back at the user, with nothing connecting it to the actual mistake.
- `SemanticErrorReporter.reportVariableNotFound` now recognizes the `${...}` shape in the unresolved name and points at Onion's actual string interpolation syntax instead: `"text #{expr}"`.
- Adds bilingual (en/ja) hint text (`suggestion.jsTemplateLiteral`) in `errorMessage.properties` / `errorMessage_ja.properties`, following the same pattern as the other diagnostic hints.

## Test plan
- [x] TDD: added `JsTemplateLiteralHintI18nSpec` (bundle resolution in both locales + fires for the backtick-template mistake + does not fire for an ordinary unresolved name); confirmed red before the fix, green after.
- [x] Regression: `DiagnosticHintsSpec` and `SyntaxHintClassifierSpec` still pass (94 tests).
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4505/4505 passed (1 pre-existing environment-gated cancel, `ProjectDistributionSpec`, unrelated to this change).
- [x] Full suite green in Japanese locale: same command with `-Duser.language=ja` — 4505/4505 passed (same 1 cancel).

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBtseNZkpWsmAHQdXeiRLL)_