### PR TITLE
Document typeof/nullish-coalescing/with-as/lambda hints in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,6 +500,7 @@ These are frequently confused with other languages. **Always check these:**
 |-------|-----------------|
 | `x -> x * 2` | ✓ correct - bare single param works; expression bodies too |
 | `(x) -> expr` | ✓ correct - param types inferred from the expected function type |
+| `lambda x: x * 2` (Python) | `(x) -> x * 2` - no `lambda` keyword, use an arrow lambda |
 | `func(arg)` for lambda | ✓ correct - function values are called directly |
 | lambda as `Runnable`/`Comparator` | ✓ correct - SAM conversion to Java functional interfaces |
 | `Int -> Int` | ✓ correct - single param function type |
@@ -522,6 +523,7 @@ These are frequently confused with other languages. **Always check these:**
 | `throw new Exception();` | `throw new Exception("msg")` - same syntax |
 | `try { } catch { } finally { }` | ✓ correct - finally is supported |
 | `using r = expr { }` | `try (val r = expr) { }` - try-with-resources; multiple via `;`, closed in reverse order |
+| `with expr as r { }` (Python) | `try (val r = expr) { }` - try-with-resources, same as above |
 | `catch (Type e)` | `catch e: Type` - no parens, type after colon |
 
 ### Tools, capabilities and effects (v0.10)
@@ -545,6 +547,8 @@ These are frequently confused with other languages. **Always check these:**
 | `&&`, `\|\|` operators | ✓ correct - same as Java |
 | `!condition` | ✓ correct - same as Java |
 | `a ? b : c` ternary | Not supported - use `if/else` expression |
+| `a ?? b` nullish coalescing (JS) | `a ?: b` - use the Elvis operator instead |
+| `typeof x` (JS/Python) | `x is Type` - check a value's type with the `is` operator instead |
 | `operator fun plus` (Kotlin) | `def plus(o: T): T` - `+ - * / %` map to plus/minus/times/div/rem on the left operand |
 | String templates `$var` or `${expr}` | `"text #{expr}"` - use `#{}` syntax |
 | `this` only | `self` also works - both refer to current instance |

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -449,6 +449,7 @@ try {
 |-----|----------------|
 | `x -> x * 2` | ✓ 正しい - 裸の単一引数はそのまま使える。式本体も使える |
 | `(x) -> expr` | ✓ 正しい - 引数の型は期待される関数型から推論される |
+| `lambda x: x * 2`（Python風） | `(x) -> x * 2` - `lambda`キーワードはなく、アロー式ラムダを使う |
 | `func(arg)` でラムダ呼び出し | ✓ 正しい - 関数値は直接呼び出せる |
 | `Runnable`/`Comparator`としてのラムダ | ✓ 正しい - JavaのSAM（関数型インターフェース）への変換が効く |
 | `Int -> Int` | ✓ 正しい - 単一引数の関数型 |
@@ -471,6 +472,7 @@ try {
 | `throw new Exception();` | `throw new Exception("msg")` - 同じ構文 |
 | `try { } catch { } finally { }` | ✓ 正しい - finallyサポートあり |
 | `using r = expr { }` | `try (val r = expr) { }` - try-with-resources。複数のリソースは`;`で区切り、逆順にクローズされる |
+| `with expr as r { }`（Python風） | `try (val r = expr) { }` - 上と同じtry-with-resources |
 | `catch (Type e)` | `catch e: Type` - 括弧なし、コロンの後に型 |
 
 ### ツール、capability、と効果 (v0.10)
@@ -494,6 +496,8 @@ try {
 | `&&`, `\|\|` 演算子 | ✓ 正しい - Javaと同じ |
 | `!condition` | ✓ 正しい - Javaと同じ |
 | `a ? b : c` 三項演算子 | 非サポート - `if/else`式を使用 |
+| `a ?? b`（JS風のnull合体演算子） | `a ?: b` - 代わりにElvis演算子を使う |
+| `typeof x`（JS/Python風） | `x is Type` - 型チェックには`is`演算子を使う |
 | `operator fun plus`（Kotlin風） | `def plus(o: T): T` - 左オペランドの`+ - * / %`はそれぞれplus/minus/times/div/remにマップされる |
 | 文字列テンプレート `$var` や `${expr}` | `"text #{expr}"` - `#{}` 構文を使用 |
 | `this`のみ | `self`も使用可 - 両方とも現在のインスタンスを参照 |


### PR DESCRIPTION
## Summary
- `SyntaxHintClassifier`/`ControlFlowSyntaxHints` already recognize the JS/Python `typeof x` check, the `??` nullish-coalescing operator, the Python `with expr as r { }` resource block, and the Python `lambda x: expr` form (each with its own bilingual `error.parsing.hint.*` message and test coverage), but the "Common Syntax Mistakes" reference table in `CLAUDE.md` never picked up rows for them alongside their siblings (`using`, try-with-resources, the existing ternary/`elif` rows).
- Adds one row per mistake to `CLAUDE.md`'s `Lambdas & Functions`, `Exceptions`, and `Miscellaneous` tables, and mirrors the same four rows into the Japanese counterpart, `docs/ja/CLAUDE_ja.md`.
- Documentation only — no compiler behavior change.

## Status
Ready for merge. This session's container repeatedly restarted mid-run, so a local `sbt testFull` could never complete (killed by restarts each time, never by an actual test failure) — opened as draft for that reason. GitHub Actions CI (`.github/workflows/scala.yml`, `sbt -v +test`) completed on the head commit and is green: both `test` runs and `deploy` succeeded.

## Test plan
- [x] GitHub Actions CI (`test` × 2, `deploy`) — all green on `1eac24dc`
- [x] Manual cross-check: each documented "Wrong" example matches the corresponding regex/message in `SyntaxHintClassifier.scala` / `ControlFlowSyntaxHints.scala` and `errorMessage.properties` (`{0}`/`{1}` placeholders line up)
