### PR TITLE
Add parser hint for Ruby-style `rescue` clause on a `try` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Parser hint for a Ruby-style `rescue` clause on a `try` block.** Writing
+  `try { ... } rescue e: Exception { ... }` (or any other Ruby `rescue`
+  clause) — `rescue` isn't a keyword in Onion, so it parsed as a bare
+  identifier-reference statement and the parser tripped on whatever followed
+  it (the exception type or bound name) instead of naming the actual mistake.
+  `ControlFlowSyntaxHints` now recognizes a bare `rescue` the same way it
+  already recognized Python's `except`, and explains that exceptions are
+  caught with `catch e: Exception { ... }` instead. Same pattern as the
+  existing `except`/`unless`/`until` Ruby/Python-style hints; pinned by new
+  `RescueClauseHintI18nSpec` and `RescueClauseHintSpec` tests plus a case in
+  `ControlFlowSyntaxHintsSpec`.
+
 - **Parser hint for a Rust-style `name!(...)` macro call.** Writing
   `println!("hi")`, `assert_eq!(x, y)`, `vec!(1, 2)`, or any other
   Rust `macro!(...)` invocation — `!` is Onion's prefix logical-not operator,

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -123,6 +123,7 @@ error.parsing.hint.elif_not_supported=Hint: Onion has no Python-style `elif` cla
 error.parsing.hint.elsif_not_supported=Hint: Onion has no Ruby-style `elsif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.elseif_not_supported=Hint: Onion has no PHP-style `elseif` clause. Chain with `else if` instead: `if a { ... } else if b { ... } else { ... }`.
 error.parsing.hint.except_not_supported=Hint: Onion has no Python-style `except` clause. Catch exceptions with `catch` instead: `try { ... } catch e: Exception { ... }`.
+error.parsing.hint.rescue_not_supported=Hint: Onion has no Ruby-style `rescue` clause. Catch exceptions with `catch` instead: `try { ... } catch e: Exception { ... }`.
 error.parsing.hint.python_style_raise_construct=Hint: Onion has no Python-style `raise` statement — throw an exception with `throw new` instead — write `throw new {0}({1})`, not `raise {0}({1})`.
 error.parsing.hint.python_style_raise=Hint: Onion has no Python-style `raise` statement — throw an exception with `throw` instead — write `throw {0}`, not `raise {0}`.
 error.parsing.hint.unless_not_supported=Hint: Onion has no Ruby-style `unless` statement. Negate the condition and use `if` instead: `if !condition { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -123,6 +123,7 @@ error.parsing.hint.elif_not_supported=ヒント: Onion に Python 風の `elif` 
 error.parsing.hint.elsif_not_supported=ヒント: Onion に Ruby 風の `elsif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.elseif_not_supported=ヒント: Onion に PHP 風の `elseif` 節はありません。代わりに `else if` で連鎖させてください: `if a { ... } else if b { ... } else { ... }`。
 error.parsing.hint.except_not_supported=ヒント: Onion に Python 風の `except` 節はありません。代わりに `catch` で例外を捕捉してください: `try { ... } catch e: Exception { ... }`。
+error.parsing.hint.rescue_not_supported=ヒント: Onion に Ruby 風の `rescue` 節はありません。代わりに `catch` で例外を捕捉してください: `try { ... } catch e: Exception { ... }`。
 error.parsing.hint.python_style_raise_construct=ヒント: Onion に Python 風の `raise` 文はありません — 例外は `throw new` で投げてください — `raise {0}({1})` ではなく `throw new {0}({1})` と書いてください。
 error.parsing.hint.python_style_raise=ヒント: Onion に Python 風の `raise` 文はありません — 例外は `throw` で投げてください — `raise {0}` ではなく `throw {0}` と書いてください。
 error.parsing.hint.unless_not_supported=ヒント: Onion に Ruby 風の `unless` 文はありません。条件を否定して `if` を使ってください: `if !condition { ... }`。

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -12,6 +12,7 @@ private[compiler] object ControlFlowSyntaxHints {
   private val LeadingUnlessStatement = """^\s*unless\b""".r
   private val LeadingUntilStatement = """^\s*until\b""".r
   private val ExceptClause = """\bexcept\b""".r
+  private val RescueClause = """\brescue\b""".r
   // A raised value shaped like a constructor call (`raise Exception("boom")`)
   // gets a `throw new` suggestion; anything else (e.g. a bare re-raise like
   // `raise e`) falls through to the plain `throw` case below it, so this must
@@ -60,6 +61,8 @@ private[compiler] object ControlFlowSyntaxHints {
       hint("error.parsing.hint.until_not_supported")
     } else if (ExceptClause.findFirstMatchIn(sourceLine).isDefined) {
       hint("error.parsing.hint.except_not_supported")
+    } else if (RescueClause.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.rescue_not_supported")
     } else if (LeadingRaiseConstructorCall.findFirstMatchIn(sourceLine).isDefined) {
       val matched = LeadingRaiseConstructorCall.findFirstMatchIn(sourceLine).get
       hint("error.parsing.hint.python_style_raise_construct", matched.group(1), matched.group(2).trim)

--- a/src/test/scala/onion/compiler/RescueClauseHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/RescueClauseHintI18nSpec.scala
@@ -1,0 +1,56 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A Ruby-style `rescue` clause on a `try` block (`ControlFlowSyntaxHints`'s
+ * `RescueClause` case) must resolve through the bilingual `error.parsing.hint.*`
+ * bundle in both locales, like every other hint in that family -- see
+ * ExceptClauseHintI18nSpec for the same pattern. Onion has no `rescue`
+ * clause; exceptions are caught with `catch`, so a bare
+ * `try { ... } rescue e: Exception { ... }` previously had no dedicated
+ * diagnostic pointing at it.
+ */
+class RescueClauseHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.rescue_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Ruby-style `rescue` clause on a `try` block") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    try {
+        |      IO::println("risky")
+        |    } rescue e: Exception {
+        |      IO::println("caught")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint text is identical in both bundles' relevant markers, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("catch"), s"expected the hint's `catch` suggestion, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
+++ b/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
@@ -15,6 +15,7 @@ class ControlFlowSyntaxHintsSpec extends AnyFunSpec with Matchers {
         ("unless", "unless done {", "error.parsing.hint.unless_not_supported"),
         ("until", "until done {", "error.parsing.hint.until_not_supported"),
         ("error", "} except error: Exception {", "error.parsing.hint.except_not_supported"),
+        ("error", "} rescue error {", "error.parsing.hint.rescue_not_supported"),
         ("Exception", "raise Exception(\"boom\")", "error.parsing.hint.python_style_raise_construct"),
         ("e", "raise e", "error.parsing.hint.python_style_raise"),
         ("foo", "await foo()", "error.parsing.hint.await_not_supported"),

--- a/src/test/scala/onion/compiler/tools/RescueClauseHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RescueClauseHintSpec.scala
@@ -1,0 +1,58 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * Onion has no Ruby-style `rescue` clause on a `try` block -- exceptions
+ * are caught with `catch`. `rescue` isn't a keyword in Onion, so it parses
+ * as a bare identifier-reference statement and the parser actually trips on
+ * whatever follows it (the exception type or bound name), never on `rescue`
+ * itself.
+ */
+class RescueClauseHintSpec extends AbstractShellSpec {
+  private def messages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("rescue clause") {
+    it("hints at catch for a Ruby-style rescue chained onto the closing brace") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    try {
+          |      IO::println("risky")
+          |    } rescue e: Exception {
+          |      IO::println("caught")
+          |    }
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("catch"), s"expected a hint mentioning catch, got: $msgs")
+      assert(msgs.contains("rescue"), s"expected the hint to name rescue, got: $msgs")
+    }
+
+    it("does not fire for an unrelated bare-identifier-statement typo") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    foo bar
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(!msgs.contains("rescue"), s"hint should not fire without a `rescue`, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `rescue` isn't an Onion keyword, so a Ruby-style `try { ... } rescue e: Exception { ... }` clause parsed as a bare identifier-reference statement and the parser tripped on whatever followed it (the exception type or bound name), with no diagnostic connecting the failure back to the actual mistake.
- `ControlFlowSyntaxHints` now recognizes a bare `rescue` the same way it already recognizes Python's `except`, and points at `catch e: Exception { ... }` instead — same bilingual (en/ja) hint pattern as the existing `except`/`unless`/`until` Ruby/Python-style hints.
- Added `error.parsing.hint.rescue_not_supported` to both message bundles, a case in `ControlFlowSyntaxHints.scala`, a case in `ControlFlowSyntaxHintsSpec`, and new `RescueClauseHintI18nSpec` / `RescueClauseHintSpec` integration tests.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4644 tests, 0 failed, 1 canceled (pre-existing), all passed.
- [x] Targeted run of the new/changed specs (`ControlFlowSyntaxHintsSpec`, `RescueClauseHintI18nSpec`, `RescueClauseHintSpec`, `HintMessageKeyCoverageSpec`, `MessageBundleKeyParitySpec`) confirmed red before the fix and green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKDYux9GyqBdYk8NS6Jpv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKDYux9GyqBdYk8NS6Jpv5)_