### PR TITLE
Add parser hint for Python-style `with expr as name { ... }` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   construct — a function returns one value, so build and return a `List` of
   the results instead.
 
+- **Parser hint for a Python-style `with expr as name { ... }` resource block.**
+  Writing `with open(path) as f { ... }` — Python's context-manager idiom —
+  parsed `with` as a bare identifier statement and hit the generic "a call's
+  arguments need parentheses" fallback (suggesting the nonsensical
+  `with(...)`), since `with` is not a keyword in Onion's grammar. The
+  diagnostic now recognizes the `with expr as name { ... }` shape and points
+  at Onion's actual equivalent, `try (val name = expr) { ... }`.
+
 ## [0.27.0] - 2026-08-30
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -121,6 +121,7 @@ error.parsing.hint.python_style_raise=Hint: Onion has no Python-style `raise` st
 error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.
 error.parsing.hint.await_not_supported=Hint: Onion has no JavaScript/Python-style prefix `await` — a `Future` is awaited postfix instead — write `{0}.await()`, not `await {0}`.
 error.parsing.hint.yield_not_supported=Hint: Onion has no JavaScript/Python-style `yield` for generators or coroutines. A function returns one value, so build and return a `List` of the results instead.
+error.parsing.hint.with_as_statement=Hint: Onion has no Python-style `with ... as ...` resource-management block — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `with {1} as {0} '{' ... '}'`.
 error.parsing.hint.until_not_supported=Hint: Onion has no Ruby-style `until` loop. Negate the condition and use `while` instead: `while !condition { ... }`.
 error.parsing.hint.not_operator=Hint: Onion has no Python/Ruby-style `not` operator for boolean negation. Use `!` instead: `if !condition { ... }`, not `if not condition { ... }`.
 error.parsing.hint.python_style_colon_block=Hint: Onion blocks use '{' ... '}', not a trailing `:` — write `{0} {1} '{' ... '}'`, not `{0} {1}:`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -121,6 +121,7 @@ error.parsing.hint.python_style_raise=ヒント: Onion に Python 風の `raise`
 error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。
 error.parsing.hint.await_not_supported=ヒント: Onion に JavaScript/Python 風の前置 `await` はありません — `Future` は後置で待ち合わせます — `await {0}` ではなく `{0}.await()` と書いてください。
 error.parsing.hint.yield_not_supported=ヒント: Onion にジェネレータやコルーチン用の JavaScript/Python 風 `yield` はありません。関数は値を1つ返すので、代わりに結果をまとめた `List` を構築して返してください。
