### PR TITLE
Add console.log diagnostic hint; fix locale-fragile test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnostic hint for a JS-style `console.log`/`console.error`/`console.warn`
+  call.** Onion has no `console` object, so `console` parsed as a bare
+  identifier reference and the mistake surfaced as a generic
+  `local variable console is not found` (E0002) error with nothing pointing
+  at the actual fix. The diagnostic now recognizes the exact unresolved name
+  `console` and points at `IO::println(...)` instead.
+
+- **Locale-fragile assertion in `DanglingElseHintI18nSpec`.** The spec
+  asserted that the hint's message contains the English phrase
+  `` "only `if` takes an `else`" ``, assuming it was a literal code example
+  (like `TernaryHintI18nSpec`'s `` if cond { a } else { b } ``) and therefore
+  locale invariant. It is actually translated prose, so the assertion only
+  held under an English-default JVM and failed under `-Duser.language=ja` —
+  exactly the trap this project's own testing guidance warns against. Fixed
+  to assert on the backticked `` `else` ``/`` `if` `` tokens instead, which
+  are left untranslated in both bundles.
+
 - **Diagnostic hint for a JS/TS-style backtick template literal used as a
   string.** Writing `` `Hello ${name}` `` — Onion uses backticks only to
   escape a reserved word into an identifier, not for template literals — made

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -66,6 +66,7 @@ suggestion.didYouMean=did you mean: {0}
 suggestion.nullableToNonNull=hint: the value is nullable; use `!!` to assert non-null, `?:` to provide a default, or check for null first
 suggestion.fieldNotMethod=hint: {0} is a field, not a method; access it without parentheses ({0})
 suggestion.jsTemplateLiteral=hint: Onion has no JS/TS-style backtick template literals; a backtick only escapes a reserved word into an identifier. Use string interpolation instead: write "text #{expr}", not `text ${expr}`.
+suggestion.jsConsoleLog=hint: Onion has no JS-style `console` object; there is no console.log/console.error/console.warn. Use IO::println(...) for output instead.
 error.parsing.unterminated_string=unterminated string literal: missing closing quote.
 error.suggestion.candidates=available: {0}
 error.suggestion.availableConstructors=available constructors:

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -65,6 +65,7 @@ suggestion.didYouMean=\u3082\u3057\u304B\u3057\u3066: {0}
 suggestion.nullableToNonNull=\u30D2\u30F3\u30C8: \u5024\u306F null \u8A31\u5BB9\u3067\u3059; \u975E null \u3092\u65AD\u8A00\u3059\u308B\u306B\u306F `!!`\u3001\u30C7\u30D5\u30A9\u30EB\u30C8\u5024\u3092\u4E0E\u3048\u308B\u306B\u306F `?:`\u3001\u307E\u305F\u306F\u5148\u306B null \u30C1\u30A7\u30C3\u30AF\u3092\u884C\u3063\u3066\u304F\u3060\u3055\u3044\u3002
 suggestion.fieldNotMethod=ヒント: {0} はメソッドではなくフィールドです。括弧なしでアクセスしてください ({0})。
 suggestion.jsTemplateLiteral=ヒント: Onion に JS/TS 風のバッククォートテンプレートリテラルはありません。バッククォートは予約語を識別子にエスケープするだけです。文字列補間を使ってください: `text ${expr}` ではなく "text #{expr}" と書きます。
+suggestion.jsConsoleLog=ヒント: Onion に JS 風の console オブジェクトはありません。console.log/console.error/console.warn は存在しません。出力には代わりに IO::println(...) を使ってください。
 error.parsing.unterminated_string=\u6587\u5b57\u5217\u30ea\u30c6\u30e9\u30eb\u304c\u9589\u3058\u3089\u308c\u3066\u3044\u307e\u305b\u3093\u3002\u9589\u3058\u5f15\u7528\u7b26 " \u3092\u8ffd\u52a0\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 error.suggestion.candidates=\u5019\u88dc: {0}
 error.suggestion.availableConstructors=\u5229\u7528\u53ef\u80fd\u306a\u30b3\u30f3\u30b9\u30c8\u30e9\u30af\u30bf:

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -489,6 +489,13 @@ class SemanticErrorReporter(threshold: Int) {
   // and point at Onion's actual interpolation syntax instead of a name-similarity guess.
   private val TemplateLiteralInName = """\$\{.*\}""".r
 
+  // A JS-style `console.log(...)`/`console.error(...)`/`console.warn(...)` call has no
+  // `console` object in Onion, so `console` parses as a bare identifier reference and
+  // the mistake surfaces as a VARIABLE_NOT_FOUND on exactly that name, with nothing
+  // connecting it back to Onion's actual output API. Detect that exact identifier and
+  // point at `IO::println` instead of a name-similarity guess.
+  private val ConsoleObjectName = "console"
+
   /**
    * Handles VARIABLE_NOT_FOUND with optional suggestions.
    */
@@ -501,6 +508,8 @@ class SemanticErrorReporter(threshold: Int) {
     val suggestion =
       if (TemplateLiteralInName.findFirstIn(name).isDefined) {
         Some(message("suggestion.jsTemplateLiteral"))
+      } else if (name == ConsoleObjectName) {
+        Some(message("suggestion.jsConsoleLog"))
       } else if (items.length > 2 && items(2) != null) {
         Some(format(message("suggestion.didYouMean"), Seq(asString(items(2)))))
       } else if (items.length > 1) {

--- a/src/test/scala/onion/compiler/DanglingElseHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/DanglingElseHintI18nSpec.scala
@@ -40,8 +40,12 @@ class DanglingElseHintI18nSpec extends AnyFunSpec with Diagrams {
       case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
       case _ => ""
     }
-    // The example code shown in the hint is literal, identical in both bundles,
-    // so this assertion holds regardless of the JVM's default locale.
-    assert(msgs.contains("only `if` takes an `else`"), s"expected the hint's dangling-else explanation, got: $msgs")
+    // Unlike TernaryHintI18nSpec's literal code example, this hint's explanation is
+    // ordinary prose, and the Japanese bundle translates it in full -- so an English
+    // phrase like "only `if` takes an `else`" is not actually present under a
+    // Japanese-locale JVM. The backticked tokens themselves are the one part left
+    // untranslated in both bundles, so assert on those instead.
+    assert(msgs.contains("`else`"), s"expected the hint to mention `else`, got: $msgs")
+    assert(msgs.contains("`if`"), s"expected the hint to mention `if`, got: $msgs")
   }
 }

--- a/src/test/scala/onion/compiler/JsConsoleLogHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JsConsoleLogHintI18nSpec.scala
@@ -1,0 +1,83 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A JS-style `console.log(...)`/`console.error(...)`/`console.warn(...)` call has no
+ * `console` object in Onion, so `console` parses as a bare identifier reference and the
+ * mistake surfaces as a VARIABLE_NOT_FOUND (E0002) on `console` with nothing connecting
+ * it back to Onion's actual output API. `SemanticErrorReporter.reportVariableNotFound`
+ * recognizes the exact unresolved name `console` and points at `IO::println` instead.
+ */
+class JsConsoleLogHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "suggestion.jsConsoleLog"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("IO::println"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("IO::println"), s"expected the IO::println hint, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a JS-style `console.log(...)` call") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    console.log("hi")
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("IO::println"), s"expected the console.log hint, got: $msgs")
+  }
+
+  it("fires for a JS-style `console.error(...)` call") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    console.error("boom")
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("IO::println"), s"expected the console.log hint, got: $msgs")
+  }
+
+  it("does not fire for an ordinary unresolved variable name") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    IO::println(doesNotExist)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(!msgs.contains("IO::println"), s"did not expect the console.log hint, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a diagnostic hint for a JS-style `console.log`/`console.error`/`console.warn` call: `console` has no meaning in Onion, so it previously surfaced as a bare `local variable console is not found` (E0002) with no pointer to the fix. The unresolved-name handler now recognizes the exact identifier `console` and points at `IO::println(...)`, following the same pattern as the existing JS/TS template-literal hint.
- Fixes a locale-fragile assertion in `DanglingElseHintI18nSpec` discovered while verifying this change: it asserted an English prose phrase that the Japanese bundle fully translates, so it passed under `-Duser.language=en` but failed under `-Duser.language=ja` — the exact trap this repo's own testing guidance (CLAUDE.md) warns against. Now asserts on the backticked `` `else` ``/`` `if` `` tokens, which are untranslated in both bundles.
- Adds a CHANGELOG entry for both.

## Test plan
- [x] New spec `JsConsoleLogHintI18nSpec` added via TDD (confirmed red before the fix, green after).
- [x] Full suite green under `-Duser.language=en testFull`: 4531 tests, 0 failed.
- [x] Full suite green under `-Duser.language=ja testFull`: 4531 tests, 0 failed (this also confirms the `DanglingElseHintI18nSpec` fix, which failed here before the fix).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CkN41EvgbX8TaKjJ52p4SM)_