### PR TITLE
Add diagnostic hint for TypeScript-style optional field/parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suggesting `record Name(...)`. Pinned by new `CaseClassDeclarationHintI18nSpec`
   and cases in `SyntaxHintClassifierSpec`.
 
+- **Diagnostic hint for a TypeScript-style optional field/parameter `name?: Type`.**
+  Onion attaches nullability to the type (`name: Type?`), not the name. Because
+  Onion's Elvis operator `?:` lexes as a single token, `name?: Type` never reached
+  the parser as the separate `?` and `:` a TypeScript reader intended — it reported
+  the whole `?:` as an unexpected token where a plain `:` was expected, with nothing
+  connecting the error back to the actual mistake. `SyntaxHintClassifier` now
+  recognizes this shape in both field and parameter position and suggests the
+  equivalent `name: Type?`. Pinned by new `TypeScriptStyleOptionalAnnotationHintI18nSpec`
+  and cases in `SyntaxHintClassifierSpec`.
+
 ## [0.33.0] - 2026-09-02
 
 ### Fixed

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -113,6 +113,7 @@ error.parsing.hint.python_style_return_arrow=Hint: a method''s return type follo
 error.parsing.hint.dangling_return_type_colon=Hint: after `:` a method needs its return type on the same line -- write `def {0}(...): Void '{' ... '}'`, or drop the `:` entirely if you meant no declared return type: `def {0}(...) '{' ... '}'`.
 error.parsing.hint.ternary=Hint: Onion has no `cond ? a : b` ternary operator. `if`/`else` works as an expression, so write `if cond { a } else { b }`.
 error.parsing.hint.nullish_coalescing=Hint: Onion has no `??` nullish-coalescing operator — use the Elvis operator instead — write `a ?: b`, not `a ?? b`.
