### PR TITLE
Fix retired-codes note in SemanticError.scala to include E0056

### DIFF
--- a/src/main/scala/onion/compiler/SemanticError.scala
+++ b/src/main/scala/onion/compiler/SemanticError.scala
@@ -38,7 +38,7 @@ package onion.compiler
  *   - CYCLIC_INHERITANCE, ILLEGAL_INHERITANCE, INTERFACE_REQUIRED
  *   - UNIMPLEMENTED_ABSTRACT_METHOD, ABSTRACT_CLASS_INSTANTIATION, FINAL_METHOD_OVERRIDE
  *   - OVERRIDE_TARGET_NOT_FOUND, ABSTRACT_METHOD_WITH_BODY
- *   (E0017 and E0024 are retired codes, kept unassigned rather than reused.)
+ *   (E0017, E0024, and E0056 are retired codes, kept unassigned rather than reused.)
  *
  * '''Call and Value-Use Errors (E0019-E0020, E0040-E0041, E0071, E0091)'''
  *   - ILLEGAL_METHOD_CALL, CANNOT_RETURN_VALUE, CANNOT_CALL_METHOD_ON_PRIMITIVE

--- a/src/test/scala/onion/compiler/tools/SemanticErrorRetiredCodesDocSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorRetiredCodesDocSpec.scala
@@ -1,0 +1,43 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard tying the "retired codes" note in `SemanticError.scala`'s class-level
+ * scaladoc to the numbering gaps the file actually contains. The note undercounted
+ * by one (only mentioning E0017 and E0024) after E0056 was deleted, so a future
+ * deletion or restoration of a code can silently leave the note wrong again without
+ * this test catching it.
+ */
+class SemanticErrorRetiredCodesDocSpec extends AnyFunSpec {
+
+  private lazy val source: String =
+    java.nio.file.Files.readString(
+      java.nio.file.Path.of("src/main/scala/onion/compiler/SemanticError.scala")
+    )
+
+  private lazy val declaredCodes: Set[Int] =
+    """case object \w+ extends SemanticError\((\d+)\)""".r
+      .findAllMatchIn(source)
+      .map(_.group(1).toInt)
+      .toSet
+
+  private lazy val actualGaps: Set[Int] = {
+    assert(declaredCodes.nonEmpty, "no SemanticError cases found -- the scan has rotted")
+    (declaredCodes.min to declaredCodes.max).toSet -- declaredCodes
+  }
+
+  private lazy val notedGaps: Set[Int] = {
+    val noteLine = source.linesIterator
+      .find(l => l.contains("retired codes") && l.contains("kept unassigned"))
+      .getOrElse(fail("no \"retired codes, kept unassigned\" note found in SemanticError.scala"))
+    """E(\d{4})""".r.findAllMatchIn(noteLine).map(_.group(1).toInt).toSet
+  }
+
+  it("names every numbering gap left by a retired SemanticError code, and no other") {
+    assert(
+      notedGaps == actualGaps,
+      s"note lists $notedGaps but the actual gaps in the SemanticError(N) numbering are $actualGaps"
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- The class-level scaladoc in `SemanticError.scala` said only E0017 and E0024 are retired codes kept unassigned, but the file's own `SemanticError(N)` numbering also skips 56 (`ENUM_CONSTANT_ARGS_UNSUPPORTED`, deleted alongside E0017/E0024 per `CHANGELOG.md` and `SemanticErrorCodeCoverageSpec`) — the one place documenting the numbering gaps was itself under-reporting them.
- Adds `SemanticErrorRetiredCodesDocSpec`, a drift guard that computes the actual gaps in the `SemanticError(N)` sequence from the source and asserts the note names exactly those, so a future code deletion or restoration can't leave the note silently wrong again.

## Test plan
- [x] New spec fails against the stale comment (confirmed red before the fix)
- [x] New spec passes after the one-line comment fix (green)
- [x] Full suite green: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4585 succeeded, 0 failed, 1 canceled

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJnSVQgkoM6gcmAUexu9py)_