### PR TITLE
Consolidate the builtin-extension container list into one source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A single source of truth for the builtin-extension container list.** The
+  stdlib containers whose static helpers become extension methods (`onion.Colls`,
+  `onion.Strings`, `onion.Maps`, ...) were listed twice: once in
+  `Typing.registerBuiltinExtensions` (which registers them) and again in
+  `ExtensionMethodFallbackSupport.BuiltinExtensionContainers` (which decides
+  whether a user-declared `extension` may shadow one of them instead of
+  colliding as an ambiguity) -- the same two-copies-of-one-list drift risk
+  already closed for `derive!` markers (`DeriveMarkers`) and shape formats
+  (`ShapeFormats`), flagged by its own "keep in sync" comment. `Typing.scala`
+  now iterates `BuiltinExtensionContainers` directly (kept as an ordered `Seq`
+  so the existing first-container-wins overlap resolution is unaffected).
+  Added a regression test that shadows a builtin from a second container
+  (`onion.Strings`, alongside the existing `onion.Colls` coverage) so a future
+  drift between the two use sites fails a test instead of only miscompiling
+  silently at the ambiguity check.
+
 - **A drift guard tying the E0061/E0062/E0081 "supported scalar types" prose to
   `ScalarConversions.all`.** `record ... from re"..."`, `derive!(Json, Yaml)`, and
   `tool` auto-CLI parameters all restrict components to the same eight-type scalar

--- a/src/main/scala/onion/compiler/Typing.scala
+++ b/src/main/scala/onion/compiler/Typing.scala
@@ -155,7 +155,7 @@ class Typing(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Compi
     // unaffected — this only deduplicates the extension registry.
     val registered = scala.collection.mutable.HashSet[String]()
     for {
-      containerName <- Seq("onion.Colls", "onion.Iterables", "onion.Maps", "onion.Strings", "onion.Sets", "onion.Hash", "onion.Codec", "onion.Text", "onion.Stats", "onion.Format")
+      containerName <- _root_.onion.compiler.typing.ExtensionMethodFallbackSupport.BuiltinExtensionContainers
       container <- load(containerName)
       method <- container.methods
       if Modifier.isStatic(method.modifier) && Modifier.isPublic(method.modifier) && method.arguments.nonEmpty

--- a/src/main/scala/onion/compiler/typing/ExtensionMethodFallbackSupport.scala
+++ b/src/main/scala/onion/compiler/typing/ExtensionMethodFallbackSupport.scala
@@ -257,8 +257,7 @@ private[compiler] final class ExtensionMethodFallbackSupport(
 
   /** A builtin stdlib extension (the bundled collection/string utilities), as
    *  opposed to a user-declared `extension` block — used so a user extension can
-   *  shadow a builtin of the same name instead of colliding as an ambiguity.
-   *  Keep in sync with the container list in Typing.registerBuiltinExtensions. */
+   *  shadow a builtin of the same name instead of colliding as an ambiguity. */
   private def isBuiltinExtension(m: ExtensionMethodDefinition): Boolean =
     ExtensionMethodFallbackSupport.BuiltinExtensionContainers.contains(m.containerClass.name)
 
@@ -275,9 +274,14 @@ private[compiler] final class ExtensionMethodFallbackSupport(
 }
 
 private[compiler] object ExtensionMethodFallbackSupport {
-  /** Containers whose static helpers are registered as builtin extension methods
-   *  (see Typing.registerBuiltinExtensions). A user-declared `extension` of the
-   *  same name shadows these rather than colliding as an ambiguity. */
-  val BuiltinExtensionContainers: Set[String] =
-    Set("onion.Colls", "onion.Iterables", "onion.Maps", "onion.Strings", "onion.Sets", "onion.Hash", "onion.Codec", "onion.Text", "onion.Stats", "onion.Format")
+  /** The single source of truth for which stdlib containers' static helpers are
+   *  registered as builtin extension methods -- consumed both by
+   *  `Typing.registerBuiltinExtensions` (which registers them, in this order: for
+   *  an overlapping receiver+name+signature the first container listed wins) and by
+   *  `isBuiltinExtension` above (so a user-declared `extension` of the same name
+   *  shadows these rather than colliding as an ambiguity). Kept as an ordered `Seq`
+   *  rather than a `Set` so that registration order -- and with it, which container
+   *  wins an overlap -- stays defined. */
+  val BuiltinExtensionContainers: Seq[String] =
+    Seq("onion.Colls", "onion.Iterables", "onion.Maps", "onion.Strings", "onion.Sets", "onion.Hash", "onion.Codec", "onion.Text", "onion.Stats", "onion.Format")
 }

--- a/src/test/scala/onion/compiler/tools/ExtensionMethodSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ExtensionMethodSpec.scala
@@ -181,5 +181,33 @@ class ExtensionMethodSpec extends AbstractShellSpec {
       )
       assert(Shell.Success("user:A") == result)
     }
+
+    it("lets a user extension method shadow a builtin Strings extension of the same name") {
+      // Colls and Strings are two of several containers listed in
+      // ExtensionMethodFallbackSupport.BuiltinExtensionContainers -- the single list
+      // that both registers builtin extensions (Typing.registerBuiltinExtensions) and
+      // decides which extensions a user `extension` block is allowed to shadow
+      // (isBuiltinExtension). Exercising a second container here, not just Colls,
+      // guards against that list losing an entry on just one of its two use sites: if
+      // it did, this shadowing would fail with an ambiguous-extension-method error
+      // instead of returning the user's implementation.
+      val result = shell.run(
+        """
+          |extension String {
+          |  def upper(): String { return "user:" + this }
+          |}
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): String {
+          |    return "a".upper()
+          |  }
+          |}
+          |""".stripMargin,
+        "None",
+        Array()
+      )
+      assert(Shell.Success("user:a") == result)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `Typing.registerBuiltinExtensions` (which registers the stdlib containers' static helpers as extension methods) and `ExtensionMethodFallbackSupport.isBuiltinExtension` (which decides whether a user `extension` block may shadow one of them instead of colliding as an ambiguity) each hardcoded their own copy of the same 10-container list — flagged by an explicit "keep in sync" comment on the latter. This is the same two-copies-of-one-list drift risk already closed for `derive!` markers (`DeriveMarkers`) and shape formats (`ShapeFormats`).
- `Typing.scala` now iterates `ExtensionMethodFallbackSupport.BuiltinExtensionContainers` directly instead of its own literal. The list is kept as an ordered `Seq` (not a `Set`) so the existing "first container wins an overlap" registration order is unaffected.
- Added a regression test that shadows a builtin extension from a second container (`onion.Strings`, alongside the existing `onion.Colls` coverage), so a future drift between the two use sites fails a test instead of only surfacing as a confusing ambiguity error at compile time.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4573 tests, 0 failed, 1 canceled (pre-existing), all passed.
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.ExtensionMethodSpec"` — new test passes alongside the existing shadowing test.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6s3qdubBVidPC5PsYndjw)_