### PR TITLE
Add a drift guard for errorMessage.properties/ja key parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A drift guard for key parity between `errorMessage.properties` and
+  `errorMessage_ja.properties`.** `ResourceBundle` chains the Japanese bundle to the
+  English one as its parent, so a key present only in English still *resolves* through
+  the Japanese bundle -- silently, in English -- and every existing bundle spec only
+  checks that a key resolves in both locales, never that both `.properties` files
+  actually declare it. A dropped or renamed translation was therefore invisible to the
+  suite. Added `MessageBundleKeyParitySpec`, which reads both files directly (bypassing
+  the fallback chain) and fails if either declares a key the other doesn't.
+
 ### Fixed
 
 - **Stale `E0062`/`E0063` docs in the error-code reference.** `docs/reference/error-codes.md`

--- a/src/test/scala/onion/compiler/MessageBundleKeyParitySpec.scala
+++ b/src/test/scala/onion/compiler/MessageBundleKeyParitySpec.scala
@@ -1,0 +1,46 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.FileInputStream
+import java.util.Properties
+
+/**
+ * Regression guard for key drift between `errorMessage.properties` (English) and
+ * `errorMessage_ja.properties` (Japanese).
+ *
+ * `ResourceBundle.getBundle("errorMessage", Locale.JAPANESE)` chains the Japanese file to
+ * the English one as its parent, so a key present only in English still *resolves* through
+ * the Japanese bundle -- silently, in English, with no test failure. That makes a dropped
+ * or renamed translation invisible to every existing bundle spec (`LawCheckMessageI18nSpec`,
+ * the many `*HintI18nSpec`s), all of which only check that a key resolves in both bundles,
+ * never that both files actually declare it. This reads the two `.properties` files
+ * directly -- bypassing `ResourceBundle`'s fallback chain entirely -- so a key missing from
+ * either side is caught instead of quietly falling back.
+ */
+class MessageBundleKeyParitySpec extends AnyFunSpec with Diagrams {
+
+  private def rawKeys(path: String): Set[String] = {
+    val props = new Properties()
+    val in = new FileInputStream(path)
+    try props.load(in) finally in.close()
+    import scala.jdk.CollectionConverters._
+    props.stringPropertyNames().asScala.toSet
+  }
+
+  private lazy val enKeys = rawKeys("src/main/resources/errorMessage.properties")
+  private lazy val jaKeys = rawKeys("src/main/resources/errorMessage_ja.properties")
+
+  it("declares every English key in the Japanese bundle") {
+    assert(enKeys.nonEmpty, "no keys read from errorMessage.properties -- the scan has rotted")
+    val missing = (enKeys -- jaKeys).toSeq.sorted
+    assert(missing.isEmpty, s"errorMessage_ja.properties is missing key(s): ${missing.mkString(", ")}")
+  }
+
+  it("declares no Japanese-only key absent from the English bundle") {
+    assert(jaKeys.nonEmpty, "no keys read from errorMessage_ja.properties -- the scan has rotted")
+    val stale = (jaKeys -- enKeys).toSeq.sorted
+    assert(stale.isEmpty, s"errorMessage_ja.properties declares key(s) not in errorMessage.properties: ${stale.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary
- `ResourceBundle.getBundle("errorMessage", Locale.JAPANESE)` chains the Japanese `.properties` file to the English one as its parent, so a key present only in English still *resolves* through the Japanese bundle — silently, in English — with no test failure.
- Every existing bundle spec (`LawCheckMessageI18nSpec`, the many `*HintI18nSpec`s) only checks that a key *resolves* in both locales, never that both `.properties` files actually declare it, so a dropped or renamed translation was invisible to the suite.
- Adds `MessageBundleKeyParitySpec`, which reads `errorMessage.properties` and `errorMessage_ja.properties` directly (bypassing `ResourceBundle`'s fallback chain) and fails if either file declares a key the other doesn't.
- No current drift: both files declare the same 201 keys today. This is a preventive regression guard, verified against a real failure by temporarily deleting a key from the Japanese file and confirming the new spec catches it before reverting.
- `CHANGELOG.md` `[Unreleased]` updated.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4556 succeeded, 0 failed, 1 expected cancellation (opt-in dist smoke test)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4556 succeeded, 0 failed, 1 expected cancellation
- [x] Verified the new spec actually detects drift (temporarily removed a key from `errorMessage_ja.properties`, confirmed failure, reverted)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01B3FwVTcYQoJC1eHY1gpS4y


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3FwVTcYQoJC1eHY1gpS4y)_