### PR TITLE
Add a drift guard tying E0061/E0062/E0081 scalar-type prose to ScalarConversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A drift guard tying the E0061/E0062/E0081 "supported scalar types" prose to
+  `ScalarConversions.all`.** `record ... from re"..."`, `derive!(Json, Yaml)`, and
+  `tool` auto-CLI parameters all restrict components to the same eight-type scalar
+  set, and `docs/reference/error-codes.md` (and its `ja` translation) repeat that
+  set as literal prose in all three sections -- the same whitelist-drift risk
+  already fixed for E0063's `derive!` markers and E0076's shape formats, one
+  section over each time, but with nothing tying these three to their source of
+  truth. Added `checkScalarConversions` to `ErrorCodeDocCoverageSpec`, verified it
+  actually catches a dropped type before confirming today's docs are still
+  accurate.
+
 - **A drift guard for the "Error Categories" doc block atop `SemanticError`.**
   That scaladoc sorts every declared code into a category (Type Errors,
   Resolution Errors, ...) via a curated bullet list, but nothing tied it to

--- a/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
@@ -95,4 +95,43 @@ class ErrorCodeDocCoverageSpec extends AnyFunSpec {
   it("the Japanese E0076 section names every shape format the compiler supports") {
     checkShapeFormats("docs/ja/reference/error-codes.md")
   }
+
+  // `record ... from re"..."`, `derive!`, and `tool` auto-CLI all restrict components to
+  // the same eight-type scalar set, read from the single `ScalarConversions.all` table
+  // (added for issue #349 after that list used to be written out five times). The E0061,
+  // E0062, and E0081 sections each repeat the set as prose/comment instead of citing the
+  // table, so nothing previously tied them to it -- the same drift risk already fixed for
+  // E0063's markers and E0076's formats, one section over each time.
+
+  private def checkScalarConversions(docPath: String, code: String): Unit = {
+    val tags = onion.compiler.ScalarConversions.all.map(_.tag)
+    assert(tags.nonEmpty, "no scalar conversions found in ScalarConversions.all -- the scan has rotted")
+    val doc = section(read(docPath), code)
+    val missing = tags.filterNot(doc.contains)
+    assert(missing.isEmpty, s"$docPath $code section does not mention scalar type(s): ${missing.mkString(", ")}")
+  }
+
+  it("the English E0061 section names every scalar type the compiler supports") {
+    checkScalarConversions("docs/reference/error-codes.md", "E0061")
+  }
+
+  it("the Japanese E0061 section names every scalar type the compiler supports") {
+    checkScalarConversions("docs/ja/reference/error-codes.md", "E0061")
+  }
+
+  it("the English E0062 section names every scalar type the compiler supports") {
+    checkScalarConversions("docs/reference/error-codes.md", "E0062")
+  }
+
+  it("the Japanese E0062 section names every scalar type the compiler supports") {
+    checkScalarConversions("docs/ja/reference/error-codes.md", "E0062")
+  }
+
+  it("the English E0081 section names every scalar type the compiler supports") {
+    checkScalarConversions("docs/reference/error-codes.md", "E0081")
+  }
+
+  it("the Japanese E0081 section names every scalar type the compiler supports") {
+    checkScalarConversions("docs/ja/reference/error-codes.md", "E0081")
+  }
 }


### PR DESCRIPTION
## Summary

- `record ... from re"..."`, `derive!(Json, Yaml)`, and `tool` auto-CLI parameters all restrict components to the same eight-type scalar set, read from the single `ScalarConversions.all` table (added for issue #349).
- `docs/reference/error-codes.md` (and its `ja` translation) repeat that set as literal prose in the E0061, E0062, and E0081 sections — the same whitelist-drift risk already closed for E0063's `derive!` markers and E0076's shape formats via `ErrorCodeDocCoverageSpec`, but nothing tied these three sections to `ScalarConversions.all`.
- Added `checkScalarConversions` to `ErrorCodeDocCoverageSpec`, mirroring the existing `checkDeriveMarkers`/`checkShapeFormats` pattern, with 6 new specs (en/ja × E0061/E0062/E0081).
- No current drift was found — docs are accurate today — so this is a preventive regression guard. Verified it actually detects drift (temporarily dropped `Byte` from the E0061 prose locally, confirmed the new spec goes red, then reverted).

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4572 succeeded, 0 failed, 1 canceled
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4572 succeeded, 0 failed, 1 canceled
- [x] Manually verified the new guard fails when a scalar type is dropped from the doc prose

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014demyvjZUoH9iChCU4N33b)_