### PR TITLE
docs(error-codes): fix stale E0076 shape-format example (missing config)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by a regression test tying the doc to the property file so they can't
   drift apart again.
 
+- **Stale `E0076` example in the error-code reference.** The same whitelist-drift
+  mistake as `E0063`, one code later: `docs/reference/error-codes.md` (and its `ja`
+  translation) showed the `shape name = <format>` error listing only `json, yaml`
+  as supported formats, even though `ShapeFormats.all` (and the compiler's own
+  `E0076` message) has included `config` for a while. Docs now list all three,
+  backed by a regression test tying the doc to `ShapeFormats.all` so a fourth
+  format can't leave the example stale again.
+
 ## [0.29.0] - 2026-08-31
 
 ### Added

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -761,7 +761,7 @@ law はコンパイル済みクラスに対して実行されます。`law` / `e
 
 ```onion
 record Pt(x: Int, y: Int)
-  shape doc = toml     // E0076: サポートしているのは json, yaml
+  shape doc = toml     // E0076: サポートしているのは json, yaml, config
 ```
 
 インラインのパターンを書く場合は `shape name = re"..."` としてください。

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -765,7 +765,7 @@ what is supported.
 
 ```onion
 record Pt(x: Int, y: Int)
-  shape doc = toml     // E0076: supported formats are json, yaml
+  shape doc = toml     // E0076: supported formats are json, yaml, config
 ```
 
 For an inline pattern, write `shape name = re"..."`.

--- a/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
@@ -88,4 +88,26 @@ class ErrorCodeDocCoverageSpec extends AnyFunSpec {
   it("the Japanese E0063 section names every derive! marker the compiler supports") {
     checkDeriveMarkers("docs/ja/reference/error-codes.md", "src/main/resources/errorMessage_ja.properties")
   }
+
+  // `shape name = <format>` supports `json`, `yaml` and `config` (`ShapeFormats.all`),
+  // but the E0076 example comment in error-codes.md still listed only `json, yaml`
+  // -- the same whitelist-drift mistake E0063 made, against a doc whose own
+  // surrounding prose reads as authoritative. Ties the doc to `ShapeFormats.all` so
+  // adding a fourth format can't leave the example stale again.
+
+  private def checkShapeFormats(docPath: String): Unit = {
+    val names = onion.compiler.ShapeFormats.all.map(_._1)
+    assert(names.nonEmpty, "no shape formats found in ShapeFormats.all -- the scan has rotted")
+    val e0076 = section(read(docPath), "E0076")
+    val missing = names.filterNot(e0076.contains)
+    assert(missing.isEmpty, s"$docPath E0076 section does not mention format(s): ${missing.mkString(", ")}")
+  }
+
+  it("the English E0076 section names every shape format the compiler supports") {
+    checkShapeFormats("docs/reference/error-codes.md")
+  }
+
+  it("the Japanese E0076 section names every shape format the compiler supports") {
+    checkShapeFormats("docs/ja/reference/error-codes.md")
+  }
 }


### PR DESCRIPTION
## Summary
- `docs/reference/error-codes.md` (and its `ja` translation) showed the `shape name = <format>` `E0076` example listing only `json, yaml` as supported formats, even though `ShapeFormats.all` — and the compiler's own `E0076` message — has included `config` for a while. Same whitelist-drift class of bug as the earlier E0063 `derive!` marker doc fix (#1019).
- Fixed the example comment in both the English and Japanese docs to list `json, yaml, config`.
- Extended `ErrorCodeDocCoverageSpec` with a regression test tying the E0076 doc section to `ShapeFormats.all`, so a future added/removed format can't leave the example stale again (mirrors the existing E0063/derive-marker check in the same spec).
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] TDD: added the new spec assertions first, confirmed they failed (`docs/reference/error-codes.md E0076 section does not mention format(s): config`) before the doc fix
- [x] `sbt -Duser.language=en testOnly onion.compiler.tools.ErrorCodeDocCoverageSpec` — green after the fix
- [x] Full suite, English locale: `sbt -Duser.language=en testFull` — 4558 succeeded, 0 failed, 1 canceled (expected — `ProjectDistributionSpec`'s distribution smoke test requires `-Donion.dist.path`, unrelated to this change)
- [x] Full suite, Japanese locale: `sbt -Duser.language=ja testFull` — 4558 succeeded, 0 failed, 1 canceled (same expected skip)

---
_Generated by [Claude Code](https://claude.ai/code/session_012vWKJ6uMJe6DJBMMiADRFY)_