### PR TITLE
docs(error-codes): fix stale E0062/E0063 derive! marker docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale `E0062`/`E0063` docs in the error-code reference.** `docs/reference/error-codes.md`
+  (and its `ja` translation) described `derive!(Json)` as the only supported
+  form and claimed `Json` was the sole `E0063` marker, even though `derive!`
+  has supported `Yaml` (and `derive!(Json, Yaml)`) for a while — contradicting
+  the compiler's own `E0063` message. Docs now describe both markers, backed
+  by a regression test tying the doc to the property file so they can't
+  drift apart again.
+
 ## [0.29.0] - 2026-08-31
 
 ### Added

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -641,11 +641,12 @@ record R(a: String, b: Inner) from re"(\S+) (\S+)"   // E0061: Inner はサポ�
 対処: すべての成分をサポートされているスカラー型にとどめるか、通常の `from re"..."`
 マッチのあとで該当フィールドを手動でパースしてください。
 
-### `E0062` — `derive!(Json)` がサポートしないレコード成分型
+### `E0062` — `derive!` がサポートしないレコード成分型
 
-`derive!(Json)` は各成分を JSON のスカラー値にマッピングすることで `fromJson`/`toJson`
-を生成します。サポートされる成分型は `from re"..."` と同じ、`String`、`Int`、`Long`、
-`Double`、`Float`、`Boolean`、`Short`、`Byte` です。
+`derive!(Json)` と `derive!(Yaml)` はどちらも、各成分をスカラー値にマッピングする
+ことで `fromX`/`toX` の対を生成します。両者は同じ `toMap`/`fromMap` コアを共有して
+いるため、この制約はどちらでも同一です。サポートされる成分型は `from re"..."` と
+同じ、`String`、`Int`、`Long`、`Double`、`Float`、`Boolean`、`Short`、`Byte` です。
 
 ```onion
 record Inner(z: Int)
@@ -657,13 +658,15 @@ record Bad(a: String, b: Inner) derive!(Json)   // E0062: Inner はシリアラ�
 ### `E0063` — 未知の `derive!` マーカー
 
 `derive!(...)` が、コンパイラが実装していないフォーマット名を指定しています。
-現在サポートされているマーカーは `Json` のみです。
+サポートされているマーカーは `Json` と `Yaml` で、単独でも
+`derive!(Json, Yaml)` のように併用してもかまいません。
 
 ```onion
 record U(a: String) derive!(Bogus)   // E0063: 未知の derive! マーカー Bogus
 ```
 
-対処: `derive!(Json)` を使うか、この句を削除してください。
+対処: `derive!(Json)`、`derive!(Yaml)`、`derive!(Json, Yaml)` のいずれかを使うか、
+この句を削除してください。
 
 ### `E0086` — レコード成分名の重複
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -644,11 +644,13 @@ record R(a: String, b: Inner) from re"(\S+) (\S+)"   // E0061: Inner is not a su
 Fix: keep every component in the supported scalar set, or parse the field
 manually after a plain `from re"..."` match on the rest.
 
-### `E0062` — Record component type unsupported by `derive!(Json)`
+### `E0062` — Record component type unsupported by `derive!`
 
-`derive!(Json)` generates `fromJson`/`toJson` by mapping each component to a
-JSON scalar. Only `String`, `Int`, `Long`, `Double`, `Float`, `Boolean`,
-`Short`, and `Byte` components are supported — the same set as `from re"..."`.
+`derive!(Json)` and `derive!(Yaml)` both generate their `fromX`/`toX` pair by
+mapping each component to a scalar — they share the same `toMap`/`fromMap`
+core, so the restriction is identical for both. Only `String`, `Int`, `Long`,
+`Double`, `Float`, `Boolean`, `Short`, and `Byte` components are supported —
+the same set as `from re"..."`.
 
 ```onion
 record Inner(z: Int)
@@ -659,14 +661,15 @@ Fix: keep every component in the supported scalar set.
 
 ### `E0063` — Unknown `derive!` marker
 
-`derive!(...)` names a format the compiler does not implement. The only
-supported marker today is `Json`.
+`derive!(...)` names a format the compiler does not implement. The supported
+markers are `Json` and `Yaml` — either alone, or together as
+`derive!(Json, Yaml)`.
 
 ```onion
 record U(a: String) derive!(Bogus)   // E0063: unknown derive! marker Bogus
 ```
 
