### PR TITLE
Add diagnostic hint for `async def`/`async function`/`async fn` declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnostic hint for a JavaScript/Python/Rust-style `async def`/`async function`/
+  `async fn` declaration.** Onion has no `async` keyword, so `async def foo():`,
+  `async function foo() { ... }`, and similar forms parsed `async` as a bare
+  identifier statement, with the following declaration keyword falling through to
+  the generic "missing call parens" fallback and suggesting the nonsensical
+  `async(...)`. `ControlFlowSyntaxHints` now recognizes the leading `async` +
+  `def`/`fun`/`func`/`fn`/`function` shape and points at Onion's actual equivalent:
+  a plain `def` returning a `Future`, built with `Future::async(() -> { ... })`.
+  Pinned by new `AsyncFunctionDeclarationHintI18nSpec`.
+
 - **Diagnostic hint for a Java/Kotlin/C#/Go-style `package` declaration.** Onion's
   source-file header declaration is `module foo.bar;`, not `package`. Since
   `package` isn't a reserved word, `package com.example.app;` (Java/Kotlin/C#)

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -133,6 +133,7 @@ error.parsing.hint.yield_not_supported=Hint: Onion has no JavaScript/Python-styl
 error.parsing.hint.defer_not_supported=Hint: Onion has no Go-style `defer` statement — run cleanup at scope exit with `try`/`finally` instead — write `try '{' ... '}' finally '{' {0} '}'`, not `defer {0}`.
 error.parsing.hint.with_as_statement=Hint: Onion has no Python-style `with ... as ...` resource-management block — write a try-with-resources block instead: `try (val {0} = {1}) '{' ... '}'`, not `with {1} as {0} '{' ... '}'`.
 error.parsing.hint.until_not_supported=Hint: Onion has no Ruby-style `until` loop. Negate the condition and use `while` instead: `while !condition { ... }`.
+error.parsing.hint.async_function_not_supported=Hint: Onion has no `async` keyword — an asynchronous function is a plain `def` that returns a `Future`, built with `Future::async(() -> '{' ... '}')` — write `def {0}({1}): Future[T] = Future::async(() -> '{' ... '}')`, not `async ... {0}({1})`.
 error.parsing.hint.not_operator=Hint: Onion has no Python/Ruby-style `not` operator for boolean negation. Use `!` instead: `if !condition { ... }`, not `if not condition { ... }`.
 error.parsing.hint.typeof_not_supported=Hint: Onion has no JavaScript/Python-style `typeof` operator — check a value''s type with the `is` operator instead — write `{0} is Type`, not `typeof {0}`.
 error.parsing.hint.python_style_colon_block=Hint: Onion blocks use '{' ... '}', not a trailing `:` — write `{0} {1} '{' ... '}'`, not `{0} {1}:`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -133,6 +133,7 @@ error.parsing.hint.yield_not_supported=ヒント: Onion にジェネレータや
 error.parsing.hint.defer_not_supported=ヒント: Onion に Go 風の `defer` 文はありません — スコープ終了時のクリーンアップは `try`/`finally` を使ってください — `defer {0}` ではなく `try '{' ... '}' finally '{' {0} '}'` と書いてください。
 error.parsing.hint.with_as_statement=ヒント: Onion に Python 風の `with ... as ...` リソース管理ブロックはありません — 代わりに try-with-resources ブロックを使ってください: `with {1} as {0} '{' ... '}'` ではなく `try (val {0} = {1}) '{' ... '}'` と書いてください。
 error.parsing.hint.until_not_supported=ヒント: Onion に Ruby 風の `until` ループはありません。条件を否定して `while` を使ってください: `while !condition { ... }`。
+error.parsing.hint.async_function_not_supported=ヒント: Onion に `async` キーワードはありません — 非同期関数は `Future` を返す普通の `def` で、`Future::async(() -> '{' ... '}')` を使って組み立てます — `async ... {0}({1})` ではなく `def {0}({1}): Future[T] = Future::async(() -> '{' ... '}')` と書いてください。
 error.parsing.hint.not_operator=ヒント: Onion に Python/Ruby 風の論理否定演算子 `not` はありません。代わりに `!` を使ってください: `if not condition { ... }` ではなく `if !condition { ... }` と書いてください。
 error.parsing.hint.typeof_not_supported=ヒント: Onion に JavaScript/Python 風の `typeof` 演算子はありません — 代わりに型検査演算子 `is` を使って値の型を調べてください — `typeof {0}` ではなく `{0} is Type` と書いてください。
 error.parsing.hint.python_style_colon_block=ヒント: Onion のブロックは末尾の `:` ではなく '{' ... '}' を使います — `{0} {1}:` ではなく `{0} {1} '{' ... '}'` と書いてください。

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -45,6 +45,13 @@ private[compiler] object ControlFlowSyntaxHints {
   // `with(...)`); keep this ahead of that case.
   private val LeadingWithAsStatement =
     """^\s*with\s+(.+?)\s+as\s+([A-Za-z_]\w*)\s*:?\s*\{?\s*$""".r
+  // A JavaScript/Python/Rust-style prefix `async def`/`async function`/`async fn`/
+  // `async func` declaration -- `async` is not a reserved word, so it parses as a
+  // bare identifier statement and the declaration keyword that follows reads as a
+  // stray second statement, which also matches the generic missing-call-parens
+  // fallback (suggesting the nonsensical `async(...)`); keep this ahead of that case.
+  private val LeadingAsyncFunctionDeclaration =
+    """^\s*async\s+(?:def|fun|func|fn|function)\s+([A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\(([^()]*)\)""".r
 
   def classify(found: String, sourceLine: String): Option[SyntaxHint] = {
     if (LeadingSwitchStatement.findFirstMatchIn(sourceLine).isDefined) {
@@ -86,6 +93,9 @@ private[compiler] object ControlFlowSyntaxHints {
     } else if (LeadingWithAsStatement.findFirstMatchIn(sourceLine).isDefined) {
       val matched = LeadingWithAsStatement.findFirstMatchIn(sourceLine).get
       hint("error.parsing.hint.with_as_statement", matched.group(2), matched.group(1).trim)
+    } else if (LeadingAsyncFunctionDeclaration.findFirstMatchIn(sourceLine).isDefined) {
+      val matched = LeadingAsyncFunctionDeclaration.findFirstMatchIn(sourceLine).get
+      hint("error.parsing.hint.async_function_not_supported", matched.group(1), matched.group(2).trim)
     } else {
       None
     }

--- a/src/test/scala/onion/compiler/AsyncFunctionDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/AsyncFunctionDeclarationHintI18nSpec.scala
@@ -1,0 +1,68 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A JavaScript/Python/Rust-style prefix `async def`/`async function`/`async fn`
+ * declaration (`ControlFlowSyntaxHints`'s `LeadingAsyncFunctionDeclaration` case)
+ * must resolve through the bilingual `error.parsing.hint.*` bundle in both locales,
+ * like every other hint in that family -- see AwaitStatementHintI18nSpec and
+ * DeferStatementHintI18nSpec for the same pattern. Onion has no `async` keyword, so
+ * `async` parsed as a bare identifier statement and the following declaration
+ * keyword fell through to the generic "missing call parens" fallback, suggesting
+ * the nonsensical `async(...)`.
+ */
+class AsyncFunctionDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.async_function_not_supported"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves the key in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves the key in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  private def compileErrors(src: String): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  it("fires for a Python-style prefix `async def name(...):` declaration") {
+    val src =
+      """
+        |async def fetchData(url: String):
+        |  return url
+        |""".stripMargin
+    val msgs = compileErrors(src)
+    assert(msgs.contains("Future::async"), s"expected the hint's `Future::async` example, got: $msgs")
+    assert(!msgs.contains("async(fetchData)"), s"the misleading missing-call-parens fallback should not fire, got: $msgs")
+  }
+
+  it("fires for a JavaScript-style prefix `async function name(...)` declaration") {
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    async function fetchData(url) {
+        |      return url
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = compileErrors(src)
+    assert(msgs.contains("Future::async"), s"expected the hint's `Future::async` example, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary
- Onion has no `async` keyword, so `async def foo():`, `async function foo() { ... }`, and similar JS/Python/Rust-style declarations parsed `async` as a bare identifier statement, with the following declaration keyword falling through to the generic "missing call parens" fallback — suggesting the nonsensical `async(...)`.
- `ControlFlowSyntaxHints` now recognizes the leading `async` + `def`/`fun`/`func`/`fn`/`function` shape and points at Onion's actual equivalent: a plain `def` returning a `Future`, built with `Future::async(() -> { ... })`.
- Added bilingual (en/ja) message bundle entries and a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] New `AsyncFunctionDeclarationHintI18nSpec` (message-bundle resolution in both locales + end-to-end compile assertions for `async def` and `async function` shapes)
- [x] `sbt -Duser.language=en testOnly onion.compiler.AsyncFunctionDeclarationHintI18nSpec` — green
- [x] Related hint specs (`FunDeclarationHintI18nSpec`, `MissingCallParensHintI18nSpec`, `AwaitStatementHintI18nSpec`, `DeferStatementHintI18nSpec`, `SyntaxHintClassifierSpec`) — no regressions (112/112)
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4670/4670 passed (1 unrelated environment-gated distribution smoke test canceled, as expected without `-Donion.dist.path`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmsM9XB6MTMsi8CBRJeEk6


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmsM9XB6MTMsi8CBRJeEk6)_