### PR TITLE
Fix missing articles in E0005 and E0021 messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **E0005 "method not found" and E0021 "constructor not found" were missing
+  articles.** Same defect class as the recent E0018/E0020/E0027/E0028/E0050
+  fixes: E0005 read `method applicable for X.Y(Z) is not found.` and E0021 read
+  `constructor applicable for X(Y) is not found.` -- both now read `a method
+  applicable for ...` / `a constructor applicable for ...`. Fixed in the
+  English message bundle, in the quick-reference table of
+  `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` (the
+  Japanese messages themselves were unaffected -- no articles in Japanese),
+  and pinned by a new `E0005E0021MissingArticleSpec` using `MessageBundles`
+  so the exact English text is checked regardless of the JVM's default
+  locale.
+
 - **E0028 "lvalue is required" and E0050 "current instance not available" were
   missing articles.** Same defect class as the recent E0018/E0020/E0027 fixes:
   E0028 read `lvalue is required.` instead of `an lvalue is required.`, and

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -1455,7 +1455,7 @@ Test.on:2:10: Syntax error. Encountered "{", but expecting ";"
 | `E0002` | variable not found |
 | `E0003` | class not found |
 | `E0004` | field ….… is not found |
-| `E0005` | method applicable for ….…(…) is not found |
+| `E0005` | a method applicable for ….…(…) is not found |
 | `E0006` | ambiguous method |
 | `E0007` | duplicated local variable definition … |
 | `E0008` | duplicated class definition … |

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1466,7 +1466,7 @@ table lists all of them, so a code seen in a build log can always be looked up.
 | `E0002` | variable not found |
 | `E0003` | class not found |
 | `E0004` | field ….… is not found |
-| `E0005` | method applicable for ….…(…) is not found |
+| `E0005` | a method applicable for ….…(…) is not found |
 | `E0006` | ambiguous method |
 | `E0007` | duplicated local variable definition … |
 | `E0008` | duplicated class definition … |

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -23,8 +23,8 @@ error.semantic.fieldNotFound=field {0}.{1} is not found. Check spelling or field
 error.semantic.variableNotFound=local variable {0} is not found.
 error.semantic.cannotAssignToVal=cannot assign to val {0}. Use var for mutable variables.
 error.semantic.valRequiresInitializer=local val {0} must be initialized at its declaration. Add an initializer (val {0}: T = ...), or use var if you must assign it later.
-error.semantic.methodNotFound=method applicable for {0}.{1}({2}) is not found. Check spelling and argument types.
-error.semantic.constructorNotFound=constructor applicable for {0}({1}) is not found. Check argument types.
+error.semantic.methodNotFound=a method applicable for {0}.{1}({2}) is not found. Check spelling and argument types.
+error.semantic.constructorNotFound=a constructor applicable for {0}({1}) is not found. Check argument types.
 error.semantic.incompatibleOperandType=operator {0} is not applicable for type {1}. Check operand types.
 error.semantic.incompatibleType=type {0} is expected, but type {1} is used. Consider a cast or check return type.
 error.semantic.ambiguousMethod=method call is applicable for both {0}.{1}({2}) and {3}.{4}({5}).

--- a/src/test/scala/onion/compiler/E0005E0021MissingArticleSpec.scala
+++ b/src/test/scala/onion/compiler/E0005E0021MissingArticleSpec.scala
@@ -1,0 +1,37 @@
+package onion.compiler
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * E0005 ("method not found") and E0021 ("constructor not found") read "method
+ * applicable for X.Y(Z) is not found." and "constructor applicable for X(Y) is not
+ * found." -- missing the leading article, the same defect class already fixed for
+ * E0018/E0020/E0027/E0028/E0050 and the CLI `error.command.*` messages. The fixed
+ * text reads "a method applicable for ..." / "a constructor applicable for ...".
+ *
+ * Uses `MessageBundles.english`, which pins `Locale.ROOT` regardless of the JVM's
+ * default locale, so this test's assertions on English text hold under both the `en`
+ * and `ja` full-suite runs (see `MessageBundles` for why a naive
+ * `ResourceBundle.getBundle("errorMessage", Locale.ENGLISH)` would not).
+ */
+class E0005E0021MissingArticleSpec extends AnyFunSuite with Matchers:
+  private def englishMessage(key: String, args: Any*): String =
+    MessageBundles.format(MessageBundles.english, key, args*)
+
+  test("error.semantic.methodNotFound (E0005) reads 'a method applicable for ...'"):
+    englishMessage("error.semantic.methodNotFound", "Foo", "bar", "Int") shouldBe
+      "a method applicable for Foo.bar(Int) is not found. Check spelling and argument types."
+
+  test("error.semantic.constructorNotFound (E0021) reads 'a constructor applicable for ...'"):
+    englishMessage("error.semantic.constructorNotFound", "Foo", "Int") shouldBe
+      "a constructor applicable for Foo(Int) is not found. Check argument types."
+
+  test("Japanese translations are unaffected (no articles in Japanese)"):
+    val ja = MessageBundles.japanese
+    MessageBundles.format(ja, "error.semantic.methodNotFound", "Foo", "bar", "Int") should include(
+      "メソッドが見つかりません"
+    )
+    MessageBundles.format(ja, "error.semantic.constructorNotFound", "Foo", "Int") should include(
+      "コンストラクタが見つかりません"
+    )


### PR DESCRIPTION
## Summary
- E0005 ("method not found") read `method applicable for X.Y(Z) is not found.` and E0021 ("constructor not found") read `constructor applicable for X(Y) is not found.` -- both missing the leading article, the same defect class as the recent E0018/E0020/E0027/E0028/E0050 fixes.
- Now read `a method applicable for ...` / `a constructor applicable for ...` in the English message bundle.
- Updated the `E0005` row in the quick-reference tables of `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` to match (the Japanese messages themselves are unaffected -- no articles in Japanese; `E0021`'s quick-ref row is already a paraphrase, "constructor not found", not a literal quote, so it needed no change).
- Added `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- Added `src/test/scala/onion/compiler/E0005E0021MissingArticleSpec.scala`, which pins the exact English text via `MessageBundles.english` (`Locale.ROOT`), so it holds regardless of the JVM's default locale. Confirmed it fails against the pre-fix message text, then passes after the fix.
- Ran the full suite locally: `sbt shutdown && SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` -> 4598 succeeded, 0 failed, 1 canceled (pre-existing, opt-in `ProjectDistributionSpec` smoke test that self-cancels without `-Donion.dist.path`), completed in 2m15s.

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01MGPeQxzxG717b8cGAReqP4)_