-Fix: use `derive!(Json)`, or remove the clause.
+Fix: use `derive!(Json)`, `derive!(Yaml)`, or `derive!(Json, Yaml)`, or remove the clause.
 
 ### `E0086` — Duplicate record component
 

--- a/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
@@ -42,4 +42,50 @@ class ErrorCodeDocCoverageSpec extends AnyFunSpec {
   it("the Japanese reference mentions every declared code, and no retired one") {
     check("docs/ja/reference/error-codes.md")
   }
+
+  // `derive!` has supported both `Json` and `Yaml` markers for a while (see
+  // `error.semantic.recordDeriveUnknownMarker`), but the E0063 prose in
+  // error-codes.md still claimed `Json` was the only one — actively
+  // contradicting the compiler's own error message. Ties the doc's marker
+  // list to the property file so the two can't drift apart silently again.
+
+  private def section(doc: String, code: String): String = {
+    val start = doc.indexOf(s"`$code`")
+    assert(start >= 0, s"doc does not mention $code")
+    val next = doc.indexOf("\n### `E", start + 1)
+    if (next >= 0) doc.substring(start, next) else doc.substring(start)
+  }
+
+  private def supportedMarkers(propsPath: String): Set[String] = {
+    val props = read(propsPath)
+    val line = props.linesIterator
+      .find(_.startsWith("error.semantic.recordDeriveUnknownMarker="))
+      .getOrElse(fail(s"recordDeriveUnknownMarker key not found in $propsPath"))
+    val tail = """(?:Supported markers|サポートしているマーカー): (.*)$""".r
+      .findFirstMatchIn(line)
+      .map(_.group(1))
+      .getOrElse(fail(s"unexpected recordDeriveUnknownMarker format in $propsPath: $line"))
+    tail
+      .replaceAll("[。.]\\s*$", "")
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .toSet
+  }
+
+  private def checkDeriveMarkers(docPath: String, propsPath: String): Unit = {
+    val markers = supportedMarkers(propsPath)
+    assert(markers.nonEmpty, s"no derive! markers parsed from $propsPath — the scan has rotted")
+    val e0063 = section(read(docPath), "E0063")
+    val missing = markers.filterNot(e0063.contains).toSeq.sorted
+    assert(missing.isEmpty, s"$docPath E0063 section does not mention marker(s): ${missing.mkString(", ")}")
+  }
+
+  it("the English E0063 section names every derive! marker the compiler supports") {
+    checkDeriveMarkers("docs/reference/error-codes.md", "src/main/resources/errorMessage.properties")
+  }
+
+  it("the Japanese E0063 section names every derive! marker the compiler supports") {
+    checkDeriveMarkers("docs/ja/reference/error-codes.md", "src/main/resources/errorMessage_ja.properties")
+  }
 }


### PR DESCRIPTION
## Summary
- `docs/reference/error-codes.md` (and its `ja` translation) described `derive!(Json)` as the only supported form and claimed `Json` was the sole `E0063` marker — but the compiler has supported `Yaml` (and `derive!(Json, Yaml)`) for a while now, and its own `E0063` message already says "Supported markers: Json, Yaml". The docs actively contradicted the compiler's own diagnostic.
- Fixed the `E0062` heading/body and `E0063` body in both `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` to describe both markers.
- Added a regression test in `ErrorCodeDocCoverageSpec` that ties the `E0063` doc section's marker list to `error.semantic.recordDeriveUnknownMarker` in `errorMessage.properties`/`errorMessage_ja.properties`, so the two can't drift apart silently again (confirmed red before the doc fix, green after).
- Added a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan
- [x] `sbt -Duser.language=en testFull` — 4554 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated distribution-packaging test, unrelated to this change). Ran once against a default 4G heap (hit an unrelated `OutOfMemoryError` in `MutationFuzzSpec` from sandbox memory limits) and once against a larger heap, which completed cleanly.
- [x] New `ErrorCodeDocCoverageSpec` tests confirmed red (missing `Yaml`) before the doc edit, green after.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qr7CSZyEXk9VbbjPgrcYdW)_