### PR TITLE
Fix missing articles in CLI error.command.* messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CLI usage errors (`error.command.*`) were missing articles.** `onionc -classpath`
+  (no value) read "`-classpath` requires argument.", an unrecognized flag read
+  "is invalid argument.", `-encoding` with a bad value read "is not valid encoding
+  name.", and worst, `-maxErrorReport` with a non-numeric value read "is required to
+  natural number." -- not just missing an article but missing the verb linking
+  "required" to "natural number." These are CLI-level messages (no E-code, no doc
+  entry), so the only regression net was a new test
+  (`CommandErrorMessageGrammarSpec`) pinning the English text via `Locale.ROOT`
+  (immune to the suite's `en`/`ja` locale switch) alongside the unaffected Japanese
+  translations.
+
 - **E0020 "cannot return value" was missing an article.** Same defect as the
   recent E0018/E0027 fixes: the message read `this method cannot return
   value.` instead of `this method cannot return a value.`. Fixed in the

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -1,8 +1,8 @@
 error.count={0,choice,1#1 error is found.|1<{0,number,integer} errors are found.}
-error.command.noArgument={0} requires argument.
-error.command.invalidArgument={0} is invalid argument.
-error.command.requireNaturalNumber=value of {0} is required to natural number.
-error.command.invalidEncoding=value of {0} is not valid encoding name.
+error.command.noArgument={0} requires an argument.
+error.command.invalidArgument={0} is an invalid argument.
+error.command.requireNaturalNumber=value of {0} is required to be a natural number.
+error.command.invalidEncoding=value of {0} is not a valid encoding name.
 error.command.noEntryPoint=no entry point found: none of the compiled classes ({0}) has a public static main(String[]) method -- define `def main(args: String[]): void '{' ... '}'` at the top level, or add executable top-level statements.
 error.parsing.read_error=read error: cannot read file {0}.
 error.parsing.syntax_error=Syntax error. Encountered "{0}", but expecting {1}

--- a/src/test/scala/onion/compiler/CommandErrorMessageGrammarSpec.scala
+++ b/src/test/scala/onion/compiler/CommandErrorMessageGrammarSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * The CLI-level `error.command.*` messages (raised by `CompilerFrontend`/`ScriptRunner`
+ * for a malformed command line -- a missing option value, an unrecognized flag, a bad
+ * `-maxErrorReport`/`-encoding` value) were missing articles, the same defect already
+ * fixed for E0018/E0020/E0027: "requires argument.", "is invalid argument.", "is not
+ * valid encoding name.", and (worst) "is required to natural number." -- which is not
+ * just missing an article but grammatically broken (no verb linking "required" to
+ * "natural number"). None of these have an E-code or a doc entry (they are CLI usage
+ * errors, not compiler diagnostics), so the only regression net is this test.
+ *
+ * Uses `MessageBundles.english`, which pins `Locale.ROOT` regardless of the JVM's
+ * default locale, so this test's assertions on English text hold under both the `en`
+ * and `ja` full-suite runs (see `MessageBundles` for why a naive
+ * `ResourceBundle.getBundle("errorMessage", Locale.ENGLISH)` would not).
+ */
+class CommandErrorMessageGrammarSpec extends AnyFunSuite with Matchers:
+  private def englishMessage(key: String, arg: String): String =
+    MessageBundles.format(MessageBundles.english, key, arg)
+
+  test("error.command.noArgument reads 'requires an argument'"):
+    englishMessage("error.command.noArgument", "-classpath") shouldBe
+      "-classpath requires an argument."
+
+  test("error.command.invalidArgument reads 'is an invalid argument'"):
+    englishMessage("error.command.invalidArgument", "-bogus") shouldBe
+      "-bogus is an invalid argument."
+
+  test("error.command.requireNaturalNumber reads 'is required to be a natural number'"):
+    englishMessage("error.command.requireNaturalNumber", "-maxErrorReport") shouldBe
+      "value of -maxErrorReport is required to be a natural number."
+
+  test("error.command.invalidEncoding reads 'is not a valid encoding name'"):
+    englishMessage("error.command.invalidEncoding", "-encoding") shouldBe
+      "value of -encoding is not a valid encoding name."
+
+  test("Japanese translations are unaffected (no articles in Japanese)"):
+    val ja = MessageBundles.japanese
+    MessageBundles.format(ja, "error.command.noArgument", "-classpath") should include("は引数を要求します")
+    MessageBundles.format(ja, "error.command.invalidArgument", "-bogus") should include("は不正な引数です")
+    MessageBundles.format(ja, "error.command.requireNaturalNumber", "-maxErrorReport") should include(
+      "正の整数でなければなりません"
+    )
+    MessageBundles.format(ja, "error.command.invalidEncoding", "-encoding") should include(
+      "不正なエンコーディング名です"
+    )


### PR DESCRIPTION
## Summary
- `onionc`/`onion`'s CLI-level usage errors (`error.command.*`, raised by `CompilerFrontend`/`ScriptRunner` for a malformed command line) were missing articles: `-classpath` with no value read `-classpath requires argument.`, an unrecognized flag read `is invalid argument.`, a bad `-encoding` value read `is not valid encoding name.`, and a non-numeric `-maxErrorReport` value read `is required to natural number.` -- the last one not just missing an article but missing the verb linking "required" to "natural number".
- Same class of defect as the recent E0018/E0020/E0027 message fixes, just for CLI-level messages that carry no E-code and no `docs/reference/error-codes.md` entry.
- Added `CommandErrorMessageGrammarSpec`, which pins the English text via `MessageBundles.english` (`Locale.ROOT`), so the assertions hold under both the suite's `en` and `ja` locale runs, and asserts the Japanese translations are unaffected (no articles in Japanese).
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` -- 4590 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated distribution test, unrelated to this change)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` -- 4590 succeeded, 0 failed, same 1 canceled

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSwn569QiQ8rScZsJSe1hz)_