+error.parsing.hint.with_as_statement=ヒント: Onion に Python 風の `with ... as ...` リソース管理ブロックはありません — 代わりに try-with-resources ブロックを使ってください: `with {1} as {0} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
 error.parsing.hint.until_not_supported=ヒント: Onion に Ruby 風の `until` ループはありません。条件を否定して `while` を使ってください: `while !condition { ... }`。
 error.parsing.hint.not_operator=ヒント: Onion に Python/Ruby 風の論理否定演算子 `not` はありません。代わりに `!` を使ってください: `if not condition { ... }` ではなく `if !condition { ... }` と書いてください。
 error.parsing.hint.python_style_colon_block=ヒント: Onion のブロックは末尾の `:` ではなく '{' ... '}' を使います — `{0} {1}:` ではなく `{0} {1} '{' ... '}'` と書いてください。

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -31,6 +31,13 @@ private[compiler] object ControlFlowSyntaxHints {
   // the generic missing-call-parens fallback (suggesting the nonsensical
   // `yield(...)`); keep this ahead of that case.
   private val LeadingYieldStatement = """^\s*yield\s+(.+?)\s*$""".r
+  // A Python-style `with expr as name { ... }` resource-management block --
+  // `with` is not a keyword in Onion, so this reads as a bare `with` identifier
+  // followed by another expression with nothing in between, which also matches
+  // the generic missing-call-parens fallback (suggesting the nonsensical
+  // `with(...)`); keep this ahead of that case.
+  private val LeadingWithAsStatement =
+    """^\s*with\s+(.+?)\s+as\s+([A-Za-z_]\w*)\s*:?\s*\{?\s*$""".r
 
   def classify(found: String, sourceLine: String): Option[SyntaxHint] = {
     if (LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined) {
@@ -64,6 +71,9 @@ private[compiler] object ControlFlowSyntaxHints {
       hint("error.parsing.hint.await_not_supported", matched.group(1).trim)
     } else if (LeadingYieldStatement.findFirstMatchIn(sourceLine).isDefined) {
       hint("error.parsing.hint.yield_not_supported")
+    } else if (LeadingWithAsStatement.findFirstMatchIn(sourceLine).isDefined) {
+      val matched = LeadingWithAsStatement.findFirstMatchIn(sourceLine).get
+      hint("error.parsing.hint.with_as_statement", matched.group(2), matched.group(1).trim)
     } else {
       None
     }

--- a/src/test/scala/onion/compiler/WithAsStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/WithAsStatementHintI18nSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A Python-style `with expr as name { ... }` resource-management block
+ * (`ControlFlowSyntaxHints`'s `LeadingWithAsStatement` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that family -- see AwaitStatementHintI18nSpec for the
+ * same pattern. `with` is not a keyword in Onion, so this previously read as
+ * a bare `with` identifier followed by another expression with nothing in
+ * between, hitting the generic "missing call parens" fallback (suggesting
+ * the nonsensical `with(...)`), which pointed nowhere near Onion's actual
+ * equivalent, `try (val name = expr) { ... }`.
+ */
+class WithAsStatementHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.with_as_statement"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Python-style `with expr as name { ... }` block") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    with openResource() as f {
+        |      IO::println(f)
+        |    }
+        |  }
+        |  static def openResource(): Int = 1
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The substituted name/expression are literal source text, identical in
+    // both bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("try (val f = openResource())"), s"expected the hint's try-with-resources example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
+++ b/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
@@ -17,7 +17,8 @@ class ControlFlowSyntaxHintsSpec extends AnyFunSpec with Matchers {
         ("error", "} except error: Exception {", "error.parsing.hint.except_not_supported"),
         ("Exception", "raise Exception(\"boom\")", "error.parsing.hint.python_style_raise_construct"),
         ("e", "raise e", "error.parsing.hint.python_style_raise"),
-        ("foo", "await foo()", "error.parsing.hint.await_not_supported")
+        ("foo", "await foo()", "error.parsing.hint.await_not_supported"),
+        ("f", "with openResource() as f {", "error.parsing.hint.with_as_statement")
       )
 
       cases.foreach { case (found, sourceLine, expectedKey) =>
@@ -50,6 +51,15 @@ class ControlFlowSyntaxHintsSpec extends AnyFunSpec with Matchers {
 
       hint.messageKey shouldBe "error.parsing.hint.await_not_supported"
       hint.arguments shouldBe Seq("foo()")
+    }
+
+    it("captures the resource expression and bound name from a `with ... as ...` block") {
+      val hint = ControlFlowSyntaxHints
+        .classify(found = "f", sourceLine = "with openResource() as f {")
+        .getOrElse(fail("expected a syntax hint"))
+
+      hint.messageKey shouldBe "error.parsing.hint.with_as_statement"
+      hint.arguments shouldBe Seq("f", "openResource()")
     }
 
     it("preserves rule order inside the family") {


### PR DESCRIPTION
## Summary

- `with` is not a keyword in Onion's grammar, so Python's `with expr as name { ... }` context-manager idiom parsed `with` as a bare identifier statement and hit the generic "a call's arguments need parentheses" fallback (suggesting the nonsensical `with(...)`).
- Adds a dedicated `ControlFlowSyntaxHints.LeadingWithAsStatement` rule that recognizes the `with expr as name { ... }` shape and points at Onion's actual equivalent, `try (val name = expr) { ... }`.
- Bilingual (en/ja) message bundle entries for `error.parsing.hint.with_as_statement`, following the existing `await`/`yield`/`using` hint pattern.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Test plan

- [x] New failing tests written first (TDD): `WithAsStatementHintI18nSpec`, plus classifier-level cases in `ControlFlowSyntaxHintsSpec`.
- [x] Confirmed red before the fix, green after.
- [x] Manually verified via `sbt runScript` that the new hint fires end-to-end on a `with ... as ...` snippet.
- [x] Full suite green in both locales: `sbt -Duser.language=en testFull` and `sbt -Duser.language=ja testFull` — 4475 tests, 0 failed (1 pre-existing unrelated cancellation in `an unpacked distribution completes the new -> run -> test -> clean journey`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDP1DPxL1TWqBJw1aW3ryR)_