### PR TITLE
Add I18n end-to-end spec for the except-clause parser hint

### DIFF
--- a/src/test/scala/onion/compiler/ExceptClauseHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/ExceptClauseHintI18nSpec.scala
@@ -1,0 +1,56 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A Python-style `except` clause on a `try` block (`ControlFlowSyntaxHints`'s
+ * `ExceptClause` case) must resolve through the bilingual `error.parsing.hint.*`
+ * bundle in both locales, like every other hint in that family -- see
+ * SwitchStatementHintI18nSpec for the same pattern. Onion has no `except`
+ * clause; exceptions are caught with `catch`, so a bare
+ * `try { ... } except e: Exception { ... }` previously had no dedicated
+ * diagnostic pointing at it.
+ */
+class ExceptClauseHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.except_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Python-style `except` clause on a `try` block") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    try {
+        |      IO::println("risky")
+        |    } except e: Exception {
+        |      IO::println("caught")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint text is identical in both bundles' relevant markers, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("catch"), s"expected the hint's `catch` suggestion, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- `ControlFlowSyntaxHints`'s `except_not_supported` hint (fired for a Python-style `except` clause on a `try` block) already had locale-agnostic coverage via `ExceptClauseHintSpec`, but unlike its sibling hints (switch, yield, await, object declaration, ...) it had no end-to-end spec verifying the message resolves correctly through the bilingual `error.parsing.hint.*` bundle in both English and Japanese.
- Adds `ExceptClauseHintI18nSpec`, following the same pattern as `SwitchStatementHintI18nSpec`/`YieldStatementHintI18nSpec`: asserts the English bundle resolves with `Hint:`, the Japanese bundle resolves with real Japanese text (not a leaked English fallback), and a compile of a `try { ... } except e: Exception { ... }` snippet surfaces the `catch` suggestion.
- Test-only change; no production code touched.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4474 tests, 0 failed (1 canceled: `ProjectDistributionSpec`'s dist smoke test, which is gated behind `-Donion.dist.path` and expected to cancel without it)
- [x] Same full suite re-run with `-Duser.language=ja` — 4474 tests, 0 failed, same expected cancellation

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012HHFLiV3wJtE8HL3WF4Viw)_