### PR TITLE
Consolidate the E0079 parameterized-effect whitelist into one source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name appears in the doc block so a newly added code can't go
   uncategorized again.
 
+- **A single source of truth for the E0079 "which effects take a parameter
+  argument" whitelist.** `CapabilityCheckPass` hardcoded its own private
+  `parameterized: Set[Effect]` (deciding whether a `requires { read(src) }`-style
+  entry may carry a parameter) with nothing tying it to the matching prose
+  repeated in both `docs/reference/error-codes.md` and its `ja` translation --
+  the same whitelist-drift risk already closed for E0063's `derive!` markers,
+  E0076's shape formats, and E0061/E0062/E0081's scalar types. The set now
+  lives as `Effect.parameterized` in `effects/Effect.scala`, and
+  `ErrorCodeDocCoverageSpec` asserts the E0079 sections in both docs name
+  every parameterized effect so a future addition can't leave them stale.
+
 - **A drift guard for key parity between `errorMessage.properties` and
   `errorMessage_ja.properties`.** `ResourceBundle` chains the Japanese bundle to the
   English one as its parent, so a key present only in English still *resolves* through

--- a/src/main/scala/onion/compiler/effects/Effect.scala
+++ b/src/main/scala/onion/compiler/effects/Effect.scala
@@ -37,6 +37,9 @@ object Effect {
 
   val all: Seq[Effect] = Seq(Read, Write, Net, Exec, Env, Clock, Rand, Console, Unknown)
 
+  /** Effects that can be tied to a parameter (`read(src)`); the rest are ambient. */
+  val parameterized: Set[Effect] = Set(Read, Write, Net, Exec)
+
   private val byName: Map[String, Effect] = all.map(e => e.name -> e).toMap
 
   def parse(name: String): Option[Effect] = byName.get(name)

--- a/src/main/scala/onion/compiler/typing/CapabilityCheckPass.scala
+++ b/src/main/scala/onion/compiler/typing/CapabilityCheckPass.scala
@@ -29,10 +29,6 @@ final class CapabilityCheckPass(typing: Typing) {
   private val RequiresPrefix = "requires:"
   private val CapabilityForm = """([A-Za-z]+)(?:\(([A-Za-z0-9_]+)\))?""".r
 
-  /** Effects that can be tied to a parameter (`read(src)`); the rest are ambient. */
-  private val parameterized: Set[Effect] =
-    Set(Effect.Read, Effect.Write, Effect.Net, Effect.Exec)
-
   def run(classes: Seq[ClassDefinition]): Unit = {
     val tools: Seq[MethodDefinition] = for {
       cd <- classes
@@ -65,7 +61,7 @@ final class CapabilityCheckPass(typing: Typing) {
             report(SemanticError.TOOL_BAD_CAPABILITY, tool.location, tool.name, cap,
               Message("error.semantic.toolCapability.notAnEffect", name, Effect.all.map(_.name).mkString(", ")))
           case Some(effect) =>
-            if (arg != null && !parameterized.contains(effect))
+            if (arg != null && !Effect.parameterized.contains(effect))
               report(SemanticError.TOOL_BAD_CAPABILITY, tool.location, tool.name, cap,
                 Message("error.semantic.toolCapability.takesNoArgument", name))
             else if (arg != null && !paramNames.contains(arg))

--- a/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
@@ -134,4 +134,27 @@ class ErrorCodeDocCoverageSpec extends AnyFunSpec {
   it("the Japanese E0081 section names every scalar type the compiler supports") {
     checkScalarConversions("docs/ja/reference/error-codes.md", "E0081")
   }
+
+  // `CapabilityCheckPass` used to hardcode its own private `parameterized: Set[Effect]`
+  // (which effects a `requires { read(src) }`-style entry may take a parameter for) --
+  // duplicated as prose in the E0079 section of both docs with nothing tying the two
+  // together, the same drift risk already fixed for E0063's markers, E0076's formats,
+  // and E0061/E0062/E0081's scalar types. `Effect.parameterized` is now the single
+  // source of truth both the pass and this test read from.
+
+  private def checkParameterizedEffects(docPath: String): Unit = {
+    val names = onion.compiler.effects.Effect.parameterized.toSeq.sorted.map(_.name)
+    assert(names.nonEmpty, "no parameterized effects found in Effect.parameterized -- the scan has rotted")
+    val e0079 = section(read(docPath), "E0079")
+    val missing = names.filterNot(e0079.contains)
+    assert(missing.isEmpty, s"$docPath E0079 section does not mention parameterized effect(s): ${missing.mkString(", ")}")
+  }
+
+  it("the English E0079 section names every effect that takes a parameter argument") {
+    checkParameterizedEffects("docs/reference/error-codes.md")
+  }
+
+  it("the Japanese E0079 section names every effect that takes a parameter argument") {
+    checkParameterizedEffects("docs/ja/reference/error-codes.md")
+  }
 }


### PR DESCRIPTION
## Summary

- `CapabilityCheckPass` hardcoded its own private `parameterized: Set[Effect]` (which effects a `requires { read(src) }`-style entry may carry a parameter for), duplicated as prose in the E0079 section of both `docs/reference/error-codes.md` and its `ja` translation — with nothing tying the two together. Same whitelist-drift risk already closed for E0063's `derive!` markers, E0076's shape formats, and E0061/E0062/E0081's scalar types.
- The set now lives as `Effect.parameterized` in `effects/Effect.scala`; `CapabilityCheckPass` reads from it instead of its own private copy. Pure refactor — behavior unchanged.
- Added two `ErrorCodeDocCoverageSpec` cases (English + Japanese) tying both docs' E0079 sections to `Effect.parameterized`, so a future addition can't leave the docs stale.
- `CHANGELOG.md` `[Unreleased]` updated.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4578 succeeded, 0 failed (1 canceled: `ProjectDistributionSpec`'s environment-gated smoke test, expected without `-Donion.dist.path`).
- [x] New spec cases verified red (missing `Effect.parameterized` → compile error) before the fix, green after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCokoNxZ5eoDco1XM5biZr)_