### PR TITLE
Add diagnostic hint for Ruby-style bare `puts(...)` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnostic hint for a Ruby-style bare `puts(...)` call.** Onion has no
+  default-imported `puts` function, so `puts("hi")` surfaced as an ordinary
+  `E0005` "method not found" on the enclosing script's synthesized main class,
+  with nothing connecting it back to Onion's actual output API.
+  `SemanticErrorReporter.reportMethodNotFound` now recognizes an unqualified
+  call to the exact name `puts` and points at `IO::println` instead of a
+  name-similarity guess. Pinned by new `RubyStylePutsHintI18nSpec`.
+
 - **Diagnostic hint for a JavaScript/Python/Rust-style `async def`/`async function`/
   `async fn` declaration.** Onion has no `async` keyword, so `async def foo():`,
   `async function foo() { ... }`, and similar forms parsed `async` as a bare

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -71,6 +71,7 @@ suggestion.jsTemplateLiteral=hint: Onion has no JS/TS-style backtick template li
 suggestion.jsConsoleLog=hint: Onion has no JS-style `console` object; there is no console.log/console.error/console.warn. Use IO::println(...) for output instead.
 suggestion.pythonFString=hint: Onion has no Python-style f-string prefix; an identifier directly before a string literal desugars to a call, so f"text {expr}" parses as a call to a function named f. Use string interpolation instead: write "text #{expr}", not f"text {expr}".
 suggestion.stdlibNoLongerDefaultImported=hint: {1} is a static member of {0}, which is no longer a default import (the default static import set was narrowed to pure classes) -- qualify the call as {0}::{1}(...).
+suggestion.rubyPuts=hint: Onion has no Ruby-style `puts` function. Use IO::println(...) for output instead.
 error.parsing.unterminated_string=unterminated string literal: missing closing quote.
 error.suggestion.candidates=available: {0}
 error.suggestion.availableConstructors=available constructors:

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -70,6 +70,7 @@ suggestion.jsTemplateLiteral=ヒント: Onion に JS/TS 風のバッククォー
 suggestion.jsConsoleLog=ヒント: Onion に JS 風の console オブジェクトはありません。console.log/console.error/console.warn は存在しません。出力には代わりに IO::println(...) を使ってください。
 suggestion.pythonFString=ヒント: Onion に Python 風の f-string プレフィックスはありません。文字列リテラルの直前の識別子は呼び出しとして解釈されるため、f"text {expr}" は関数 f の呼び出しとして解析されます。文字列補間を使ってください: f"text {expr}" ではなく "text #{expr}" と書きます。
 suggestion.stdlibNoLongerDefaultImported=ヒント: {1} は {0} の静的メンバーで、デフォルトではインポートされなくなりました (デフォルトの静的インポート対象は副作用のないクラスに絞られています)。{0}::{1}(...) のように修飾して呼び出してください。
+suggestion.rubyPuts=ヒント: Onion に Ruby 風の puts 関数はありません。出力には代わりに IO::println(...) を使ってください。
 error.parsing.unterminated_string=\u6587\u5b57\u5217\u30ea\u30c6\u30e9\u30eb\u304c\u9589\u3058\u3089\u308c\u3066\u3044\u307e\u305b\u3093\u3002\u9589\u3058\u5f15\u7528\u7b26 " \u3092\u8ffd\u52a0\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 error.suggestion.candidates=\u5019\u88dc: {0}
 error.suggestion.availableConstructors=\u5229\u7528\u53ef\u80fd\u306a\u30b3\u30f3\u30b9\u30c8\u30e9\u30af\u30bf:

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -621,6 +621,14 @@ class SemanticErrorReporter(threshold: Int) {
         // reads as a call to a function named `f` that nothing defines. Point at Onion's
         // actual interpolation syntax instead of a name-similarity guess.
         Some(message("suggestion.pythonFString"))
+      } else if (isUnqualifiedCall && name == "puts") {
+        // A Ruby-style bare `puts(...)` call -- Onion has no default-imported `puts`
+        // function, so this reads as an ordinary unresolved call on the enclosing
+        // script's synthesized main class. Point at Onion's actual output API instead
+        // of a name-similarity guess. Restricted to unqualified calls, same as
+        // FormerDefaultImportLookup below, so a real method named `puts` on some other
+        // type is unaffected.
+        Some(message("suggestion.rubyPuts"))
       } else if (fieldNamed(targetType, name) || isArrayLengthProperty(targetType, name)) {
         // `p.name()` where `name` is a field, not a method -- a common mix-up
         // with record component accessors (which really are methods). A

--- a/src/test/scala/onion/compiler/RubyStylePutsHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/RubyStylePutsHintI18nSpec.scala
@@ -1,0 +1,103 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * A Ruby-style bare `puts(...)` call has no equivalent in Onion -- there is no
+ * default-imported `puts` function -- so it surfaces as an ordinary METHOD_NOT_FOUND
+ * (E0005) on the enclosing script's synthesized main class, with nothing connecting it
+ * back to Onion's actual output API. `SemanticErrorReporter.reportMethodNotFound`
+ * recognizes an unqualified call to the exact name `puts` and points at `IO::println`
+ * instead of a name-similarity guess.
+ */
+class RubyStylePutsHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "suggestion.rubyPuts"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("IO::println"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("IO::println"), s"expected the IO::println hint, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Ruby-style `puts(...)` call with an argument") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    puts("hi")
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("IO::println"), s"expected the puts hint, got: $msgs")
+  }
+
+  it("fires for a Ruby-style bare `puts()` call") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    puts()
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("IO::println"), s"expected the puts hint, got: $msgs")
+  }
+
+  it("does not fire for an ordinary unresolved method call") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    doesNotExist("hi")
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(!msgs.contains("IO::println"), s"did not expect the puts hint, got: $msgs")
+  }
+
+  it("does not fire when the class defines its own `puts` method with a mismatched call") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    puts(1, 2, 3)
+        |  }
+        |  static def puts(x: Int): void { }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(!msgs.contains("IO::println"), s"did not expect the puts hint, got: $msgs")
+  }
+}


### PR DESCRIPTION
## Summary

- Onion has no default-imported `puts` function, so a Ruby-style `puts("hi")` surfaced as an ordinary `E0005` "method not found" on the enclosing script's synthesized main class, with nothing connecting it back to Onion's actual output API.
- `SemanticErrorReporter.reportMethodNotFound` now recognizes an unqualified call to the exact name `puts` and points at `IO::println` instead of a name-similarity guess. Guarded the same way as the existing `FormerDefaultImportLookup` case, so a real method named `puts` on some other type is unaffected.
- Follows the existing bilingual diagnostic-hint pattern (see `JsConsoleLogHintI18nSpec` for the JS `console.log` equivalent): new `suggestion.rubyPuts` key added to both `errorMessage.properties` and `errorMessage_ja.properties`.

## Test plan

- [x] New `RubyStylePutsHintI18nSpec` (TDD: written first, confirmed red, then green after the fix) covers: English/Japanese bundle resolution, firing for `puts("hi")` and bare `puts()`, not firing for an unrelated unresolved call, and not firing when the class defines its own mismatched `puts` method.
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 4683 succeeded, 0 failed, 1 canceled (pre-existing, unrelated `ProjectDistributionSpec` environment-dependent case).
- [x] `CHANGELOG.md` updated under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDTaiX2MyakwbpjB51Lbkt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDTaiX2MyakwbpjB51Lbkt)_