### PR TITLE
Consolidate the primitive-type-name whitelist into one source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A single source of truth for the primitive-type-name whitelist.** `typing.NameResolver`
+  (class-not-found suggestions -- "did you mean `Int`?" for a Java/Scala-style lowercase
+  `int`) and `parser.SyntaxHintClassifier` (the `hint.primitive_dot_static` hint for
+  `Int.parseInt(...)`-style mistakes) each listed Onion's eight capitalized primitive
+  type names separately -- the same two-copies-of-one-list drift risk already closed for
+  `DeriveMarkers` and `ShapeFormats`. Both now read from a shared
+  `onion.compiler.PrimitiveTypeNames.all`. Added a regression test asserting the two call
+  sites agree and that the `primitive_dot_static` hint actually fires for every name in
+  the shared list.
+
 - **A single source of truth for the builtin-extension container list.** The
   stdlib containers whose static helpers become extension methods (`onion.Colls`,
   `onion.Strings`, `onion.Maps`, ...) were listed twice: once in

--- a/src/main/scala/onion/compiler/PrimitiveTypeNames.scala
+++ b/src/main/scala/onion/compiler/PrimitiveTypeNames.scala
@@ -1,0 +1,20 @@
+package onion.compiler
+
+/**
+ * Onion's primitive type keywords, capitalized (`void` is the one exception --
+ * it stays lowercase in the grammar, so it is not a candidate for either use below).
+ *
+ * One list, shared by two independent "did you mean a primitive?" diagnostics that
+ * used to enumerate the same eight names separately:
+ *   - `typing.NameResolver` -- class-not-found suggestions, so a Java/Scala-style
+ *     lowercase spelling (`int`, `boolean`, ...), which parses as an ordinary
+ *     unresolved reference type, gets "did you mean `Int`?" instead of a bare
+ *     "check spelling or add import".
+ *   - `parser.SyntaxHintClassifier` -- the `hint.primitive_dot_static` syntax hint
+ *     for `Int.parseInt(...)`-style mistakes (a primitive's static members are
+ *     accessed with `::`, not `.`).
+ */
+private[compiler] object PrimitiveTypeNames {
+
+  val all: Seq[String] = Seq("Int", "Long", "Short", "Byte", "Char", "Float", "Double", "Boolean")
+}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -111,8 +111,9 @@ private[compiler] object SyntaxHintClassifier {
   // independent of the found token, to still catch it.
   private val JavaStyleGenericConstructorCall =
     """\bnew\s+([A-Za-z_][\w.]*)\s*<\s*([^<>]*?)\s*>\s*\(""".r
-  private val PrimitiveTypeNames =
-    Set("Int", "Long", "Double", "Float", "Boolean", "Byte", "Short", "Char")
+  // Kept in sync with typing.NameResolver's own copy via the shared
+  // onion.compiler.PrimitiveTypeNames -- see its doc comment.
+  private val PrimitiveTypeNames = onion.compiler.PrimitiveTypeNames.all.toSet
   private val DotAfterPrimitiveTypeName = """\A[A-Za-z]+\s*\.\s*([A-Za-z_]\w*)""".r
   private val JavaStyleRecordBody =
     """^\s*record\s+([A-Za-z_]\w*)(?:\[[^\]]*\])?\s*\{""".r

--- a/src/main/scala/onion/compiler/typing/NameResolution.scala
+++ b/src/main/scala/onion/compiler/typing/NameResolution.scala
@@ -26,13 +26,12 @@ final case class TypeAliasEntry(
 )
 
 object NameResolver {
-  /** Onion's primitive type keywords, capitalized (`void` is the one exception --
-    * it is already lowercase in the grammar). Included as class-not-found
-    * suggestion candidates so a Java/Scala-style lowercase spelling (`int`, `boolean`,
-    * ...), which parses as an ordinary unresolved reference type, gets "did you mean
-    * `Int`?" instead of a bare "check spelling or add import". */
-  private[typing] val PrimitiveTypeNames: Seq[String] =
-    Seq("Int", "Long", "Short", "Byte", "Char", "Float", "Double", "Boolean")
+  /** Class-not-found suggestion candidates so a Java/Scala-style lowercase spelling
+    * (`int`, `boolean`, ...), which parses as an ordinary unresolved reference type,
+    * gets "did you mean `Int`?" instead of a bare "check spelling or add import".
+    * Delegates to the shared `onion.compiler.PrimitiveTypeNames` -- see its doc
+    * comment for the other call site this must stay in sync with. */
+  private[compiler] val PrimitiveTypeNames: Seq[String] = onion.compiler.PrimitiveTypeNames.all
 }
 
 class NameResolver(private val context: NameResolutionContext) {

--- a/src/test/scala/onion/compiler/PrimitiveTypeNamesConsistencySpec.scala
+++ b/src/test/scala/onion/compiler/PrimitiveTypeNamesConsistencySpec.scala
@@ -1,0 +1,51 @@
+package onion.compiler
+
+import onion.compiler.typing.NameResolver
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * `PrimitiveTypeNames` (Onion's eight capitalized primitive keywords) used to be
+ * listed twice: once in `typing.NameResolver` (class-not-found suggestions -- a
+ * lowercase `int` reads as an ordinary unresolved reference type and gets "did you
+ * mean `Int`?") and again in `parser.SyntaxHintClassifier` (the
+ * `hint.primitive_dot_static` syntax hint for `Int.parseInt(...)`-style mistakes).
+ * Nothing tied the two together -- the same drift risk already closed for
+ * `DeriveMarkers` and `ShapeFormats`. This asserts both call sites now read from the
+ * single shared `PrimitiveTypeNames.all`.
+ */
+class PrimitiveTypeNamesConsistencySpec extends AnyFunSpec {
+
+  private def messages(src: String): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  it("lists the eight capitalized primitive keywords") {
+    assert(PrimitiveTypeNames.all == Seq("Int", "Long", "Short", "Byte", "Char", "Float", "Double", "Boolean"))
+  }
+
+  it("is the same list NameResolver suggests for an unresolved lowercase primitive") {
+    assert(NameResolver.PrimitiveTypeNames == PrimitiveTypeNames.all)
+  }
+
+  it("fires the primitive_dot_static hint for every name in PrimitiveTypeNames.all") {
+    PrimitiveTypeNames.all.foreach { name =>
+      val msgs = messages(
+        s"""
+           |class Main {
+           |public:
+           |  static def main(args: String[]): void {
+           |    IO::println($name.parseIt("x"))
+           |  }
+           |}
+           |""".stripMargin
+      )
+      assert(msgs.contains(s"$name::parseIt"), s"expected a `$name::parseIt` hint for `$name`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `typing.NameResolver` (class-not-found suggestions — "did you mean `Int`?" for a Java/Scala-style lowercase `int`) and `parser.SyntaxHintClassifier` (the `hint.primitive_dot_static` hint for `Int.parseInt(...)`-style mistakes) each listed Onion's eight capitalized primitive type names separately, with nothing tying the two together — the same two-copies-of-one-list drift risk already closed for `DeriveMarkers` and `ShapeFormats`.
- Both now read from a shared `onion.compiler.PrimitiveTypeNames.all`.
- Added `PrimitiveTypeNamesConsistencySpec`, which asserts the two call sites agree and that the `primitive_dot_static` hint actually fires for every name in the shared list (compiles a real snippet through the full compiler for each of the 8 names).
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4576 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging integration test)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4576 succeeded, 0 failed, 1 canceled (same pre-existing test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTusB858g9bLG78ykEeU4Q)_