### PR TITLE
Add missing bilingual I18n specs for two untested SemanticErrorReporter hints

### DIFF
--- a/src/test/scala/onion/compiler/FieldNotMethodHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/FieldNotMethodHintI18nSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * `SemanticErrorReporter.reportMethodNotFound` appends a bilingual
+ * `suggestion.fieldNotMethod` hint when a call like `arr.length()` resolves to a
+ * same-named field/property instead of a method, pointing at the paren-less form.
+ * The hint carries a bilingual `errorMessage*.properties` entry but had no dedicated
+ * i18n-robustness test, unlike the parser-classifier hints covered by the other
+ * `*HintI18nSpec` files.
+ */
+class FieldNotMethodHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "suggestion.fieldNotMethod"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  private val src =
+    """
+      |class Main {
+      |public:
+      |  static def main(args: String[]): Int {
+      |    val arr: Int[] = new Int[3]
+      |    val n = arr.length()
+      |    return 0
+      |  }
+      |}
+      |""".stripMargin
+
+  private def compileErrors(): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).nonEmpty)
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text, distinct from English") {
+    val text = ja.getString(key)
+    assert(!text.toLowerCase(java.util.Locale.ROOT).contains("field"), s"leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires the hint when a paren-less field/property is called like a method") {
+    val msgs = compileErrors()
+    // "length" is the property name, identical literal text in both bundles, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("length"), s"expected the field-not-method hint naming 'length', got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/NullableToNonNullHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/NullableToNonNullHintI18nSpec.scala
@@ -1,0 +1,59 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * `SemanticErrorReporter.reportIncompatibleType` appends a bilingual
+ * `suggestion.nullableToNonNull` hint when a nullable value (`T?`) flows into a
+ * position that expects a non-null `T`, pointing at `!!`/`?:`/a null check. The hint
+ * carries a bilingual `errorMessage*.properties` entry but had no dedicated
+ * i18n-robustness test, unlike the parser-classifier hints covered by the other
+ * `*HintI18nSpec` files.
+ */
+class NullableToNonNullHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "suggestion.nullableToNonNull"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  private val src =
+    """
+      |class Main {
+      |public:
+      |  static def take(s: String?): void {
+      |    val n: String = s
+      |  }
+      |  static def main(args: String[]): Int {
+      |    take("x")
+      |    return 0
+      |  }
+      |}
+      |""".stripMargin
+
+  private def compileErrors(): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).nonEmpty)
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text, distinct from English") {
+    val text = ja.getString(key)
+    assert(!text.toLowerCase(java.util.Locale.ROOT).contains("nullable"), s"leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires the hint when a nullable value is assigned to a non-null local") {
+    val msgs = compileErrors()
+    // `!!` and `?:` are literal operator tokens, identical in both bundles, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("!!") && msgs.contains("?:"), s"expected the nullable-to-non-null hint, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary

- `suggestion.fieldNotMethod` (fired from `reportMethodNotFound` when a paren-less field/property, e.g. `arr.length()`, is called like a method) and `suggestion.nullableToNonNull` (fired from `reportIncompatibleType` when a nullable value flows into a non-null position) both have bilingual `errorMessage.properties`/`errorMessage_ja.properties` entries but had no dedicated `*HintI18nSpec`, unlike every parser-classifier hint (`SyntaxHintClassifier`/`ControlFlowSyntaxHints`), which is fully covered.
- Adds `FieldNotMethodHintI18nSpec` and `NullableToNonNullHintI18nSpec`, following the established pattern used by `ConstructorNotFoundHintI18nSpec` and PR #1017: bundle resolution in both locales (English present, Japanese present and distinct/untranslated-leak-free) plus an end-to-end compile that actually trips the hint, asserted on locale-invariant substrings (literal tokens `!!`/`?:`, and the property name `length`) rather than translated prose.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4552 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`), 0 ignored
- [x] `sbt shutdown` between locale switches (`-Duser.language=en` / `-Duser.language=ja` only takes effect on a fresh server)
- [x] Ran the two new specs individually under both `-Duser.language=en` and `-Duser.language=ja` before the full run

---
_Generated by [Claude Code](https://claude.ai/code/session_01Poa6Er8V52At31P7puuWxk)_