### PR TITLE
Hint at the qualified form for a bare call to a former default import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Diagnostic hint for a bare call to a former default import.** `readText(p)`,
+  `get(url)`, `now()`, `exit(1)` and similar calls used to resolve bare; v0.10 narrowed
+  the default static import set to pure classes, dropping `System`, `Runtime`, `Files`,
+  `Http` and `DateTime` (CLAUDE.md's own migration note for #360). An unqualified call
+  to one of their real static methods surfaced as an ordinary "method not found" naming
+  the synthetic top-level (or enclosing) class as if the call were simply misspelled,
+  with nothing connecting it back to the import change. `SemanticErrorReporter` now
+  points at the qualified form (e.g. `Files::readText(...)`) whenever the call's name
+  and argument count exactly match one of those five classes' real static methods --
+  looked up by reflecting on the actual runtime classes rather than a hand-maintained
+  list that could drift -- restricted to a genuinely unqualified call so a qualified
+  call on an unrelated receiver is left alone even when the name happens to collide.
+  Pinned by new `StdlibNoLongerDefaultImportedHintSpec` and
+  `StdlibNoLongerDefaultImportedMessageSpec` tests.
+
 ## [0.32.0] - 2026-09-02
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -70,6 +70,7 @@ suggestion.fieldNotMethod=hint: {0} is a field, not a method; access it without 
 suggestion.jsTemplateLiteral=hint: Onion has no JS/TS-style backtick template literals; a backtick only escapes a reserved word into an identifier. Use string interpolation instead: write "text #{expr}", not `text ${expr}`.
 suggestion.jsConsoleLog=hint: Onion has no JS-style `console` object; there is no console.log/console.error/console.warn. Use IO::println(...) for output instead.
 suggestion.pythonFString=hint: Onion has no Python-style f-string prefix; an identifier directly before a string literal desugars to a call, so f"text {expr}" parses as a call to a function named f. Use string interpolation instead: write "text #{expr}", not f"text {expr}".
+suggestion.stdlibNoLongerDefaultImported=hint: {1} is a static member of {0}, which is no longer a default import (the default static import set was narrowed to pure classes) -- qualify the call as {0}::{1}(...).
 error.parsing.unterminated_string=unterminated string literal: missing closing quote.
 error.suggestion.candidates=available: {0}
 error.suggestion.availableConstructors=available constructors:

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -69,6 +69,7 @@ suggestion.fieldNotMethod=ヒント: {0} はメソッドではなくフィール
 suggestion.jsTemplateLiteral=ヒント: Onion に JS/TS 風のバッククォートテンプレートリテラルはありません。バッククォートは予約語を識別子にエスケープするだけです。文字列補間を使ってください: `text ${expr}` ではなく "text #{expr}" と書きます。
 suggestion.jsConsoleLog=ヒント: Onion に JS 風の console オブジェクトはありません。console.log/console.error/console.warn は存在しません。出力には代わりに IO::println(...) を使ってください。
 suggestion.pythonFString=ヒント: Onion に Python 風の f-string プレフィックスはありません。文字列リテラルの直前の識別子は呼び出しとして解釈されるため、f"text {expr}" は関数 f の呼び出しとして解析されます。文字列補間を使ってください: f"text {expr}" ではなく "text #{expr}" と書きます。
+suggestion.stdlibNoLongerDefaultImported=ヒント: {1} は {0} の静的メンバーで、デフォルトではインポートされなくなりました (デフォルトの静的インポート対象は副作用のないクラスに絞られています)。{0}::{1}(...) のように修飾して呼び出してください。
 error.parsing.unterminated_string=\u6587\u5b57\u5217\u30ea\u30c6\u30e9\u30eb\u304c\u9589\u3058\u3089\u308c\u3066\u3044\u307e\u305b\u3093\u3002\u9589\u3058\u5f15\u7528\u7b26 " \u3092\u8ffd\u52a0\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 error.suggestion.candidates=\u5019\u88dc: {0}
 error.suggestion.availableConstructors=\u5229\u7528\u53ef\u80fd\u306a\u30b3\u30f3\u30b9\u30c8\u30e9\u30af\u30bf:

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -597,7 +597,11 @@ class SemanticErrorReporter(threshold: Int) {
   private def reportMethodNotFound(position: Location, items: Array[AnyRef]): Unit = {
     val targetType = items(0).asInstanceOf[TypedAST.Type]
     val name = asString(items(1))
-    val args = typeNames(asTypeArray(items(2)))
+    val argTypes = asTypeArray(items(2))
+    val args = typeNames(argTypes)
+    // Set only by an actually-unqualified call (UnqualifiedMethodCallSupport); every
+    // other report site omits it, defaulting to false -- see FormerDefaultImportLookup.
+    val isUnqualifiedCall = items.length > 3 && items(3) == java.lang.Boolean.TRUE
     val baseMessage = format(message("error.semantic.methodNotFound"), Seq(typeName(targetType), name, args))
     // A method with that exact name exists: show its signatures instead of
     // a (possibly misleading) name-similarity suggestion
@@ -626,6 +630,14 @@ class SemanticErrorReporter(threshold: Int) {
         // fieldNamed to match (their length is resolved specially, not as a
         // TypedAST field), so it needs its own check.
         Some(format(message("suggestion.fieldNotMethod"), Seq(name)))
+      } else if (isUnqualifiedCall && FormerDefaultImportLookup.find(name, argTypes.length).isDefined) {
+        // A bare call to a method that used to be default-imported (v0.10 narrowed the
+        // set to pure classes -- CLAUDE.md's own migration note). Restricted to
+        // genuinely unqualified calls: at that report site every other resolution path
+        // (current class, top-level functions, static imports, callable values) has
+        // already failed, so a name+arity match here can only be this stdlib method.
+        val className = FormerDefaultImportLookup.find(name, argTypes.length).get
+        Some(format(message("suggestion.stdlibNoLongerDefaultImported"), Seq(className, name)))
       } else {
         val candidates = targetType match
           case obj: TypedAST.ObjectType =>
@@ -634,6 +646,45 @@ class SemanticErrorReporter(threshold: Int) {
         toolbox.Suggestions.formatSuggestion(name, candidates)
       }
     problem(position, appendSuggestion(baseMessage, suggestion))
+  }
+
+  /**
+   * `readText(p)`, `get(url)`, `now()`, `exit(1)` and similar calls used to resolve
+   * bare: v0.10 narrowed the default static import set to pure classes, dropping
+   * `System`, `Runtime`, `Files`, `Http` and `DateTime` (CLAUDE.md's own migration
+   * note for that change). An unqualified call to one of their real static methods
+   * then surfaces as an ordinary METHOD_NOT_FOUND with nothing connecting it back to
+   * that change, so `reportMethodNotFound` points at the qualified form instead of a
+   * name-similarity guess. Built by reflecting on the actual runtime classes -- shipped
+   * with the compiler itself, so always on its classpath regardless of the program
+   * being compiled -- rather than a hand-maintained list that could drift from the
+   * real API surface.
+   */
+  private object FormerDefaultImportLookup {
+    private val classes: Seq[Class[?]] = Seq(
+      classOf[java.lang.System],
+      classOf[java.lang.Runtime],
+      classOf[onion.Files],
+      classOf[onion.Http],
+      classOf[onion.DateTime]
+    )
+
+    // (name, arity) -> simple class name. A name/arity pair shared by two of these
+    // classes is dropped rather than guessed at.
+    private lazy val index: Map[(String, Int), String] = {
+      val entries = for {
+        cls <- classes
+        m <- cls.getMethods
+        mods = m.getModifiers
+        if java.lang.reflect.Modifier.isStatic(mods) && java.lang.reflect.Modifier.isPublic(mods)
+        if m.getDeclaringClass == cls
+      } yield (m.getName, m.getParameterCount) -> cls.getSimpleName
+      entries.groupBy(_._1).collect {
+        case (key, matches) if matches.map(_._2).distinct.size == 1 => key -> matches.head._2
+      }
+    }
+
+    def find(name: String, arity: Int): Option[String] = index.get((name, arity))
   }
 
   private def fieldNamed(targetType: TypedAST.Type, name: String): Boolean =

--- a/src/main/scala/onion/compiler/typing/MethodCallReportingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallReportingSupport.scala
@@ -13,9 +13,10 @@ private[compiler] final class MethodCallReportingSupport(
     node: AST.Node,
     targetType: AnyRef,
     name: String,
-    argTypes: Array[Type]
+    argTypes: Array[Type],
+    isUnqualifiedCall: Boolean = false
   ): Unit =
-    bodyContext.report(METHOD_NOT_FOUND, node, targetType, name, argTypes)
+    bodyContext.report(METHOD_NOT_FOUND, node, targetType, name, argTypes, java.lang.Boolean.valueOf(isUnqualifiedCall))
 
   def reportAmbiguousMethods(
     node: AST.Node,

--- a/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
@@ -214,9 +214,10 @@ final class MethodCallTyping(
     node: AST.Node,
     targetType: AnyRef,
     name: String,
-    argTypes: Array[Type]
+    argTypes: Array[Type],
+    isUnqualifiedCall: Boolean = false
   ): Unit =
-    methodCallReportingSupport.reportMethodNotFound(node, targetType, name, argTypes)
+    methodCallReportingSupport.reportMethodNotFound(node, targetType, name, argTypes, isUnqualifiedCall)
 
   /** Error count so far; a checkpoint before typing a trailing-closure body and a
    *  comparison after tells whether the body itself reported an error, so a

--- a/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
@@ -101,7 +101,7 @@ private[compiler] final class UnqualifiedMethodCallSupport(
               resolveTopLevelStaticCall(node, params, expected) match {
                 case Some(term) => Some(term)
                 case None =>
-                  calls.reportMethodNotFound(node, targetType, node.name, calls.types(params))
+                  calls.reportMethodNotFound(node, targetType, node.name, calls.types(params), isUnqualifiedCall = true)
                   None
               }
           }
@@ -195,7 +195,7 @@ private[compiler] final class UnqualifiedMethodCallSupport(
             callableValueCallSupport.resolveCallableValue(node, params0, context, expected) match {
               case some @ Some(_) => some
               case None =>
-                calls.reportMethodNotFound(node, targetType, name, calls.types(params0))
+                calls.reportMethodNotFound(node, targetType, name, calls.types(params0), isUnqualifiedCall = true)
                 None
             }
         }

--- a/src/test/scala/onion/compiler/StdlibNoLongerDefaultImportedMessageSpec.scala
+++ b/src/test/scala/onion/compiler/StdlibNoLongerDefaultImportedMessageSpec.scala
@@ -1,0 +1,25 @@
+package onion.compiler
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Pins the exact bilingual text of `suggestion.stdlibNoLongerDefaultImported`
+ * (see `StdlibNoLongerDefaultImportedHintSpec` for the end-to-end behavior),
+ * independent of the JVM's default locale -- same pattern as
+ * `E0067MissingReturnArticleSpec`.
+ */
+class StdlibNoLongerDefaultImportedMessageSpec extends AnyFunSuite with Matchers:
+  private def englishMessage(key: String, args: Any*): String =
+    MessageBundles.format(MessageBundles.english, key, args*)
+
+  test("suggestion.stdlibNoLongerDefaultImported names the class and the qualified call in English"):
+    englishMessage("suggestion.stdlibNoLongerDefaultImported", "Files", "readText") shouldBe
+      "hint: readText is a static member of Files, which is no longer a default import (the default static import set was narrowed to pure classes) -- qualify the call as Files::readText(...)."
+
+  test("Japanese translation names the class and the qualified call"):
+    val ja = MessageBundles.japanese
+    val text = MessageBundles.format(ja, "suggestion.stdlibNoLongerDefaultImported", "Files", "readText")
+    text should include("Files::readText(...)")
+    text should include("Files")
+    text should include("readText")

--- a/src/test/scala/onion/compiler/tools/StdlibNoLongerDefaultImportedHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibNoLongerDefaultImportedHintSpec.scala
@@ -1,0 +1,116 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import java.io.StringReader
+
+/**
+ * v0.10 narrowed the default static import set to pure classes (#360): `System`,
+ * `Runtime`, `Files`, `Http` and `DateTime` are no longer imported into every file, so
+ * a bare `readText(p)` / `get(url)` / `now()` / `exit(1)` stops resolving -- exactly
+ * the gotcha CLAUDE.md documents under "Tools, capabilities and effects". Without a
+ * hint, the failure is an ordinary METHOD_NOT_FOUND naming the synthetic top-level (or
+ * enclosing) class as if the call were simply misspelled, with nothing connecting it
+ * back to the import change. `SemanticErrorReporter.reportMethodNotFound` now points at
+ * the qualified form whenever the name and argument count exactly match one of those
+ * five classes' real static methods -- but only for a genuinely unqualified call, since
+ * that is the one situation where every other resolution path has already failed and a
+ * name+arity match can only be this stdlib method.
+ */
+class StdlibNoLongerDefaultImportedHintSpec extends AbstractShellSpec {
+  private def errors(src: String) = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs
+      case _ => Seq.empty
+    }
+  }
+
+  private def messagesOf(src: String): String = errors(src).map(_.message).mkString("\n")
+  private def codesOf(src: String): Seq[String] = errors(src).flatMap(_.code)
+
+  describe("bare call to a former default import") {
+    it("hints at Files::readText for a bare one-argument readText call") {
+      val src =
+        """
+          |def main(): void {
+          |  val x = readText("f.txt")
+          |  IO::println(x)
+          |}
+          |""".stripMargin
+      assert(codesOf(src).contains("E0005"), s"expected E0005 (method not found), got: ${codesOf(src)}")
+      val msgs = messagesOf(src)
+      assert(msgs.contains("Files::readText"), s"expected a hint naming Files::readText, got: $msgs")
+    }
+
+    it("hints at DateTime::now for a bare zero-argument now call") {
+      val src =
+        """
+          |def main(): void {
+          |  val t = now()
+          |  IO::println(t)
+          |}
+          |""".stripMargin
+      val msgs = messagesOf(src)
+      assert(msgs.contains("DateTime::now"), s"expected a hint naming DateTime::now, got: $msgs")
+    }
+
+    it("hints at System::exit for a bare one-argument exit call") {
+      val src =
+        """
+          |def main(): void {
+          |  exit(1)
+          |}
+          |""".stripMargin
+      val msgs = messagesOf(src)
+      assert(msgs.contains("System::exit"), s"expected a hint naming System::exit, got: $msgs")
+    }
+
+    it("fires inside an ordinary class method, not only at the top level") {
+      val src =
+        """
+          |class Greeter {
+          |public:
+          |  def greet(): void {
+          |    val body = readText("f.txt")
+          |    IO::println(body)
+          |  }
+          |}
+          |def main(): void {
+          |  new Greeter().greet()
+          |}
+          |""".stripMargin
+      val msgs = messagesOf(src)
+      assert(msgs.contains("Files::readText"), s"expected a hint naming Files::readText, got: $msgs")
+    }
+
+    it("does not fire for an unrelated unqualified not-found call") {
+      val src =
+        """
+          |def main(): void {
+          |  frobnicate(1)
+          |}
+          |""".stripMargin
+      assert(codesOf(src).contains("E0005"), s"expected E0005 (method not found), got: ${codesOf(src)}")
+      val msgs = messagesOf(src)
+      assert(!msgs.contains("no longer a default import"), s"hint should not fire for an unrelated name, got: $msgs")
+    }
+
+    it("does not fire for a qualified call on an unrelated receiver, even with a matching name") {
+      val src =
+        """
+          |class Box {
+          |public:
+          |  val value: Int
+          |  def this(value: Int) { self.value = value }
+          |}
+          |def main(): void {
+          |  val b = new Box(1)
+          |  b.get()
+          |}
+          |""".stripMargin
+      assert(codesOf(src).contains("E0005"), s"expected E0005 (method not found), got: ${codesOf(src)}")
+      val msgs = messagesOf(src)
+      assert(!msgs.contains("no longer a default import"), s"hint should not fire for a qualified call, got: $msgs")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`readText(p)`, `get(url)`, `now()`, `exit(1)` and similar calls used to resolve bare. v0.10 narrowed the default static import set to pure classes, dropping `System`, `Runtime`, `Files`, `Http` and `DateTime` (CLAUDE.md's own migration note for #360). Since then, an unqualified call to one of their real static methods has surfaced as an ordinary "method not found" error naming the synthetic top-level (or enclosing) class as if the call were simply misspelled — with nothing connecting the failure back to the import change.

`SemanticErrorReporter.reportMethodNotFound` now appends a hint pointing at the qualified form (e.g. `Files::readText(...)`) whenever the call's name and argument count exactly match one of those five classes' real static methods. The lookup table is built by reflecting on the actual runtime classes (shipped with the compiler itself, so always on its own classpath) rather than a hand-maintained list that could drift from the real API surface.

To avoid false positives, the hint is restricted to a genuinely *unqualified* call — a new `isUnqualifiedCall` flag is threaded through `reportMethodNotFound`, set only by `UnqualifiedMethodCallSupport`. At that report site every other resolution path (current class, top-level functions, static imports, callable values) has already failed, so a name+arity match can only be this stdlib method. A qualified call on an unrelated receiver (`obj.get()` on some unrelated class) is left alone even when the name happens to collide.

Both English and Japanese message bundles are updated.

## Test plan

- [x] New `StdlibNoLongerDefaultImportedHintSpec` (end-to-end compile): fires for bare `readText`/`now`/`exit` at top level and inside a class method; does not fire for an unrelated unqualified not-found call or for a qualified call on an unrelated receiver with a colliding name.
- [x] New `StdlibNoLongerDefaultImportedMessageSpec`: pins the exact English and Japanese hint text via `MessageBundles`, independent of the JVM's default locale.
- [x] Full suite green under `-Duser.language=en`: 4652 succeeded, 0 failed (1 pre-existing environment-gated cancel, unrelated to this change).
- [x] Full suite green under `-Duser.language=ja`: 4652 succeeded, 0 failed (same pre-existing cancel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxcvMPPgckTBXWuKpovX6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxcvMPPgckTBXWuKpovX6w)_