### PR TITLE
Fix stale E0021 quick-reference table row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **E0021's quick-reference table row was stale.** The E0005/E0021
+  missing-article fix updated `error.semantic.constructorNotFound` to read `a
+  constructor applicable for X(Y) is not found.` and updated E0005's row in
+  the quick-reference table of `docs/reference/error-codes.md` and
+  `docs/ja/reference/error-codes.md` to match, but missed E0021's row, which
+  still read the pre-fix paraphrase `constructor not found`. Now reads `a
+  constructor applicable for …(…) is not found` in both tables, pinned by a
+  new `E0021QuickReferenceDriftSpec` so the table can't drift from the
+  message bundle again.
+
 - **E0016 "cyclic inheritance" had a subject-verb agreement error.** The message
   read `inheritance relations which includes X have cyclicity.` -- plural
   "relations" paired with singular "includes". Now reads `inheritance relations

--- a/docs/ja/reference/error-codes.md
+++ b/docs/ja/reference/error-codes.md
@@ -1470,7 +1470,7 @@ Test.on:2:10: Syntax error. Encountered "{", but expecting ";"
 | `E0018` | class … has illegal inheritance: … |
 | `E0019` | method ….… cannot be called |
 | `E0020` | this method cannot return a value |
-| `E0021` | constructor not found |
+| `E0021` | a constructor applicable for …(…) is not found |
 | `E0022` | ambiguous constructor |
 | `E0023` | an interface is required, but type … is used |
 | `E0025` | duplicated constructor definition …(…) |

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1481,7 +1481,7 @@ table lists all of them, so a code seen in a build log can always be looked up.
 | `E0018` | class … has illegal inheritance: … |
 | `E0019` | method ….… cannot be called |
 | `E0020` | this method cannot return a value |
-| `E0021` | constructor not found |
+| `E0021` | a constructor applicable for …(…) is not found |
 | `E0022` | ambiguous constructor |
 | `E0023` | an interface is required, but type … is used |
 | `E0025` | duplicated constructor definition …(…) |

--- a/src/test/scala/onion/compiler/E0021QuickReferenceDriftSpec.scala
+++ b/src/test/scala/onion/compiler/E0021QuickReferenceDriftSpec.scala
@@ -1,0 +1,26 @@
+package onion.compiler
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * The E0005/E0021 missing-article fix (see `E0005E0021MissingArticleSpec`) updated
+ * `error.semantic.constructorNotFound` to read "a constructor applicable for X(Y) is
+ * not found." and updated E0005's row in the quick-reference table of both
+ * `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` to match --
+ * but missed E0021's row, which still reads the pre-fix paraphrase "constructor not
+ * found" (it never even carried the "constructor applicable for ..." wording the
+ * property file had before that fix). This pins the row to the actual message text
+ * so the quick-reference table can't drift from the message bundle again.
+ */
+class E0021QuickReferenceDriftSpec extends AnyFunSuite with Matchers:
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private val expectedRow = "| `E0021` | a constructor applicable for …(…) is not found |"
+
+  test("the English quick-reference table's E0021 row matches the actual message"):
+    read("docs/reference/error-codes.md") should include(expectedRow)
+
+  test("the Japanese quick-reference table's E0021 row matches the actual message"):
+    read("docs/ja/reference/error-codes.md") should include(expectedRow)


### PR DESCRIPTION
## Summary
- The E0005/E0021 missing-article fix (#1040) updated `error.semantic.constructorNotFound` to read "a constructor applicable for X(Y) is not found." and updated E0005's row in the quick-reference table of `docs/reference/error-codes.md` and `docs/ja/reference/error-codes.md` to match, but missed E0021's row, which still read the pre-fix paraphrase "constructor not found."
- Fixed both tables' E0021 row to read "a constructor applicable for …(…) is not found", matching the actual message and the style used for E0005's row.
- Added `E0021QuickReferenceDriftSpec` to pin the table rows to the actual message text so this can't drift again.

## Test plan
- [x] Added a failing test (`E0021QuickReferenceDriftSpec`) confirming the doc drift, then fixed the docs and confirmed it passes.
- [x] Full suite green: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4606 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01J3zKx8cbAV2Yw6qVNMwkBh)_