### PR TITLE
Add I18n end-to-end spec for the when-statement parser hint

### DIFF
--- a/src/test/scala/onion/compiler/WhenStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/WhenStatementHintI18nSpec.scala
@@ -1,0 +1,56 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A Kotlin-style `when` expression (`ControlFlowSyntaxHints`'s
+ * `LeadingWhenStatement` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that family -- see SwitchStatementHintI18nSpec for the same pattern. Onion
+ * has no `when` expression (the keyword is reserved only as the case-guard
+ * `case p when guard:`); `select` covers the same ground, so a bare
+ * `when value { ... }` previously had no dedicated diagnostic pointing at it.
+ */
+class WhenStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.when_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Kotlin-style `when` expression") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val x: Int = 1
+        |    when x {
+        |      case 1:
+        |        IO::println("one")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint text is identical in both bundles' relevant markers, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("select"), s"expected the hint's `select` suggestion, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- The Kotlin-style `when` expression hint (`error.parsing.hint.when_not_supported`) had classifier-level coverage in `ControlFlowSyntaxHintsSpec`, but unlike its sibling hints (switch/match/elif/unless/except/...) it had no dedicated end-to-end spec verifying the bilingual bundle resolves correctly through the full compile pipeline in both locales.
- Adds `WhenStatementHintI18nSpec`, following the same pattern as `SwitchStatementHintI18nSpec`: asserts the English bundle resolves with `Hint:`, the Japanese bundle resolves with actual Japanese text (and doesn't leak English), and a real `when value { ... }` program fails to compile with a message pointing at Onion's `select` equivalent.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4517 succeeded, 0 failed, 1 canceled (opt-in distribution smoke test, expected)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4514 succeeded, 0 failed, 1 canceled (same opt-in smoke test)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01H68vM4deditYLjenNqUAtY)_