### PR TITLE
docs: document CI-matching heap size for local test runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,15 @@ sbt shutdown && sbt -Duser.language=en testFull    # then repeat with =ja
 CI is unaffected by both: the incremental state lives in `target/`, which `setup-java`'s
 `cache: 'sbt'` does not cache, so every CI run starts cold and runs the full suite.
 
+**Heap size:** `.github/workflows/scala.yml` runs CI with `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m"`.
+Match that locally — `-Xmx4G` reliably OOMs in `MutationFuzzSpec` (a heavy mutation-fuzzing
+test) even on an otherwise-clean `develop` HEAD, which looks like a test failure but is only
+an under-provisioned heap:
+
+```bash
+SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull
+```
+
 **Test Suites:**
 - `HelloWorldSpec.scala` - Basic output
 - `FactorialSpec.scala` - Recursion


### PR DESCRIPTION
## Summary
- `CLAUDE.md`'s local test command had no heap guidance, so it silently ran on sbt's default heap
- That reliably OOMs in `MutationFuzzSpec` (a heavy mutation-fuzzing test) even on a clean `develop` HEAD with no code changes — looking like a failing test rather than an under-sized heap
- CI's `.github/workflows/scala.yml` already runs with `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m"`; document that same value as the local command so local pre-merge verification and real CI agree

Fixes #1026.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4566/4566 passed, 0 failed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4566/4566 passed, 0 failed
- [x] Docs-only change, no source files touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01RimFjZ36Sr5hA4cSdaimkb)_