### PR TITLE
Add diagnostic hint for Java/Kotlin/C#/Go-style `package` declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnostic hint for a Java/Kotlin/C#/Go-style `package` declaration.** Onion's
+  source-file header declaration is `module foo.bar;`, not `package`. Since
+  `package` isn't a reserved word, `package com.example.app;` (Java/Kotlin/C#)
+  or a bare `package main` (Go) previously parsed as a stray bare identifier
+  followed by an unconnected second statement, producing a generic "expecting
+  `<EOF>`, `<EOL>`, `;`" parse error instead of pointing at the fix.
+  `SyntaxHintClassifier` now recognizes both the dotted and bare `package`
+  forms and suggests the equivalent `module` declaration. Pinned by new
+  `PackageDeclarationHintI18nSpec` and cases in `SyntaxHintClassifierSpec`.
+
 - **Diagnostic hint for a Scala-style `case class` declaration.** Onion has no
   `case class` — a data-carrying type is a `record` — but unlike the existing
   Kotlin-style `data class` hint, `case` is itself an Onion reserved word (used

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -175,6 +175,7 @@ error.parsing.hint.object_declaration=Hint: Onion has no Kotlin/Scala-style sing
 error.parsing.hint.go_style_short_var_decl=Hint: Onion has no Go-style `:=` short variable declaration — declare it with `val` (immutable) or `var` (mutable) instead — write `val {0} = {1}`, not `{0} := {1}`.
 error.parsing.hint.using_resource_statement=Hint: Onion has no C#/Python-style `using` resource statement — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `using {0} = {1} '{' ... '}'`.
 error.parsing.hint.csharp_style_using_import=Hint: Onion has no C#-style `using` import directive — imports are wrapped in braces — write `import '{' {0} '}'`, not `using {0};`.
+error.parsing.hint.package_declaration=Hint: Onion has no Java/Kotlin/C#/Go-style `package` declaration — the source-file header is `module`, not `package` — write `module {0};`, not `package {0};`.
 error.parsing.hint.python_style_from_import=Hint: Onion has no Python-style `from ... import ...` statement — imports are wrapped in braces — write `import '{' {0} '}'`, not `from {1} import {2}`.
 error.parsing.hint.c_style_cast=Hint: a type cast uses postfix `as`, not a C-style prefix — write `(expr as {0})`, not `({0}) expr`.
 error.parsing.hint.dollar_sigil=Hint: Onion has no `$` sigil for variables or string interpolation — interpolate inside a string with `#{expr}` instead — write `"Hello, #{name}!"`, not `$"Hello, {name}!"` or `$name`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -175,6 +175,7 @@ error.parsing.hint.object_declaration=ヒント: Onion に Kotlin/Scala 風の�
 error.parsing.hint.go_style_short_var_decl=ヒント: Onion に Go 風の `:=` 短縮変数宣言はありません — 変数は `val`（不変）または `var`（可変）で宣言します — `{0} := {1}` ではなく `val {0} = {1}` と書いてください。
 error.parsing.hint.using_resource_statement=ヒント: Onion に C#/Python 風の `using` リソース文はありません — 代わりに try-with-resources ブロックを使ってください: `using {0} = {1} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
 error.parsing.hint.csharp_style_using_import=ヒント: Onion に C# 風の `using` インポート指令はありません — import は波かっこで囲みます — `using {0};` ではなく `import '{' {0} '}'` と書いてください。
+error.parsing.hint.package_declaration=ヒント: Onion に Java/Kotlin/C#/Go 風の `package` 宣言はありません — ソースファイルの先頭宣言は `package` ではなく `module` です — `package {0};` ではなく `module {0};` と書いてください。
 error.parsing.hint.python_style_from_import=ヒント: Onion に Python 風の `from ... import ...` 文はありません — import は波かっこで囲みます — `from {1} import {2}` ではなく `import '{' {0} '}'` と書いてください。
 error.parsing.hint.c_style_cast=ヒント: 型キャストは前置ではなく後置の `as` を使います — `({0}) expr` ではなく `(expr as {0})` と書いてください。
 error.parsing.hint.dollar_sigil=ヒント: Onion に変数や文字列補間のための `$` シジルはありません — 文字列内での補間は `#{expr}` を使ってください — `$"Hello, {name}!"` や `$name` ではなく `"Hello, #{name}!"` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -47,6 +47,12 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*using\s+([A-Za-z_]\w*)\s*=\s*(.+?)\s*\{?\s*$""".r
   private val CSharpStyleUsingImport =
     """^\s*using\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*;\s*$""".r
+  // A Java/Kotlin/C#/Go-style `package foo.bar;` (or bare Go `package main`) source-file
+  // header -- `package` isn't a reserved word, so it parses as a bare identifier and the
+  // dotted path (or the next token) reads as a stray second statement, same failure mode
+  // as CSharpStyleUsingImport above. Onion's own file-header declaration is `module`.
+  private val PackageDeclaration =
+    """^\s*package\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*;?\s*$""".r
   private val PythonStyleFromImport =
     """^\s*from\s+([A-Za-z_][\w.]*)\s+import\s+(.+?)\s*;?\s*$""".r
   private val DataClassDeclaration =
@@ -260,6 +266,9 @@ private[compiler] object SyntaxHintClassifier {
       case _ if CSharpStyleUsingImport.findFirstMatchIn(sourceLine).isDefined =>
         val matched = CSharpStyleUsingImport.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.csharp_style_using_import", matched.group(1))
+      case _ if PackageDeclaration.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = PackageDeclaration.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.package_declaration", matched.group(1))
       case _ if PythonStyleFromImport.findFirstMatchIn(sourceLine).isDefined =>
         val matched = PythonStyleFromImport.findFirstMatchIn(sourceLine).get
         val module = matched.group(1)

--- a/src/test/scala/onion/compiler/PackageDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/PackageDeclarationHintI18nSpec.scala
@@ -1,0 +1,71 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java/Kotlin/C#/Go-style `package` declaration hint (`SyntaxHintClassifier`'s
+ * `PackageDeclaration` case) must resolve through the bilingual `error.parsing.hint.*`
+ * bundle in both locales, like every other hint in that match -- see
+ * OldForInHintI18nSpec for the motivating regression.
+ */
+class PackageDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.package_declaration"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java/Kotlin/C#-style dotted `package` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |package com.example.app;
+        |
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example module declaration shown in the hint is literal code, identical in
+    // both bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("module com.example.app;"), s"expected the hint's example module declaration, got: $msgs")
+  }
+
+  it("fires for a Go-style bare `package main` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |package main
+        |
+        |class Main {
+        |public:
+        |  static def main(args: String[]): Int {
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("module main;"), s"expected the hint's example module declaration, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -318,6 +318,28 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       ).messageKey shouldBe "error.parsing.hint.using_resource_statement"
     }
 
+    it("recognizes a Java/Kotlin/C#-style dotted `package` declaration") {
+      val hint = classify(
+        found = "com",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "package com.example.app;"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.package_declaration"
+      hint.arguments shouldBe Seq("com.example.app")
+    }
+
+    it("recognizes a Go-style bare `package main` declaration") {
+      val hint = classify(
+        found = "main",
+        expected = "<EOF>, <EOL>, \";\"",
+        sourceLine = "package main"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.package_declaration"
+      hint.arguments shouldBe Seq("main")
+    }
+
     it("recognizes a Python-style `from ... import ...` statement") {
       val hint = classify(
         found = "import",


### PR DESCRIPTION
## Summary
- Onion's source-file header declaration is `module foo.bar;`, not `package`. Since `package` isn't a reserved word, `package com.example.app;` (Java/Kotlin/C#) or a bare `package main` (Go) previously parsed as a stray bare identifier followed by an unconnected second statement, producing a generic `expecting <EOF>, <EOL>, ;` parse error instead of pointing at the actual fix.
- `SyntaxHintClassifier` now recognizes both the dotted (`package com.example.app;`) and bare (`package main`) forms and suggests the equivalent `module` declaration, in both English and Japanese bundles.
- Follows the exact pattern of the existing `CSharpStyleUsingImport` hint (placed ahead of the generic `missing_call_parens` fallback so it takes priority).

## Test plan
- [x] New `PackageDeclarationHintI18nSpec` (bilingual bundle resolution + `.compile(...)` firing tests for both the dotted and bare `package` forms)
- [x] New cases added to `SyntaxHintClassifierSpec` for both forms
- [x] `HintMessageKeyCoverageSpec` / `MessageBundleKeyParitySpec` confirm no key drift
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4666 succeeded, 0 failed, 1 canceled
- [x] Full suite green in Japanese locale: same with `-Duser.language=ja` — 4666 succeeded, 0 failed, 1 canceled
- [x] `CHANGELOG.md` updated under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sg9pTkUnAZQrVNxp4pPtBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sg9pTkUnAZQrVNxp4pPtBW)_