### PR TITLE
Add parser hint for C++/C#-style `auto x = expr` declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `lambda params: expr` shape and points at Onion's arrow-lambda syntax
   (`(x) -> x + 1`) instead.
 
+- **Parser hint for a C++/C#-style `auto x = expr` type-inferred
+  declaration.** Since `auto` isn't a reserved word in Onion, `auto x = 5`
+  parsed `auto` as a bare identifier reference, which left `x = 5` reading as
+  a second, unrelated statement; the failure previously surfaced as the
+  generic missing-call-parens fallback (suggesting the nonsensical
+  `auto(...)`). The diagnostic now recognizes the `auto name = value` shape
+  and points at Onion's actual equivalent: `val name = value` (immutable) or
+  `var name = value` (mutable).
+
 ## [0.28.0] - 2026-08-30
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -155,6 +155,7 @@ error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and c
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.
 error.parsing.hint.js_style_let=Hint: Onion has no `let` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `let name = value`.
+error.parsing.hint.cpp_style_auto=Hint: Onion has no `auto` type-inference keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `auto name = value`.
 error.parsing.hint.rust_style_mut=Hint: Onion has no `mut` keyword — mutability is chosen by `val` (immutable) or `var` (mutable) directly, so drop `mut` — write `var {1} = ...`, not `{0} mut {1} = ...`.
 error.parsing.hint.if_let_binding=Hint: Onion has no Swift/Rust-style `{0} let` optional binding — bind the variable first, then null-check it: `var {1} = {2}; {0} {1} != null '{' ... '}'`, not `{0} let {1} = {2} '{' ... '}'`.
 error.parsing.hint.guard_let_else=Hint: Onion has no Swift-style `guard let ... else` early exit — bind the value, then invert the check for the exit: `val {0} = {1}; if {0} == null '{' ... '}'`, not `guard let {0} = {1} else '{' ... '}'`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -155,6 +155,7 @@ error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のた�
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。
 error.parsing.hint.js_style_let=ヒント: Onion に `let` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `let name = value` ではなく `val name: Type = value` と書いてください。
+error.parsing.hint.cpp_style_auto=ヒント: Onion に `auto` 型推論キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `auto name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.rust_style_mut=ヒント: Onion に `mut` キーワードはありません — 可変かどうかは `val`（不変）か `var`（可変）で直接指定するので、`mut` は取り除いてください — `{0} mut {1} = ...` ではなく `var {1} = ...` と書いてください。
 error.parsing.hint.if_let_binding=ヒント: Onion に Swift/Rust 風の `{0} let` オプショナルバインディングはありません — 先に変数を束縛してから null チェックしてください: `{0} let {1} = {2} '{' ... '}'` ではなく `var {1} = {2}; {0} {1} != null '{' ... '}'` と書いてください。
 error.parsing.hint.guard_let_else=ヒント: Onion に Swift 風の `guard let ... else` 早期リターンはありません — 先に値を束縛してから、脱出の条件を反転してください: `guard let {0} = {1} else '{' ... '}'` ではなく `val {0} = {1}; if {0} == null '{' ... '}'` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -26,6 +26,10 @@ private[compiler] object SyntaxHintClassifier {
   private val PythonStyleColonBlockClassHeader =
     """^\s*class\s+(.+?):\s*$""".r
   private val LeadingLetDeclaration = """^\s*let\s+[A-Za-z_]\w*\b""".r
+  // A C++/C#-style `auto x = expr;` type-inferred declaration -- `auto` isn't
+  // a reserved word, so it parses as a bare identifier and the rest reads as
+  // a stray second statement, same failure mode as LeadingLetDeclaration above.
+  private val LeadingAutoDeclaration = """^\s*auto\s+[A-Za-z_]\w*\s*=""".r
   private val RustStyleMutDeclaration =
     """^\s*(val|var)\s+mut\s+([A-Za-z_]\w*)""".r
   private val IfWhileLetBinding =
@@ -208,6 +212,8 @@ private[compiler] object SyntaxHintClassifier {
         controlFlowHint
       case _ if LeadingLetDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.js_style_let")
+      case _ if LeadingAutoDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+        hint("error.parsing.hint.cpp_style_auto")
       case _ if RustStyleMutDeclaration.findFirstMatchIn(sourceLine).isDefined =>
         val matched = RustStyleMutDeclaration.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.rust_style_mut", matched.group(1), matched.group(2))

--- a/src/test/scala/onion/compiler/CppStyleAutoDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/CppStyleAutoDeclarationHintI18nSpec.scala
@@ -1,0 +1,52 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The C++/C#-style `auto x = ...` type-inferred declaration hint
+ * (`SyntaxHintClassifier`'s `LeadingAutoDeclaration` case) must resolve
+ * through the bilingual `error.parsing.hint.*` bundle in both locales, like
+ * every other hint in that match -- see RustStyleMutDeclarationHintI18nSpec
+ * for the same pattern.
+ */
+class CppStyleAutoDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.cpp_style_auto"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a C++/C#-style `auto x = 5` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    auto x = 5
+        |    IO::println(x)
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint's `val`/`var` example text is literal source text, identical
+    // in both bundles, so this assertion holds regardless of the JVM's
+    // default locale.
+    assert(msgs.contains("val name"), s"expected the hint's `val name = ...` example, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary

- Onion has no `auto` type-inference keyword, and `auto` isn't a reserved word, so `auto x = 5` parsed `auto` as a bare identifier reference. The rest of the line (`x = 5`) then read as a second, unrelated statement, and the failure surfaced through the generic missing-call-parens fallback hint (suggesting the nonsensical `auto(...)`), with nothing connecting it back to the actual mistake.
- Adds a dedicated `SyntaxHintClassifier` rule (`LeadingAutoDeclaration`) that recognizes the `auto name = value` shape and points at Onion's actual equivalent: `val name = value` (immutable) or `var name = value` (mutable) — matching the existing hints for `let`/`const`/`mut`-style declarations from other languages.
- Adds the bilingual `error.parsing.hint.cpp_style_auto` message to both `errorMessage.properties` and `errorMessage_ja.properties`, plus an I18n end-to-end spec (`CppStyleAutoDeclarationHintI18nSpec`) following the same pattern as `RustStyleMutDeclarationHintI18nSpec`.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `CppStyleAutoDeclarationHintI18nSpec` written first and confirmed red (showed the confusing `auto(...)` missing-call-parens hint) before the fix
- [x] `CppStyleAutoDeclarationHintI18nSpec` green after the fix
- [x] Related hint/classifier specs (`SyntaxHintClassifierSpec`, `SyntaxErrorHintsSpec`, `DiagnosticHintsSpec`, `JsStyleLetHintI18nSpec`, `RustStyleMutDeclarationHintI18nSpec`) green, no regressions
- [x] Full suite (`sbt -Duser.language=en testFull`): 4511 tests, 0 failed, 1 canceled (pre-existing, unrelated)
- [x] Full suite (`sbt -Duser.language=ja testFull`): 4511 tests, 0 failed, 1 canceled (pre-existing, unrelated)


---
_Generated by [Claude Code](https://claude.ai/code/session_0134X3HX3UXLtx8JrkFRKc71)_