### PR TITLE
Fix wrong article in E0067 "missing return" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **E0067 "missing return" had a wrong article for vowel-initial return types.**
+  The message read `... without returning a {1}.` with `{1}` filled with the
+  method's declared return type, so a vowel-initial type read `without
+  returning a Int.` / `without returning a Object.` instead of `an Int.` /
+  `an Object.`. Same defect class as the recent E0089 wrong-article fix:
+  `SemanticErrorReporter` now derives the article from the substituted type
+  name (`indefiniteArticled`, already used for E0089) instead of hardcoding
+  one in the English message bundle; the Japanese message (no articles) is
+  unaffected. Fixed in the English message bundle only, and pinned by a new
+  `E0067MissingReturnArticleSpec` using `MessageBundles` so the exact English
+  text is checked regardless of the JVM's default locale.
+
 - **E0060 "regex capture group / binding count mismatch" had a number agreement
   bug.** The message spliced the raw counts into a literal `(s)` suffix instead of
   real pluralization: `the regex pattern has {0} capture group(s) but {1}

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -92,7 +92,7 @@ error.semantic.constructorDelegationCycle=constructor delegation in {0} never re
 error.semantic.constructorInRecordOrEnum={2} cannot declare `def this`: {1} already has its canonical constructor, and there is nothing a second one could mean. Use a static factory method instead.
 error.semantic.thisBeforeConstructorDelegation=`this` is used in a constructor''s delegation arguments before the object of {0} exists. Neither `this` nor a field can be read in the arguments of `: this(...)` or `extends B(...)`; pass a parameter or a constant instead.
 error.semantic.rawTypeNotAllowed=raw type {0} is not allowed; supply type arguments (e.g. {0}[...]). Onion forbids raw generic types.
-error.semantic.missingReturn=method {0} may reach the end of its body without returning a {1}. Every path must return a value (or throw); use an explicit `return`, or the `= expr` body form.
+error.semantic.missingReturn=method {0} may reach the end of its body without returning {2}. Every path must return a value (or throw); use an explicit `return`, or the `= expr` body form.
 error.semantic.exampleFailedFalse=example `{0}` in {1} failed: evaluated to false
 error.semantic.exampleFailedThrew=example `{0}` in {1} failed: threw {2}
 error.semantic.lawFalsified=law `{0}` in {1} falsified by counterexample: ({2})  [reproduce: {3}]

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -325,9 +325,16 @@ class SemanticErrorReporter(threshold: Int) {
       "error.semantic.rawTypeNotAllowed",
       Seq(items => asString(items(0)))
     ),
+    // {1} is the raw type name (used by the Japanese template, which has no
+    // article to agree). {2} is the English-only "a X"/"an X" phrase, same
+    // pattern as `indefiniteArticled`'s use for CONSTRUCTOR_IN_RECORD_OR_ENUM.
     SemanticError.MISSING_RETURN -> ErrorDef(
       "error.semantic.missingReturn",
-      Seq(items => asString(items(0)), items => typeName(items(1)))
+      Seq(
+        items => asString(items(0)),
+        items => typeName(items(1)),
+        items => indefiniteArticled(typeName(items(1)))
+      )
     ),
     // {1}/{2} are the raw counts (used by the Japanese template, which counts with
     // "個" and has no plural form to agree). {3}/{4} are English-only pre-pluralized

--- a/src/test/scala/onion/compiler/E0067MissingReturnArticleSpec.scala
+++ b/src/test/scala/onion/compiler/E0067MissingReturnArticleSpec.scala
@@ -1,0 +1,38 @@
+package onion.compiler
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * E0067 ("missing return") reads "method {0} may reach the end of its body
+ * without returning a {1}.", where {1} is filled with the method's declared
+ * return type name. The hardcoded article "a" is wrong whenever that type name
+ * starts with a vowel sound: `def bar(): Int { ... }` renders "without
+ * returning a Int." instead of "without returning an Int.", and likewise for
+ * `Object`, `Array`, etc. Same defect class as the recent E0003/E0089 missing/
+ * wrong-article fixes: `SemanticErrorReporter` now derives the article from the
+ * substituted type name (`indefiniteArticled`, already used for E0089) instead
+ * of hardcoding one in the English message bundle; the Japanese message (no
+ * articles) is unaffected.
+ *
+ * Uses `MessageBundles.english`, which pins `Locale.ROOT` regardless of the
+ * JVM's default locale, so this test's assertions on English text hold under
+ * both the `en` and `ja` full-suite runs.
+ */
+class E0067MissingReturnArticleSpec extends AnyFunSuite with Matchers:
+  private def englishMessage(key: String, args: Any*): String =
+    MessageBundles.format(MessageBundles.english, key, args*)
+
+  test("error.semantic.missingReturn (E0067) reads 'an Int' for a vowel-initial return type"):
+    englishMessage("error.semantic.missingReturn", "bar", "Int", "an Int") shouldBe
+      "method bar may reach the end of its body without returning an Int. Every path must return a value (or throw); use an explicit `return`, or the `= expr` body form."
+
+  test("error.semantic.missingReturn (E0067) reads 'a String' for a consonant-initial return type"):
+    englishMessage("error.semantic.missingReturn", "bar", "String", "a String") shouldBe
+      "method bar may reach the end of its body without returning a String. Every path must return a value (or throw); use an explicit `return`, or the `= expr` body form."
+
+  test("Japanese translation is unaffected (no articles in Japanese)"):
+    val ja = MessageBundles.japanese
+    MessageBundles.format(ja, "error.semantic.missingReturn", "bar", "Int", "unused") should include(
+      "本体の末尾に到達する可能性があります"
+    )


### PR DESCRIPTION
## Summary
- E0067 ("missing return") read `... without returning a {1}.` with `{1}` filled by the method's declared return type, so a vowel-initial type read `without returning a Int.` / `without returning a Object.` instead of `an Int.` / `an Object.`.
- Same defect class as the recent E0089 wrong-article fix: `SemanticErrorReporter` now derives the article from the substituted type name (`indefiniteArticled`, already used for E0089) instead of hardcoding one in the English message bundle. The Japanese message (no articles) is unaffected.
- Added `E0067MissingReturnArticleSpec` using `MessageBundles.english`/`.japanese` so the exact English text is checked regardless of the JVM's default locale, and added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4631 succeeded, 0 failed, 1 canceled (environment-conditional distribution smoke test, unrelated)
- [x] New `E0067MissingReturnArticleSpec` passes; existing `MissingReturnSpec` (E0067) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nfzU7xV3GtdXJct9Wjibs

---
_Generated by [Claude Code](https://claude.ai/code/session_012nfzU7xV3GtdXJct9Wjibs)_