### PR TITLE
Fix CHANGELOG placement of the with-as-statement hint entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backed by a regression test tying the doc to `ShapeFormats.all` so a fourth
   format can't leave the example stale again.
 
+- **Parser hint for a Python-style `with expr as name { ... }` resource block.**
+  Writing `with open(path) as f { ... }` — Python's context-manager idiom —
+  parsed `with` as a bare identifier statement and hit the generic "a call's
+  arguments need parentheses" fallback (suggesting the nonsensical
+  `with(...)`), since `with` is not a keyword in Onion's grammar. The
+  diagnostic now recognizes the `with expr as name { ... }` shape and points
+  at Onion's actual equivalent, `try (val name = expr) { ... }`.
+
 ## [0.29.0] - 2026-08-31
 
 ### Added
@@ -154,14 +162,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `yield expr` shape and explains that Onion has no generator/coroutine
   construct — a function returns one value, so build and return a `List` of
   the results instead.
-
-- **Parser hint for a Python-style `with expr as name { ... }` resource block.**
-  Writing `with open(path) as f { ... }` — Python's context-manager idiom —
-  parsed `with` as a bare identifier statement and hit the generic "a call's
-  arguments need parentheses" fallback (suggesting the nonsensical
-  `with(...)`), since `with` is not a keyword in Onion's grammar. The
-  diagnostic now recognizes the `with expr as name { ... }` shape and points
-  at Onion's actual equivalent, `try (val name = expr) { ... }`.
 
 ## [0.27.0] - 2026-08-30
 


### PR DESCRIPTION
## Summary

- PR #1022 (the `with expr as name { ... }` parser hint) merged while other concurrent sessions were cutting the v0.28.0/v0.29.0 releases. The textual 3-way merge landed the new changelog entry inside the already-tagged `## [0.28.0]` section instead of the current `## [Unreleased]` one.
- Verified neither `v0.28.0` nor `v0.29.0` tags actually contain the change (`git show v0.28.0:CHANGELOG.md` / `v0.29.0:CHANGELOG.md` and the corresponding source file don't mention it) — the code only exists on `develop` past those tags.
- Moves the entry back under `## [Unreleased]`, where the shipped code actually lives until the next real release cut.

CHANGELOG-only change; no code touched.

## Test plan

- [x] No code changed — documentation-only fix.
- [x] Confirmed via `git show <tag>:CHANGELOG.md` and `git show <tag>:src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala` that neither v0.28.0 nor v0.29.0 contain this entry/code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDP1DPxL1TWqBJw1aW3ryR)_