### PR TITLE
Add missing bilingual I18n specs for five untested syntax hints

### DIFF
--- a/src/test/scala/onion/compiler/CStyleCastHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/CStyleCastHintI18nSpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The C-style prefix-cast hint (`SyntaxHintClassifier`'s `CStyleCast` case)
+ * must resolve through the bilingual `error.parsing.hint.*` bundle in both
+ * locales, like every other hint in that match -- see GuardElseHintI18nSpec
+ * for the same pattern.
+ */
+class CStyleCastHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.c_style_cast"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a C-style prefix cast `(Type) expr`") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val o: Object = "hi"
+        |    val s: String = (String) o
+        |    IO::println(s)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted type name is literal source text, identical in both
+    // bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("(expr as String)"), s"expected the hint's postfix-`as` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/DanglingReturnTypeColonHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/DanglingReturnTypeColonHintI18nSpec.scala
@@ -1,0 +1,49 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The dangling-return-type-colon hint (`SyntaxHintClassifier`'s
+ * `DanglingReturnTypeColon` case, for a `def foo():` header with no return
+ * type before the block) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in
+ * that match -- see GuardElseHintI18nSpec for the same pattern.
+ */
+class DanglingReturnTypeColonHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.dangling_return_type_colon"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a `def foo():` header with no return type before the block") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  def foo():
+        |    IO::println("hi")
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted method name is literal source text, identical in both
+    // bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("def foo(...): Void"), s"expected the hint's `: Void` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/ForEachDestructureHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/ForEachDestructureHintI18nSpec.scala
@@ -1,0 +1,54 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The destructuring `for (a, b) in coll` mistake hint (`SyntaxHintClassifier`'s
+ * `ForEachDestructureMistake`/`ForEachDestructureWrappedMistake` cases -- `for`
+ * doesn't destructure or iterate, that's `foreach`'s job) must resolve through
+ * the bilingual `error.parsing.hint.*` bundle in both locales, like every
+ * other hint in that match -- see GuardElseHintI18nSpec for the same pattern.
+ */
+class ForEachDestructureHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.for_each_destructure"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a `for (key, value) in entries { ... }` destructuring mistake") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val entries: Map = ["a": 1, "b": 2]
+        |    for (key, value) in entries {
+        |      IO::println(key)
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted variable/collection text is literal source text,
+    // identical in both bundles, so this assertion holds regardless of the
+    // JVM's default locale.
+    assert(msgs.contains("foreach (key, value) in entries"), s"expected the hint's `foreach` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/JavaStyleEnhancedForHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JavaStyleEnhancedForHintI18nSpec.scala
@@ -1,0 +1,54 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java enhanced-for hint (`SyntaxHintClassifier`'s
+ * `JavaStyleEnhancedForLoop` case, for `for (Type name : coll) { ... }`) must
+ * resolve through the bilingual `error.parsing.hint.*` bundle in both
+ * locales, like every other hint in that match -- see GuardElseHintI18nSpec
+ * for the same pattern.
+ */
+class JavaStyleEnhancedForHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.java_style_enhanced_for"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java enhanced-for loop `for (String s : list) { ... }`") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val list: List = ["a", "b"]
+        |    for (String s : list) {
+        |      IO::println(s)
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted variable/type/collection text is literal source text,
+    // identical in both bundles, so this assertion holds regardless of the
+    // JVM's default locale.
+    assert(msgs.contains("foreach s: String in list"), s"expected the hint's `foreach` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/PythonStyleReturnArrowHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/PythonStyleReturnArrowHintI18nSpec.scala
@@ -1,0 +1,43 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Python/Rust/TypeScript-style `-> Type` return-type-arrow hint
+ * (`SyntaxHintClassifier`'s `PythonStyleReturnArrow` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that match -- see GuardElseHintI18nSpec for the same
+ * pattern.
+ */
+class PythonStyleReturnArrowHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.python_style_return_arrow"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a `def bar(x: Int) -> Int { ... }` return-type arrow") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src = "def bar(x: Int) -> Int { ret x }\n"
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted method name/return type are literal source text,
+    // identical in both bundles, so this assertion holds regardless of the
+    // JVM's default locale.
+    assert(msgs.contains("def bar(...): Int"), s"expected the hint's colon-return-type example, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- `c_style_cast`, `dangling_return_type_colon`, `for_each_destructure`, `java_style_enhanced_for`, and `python_style_return_arrow` were the only remaining `error.parsing.hint.*` keys in `SyntaxHintClassifier` with no dedicated `*HintI18nSpec` — every other hint key has one covering bundle resolution in both locales plus an end-to-end compile that trips the hint.
- Add the five missing specs following the established pattern (see e.g. `GuardElseHintI18nSpec`).
- Test-only change; no user-visible behavior change, so no CHANGELOG entry (matches the precedent of PR #1015, which added three similar specs).

## Test plan
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4546 succeeded, 0 failed, 1 canceled (pre-existing, unrelated)
- [x] `SBT_OPTS="-Xmx8G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4546 succeeded, 0 failed, 1 canceled (pre-existing, unrelated)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DwRZGwWkkabb5EF3yyHhVQ)_