+error.parsing.hint.typescript_style_optional_annotation=Hint: Onion has no TypeScript-style optional field/parameter `{0}?: {1}` — nullability belongs to the type, not the name — write `{0}: {1}?`, not `{0}?: {1}`.
 error.parsing.hint.dangling_else=Hint: `else` must directly follow an `if` block's closing `}` -- check that a matching `if` immediately precedes it (only `if` takes an `else`).
 error.parsing.hint.old_for_in=Hint: Onion does not support `for x in xs`. Use `foreach x: Type in xs { ... }` (or a C-style loop: `for var i = 0; i < xs.size(); i = i + 1 { ... }`).
 error.parsing.hint.foreach_parens=Hint: `foreach` doesn''t parenthesize a single loop variable — write `foreach x: Type in xs { ... }`, not `foreach (x in xs) { ... }`. Parentheses are only for destructuring a map''s entries: `foreach (k, v) in map { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -113,6 +113,7 @@ error.parsing.hint.python_style_return_arrow=ヒント: メソッドの戻り値
 error.parsing.hint.dangling_return_type_colon=ヒント: `:` の後には戻り値の型を同じ行に書く必要があります — `def {0}(...): Void '{' ... '}'` のように書くか、戻り値の型を宣言しないつもりなら `:` ごと削除してください: `def {0}(...) '{' ... '}'`。
 error.parsing.hint.ternary=ヒント: Onion に `cond ? a : b` の三項演算子はありません。`if`/`else` は式として使えるので `if cond { a } else { b }` と書いてください。
 error.parsing.hint.nullish_coalescing=ヒント: Onion に `??` Null 合体演算子はありません — 代わりに Elvis 演算子を使ってください — `a ?? b` ではなく `a ?: b` と書いてください。
+error.parsing.hint.typescript_style_optional_annotation=ヒント: Onion に TypeScript 風のオプショナルなフィールド/引数 `{0}?: {1}` はありません — nullable であることは名前ではなく型に付けます — `{0}?: {1}` ではなく `{0}: {1}?` と書いてください。
 error.parsing.hint.dangling_else=ヒント: `else` は `if` ブロックの閉じ `}` に直接続く必要があります — 直前に対応する `if` があるか確認してください（`else` を伴えるのは `if` だけです）。
 error.parsing.hint.old_for_in=ヒント: Onion は `for x in xs` をサポートしません。`foreach x: Type in xs { ... }` を使ってください（または C スタイルのループ: `for var i = 0; i < xs.size(); i = i + 1 { ... }`）。
 error.parsing.hint.foreach_parens=ヒント: `foreach` は単一のループ変数を丸かっこで囲みません — `foreach (x in xs) { ... }` ではなく `foreach x: Type in xs { ... }` と書いてください。丸かっこはマップのエントリを分解する場合のみ使います: `foreach (k, v) in map { ... }`。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -171,6 +171,14 @@ private[compiler] object SyntaxHintClassifier {
   // from the unrelated `cond ? a : b` ternary mistake below, which also matches
   // on a bare `?` but has a differently-shaped fix (`?:`, not `if`/`else`).
   private val NullishCoalescing = """\A\?\?""".r
+  // A TypeScript-style optional field/parameter, e.g. `name?: Type`. Onion's Elvis
+  // operator `?:` lexes as a single token, so this never reaches the parser as the
+  // separate `?` and `:` a TypeScript reader intended -- it reports the whole `?:`
+  // as the found token where a plain `:` was expected, a shape that's otherwise
+  // impossible to reach (a real Elvis expression is never followed by a bare colon).
+  // Onion attaches nullability to the type instead: `name: Type?`.
+  private val TypeScriptStyleOptionalAnnotation =
+    """\b([A-Za-z_]\w*)\s*\?:\s*([A-Za-z_][\w.\[\]]*)""".r
 
   def classify(
     found: String,
@@ -340,6 +348,9 @@ private[compiler] object SyntaxHintClassifier {
       case ("\n" | "\r\n" | "\r") if DanglingReturnTypeColon.findFirstMatchIn(sourceLine).isDefined =>
         val matched = DanglingReturnTypeColon.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.dangling_return_type_colon", matched.group(1))
+      case "?:" if expected == "\":\"" && TypeScriptStyleOptionalAnnotation.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = TypeScriptStyleOptionalAnnotation.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.typescript_style_optional_annotation", matched.group(1), matched.group(2))
       case "?" if NullishCoalescing.findFirstMatchIn(context).isDefined =>
         hint("error.parsing.hint.nullish_coalescing")
       case "?" =>

--- a/src/test/scala/onion/compiler/TypeScriptStyleOptionalAnnotationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/TypeScriptStyleOptionalAnnotationHintI18nSpec.scala
@@ -1,0 +1,68 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The TypeScript-style optional field/parameter hint (`SyntaxHintClassifier`'s
+ * `"?:"` case) must resolve through the bilingual `error.parsing.hint.*` bundle
+ * in both locales, like every other hint in that match -- see
+ * NullishCoalescingHintI18nSpec for the same pattern.
+ */
+class TypeScriptStyleOptionalAnnotationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.typescript_style_optional_annotation"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a TypeScript-style optional field `name?: Type`") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Foo {
+        |  var name?: String
+        |public:
+        |  static def main(args: String[]): Int {
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The example code in the hint is literal, identical in both bundles, so this
+    // assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("name: String?"), s"expected the hint's fixed-up example, got: $msgs")
+  }
+
+  it("fires for a TypeScript-style optional parameter `name?: Type`") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Foo {
+        |public:
+        |  def bar(count?: Int): Int {
+        |    return 0
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("count: Int?"), s"expected the hint's fixed-up example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -491,6 +491,35 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe empty
     }
 
+    it("recognizes a TypeScript-style optional field `name?: Type`") {
+      val hint = classify(
+        found = "?:",
+        expected = "\":\"",
+        sourceLine = "  var name?: String"
+      )
+      hint.messageKey shouldBe "error.parsing.hint.typescript_style_optional_annotation"
+      hint.arguments shouldBe Seq("name", "String")
+    }
+
+    it("recognizes a TypeScript-style optional parameter `name?: Type`") {
+      val hint = classify(
+        found = "?:",
+        expected = "\":\"",
+        sourceLine = "  def bar(count?: Int): Int {"
+      )
+      hint.messageKey shouldBe "error.parsing.hint.typescript_style_optional_annotation"
+      hint.arguments shouldBe Seq("count", "Int")
+    }
+
+    it("does not flag a real Elvis expression that happens to precede a colon-expecting context") {
+      SyntaxHintClassifier.classify(
+        found = "?:",
+        expected = "\",\"",
+        context = "",
+        sourceLine = "  val x = a ?: b"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.typescript_style_optional_annotation")
+    }
+
     it("recognizes a JS/TS/Kotlin-style `??` nullish-coalescing operator") {
       val hint = classify(
         found = "?",


### PR DESCRIPTION
## Summary
- `name?: Type` (TypeScript's optional-member syntax) previously failed with a bare "expecting `:`" error pointing at the `?:` token, since Onion's Elvis operator `?:` lexes as a single token and never reaches the parser as the separate `?`/`:` a TypeScript reader intended.
- `SyntaxHintClassifier` now recognizes this shape in both field and parameter position and suggests Onion's actual nullable-type syntax, `name: Type?`.
- Added `TypeScriptStyleOptionalAnnotationHintI18nSpec` (bilingual bundle resolution + end-to-end compile repros) and matching cases in `SyntaxHintClassifierSpec`.
- Documented in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4677 tests, 0 failed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4677 tests, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CGLjM3aLywJwCuYsomeTW

---
_Generated by [Claude Code](https://claude.ai/code/session_013CGLjM3aLywJwCuYsomeTW)_