### PR TITLE
Add missing bilingual I18n specs for three untested syntax hints

### DIFF
--- a/src/test/scala/onion/compiler/DanglingElseHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/DanglingElseHintI18nSpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The dangling-`else`-with-no-matching-`if` hint (`SyntaxHintClassifier`'s
+ * bare `"else"` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see TernaryHintI18nSpec for the same pattern.
+ */
+class DanglingElseHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.dangling_else"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for an `else` with no matching preceding `if`") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |val x = 5
+        |else {
+        |  IO::println(x)
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("only `if` takes an `else`"), s"expected the hint's dangling-else explanation, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/FunDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/FunDeclarationHintI18nSpec.scala
@@ -1,0 +1,46 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The `fun`/`func`/`fn`/`function`-keyword hint (`SyntaxHintClassifier`'s
+ * `FunDeclaration` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see JsStyleLetHintI18nSpec for the same pattern.
+ */
+class FunDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.fun_declaration"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Kotlin/Rust/JS-style `fun add(x, y)` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |fun add(x: Int, y: Int): Int {
+        |  return x + y
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("def name(...): ReturnType"), s"expected the hint's `def name(...): ReturnType` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/TrailingLambdaParensHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/TrailingLambdaParensHintI18nSpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The parenthesized-trailing-lambda-parameter hint
+ * (`SyntaxHintClassifier`'s `ParenthesizedTrailingLambdaHead` case) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both
+ * locales, like every other hint in that match -- see TernaryHintI18nSpec
+ * for the same pattern.
+ */
+class TrailingLambdaParensHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.trailing_lambda_parens"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a trailing lambda whose single parameter is parenthesized") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |val xs = [1, 2, 3]
+        |val ys = xs.map { (x) -> x * 2 }
+        |IO::println(ys)
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code shown in the hint is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("x -> ..."), s"expected the hint's `{ x -> ... }` example, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- `error.parsing.hint.fun_declaration`, `error.parsing.hint.dangling_else`, and `error.parsing.hint.trailing_lambda_parens` were the only `error.parsing.hint.*` keys in `SyntaxHintClassifier`/`ControlFlowSyntaxHints` with **zero** test coverage — not exercised by `SyntaxHintClassifierSpec`'s regex-level tests, and missing the dedicated `*HintI18nSpec` that every other hint key already has.
- Add `FunDeclarationHintI18nSpec`, `DanglingElseHintI18nSpec`, and `TrailingLambdaParensHintI18nSpec`, following the established pattern used by e.g. `TernaryHintI18nSpec` / `JsStyleLetHintI18nSpec`: assert the message resolves in both the English and Japanese bundles, and assert an end-to-end compile of a small snippet that trips the hint contains the hint's literal example text.
- No production code changed — this closes a pure test-coverage gap. The hint logic already existed and worked; these specs simply pin it down.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.FunDeclarationHintI18nSpec onion.compiler.DanglingElseHintI18nSpec onion.compiler.TrailingLambdaParensHintI18nSpec'` — 9/9 passed
- [x] `sbt -Duser.language=en testFull` (full suite) — 4526 tests, 4526 succeeded, 0 failed, 1 canceled, 0 ignored


---
_Generated by [Claude Code](https://claude.ai/code/session_016jn3BshrYjF5bFbacW63eB)_