### PR TITLE
perf: make a warm compilation 2-2.5x faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Compiler throughput: a warm compilation runs roughly 2-2.5x faster.** Profiled with
+  JFR at full stack depth (the default `jfr print` depth of 5 frames had been
+  mis-attributing the hot paths) and reworked the per-compilation waste it exposed,
+  without changing what any program means:
+  - A shared, immutable class universe (`ClassTable.shared`) for `java.*`/`onion.*`
+    classes, so platform and runtime classes are read and parsed once per JVM rather than
+    once per compilation; `java.*` absences are final there and no longer re-probed.
+  - The built-in extension-method registry is built once per JVM instead of by reflective
+    scan per compilation; `SemanticErrorReporter`'s error table and regexes,
+    `CapabilityCheckPass`'s regex and `OperatorTyping`'s constant tables no longer live in
+    per-compilation instances.
+  - Name resolution: unqualified names are memoized per import list; scan-generated
+    candidates are no longer fed back through the import scan (`onion.Object` used to fan
+    out into `java.lang.onion$Object` and seven more probes); an absent class is a `null`,
+    not a `ClassNotFoundException` with a stack trace (~50 per compilation).
+  - Bare static-import calls (`println(x)`) resolve their candidate classes once per name
+    per unit instead of walking every default static import per call site.
+  - `AssignedVariableScanner` answers bottom-up with a per-unit memo (it re-walked each
+    method body once per nesting level); `TermContainsTry` is memoized per code generation.
+  - Fewer copies on hot paths: `AppliedTypeViews` memoized per compilation, identity maps
+    for AST bindings, cached per-name method arrays, `StatementBlock.statements`,
+    hierarchy walks without iterator/closure allocation, integer-literal parsing without
+    three regex compilations per literal, a semantic lookahead in `eols()`.
+  On the readiness benchmark (`sbt benchmark`, same machine, same session, interleaved):
+  steady-fresh stats-app 66 -> 32 ms, todo-manager 75 -> 35 ms, hello 16 -> 9 ms, REPL
+  growing-state 45 -> 26 ms, multi-file 77 -> 57 ms (medians; absolute values depend on
+  machine load, the ratios were stable across runs). Process-cold start is unchanged: it
+  is JVM start-up, not compilation. A dedicated harness measuring CPU time after JIT
+  warm-up shows 13.1 -> 5.5 ms on stats-app and 3.4 -> 0.6 ms on hello.
+  Two latent correctness bugs surfaced along the way and are fixed: the default package's
+  on-demand import produced `.Name` candidates, and arrays of user classes substituted into
+  a runtime method's vararg parameter (`T[] -> Transaction[]`) were cached by name in a
+  table that outlives the compilation, so a later compilation could see an array of the
+  previous `Transaction`.
+
 ### Fixed
 
 - **Diagnostic hint for a JavaScript/Python/Rust-style `async def`/`async function`/

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -642,10 +642,14 @@ public class JJOnionParser implements Parser {
   private static int parseIntLiteral(String content) throws ParseException {
     try {
       long lv;
-      boolean radix = content.matches("0[xXbB].*");
-      if (content.matches("0[xX].*"))      lv = Long.parseLong(content.substring(2), 16);
-      else if (content.matches("0[bB].*")) lv = Long.parseLong(content.substring(2), 2);
-      else                                  lv = Long.parseLong(content);
+      // Prefix tests, not String.matches(): each matches() call compiled a fresh
+      // regex, three per integer literal, which put literal parsing on the profile.
+      boolean hex = content.length() > 2 && content.charAt(0) == '0' && (content.charAt(1) == 'x' || content.charAt(1) == 'X');
+      boolean bin = content.length() > 2 && content.charAt(0) == '0' && (content.charAt(1) == 'b' || content.charAt(1) == 'B');
+      boolean radix = hex || bin;
+      if (hex)      lv = Long.parseLong(content.substring(2), 16);
+      else if (bin) lv = Long.parseLong(content.substring(2), 2);
+      else          lv = Long.parseLong(content);
       if (radix) { if (lv < 0L || lv > 0xFFFFFFFFL) throw new ParseException("integer literal out of range: " + content); }
       else       { if (lv < Integer.MIN_VALUE || lv > 2147483648L) throw new ParseException("integer literal out of range for Int: " + content); }
       return (int) lv;
@@ -2200,8 +2204,11 @@ void eos() :{} {
 }
 
 void eols() :{} {
-  // Lookahead reduces choice conflicts with EOL-consuming constructs.
-  ( LOOKAHEAD(2) <EOL> )*
+  // A semantic lookahead on the next token: it settles the choice conflict with
+  // EOL-consuming constructs like the LOOKAHEAD(2) it replaces, but as a kind test
+  // instead of a scan -- this loop runs at every line end and was the hottest lookahead
+  // in the parser profile.
+  ( LOOKAHEAD({ getToken(1).kind == EOL }) <EOL> )*
 }
 
 void eos_or_block_end() :{} {

--- a/src/main/scala/onion/compiler/AssignedVariableScanner.scala
+++ b/src/main/scala/onion/compiler/AssignedVariableScanner.scala
@@ -14,34 +14,65 @@ object AssignedVariableScanner {
 
   private val comparisonSymbols = Set("==", "!=", "<=", ">=", "===", "!==")
 
-  def scan(node: AST.Node): Set[String] = {
-    val assigned = mutable.Set[String]()
+  def scan(node: AST.Node): Set[String] =
+    scan(node, new java.util.IdentityHashMap[AST.Node, Set[String]]())
 
-    def markTarget(e: AST.Expression): Unit = e match {
-      case id: AST.Id => assigned += id.name
-      case _ => // field/index assignment doesn't rebind the local name
+  /**
+   * The same answer, computed bottom-up with every visited node recorded in `memo`.
+   *
+   * Body typing asks this question for a method body and then again for each `if`,
+   * `while` and `select` branch inside it, so a plain top-down scan re-walked the same
+   * subtrees at every nesting level. Recording the answer for every node makes the
+   * nested questions lookups, and the memo lives on the typing context, so the whole
+   * unit is walked once. Subtrees without an assignment share the empty set.
+   */
+  def scan(node: AST.Node, memo: java.util.IdentityHashMap[AST.Node, Set[String]]): Set[String] = {
+    def union(a: Set[String], b: Set[String]): Set[String] =
+      if (b.isEmpty) a else if (a.isEmpty) b else a ++ b
+
+    def target(e: AST.Expression, acc: Set[String]): Set[String] = e match {
+      case id: AST.Id => acc + id.name
+      case _ => acc // field/index assignment doesn't rebind the local name
     }
 
-    def visit(any: Any): Unit = any match {
-      case n: AST.Node =>
-        n match {
-          case b: AST.BinaryExpression if b.symbol.endsWith("=") && !comparisonSymbols.contains(b.symbol) =>
-            markTarget(b.lhs)
-          case u: AST.UnaryExpression if u.symbol == "++" || u.symbol == "--" =>
-            markTarget(u.term)
-          case _ =>
-        }
-        n match {
-          case p: Product => p.productIterator.foreach(visit)
-          case _ =>
-        }
-      case s: Iterable[_] => s.foreach(visit)
-      case a: Array[_] => a.foreach(visit)
-      case p: Product => p.productIterator.foreach(visit) // tuples in case classes
-      case _ =>
+    def visitNode(n: AST.Node): Set[String] = {
+      val cached = memo.get(n)
+      if (cached != null) return cached
+      var acc: Set[String] = n match {
+        case b: AST.BinaryExpression if b.symbol.endsWith("=") && !comparisonSymbols.contains(b.symbol) =>
+          target(b.lhs, Set.empty)
+        case u: AST.UnaryExpression if u.symbol == "++" || u.symbol == "--" =>
+          target(u.term, Set.empty)
+        case _ => Set.empty
+      }
+      n match {
+        case p: Product =>
+          val it = p.productIterator
+          while (it.hasNext) acc = union(acc, visitAny(it.next()))
+        case _ =>
+      }
+      memo.put(n, acc)
+      acc
     }
 
-    visit(node)
-    assigned.toSet
+    def visitAny(any: Any): Set[String] = any match {
+      case n: AST.Node => visitNode(n)
+      case s: Iterable[_] =>
+        var acc: Set[String] = Set.empty
+        s.foreach(e => acc = union(acc, visitAny(e)))
+        acc
+      case a: Array[_] =>
+        var acc: Set[String] = Set.empty
+        a.foreach(e => acc = union(acc, visitAny(e)))
+        acc
+      case p: Product => // tuples in case classes
+        var acc: Set[String] = Set.empty
+        val it = p.productIterator
+        while (it.hasNext) acc = union(acc, visitAny(it.next()))
+        acc
+      case _ => Set.empty
+    }
+
+    visitNode(node)
   }
 }

--- a/src/main/scala/onion/compiler/ClassTable.scala
+++ b/src/main/scala/onion/compiler/ClassTable.scala
@@ -7,21 +7,97 @@
  * ************************************************************** */
 package onion.compiler
 
-import java.util.{HashMap => JHashMap}
+import java.util.concurrent.ConcurrentHashMap
 import onion.compiler.environment.AsmRefs.AsmClassType
 import onion.compiler.environment.ClassFileTable
 import onion.compiler.environment.ReflectionRefs.ReflectClassType
 
 /**
- * @author Kota Mizushima
+ * The compiler's view of every class it can name: the ones being compiled (`classes`)
+ * and the ones found on the classpath, parsed on demand into `ClassType`s.
  *
+ * Classpath classes are expensive to materialize -- the class file is read and run
+ * through ASM, and its signatures are mapped into Onion types -- and until this table
+ * grew a `parent`, every compilation did that from scratch: a fresh table, so
+ * `java.lang.Object`, `java.lang.String`, `onion.IO` and the rest were re-read and
+ * re-parsed for each `new OnionCompiler`. That was a fixed cost of roughly two
+ * milliseconds on a one-line program, and a large share of typing time on any real one.
+ *
+ * The JDK and Onion's own runtime never change while the JVM is up, so those classes now
+ * come from one process-wide [[ClassTable.shared]] instance that every per-compilation
+ * table delegates to for names under the platform and `onion.` prefixes. Sharing the
+ * *instances* rather than the bytes matters: the type checker compares class types by
+ * identity (`eq`), so two `java.lang.Object` objects would be two unrelated types. With
+ * one shared universe, a user class extending `Object` and a library method returning
+ * `Object` agree on what that is.
+ *
+ * Precedence is unchanged. A class being compiled always wins (`classes` is consulted
+ * first), then the shared universe for platform names, then this compilation's own
+ * classpath. A user cannot define `java.lang.String` -- the JVM forbids it -- and an
+ * `onion.*` class the shared loader does not know falls through to the local classpath,
+ * so a project that puts its own code under `onion.` still resolves it.
+ *
+ * The shared table is reached from several compilations at once (the language server, a
+ * test suite, `onion test`), so its maps are concurrent and a race to materialize the same
+ * class is settled by whichever `putIfAbsent` wins -- both parsed the same bytes, and only
+ * one instance is ever handed out.
+ *
+ * @author Kota Mizushima
  */
-class ClassTable(classPath: String) {
+class ClassTable(classPath: String, parent: Option[ClassTable] = None) {
   val classes = new OrderedTable[TypedAST.ClassDefinition]
-  private val classFiles = new JHashMap[String, TypedAST.ClassType]
-  private val arrayClasses = new JHashMap[String, TypedAST.ArrayType]
-  private val missingClasses = new java.util.HashSet[String]
+  private val classFiles = new ConcurrentHashMap[String, TypedAST.ClassType]
+  private val arrayClasses = new ConcurrentHashMap[String, TypedAST.ArrayType]
+  private val missingClasses = ConcurrentHashMap.newKeySet[String]()
   private val table = new ClassFileTable(classPath)
+
+  /**
+   * Per-compilation memo for `AppliedTypeViews.collectAppliedViewsFrom`: the generic
+   * supertype views of a receiver type, which method resolution rebuilt by walking the
+   * whole supertype hierarchy on every call typed against that receiver. The result is a
+   * pure function of the type, so within one compilation it is computed once per receiver.
+   * Keyed by identity -- class types compare by identity throughout the checker.
+   */
+  private val appliedViewsMemo =
+    new java.util.IdentityHashMap[TypedAST.ClassType, scala.collection.immutable.Map[TypedAST.ClassType, TypedAST.AppliedClassType]]
+
+  /**
+   * The import-scan memo for a unit's import list (see `NameResolver.forName`). A resolver
+   * is created per top-level declaration, all sharing the unit's imports; keying the memo
+   * by that list lets the second class in a file reuse what the first resolved.
+   */
+  private val importScanMemos = new java.util.IdentityHashMap[AnyRef, scala.collection.mutable.HashMap[String, (TypedAST.ClassType, Int)]]()
+  def importScanMemo(imports: AnyRef): scala.collection.mutable.HashMap[String, (TypedAST.ClassType, Int)] = {
+    val existing = importScanMemos.get(imports)
+    if (existing != null) existing
+    else {
+      val fresh = scala.collection.mutable.HashMap[String, (TypedAST.ClassType, Int)]()
+      importScanMemos.put(imports, fresh)
+      fresh
+    }
+  }
+
+  /** Per-compilation memo of a method's erased parameter descriptor (duplication checks). */
+  private val erasedParamsMemo = new java.util.IdentityHashMap[TypedAST.Method, String]()
+  def erasedParamsOf(method: TypedAST.Method)(compute: => String): String = {
+    val cached = erasedParamsMemo.get(method)
+    if (cached != null) cached
+    else {
+      val d = compute
+      erasedParamsMemo.put(method, d)
+      d
+    }
+  }
+
+  def appliedViewsOf(target: TypedAST.ClassType)(compute: => scala.collection.immutable.Map[TypedAST.ClassType, TypedAST.AppliedClassType]): scala.collection.immutable.Map[TypedAST.ClassType, TypedAST.AppliedClassType] = {
+    val cached = appliedViewsMemo.get(target)
+    if (cached != null) cached
+    else {
+      val views = compute
+      appliedViewsMemo.put(target, views)
+      views
+    }
+  }
 
   def loadArray(component: TypedAST.Type, dimension: Int): TypedAST.ArrayType = {
     // The cache is keyed by name, which is ambiguous for type variables ("T" from
@@ -29,13 +105,27 @@ class ClassTable(classPath: String) {
     // List[Int]); cache only arrays of simple components.
     if (!isCacheableComponent(component))
       return new TypedAST.ArrayType(component, dimension, this)
+    // The shared universe outlives every compilation, so it may only cache arrays of its
+    // own classes. A substitution such as `T[] -> Transaction[]` over a runtime method's
+    // vararg parameter asks the parameter's table -- this one -- for the array; caching it
+    // here by name would hand the next compilation an array of the *previous* `Transaction`.
+    if ((this eq ClassTable.shared) && !isSharedComponent(component))
+      return new TypedAST.ArrayType(component, dimension, this)
     val arrayName = "[" * dimension + component.name
-    var array: TypedAST.ArrayType = arrayClasses.get(arrayName)
-    if (array != null) return array
-    array = new TypedAST.ArrayType(component, dimension, this)
-    arrayClasses.put(arrayName, array)
-    array
+    val cached = arrayClasses.get(arrayName)
+    if (cached != null) return cached
+    val fresh = new TypedAST.ArrayType(component, dimension, this)
+    val winner = arrayClasses.putIfAbsent(arrayName, fresh)
+    if (winner == null) fresh else winner
   }
+
+  private def isSharedComponent(component: TypedAST.Type): Boolean =
+    component match {
+      case _: TypedAST.BasicType => true
+      case array: TypedAST.ArrayType => isSharedComponent(array.component)
+      case ct: TypedAST.ClassType => ClassTable.isSharedName(ct.name)
+      case _ => false
+    }
 
   private def isCacheableComponent(component: TypedAST.Type): Boolean =
     component match {
@@ -55,25 +145,43 @@ class ClassTable(classPath: String) {
    * Prefer [[load]] (Option) or [[loadRequired]] elsewhere.
    */
   def loadOrNull(className: String): TypedAST.ClassType = {
-    var clazz: TypedAST.ClassType = lookup(className)
-    if (clazz == null && missingClasses.contains(className)) return null
-    if (clazz == null) {
-      val bytes = table.loadBytes(className)
-      if (bytes != null) {
-        clazz = new AsmClassType(bytes, this)
-        classFiles.put(clazz.name, clazz)
-      } else {
-        try {
-          clazz = new ReflectClassType(Class.forName(className, false, Thread.currentThread.getContextClassLoader), this)
-          classFiles.put(clazz.name, clazz)
-        }
-        catch {
-          case _: ClassNotFoundException =>
-            missingClasses.add(className)
-        }
-      }
+    val known = lookup(className)
+    if (known != null) return known
+    if (missingClasses.contains(className)) return null
+    // Platform and runtime classes live in the shared universe; ask it before touching
+    // this compilation's own classpath, so every compilation sees the same instance.
+    if (parent.isDefined && ClassTable.isSharedName(className)) {
+      val shared = parent.get.loadOrNull(className)
+      if (shared != null) return shared
+      // `java.*` is the boot loader's alone -- no user classpath can define it -- so the
+      // shared universe's "absent" is final and this compilation need not probe its own
+      // classpath for it. Other shared prefixes (javax., onion., ...) can legitimately be
+      // extended by a user jar, so they fall through.
+      if (className.startsWith("java.")) { missingClasses.add(className); return null }
     }
-    clazz
+    val bytes = table.loadBytes(className)
+    val fresh: TypedAST.ClassType =
+      if (bytes != null) new AsmClassType(bytes, this)
+      else {
+        // The reflective fallback exists for classes only the context loader can see. Asking
+        // that loader for the resource first turns an absent class into a null instead of a
+        // ClassNotFoundException -- which was thrown, with its stack trace, ~50 times per
+        // compilation for names the import scan tried and found nowhere.
+        val loader = Thread.currentThread.getContextClassLoader
+        if (loader == null || loader.getResource(className.replace('.', '/') + ".class") == null) {
+          missingClasses.add(className)
+          null
+        } else
+          try new ReflectClassType(Class.forName(className, false, loader), this)
+          catch {
+            case _: ClassNotFoundException =>
+              missingClasses.add(className)
+              null
+          }
+      }
+    if (fresh == null) return null
+    val winner = classFiles.putIfAbsent(fresh.name, fresh)
+    if (winner == null) fresh else winner
   }
 
   def load(className: String): Option[TypedAST.ClassType] = Option(loadOrNull(className))
@@ -97,4 +205,28 @@ class ClassTable(classPath: String) {
   /** Option-returning version of lookup for safer null handling */
   def lookupOpt(className: String): Option[TypedAST.ClassType] = Option(lookup(className))
 
+}
+
+object ClassTable {
+  /**
+   * Prefixes whose classes are immutable for the life of the process and are resolved
+   * from the compiler's own class loader: the platform, and Onion's runtime library.
+   */
+  private val SharedPrefixes = Array("java.", "javax.", "jdk.", "sun.", "com.sun.", "onion.")
+
+  def isSharedName(className: String): Boolean = {
+    var i = 0
+    while (i < SharedPrefixes.length) {
+      if (className.startsWith(SharedPrefixes(i))) return true
+      i += 1
+    }
+    false
+  }
+
+  /**
+   * The process-wide universe of platform and runtime classes. Built once, on first use,
+   * with no classpath of its own: an empty classpath resolves through the compiler's class
+   * loader, which is exactly the set of classes that never change while it runs.
+   */
+  lazy val shared: ClassTable = new ClassTable("", None)
 }

--- a/src/main/scala/onion/compiler/ImportItem.scala
+++ b/src/main/scala/onion/compiler/ImportItem.scala
@@ -19,12 +19,23 @@ case class ImportItem(simpleName : String, fqcn: Seq[String]) {
    * @param simpleName
    * @return fqcn.  if simpleName is not matched, then return null.
    */
+  // Every unresolved name is tried against every import, so these strings were rebuilt
+  // -- take/append/mkString over the segment list -- on each attempt. They depend only on
+  // the item, so they are built once.
+  // The default package's on-demand import is the single segment `*`: its prefix is the
+  // empty string, not `.` -- a leading dot made every default-package class unresolvable.
+  private val onDemandPrefix: String =
+    if (!isOnDemand || fqcn.isEmpty) null
+    else if (fqcn.length == 1) ""
+    else fqcn.take(fqcn.length - 1).mkString("", ".", ".")
+  private val fullName: String = fqcn.mkString(".")
+
   def matches(simpleName: String): Option[String] = {
     if (isOnDemand) {
-      if(fqcn.length == 0) None
-      else Some(fqcn.take(fqcn.length - 1).appended(simpleName).mkString("."))
+      if (onDemandPrefix == null) None
+      else Some(onDemandPrefix + simpleName)
     } else if (this.simpleName == simpleName) {
-      Some(fqcn.mkString((".")))
+      Some(fullName)
     } else {
       None
     }

--- a/src/main/scala/onion/compiler/LocalFrame.scala
+++ b/src/main/scala/onion/compiler/LocalFrame.scala
@@ -43,13 +43,16 @@ class LocalFrame(val parent: LocalFrame) {
    *
    * Shadowing is not a collision: two scopes declaring the same name produce two indices.
    */
+  // Built once per method at code generation, for the LocalVariableTable. It walked every
+  // scope through `names` (a fresh Set per scope) and a lookup per name; iterating the
+  // bindings directly is the same relation without the copies.
   def namesByIndex: Map[Int, String] =
-    allScopes.iterator.flatMap { scope =>
-      scope.names.iterator.flatMap(name => scope.get(name).map(binding => binding.index -> name))
-    }.toMap
+    allScopes.iterator.flatMap(_.bindingEntries.map { case (name, binding) => binding.index -> name }).toMap
 
   def entries: Seq[LocalBinding] = {
-    val binds: Array[LocalBinding] = entrySet.toArray
+    // Per method at codegen and for closures; the HashSet-per-scope merge it replaced
+    // showed on the profile.
+    val binds: Array[LocalBinding] = allScopes.iterator.flatMap(_.bindingEntries.map(_._2)).toArray
     JArrays.sort(binds, (b1: LocalBinding, b2: LocalBinding) => {
       val i1 = b1.index
       val i2 = b2.index

--- a/src/main/scala/onion/compiler/LocalScope.scala
+++ b/src/main/scala/onion/compiler/LocalScope.scala
@@ -42,6 +42,9 @@ class LocalScope(val parent: LocalScope) {
    */
   def names: Set[String] = bindings.keySet.toSet
 
+  /** The bindings of this scope only, without copying into a Set. */
+  def bindingEntries: Iterator[(String, LocalBinding)] = bindings.iterator
+
   /**
    * Gets all variable names in this scope and its ancestors.
    * @return Set of variable names

--- a/src/main/scala/onion/compiler/MultiTable.scala
+++ b/src/main/scala/onion/compiler/MultiTable.scala
@@ -5,33 +5,27 @@ import scala.collection.Iterator
 import scala.collection.mutable
 
 class MultiTable[E <: Named] extends Iterable[E] {
-  private[this] final val mapping = new mutable.HashMap[String, mutable.Buffer[E]]
+  // Entries per name are kept as an immutable List, appended on add (adds are rare and the
+  // lists are short -- they hold one name's overloads) so that `get`, which method
+  // resolution calls for every class up a receiver's hierarchy on every call, returns the
+  // list itself. The previous shape allocated on every lookup: a hit copied the buffer with
+  // toList, and a *miss* inserted an empty buffer into the map -- a read that grew the
+  // table for every name ever asked of every class, `size` on `Object` included.
+  private[this] final val mapping = new mutable.HashMap[String, List[E]]
 
   def add(entry: E): Boolean = {
     mapping.get(entry.name) match {
       case Some(v) =>
-        v += entry
+        mapping(entry.name) = v :+ entry
         true
       case None =>
-        val v = mutable.Buffer[E]()
-        v += entry
-        mapping(entry.name) = v
+        mapping(entry.name) = entry :: Nil
         false
     }
   }
 
-  def get(key: String): Seq[E] = {
-    (mapping.get(key) match {
-      case None =>
-        val v = mutable.Buffer[E]()
-        mapping(key) = v
-        v
-      case Some(v) =>
-        v
-    }).toList
-  }
+  def get(key: String): Seq[E] = mapping.getOrElse(key, Nil)
 
-  def values: Seq[E] =  mapping.values.toList.flatten
-
+  def values: Seq[E] = mapping.values.toList.flatten
   def iterator: Iterator[E] = values.iterator
 }

--- a/src/main/scala/onion/compiler/SemanticErrorReporter.scala
+++ b/src/main/scala/onion/compiler/SemanticErrorReporter.scala
@@ -1,5 +1,7 @@
 package onion.compiler
 
+import SemanticErrorReporter.*
+
 /* ************************************************************** *
  *                                                                *
  * Copyright (c) 2016-, Kota Mizushima, All rights reserved.  *
@@ -92,476 +94,7 @@ class SemanticErrorReporter(threshold: Int) {
 
   // ========== Type extractors ==========
 
-  private def typeName(item: AnyRef): String =
-    if (item == null) "<unknown>" else onion.compiler.toolbox.TypeFormatting.sourceForm(item.asInstanceOf[TypedAST.Type])
-  private def classTypeName(item: AnyRef): String =
-    if (item == null) "<unknown>" else onion.compiler.toolbox.TypeFormatting.sourceForm(item.asInstanceOf[TypedAST.ClassType])
-  private def objectTypeName(item: AnyRef): String =
-    if (item == null) "<unknown>" else onion.compiler.toolbox.TypeFormatting.sourceForm(item.asInstanceOf[TypedAST.ObjectType])
-  private def asString(item: AnyRef): String = item.asInstanceOf[String]
-  // English indefinite article for a noun starting with a vowel sound ("enum" -> "an
-  // enum") vs. one that doesn't ("record" -> "a record"). Only used where the same
-  // message key must grammatically agree with more than one substituted noun -- a fixed
-  // noun's article belongs directly in the .properties text instead, as everywhere else.
-  private def indefiniteArticled(noun: String): String = {
-    val article = noun.headOption.map(_.toLower) match {
-      case Some(c) if "aeiou".contains(c) => "an"
-      case _ => "a"
-    }
-    s"$article $noun"
-  }
-  private def asInt(item: AnyRef): String = item.asInstanceOf[Int].toString
-  // English count + noun agreement ("1 field" / "2 fields"). Only used where the same
-  // message key's Japanese counterpart uses a bare number with a counter word (e.g. "{1}
-  // 個の...") and has no plural form to agree -- English gets its own pre-pluralized
-  // argument instead of reusing the raw count, same pattern as `indefiniteArticled`.
-  private def pluralizeCount(count: Int, noun: String): String =
-    if (count == 1) s"1 $noun" else s"$count ${noun}s"
-  // Same, but also carries the trailing verb so subject-verb number agreement is
-  // captured too ("1 binding was specified" / "2 bindings were specified").
-  private def pluralizeCountVerb(count: Int, noun: String, verbSingular: String, verbPlural: String): String =
-    if (count == 1) s"1 $noun $verbSingular" else s"$count ${noun}s $verbPlural"
-  // Same idea, but for a clause with no noun of its own ("1 is supplied" / "2 are
-  // supplied") -- the noun was already named earlier in the sentence.
-  private def pluralizeVerbOnly(count: Int, verbSingular: String, verbPlural: String): String =
-    if (count == 1) s"1 $verbSingular" else s"$count $verbPlural"
-  private def typeNames(types: Array[TypedAST.Type]): String = {
-    if (types.isEmpty) "" else types.map(onion.compiler.toolbox.TypeFormatting.sourceForm).mkString(", ")
-  }
-  private def asTypeArray(item: AnyRef): Array[TypedAST.Type] = item.asInstanceOf[Array[TypedAST.Type]]
-
-  // ========== Message formatting ==========
-
-  private def message(property: String): String = Message(property)
-
-  private def format(template: String, args: Seq[String]): String = {
-    if (args.isEmpty) template
-    else MessageFormat.format(template, args.asInstanceOf[Seq[AnyRef]]: _*)
-  }
-
-  private def appendSuggestion(baseMessage: String, suggestion: Option[String]): String =
-    suggestion match {
-      case Some(text) => s"$baseMessage${Systems.lineSeparator}  $text"
-      case None => baseMessage
-    }
-
-  private def problem(position: Location, message: String): Unit = {
-    val errorCode = Option(currentError).map(_.errorCode)
-    val ctx = if (context == CompilationContext.empty) None else Some(context)
-    // Closure bodies are typed more than once (return-type inference,
-    // bidirectional trials); drop exact duplicates so each problem is
-    // reported a single time
-    val duplicate = problems.exists(p =>
-      p.sourceFile == sourceFile && p.location == position && p.message == message
-    )
-    if (!duplicate) {
-      problems.append(CompileError(sourceFile, position, message, errorCode, ctx))
-    }
-  }
-
-  // ========== Error definitions ==========
-
-  /**
-   * Error definition with message key and argument extractors.
-   * Each extractor function takes the items array and returns a format argument.
-   */
-  private case class ErrorDef(
-    messageKey: String,
-    extractors: Seq[Array[AnyRef] => String]
-  )
-
-  /**
-   * Error definitions for standard errors.
-   * Special cases (with suggestions, complex formatting) are handled separately.
-   */
-  private val errorDefs: Map[SemanticError, ErrorDef] = Map(
-    // Type errors
-    SemanticError.ILLEGAL_METHOD_CALL -> ErrorDef(
-      "error.semantic.illegalMethodCall",
-      Seq(items => classTypeName(items(0)), items => asString(items(1)))
-    ),
-    SemanticError.INCOMPATIBLE_TYPE -> ErrorDef(
-      "error.semantic.incompatibleType",
-      Seq(items => typeName(items(0)), items => typeName(items(1)))
-    ),
-    SemanticError.INCOMPATIBLE_OPERAND_TYPE -> ErrorDef(
-      "error.semantic.incompatibleOperandType",
-      Seq(items => asString(items(0)), items => typeNames(asTypeArray(items(1))))
-    ),
-    SemanticError.LVALUE_REQUIRED -> ErrorDef(
-      "error.semantic.lValueRequired",
-      Seq()
-    ),
-    SemanticError.CANNOT_ASSIGN_TO_VAL -> ErrorDef(
-      "error.semantic.cannotAssignToVal",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.VAL_REQUIRES_INITIALIZER -> ErrorDef(
-      "error.semantic.valRequiresInitializer",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.CANNOT_RETURN_VALUE -> ErrorDef(
-      "error.semantic.cannotReturnValue",
-      Seq()
-    ),
-    SemanticError.IS_NOT_BOXABLE_TYPE -> ErrorDef(
-      "error.semantic.isNotBoxableType",
-      Seq(items => typeName(items(0)))
-    ),
-
-    // Resolution errors - CLASS_NOT_FOUND handled specially with suggestions
-    SemanticError.FIELD_NOT_FOUND -> ErrorDef(
-      "error.semantic.fieldNotFound",
-      Seq(items => typeName(items(0)), items => asString(items(1)))
-    ),
-    SemanticError.METHOD_NOT_FOUND -> ErrorDef(
-      "error.semantic.methodNotFound",
-      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
-    ),
-    // CONSTRUCTOR_NOT_FOUND handled specially with available constructors
-    SemanticError.CANNOT_CALL_METHOD_ON_PRIMITIVE -> ErrorDef(
-      "error.semantic.cannotCallMethodOnPrimitive",
-      Seq(items => typeName(items(0)), items => asString(items(1)))
-    ),
-    SemanticError.INVALID_METHOD_CALL_TARGET -> ErrorDef(
-      "error.semantic.invalidMethodCallTarget",
-      Seq(items => typeName(items(0)))
-    ),
-
-    // Duplication errors
-    SemanticError.DUPLICATE_LOCAL_VARIABLE -> ErrorDef(
-      "error.semantic.duplicatedVariable",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.DUPLICATE_CLASS -> ErrorDef(
-      "error.semantic.duplicatedClass",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.DUPLICATE_FIELD -> ErrorDef(
-      "error.semantic.duplicatedField",
-      Seq(items => typeName(items(0)), items => asString(items(1)))
-    ),
-    SemanticError.DUPLICATE_METHOD -> ErrorDef(
-      "error.semantic.duplicatedMethod",
-      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
-    ),
-    SemanticError.DUPLICATE_GLOBAL_VARIABLE -> ErrorDef(
-      "error.semantic.duplicatedGlobalVariable",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.DUPLICATE_FUNCTION -> ErrorDef(
-      "error.semantic.duplicatedFunction",
-      Seq(items => asString(items(0)), items => typeNames(asTypeArray(items(1))))
-    ),
-    SemanticError.DUPLICATE_CONSTRUCTOR -> ErrorDef(
-      "error.semantic.duplicatedConstructor",
-      Seq(items => typeName(items(0)), items => typeNames(asTypeArray(items(1))))
-    ),
-    SemanticError.DUPLICATE_TYPE_PARAMETER -> ErrorDef(
-      "error.semantic.duplicatedTypeParameter",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.DUPLICATE_GENERATED_METHOD -> ErrorDef(
-      "error.semantic.duplicateGeneratedMethod",
-      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
-    ),
-    SemanticError.DUPLICATE_EXTENSION_METHOD -> ErrorDef(
-      "error.semantic.duplicateExtensionMethod",
-      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
-    ),
-
-    // Access errors
-    SemanticError.METHOD_NOT_ACCESSIBLE -> ErrorDef(
-      "error.semantic.methodNotAccessible",
-      Seq(
-        items => objectTypeName(items(0)),
-        items => asString(items(1)),
-        items => typeNames(asTypeArray(items(2))),
-        items => classTypeName(items(3))
-      )
-    ),
-    SemanticError.FIELD_NOT_ACCESSIBLE -> ErrorDef(
-      "error.semantic.fieldNotAccessible",
-      Seq(items => classTypeName(items(0)), items => asString(items(1)), items => classTypeName(items(2)))
-    ),
-    SemanticError.CLASS_NOT_ACCESSIBLE -> ErrorDef(
-      "error.semantic.classNotAccessible",
-      Seq(items => classTypeName(items(0)), items => classTypeName(items(1)))
-    ),
-
-    // Inheritance errors
-    SemanticError.CYCLIC_INHERITANCE -> ErrorDef(
-      "error.semantic.cyclicInheritance",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.ILLEGAL_INHERITANCE -> ErrorDef(
-      "error.semantic.illegalInheritance",
-      Seq(items => asString(items(0)), items => message(s"error.semantic.illegalInheritanceReason.${asString(items(1))}"))
-    ),
-    SemanticError.INTERFACE_REQUIRED -> ErrorDef(
-      "error.semantic.interfaceRequired",
-      Seq(items => typeName(items(0)))
-    ),
-    SemanticError.UNIMPLEMENTED_ABSTRACT_METHOD -> ErrorDef(
-      "error.semantic.unimplementedAbstractMethod",
-      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
-    SemanticError.ABSTRACT_CLASS_INSTANTIATION -> ErrorDef(
-      "error.semantic.abstractClassInstantiation",
-      Seq(items => typeName(items(0)))
-    ),
-    SemanticError.FINAL_METHOD_OVERRIDE -> ErrorDef(
-      "error.semantic.finalMethodOverride",
-      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
-    // OVERRIDE_TARGET_NOT_FOUND handled specially with suggestions
-
-    // Generic type errors
-    SemanticError.TYPE_NOT_GENERIC -> ErrorDef(
-      "error.semantic.typeNotGeneric",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.RAW_TYPE_NOT_ALLOWED -> ErrorDef(
-      "error.semantic.rawTypeNotAllowed",
-      Seq(items => asString(items(0)))
-    ),
-    // {1} is the raw type name (used by the Japanese template, which has no
-    // article to agree). {2} is the English-only "a X"/"an X" phrase, same
-    // pattern as `indefiniteArticled`'s use for CONSTRUCTOR_IN_RECORD_OR_ENUM.
-    SemanticError.MISSING_RETURN -> ErrorDef(
-      "error.semantic.missingReturn",
-      Seq(
-        items => asString(items(0)),
-        items => typeName(items(1)),
-        items => indefiniteArticled(typeName(items(1)))
-      )
-    ),
-    // {1}/{2} are the raw counts (used by the Japanese template, which counts with
-    // "個" and has no plural form to agree). {3}/{4} are English-only pre-pluralized
-    // clauses for the same counts, same pattern as WRONG_BINDING_COUNT above.
-    SemanticError.TYPE_ARGUMENT_ARITY_MISMATCH -> ErrorDef(
-      "error.semantic.typeArgumentArityMismatch",
-      Seq(
-        items => asString(items(0)),
-        items => items(1).toString,
-        items => items(2).toString,
-        items => pluralizeCount(items(1).asInstanceOf[Int], "type argument"),
-        items => pluralizeVerbOnly(items(2).asInstanceOf[Int], "is supplied", "are supplied")
-      )
-    ),
-    SemanticError.TYPE_ARGUMENT_MUST_BE_REFERENCE -> ErrorDef(
-      "error.semantic.typeArgumentMustBeReference",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.METHOD_NOT_GENERIC -> ErrorDef(
-      "error.semantic.methodNotGeneric",
-      Seq(items => asString(items(0)), items => asString(items(1)))
-    ),
-    // {2}/{3} are the raw counts (used by the Japanese template, which counts with
-    // "個" and has no plural form to agree). {4}/{5} are English-only pre-pluralized
-    // clauses for the same counts, same pattern as TYPE_ARGUMENT_ARITY_MISMATCH above.
-    SemanticError.METHOD_TYPE_ARGUMENT_ARITY_MISMATCH -> ErrorDef(
-      "error.semantic.methodTypeArgumentArityMismatch",
-      Seq(
-        items => asString(items(0)),
-        items => asString(items(1)),
-        items => items(2).toString,
-        items => items(3).toString,
-        items => pluralizeCount(items(2).asInstanceOf[Int], "type argument"),
-        items => pluralizeVerbOnly(items(3).asInstanceOf[Int], "is supplied", "are supplied")
-      )
-    ),
-    SemanticError.ERASURE_SIGNATURE_COLLISION -> ErrorDef(
-      "error.semantic.erasureSignatureCollision",
-      Seq(items => typeName(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
-
-    // Pattern matching errors
-    SemanticError.DUPLICATE_ARGUMENT -> ErrorDef(
-      "error.semantic.duplicateArgument",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.POSITIONAL_AFTER_NAMED -> ErrorDef(
-      "error.semantic.positionalAfterNamed",
-      Seq()
-    ),
-    // {1}/{2} are the raw counts (used by the Japanese template, which counts with
-    // "個" and has no plural form to agree). {3}/{4} are English-only pre-pluralized
-    // clauses for the same counts, same pattern as CONSTRUCTOR_IN_RECORD_OR_ENUM's
-    // `indefiniteArticled` below: the English template uses {3}/{4} instead of the
-    // bare numbers so "1 fields"/"1 bindings were specified" can't happen.
-    SemanticError.WRONG_BINDING_COUNT -> ErrorDef(
-      "error.semantic.wrongBindingCount",
-      Seq(
-        items => asString(items(2)),
-        items => asInt(items(0)),
-        items => asInt(items(1)),
-        items => pluralizeCount(items(0).asInstanceOf[Int], "field"),
-        items => pluralizeCountVerb(items(1).asInstanceOf[Int], "binding", "was specified", "were specified")
-      )
-    ),
-    SemanticError.NOT_A_RECORD_TYPE -> ErrorDef(
-      "error.semantic.notARecordType",
-      Seq(items => asString(items(0)))
-    ),
-
-    SemanticError.BREAK_OUTSIDE_LOOP -> ErrorDef(
-      "error.semantic.breakOutsideLoop",
-      Seq()
-    ),
-    SemanticError.CONTINUE_OUTSIDE_LOOP -> ErrorDef(
-      "error.semantic.continueOutsideLoop",
-      Seq()
-    ),
-    SemanticError.CURRENT_INSTANCE_NOT_AVAILABLE -> ErrorDef(
-      "error.semantic.currentInstanceNotAvailable",
-      Seq()
-    ),
-    SemanticError.RETURN_TYPE_REQUIRED -> ErrorDef(
-      "error.semantic.returnTypeRequired",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.LAMBDA_PARAM_TYPE_REQUIRED -> ErrorDef(
-      "error.semantic.lambdaParamTypeRequired",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.FUNCTION_BODY_REQUIRED -> ErrorDef(
-      "error.semantic.functionBodyRequired",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.TYPE_PARAMETER_MAY_BE_NULL -> ErrorDef(
-      "error.semantic.typeParameterMayBeNull",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.NULLABLE_MEMBER_ACCESS -> ErrorDef(
-      "error.semantic.nullableMemberAccess",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.STATIC_CALL_ON_INSTANCE -> ErrorDef(
-      "error.semantic.staticCallOnInstance",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.CLASS_USED_AS_VALUE -> ErrorDef(
-      "error.semantic.classUsedAsValue",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.ABSTRACT_METHOD_WITH_BODY -> ErrorDef(
-      "error.semantic.abstractMethodWithBody",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.MAP_NOT_DIRECTLY_ITERABLE -> ErrorDef(
-      "error.semantic.mapNotDirectlyIterable",
-      Seq(items => typeName(items(0)))
-    ),
-    // LABEL_NOT_FOUND handled specially with suggestions
-    SemanticError.REGEX_PATTERN_INVALID -> ErrorDef(
-      "error.semantic.regexPatternInvalid",
-      Seq(items => asString(items(0)))
-    ),
-    // {0}/{1} are the raw counts (used by the Japanese template, which counts with
-    // "個" and has no plural form to agree). {2}/{3} are English-only pre-pluralized
-    // clauses for the same counts, same pattern as WRONG_BINDING_COUNT above.
-    SemanticError.REGEX_GROUP_MISMATCH -> ErrorDef(
-      "error.semantic.regexGroupMismatch",
-      Seq(
-        items => asString(items(0)),
-        items => asString(items(1)),
-        items => pluralizeCount(asString(items(0)).toInt, "capture group"),
-        items => pluralizeCountVerb(asString(items(1)).toInt, "binding", "was given", "were given")
-      )
-    ),
-    SemanticError.RECORD_FROM_COMPONENT_UNSUPPORTED -> ErrorDef(
-      "error.semantic.recordFromComponentUnsupported",
-      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
-    SemanticError.RECORD_DERIVE_COMPONENT_UNSUPPORTED -> ErrorDef(
-      "error.semantic.recordDeriveComponentUnsupported",
-      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
-    SemanticError.RECORD_DERIVE_UNKNOWN_MARKER -> ErrorDef(
-      "error.semantic.recordDeriveUnknownMarker",
-      Seq(items => asString(items(0)), items => asString(items(1)))
-    ),
-    SemanticError.SHAPE_FORMAT_UNKNOWN -> ErrorDef(
-      "error.semantic.shapeFormatUnknown",
-      Seq(items => asString(items(0)), items => asString(items(1)))
-    ),
-    SemanticError.TOOL_UNDECLARED_EFFECT -> ErrorDef(
-      "error.semantic.toolUndeclaredEffect",
-      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
-    SemanticError.TOOL_UNUSED_CAPABILITY -> ErrorDef(
-      "error.semantic.toolUnusedCapability",
-      Seq(items => asString(items(0)), items => asString(items(1)))
-    ),
-    SemanticError.TOOL_BAD_CAPABILITY -> ErrorDef(
-      "error.semantic.toolBadCapability",
-      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
-    ),
-    SemanticError.DUPLICATE_TOOL_NAME -> ErrorDef(
-      "error.semantic.duplicateToolName",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.UNREACHABLE_CATCH_CLAUSE -> ErrorDef(
-      "error.semantic.unreachableCatchClause",
-      Seq(items => typeName(items(0)), items => typeName(items(1)))
-    ),
-    SemanticError.SHAPE_INSTANCE_WITHOUT_LAW -> ErrorDef(
-      "error.semantic.shapeInstanceWithoutLaw",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.STATIC_METHOD_WITHOUT_BODY -> ErrorDef(
-      "error.semantic.staticMethodWithoutBody",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.DUPLICATE_RECORD_COMPONENT -> ErrorDef(
-      "error.semantic.duplicateRecordComponent",
-      Seq(items => typeName(items(0)), items => asString(items(1)))
-    ),
-    // {0} = the class, {1} = the primary constructor's parameter types, so the fix is
-    // copy-pasteable: `def this(...) : this(<{1}>) { ... }`.
-    SemanticError.SECONDARY_CONSTRUCTOR_MUST_DELEGATE -> ErrorDef(
-      "error.semantic.secondaryConstructorMustDelegate",
-      Seq(items => typeName(items(0)), items => typeNames(asTypeArray(items(1))))
-    ),
-    SemanticError.CONSTRUCTOR_DELEGATION_CYCLE -> ErrorDef(
-      "error.semantic.constructorDelegationCycle",
-      Seq(items => typeName(items(0)), items => typeNames(asTypeArray(items(1))))
-    ),
-    // {2} is derived from {0} (not a separate call-site argument): the English
-    // template needs the article to agree with whichever noun ("record" or "enum")
-    // was passed, while the Japanese template uses the bare {0} directly (no
-    // articles in Japanese), so both are extracted from the same source value.
-    SemanticError.CONSTRUCTOR_IN_RECORD_OR_ENUM -> ErrorDef(
-      "error.semantic.constructorInRecordOrEnum",
-      Seq(items => asString(items(0)), items => typeName(items(1)), items => indefiniteArticled(asString(items(0))))
-    ),
-    SemanticError.THIS_BEFORE_CONSTRUCTOR_DELEGATION -> ErrorDef(
-      "error.semantic.thisBeforeConstructorDelegation",
-      Seq(items => typeName(items(0)))
-    ),
-    // Reported through the normal reporter path (NameResolution / TypingHeaderPass)
-    // but never wired here, so both rendered as "Unknown error: <NAME>" (found while
-    // sweeping E-code coverage for 0.10.1).
-    SemanticError.CYCLIC_TYPE_ALIAS -> ErrorDef(
-      "error.semantic.cyclicTypeAlias",
-      Seq(items => asString(items(0)))
-    ),
-    SemanticError.DUPLICATE_TYPE_ALIAS -> ErrorDef(
-      "error.semantic.duplicateTypeAlias",
-      Seq(items => asString(items(0)))
-    )
-  )
-
-  // ========== Special case handlers ==========
-
-  // A JS/TS-style backtick template literal (`` `Hello ${name}` ``) isn't a string in
-  // Onion -- backticks only escape a reserved word into an identifier, so the whole
-  // `${...}` text becomes the literal name of a local variable reference, and the
-  // mistake surfaces as a VARIABLE_NOT_FOUND whose message repeats the entire template
-  // text back as if it were an identifier. Detect that shape in the unresolved name
-  // and point at Onion's actual interpolation syntax instead of a name-similarity guess.
-  private val TemplateLiteralInName = """\$\{.*\}""".r
+  private def TemplateLiteralInName = SemanticErrorReporter.TemplateLiteralInName
 
   // A JS-style `console.log(...)`/`console.error(...)`/`console.warn(...)` call has no
   // `console` object in Onion, so `console` parses as a bare identifier reference and
@@ -959,4 +492,488 @@ class SemanticErrorReporter(threshold: Int) {
   def resetContext(): Unit = {
     context = CompilationContext.empty
   }
+
+  private def problem(position: Location, message: String): Unit = {
+    val errorCode = Option(currentError).map(_.errorCode)
+    val ctx = if (context == CompilationContext.empty) None else Some(context)
+    // Closure bodies are typed more than once (return-type inference,
+    // bidirectional trials); drop exact duplicates so each problem is
+    // reported a single time
+    val duplicate = problems.exists(p =>
+      p.sourceFile == sourceFile && p.location == position && p.message == message
+    )
+    if (!duplicate) {
+      problems.append(CompileError(sourceFile, position, message, errorCode, ctx))
+    }
+  }
+}
+
+/**
+ * The error-definition table and its pure helpers live on the companion object: they
+ * carry no per-compilation state, and as class members the ~90-entry map with a closure
+ * per entry was rebuilt for every `new SemanticErrorReporter` -- once per compilation.
+ * The reporter's constructor showed up in profiles of a one-line program for that reason.
+ */
+object SemanticErrorReporter {
+  // Compiled once: a reporter is created per compilation, and a regex in its body was too.
+  private val TemplateLiteralInName = """\$\{.*\}""".r
+
+  private def typeName(item: AnyRef): String =
+    if (item == null) "<unknown>" else onion.compiler.toolbox.TypeFormatting.sourceForm(item.asInstanceOf[TypedAST.Type])
+  private def classTypeName(item: AnyRef): String =
+    if (item == null) "<unknown>" else onion.compiler.toolbox.TypeFormatting.sourceForm(item.asInstanceOf[TypedAST.ClassType])
+  private def objectTypeName(item: AnyRef): String =
+    if (item == null) "<unknown>" else onion.compiler.toolbox.TypeFormatting.sourceForm(item.asInstanceOf[TypedAST.ObjectType])
+  private def asString(item: AnyRef): String = item.asInstanceOf[String]
+  // English indefinite article for a noun starting with a vowel sound ("enum" -> "an
+  // enum") vs. one that doesn't ("record" -> "a record"). Only used where the same
+  // message key must grammatically agree with more than one substituted noun -- a fixed
+  // noun's article belongs directly in the .properties text instead, as everywhere else.
+  private def indefiniteArticled(noun: String): String = {
+    val article = noun.headOption.map(_.toLower) match {
+      case Some(c) if "aeiou".contains(c) => "an"
+      case _ => "a"
+    }
+    s"$article $noun"
+  }
+  private def asInt(item: AnyRef): String = item.asInstanceOf[Int].toString
+  // English count + noun agreement ("1 field" / "2 fields"). Only used where the same
+  // message key's Japanese counterpart uses a bare number with a counter word (e.g. "{1}
+  // 個の...") and has no plural form to agree -- English gets its own pre-pluralized
+  // argument instead of reusing the raw count, same pattern as `indefiniteArticled`.
+  private def pluralizeCount(count: Int, noun: String): String =
+    if (count == 1) s"1 $noun" else s"$count ${noun}s"
+  // Same, but also carries the trailing verb so subject-verb number agreement is
+  // captured too ("1 binding was specified" / "2 bindings were specified").
+  private def pluralizeCountVerb(count: Int, noun: String, verbSingular: String, verbPlural: String): String =
+    if (count == 1) s"1 $noun $verbSingular" else s"$count ${noun}s $verbPlural"
+  // Same idea, but for a clause with no noun of its own ("1 is supplied" / "2 are
+  // supplied") -- the noun was already named earlier in the sentence.
+  private def pluralizeVerbOnly(count: Int, verbSingular: String, verbPlural: String): String =
+    if (count == 1) s"1 $verbSingular" else s"$count $verbPlural"
+  private def typeNames(types: Array[TypedAST.Type]): String = {
+    if (types.isEmpty) "" else types.map(onion.compiler.toolbox.TypeFormatting.sourceForm).mkString(", ")
+  }
+  private def asTypeArray(item: AnyRef): Array[TypedAST.Type] = item.asInstanceOf[Array[TypedAST.Type]]
+
+  // ========== Message formatting ==========
+
+  private def message(property: String): String = Message(property)
+
+  private def format(template: String, args: Seq[String]): String = {
+    if (args.isEmpty) template
+    else MessageFormat.format(template, args.asInstanceOf[Seq[AnyRef]]: _*)
+  }
+
+  private def appendSuggestion(baseMessage: String, suggestion: Option[String]): String =
+    suggestion match {
+      case Some(text) => s"$baseMessage${Systems.lineSeparator}  $text"
+      case None => baseMessage
+    }
+
+
+  // ========== Error definitions ==========
+
+  /**
+   * Error definition with message key and argument extractors.
+   * Each extractor function takes the items array and returns a format argument.
+   */
+
+  private case class ErrorDef(
+    messageKey: String,
+    extractors: Seq[Array[AnyRef] => String]
+  )
+
+  /**
+   * Error definitions for standard errors.
+   * Special cases (with suggestions, complex formatting) are handled separately.
+   */
+
+  private val errorDefs: Map[SemanticError, ErrorDef] = Map(
+    // Type errors
+    SemanticError.ILLEGAL_METHOD_CALL -> ErrorDef(
+      "error.semantic.illegalMethodCall",
+      Seq(items => classTypeName(items(0)), items => asString(items(1)))
+    ),
+    SemanticError.INCOMPATIBLE_TYPE -> ErrorDef(
+      "error.semantic.incompatibleType",
+      Seq(items => typeName(items(0)), items => typeName(items(1)))
+    ),
+    SemanticError.INCOMPATIBLE_OPERAND_TYPE -> ErrorDef(
+      "error.semantic.incompatibleOperandType",
+      Seq(items => asString(items(0)), items => typeNames(asTypeArray(items(1))))
+    ),
+    SemanticError.LVALUE_REQUIRED -> ErrorDef(
+      "error.semantic.lValueRequired",
+      Seq()
+    ),
+    SemanticError.CANNOT_ASSIGN_TO_VAL -> ErrorDef(
+      "error.semantic.cannotAssignToVal",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.VAL_REQUIRES_INITIALIZER -> ErrorDef(
+      "error.semantic.valRequiresInitializer",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.CANNOT_RETURN_VALUE -> ErrorDef(
+      "error.semantic.cannotReturnValue",
+      Seq()
+    ),
+    SemanticError.IS_NOT_BOXABLE_TYPE -> ErrorDef(
+      "error.semantic.isNotBoxableType",
+      Seq(items => typeName(items(0)))
+    ),
+
+    // Resolution errors - CLASS_NOT_FOUND handled specially with suggestions
+    SemanticError.FIELD_NOT_FOUND -> ErrorDef(
+      "error.semantic.fieldNotFound",
+      Seq(items => typeName(items(0)), items => asString(items(1)))
+    ),
+    SemanticError.METHOD_NOT_FOUND -> ErrorDef(
+      "error.semantic.methodNotFound",
+      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
+    ),
+    // CONSTRUCTOR_NOT_FOUND handled specially with available constructors
+    SemanticError.CANNOT_CALL_METHOD_ON_PRIMITIVE -> ErrorDef(
+      "error.semantic.cannotCallMethodOnPrimitive",
+      Seq(items => typeName(items(0)), items => asString(items(1)))
+    ),
+    SemanticError.INVALID_METHOD_CALL_TARGET -> ErrorDef(
+      "error.semantic.invalidMethodCallTarget",
+      Seq(items => typeName(items(0)))
+    ),
+
+    // Duplication errors
+    SemanticError.DUPLICATE_LOCAL_VARIABLE -> ErrorDef(
+      "error.semantic.duplicatedVariable",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.DUPLICATE_CLASS -> ErrorDef(
+      "error.semantic.duplicatedClass",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.DUPLICATE_FIELD -> ErrorDef(
+      "error.semantic.duplicatedField",
+      Seq(items => typeName(items(0)), items => asString(items(1)))
+    ),
+    SemanticError.DUPLICATE_METHOD -> ErrorDef(
+      "error.semantic.duplicatedMethod",
+      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
+    ),
+    SemanticError.DUPLICATE_GLOBAL_VARIABLE -> ErrorDef(
+      "error.semantic.duplicatedGlobalVariable",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.DUPLICATE_FUNCTION -> ErrorDef(
+      "error.semantic.duplicatedFunction",
+      Seq(items => asString(items(0)), items => typeNames(asTypeArray(items(1))))
+    ),
+    SemanticError.DUPLICATE_CONSTRUCTOR -> ErrorDef(
+      "error.semantic.duplicatedConstructor",
+      Seq(items => typeName(items(0)), items => typeNames(asTypeArray(items(1))))
+    ),
+    SemanticError.DUPLICATE_TYPE_PARAMETER -> ErrorDef(
+      "error.semantic.duplicatedTypeParameter",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.DUPLICATE_GENERATED_METHOD -> ErrorDef(
+      "error.semantic.duplicateGeneratedMethod",
+      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
+    ),
+    SemanticError.DUPLICATE_EXTENSION_METHOD -> ErrorDef(
+      "error.semantic.duplicateExtensionMethod",
+      Seq(items => typeName(items(0)), items => asString(items(1)), items => typeNames(asTypeArray(items(2))))
+    ),
+
+    // Access errors
+    SemanticError.METHOD_NOT_ACCESSIBLE -> ErrorDef(
+      "error.semantic.methodNotAccessible",
+      Seq(
+        items => objectTypeName(items(0)),
+        items => asString(items(1)),
+        items => typeNames(asTypeArray(items(2))),
+        items => classTypeName(items(3))
+      )
+    ),
+    SemanticError.FIELD_NOT_ACCESSIBLE -> ErrorDef(
+      "error.semantic.fieldNotAccessible",
+      Seq(items => classTypeName(items(0)), items => asString(items(1)), items => classTypeName(items(2)))
+    ),
+    SemanticError.CLASS_NOT_ACCESSIBLE -> ErrorDef(
+      "error.semantic.classNotAccessible",
+      Seq(items => classTypeName(items(0)), items => classTypeName(items(1)))
+    ),
+
+    // Inheritance errors
+    SemanticError.CYCLIC_INHERITANCE -> ErrorDef(
+      "error.semantic.cyclicInheritance",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.ILLEGAL_INHERITANCE -> ErrorDef(
+      "error.semantic.illegalInheritance",
+      Seq(items => asString(items(0)), items => message(s"error.semantic.illegalInheritanceReason.${asString(items(1))}"))
+    ),
+    SemanticError.INTERFACE_REQUIRED -> ErrorDef(
+      "error.semantic.interfaceRequired",
+      Seq(items => typeName(items(0)))
+    ),
+    SemanticError.UNIMPLEMENTED_ABSTRACT_METHOD -> ErrorDef(
+      "error.semantic.unimplementedAbstractMethod",
+      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
+    ),
+    SemanticError.ABSTRACT_CLASS_INSTANTIATION -> ErrorDef(
+      "error.semantic.abstractClassInstantiation",
+      Seq(items => typeName(items(0)))
+    ),
+    SemanticError.FINAL_METHOD_OVERRIDE -> ErrorDef(
+      "error.semantic.finalMethodOverride",
+      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
+    ),
+    // OVERRIDE_TARGET_NOT_FOUND handled specially with suggestions
+
+    // Generic type errors
+    SemanticError.TYPE_NOT_GENERIC -> ErrorDef(
+      "error.semantic.typeNotGeneric",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.RAW_TYPE_NOT_ALLOWED -> ErrorDef(
+      "error.semantic.rawTypeNotAllowed",
+      Seq(items => asString(items(0)))
+    ),
+    // {1} is the raw type name (used by the Japanese template, which has no
+    // article to agree). {2} is the English-only "a X"/"an X" phrase, same
+    // pattern as `indefiniteArticled`'s use for CONSTRUCTOR_IN_RECORD_OR_ENUM.
+    SemanticError.MISSING_RETURN -> ErrorDef(
+      "error.semantic.missingReturn",
+      Seq(
+        items => asString(items(0)),
+        items => typeName(items(1)),
+        items => indefiniteArticled(typeName(items(1)))
+      )
+    ),
+    // {1}/{2} are the raw counts (used by the Japanese template, which counts with
+    // "個" and has no plural form to agree). {3}/{4} are English-only pre-pluralized
+    // clauses for the same counts, same pattern as WRONG_BINDING_COUNT above.
+    SemanticError.TYPE_ARGUMENT_ARITY_MISMATCH -> ErrorDef(
+      "error.semantic.typeArgumentArityMismatch",
+      Seq(
+        items => asString(items(0)),
+        items => items(1).toString,
+        items => items(2).toString,
+        items => pluralizeCount(items(1).asInstanceOf[Int], "type argument"),
+        items => pluralizeVerbOnly(items(2).asInstanceOf[Int], "is supplied", "are supplied")
+      )
+    ),
+    SemanticError.TYPE_ARGUMENT_MUST_BE_REFERENCE -> ErrorDef(
+      "error.semantic.typeArgumentMustBeReference",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.METHOD_NOT_GENERIC -> ErrorDef(
+      "error.semantic.methodNotGeneric",
+      Seq(items => asString(items(0)), items => asString(items(1)))
+    ),
+    // {2}/{3} are the raw counts (used by the Japanese template, which counts with
+    // "個" and has no plural form to agree). {4}/{5} are English-only pre-pluralized
+    // clauses for the same counts, same pattern as TYPE_ARGUMENT_ARITY_MISMATCH above.
+    SemanticError.METHOD_TYPE_ARGUMENT_ARITY_MISMATCH -> ErrorDef(
+      "error.semantic.methodTypeArgumentArityMismatch",
+      Seq(
+        items => asString(items(0)),
+        items => asString(items(1)),
+        items => items(2).toString,
+        items => items(3).toString,
+        items => pluralizeCount(items(2).asInstanceOf[Int], "type argument"),
+        items => pluralizeVerbOnly(items(3).asInstanceOf[Int], "is supplied", "are supplied")
+      )
+    ),
+    SemanticError.ERASURE_SIGNATURE_COLLISION -> ErrorDef(
+      "error.semantic.erasureSignatureCollision",
+      Seq(items => typeName(items(0)), items => asString(items(1)), items => asString(items(2)))
+    ),
+
+    // Pattern matching errors
+    SemanticError.DUPLICATE_ARGUMENT -> ErrorDef(
+      "error.semantic.duplicateArgument",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.POSITIONAL_AFTER_NAMED -> ErrorDef(
+      "error.semantic.positionalAfterNamed",
+      Seq()
+    ),
+    // {1}/{2} are the raw counts (used by the Japanese template, which counts with
+    // "個" and has no plural form to agree). {3}/{4} are English-only pre-pluralized
+    // clauses for the same counts, same pattern as CONSTRUCTOR_IN_RECORD_OR_ENUM's
+    // `indefiniteArticled` below: the English template uses {3}/{4} instead of the
+    // bare numbers so "1 fields"/"1 bindings were specified" can't happen.
+    SemanticError.WRONG_BINDING_COUNT -> ErrorDef(
+      "error.semantic.wrongBindingCount",
+      Seq(
+        items => asString(items(2)),
+        items => asInt(items(0)),
+        items => asInt(items(1)),
+        items => pluralizeCount(items(0).asInstanceOf[Int], "field"),
+        items => pluralizeCountVerb(items(1).asInstanceOf[Int], "binding", "was specified", "were specified")
+      )
+    ),
+    SemanticError.NOT_A_RECORD_TYPE -> ErrorDef(
+      "error.semantic.notARecordType",
+      Seq(items => asString(items(0)))
+    ),
+
+    SemanticError.BREAK_OUTSIDE_LOOP -> ErrorDef(
+      "error.semantic.breakOutsideLoop",
+      Seq()
+    ),
+    SemanticError.CONTINUE_OUTSIDE_LOOP -> ErrorDef(
+      "error.semantic.continueOutsideLoop",
+      Seq()
+    ),
+    SemanticError.CURRENT_INSTANCE_NOT_AVAILABLE -> ErrorDef(
+      "error.semantic.currentInstanceNotAvailable",
+      Seq()
+    ),
+    SemanticError.RETURN_TYPE_REQUIRED -> ErrorDef(
+      "error.semantic.returnTypeRequired",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.LAMBDA_PARAM_TYPE_REQUIRED -> ErrorDef(
+      "error.semantic.lambdaParamTypeRequired",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.FUNCTION_BODY_REQUIRED -> ErrorDef(
+      "error.semantic.functionBodyRequired",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.TYPE_PARAMETER_MAY_BE_NULL -> ErrorDef(
+      "error.semantic.typeParameterMayBeNull",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.NULLABLE_MEMBER_ACCESS -> ErrorDef(
+      "error.semantic.nullableMemberAccess",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.STATIC_CALL_ON_INSTANCE -> ErrorDef(
+      "error.semantic.staticCallOnInstance",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.CLASS_USED_AS_VALUE -> ErrorDef(
+      "error.semantic.classUsedAsValue",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.ABSTRACT_METHOD_WITH_BODY -> ErrorDef(
+      "error.semantic.abstractMethodWithBody",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.MAP_NOT_DIRECTLY_ITERABLE -> ErrorDef(
+      "error.semantic.mapNotDirectlyIterable",
+      Seq(items => typeName(items(0)))
+    ),
+    // LABEL_NOT_FOUND handled specially with suggestions
+    SemanticError.REGEX_PATTERN_INVALID -> ErrorDef(
+      "error.semantic.regexPatternInvalid",
+      Seq(items => asString(items(0)))
+    ),
+    // {0}/{1} are the raw counts (used by the Japanese template, which counts with
+    // "個" and has no plural form to agree). {2}/{3} are English-only pre-pluralized
+    // clauses for the same counts, same pattern as WRONG_BINDING_COUNT above.
+    SemanticError.REGEX_GROUP_MISMATCH -> ErrorDef(
+      "error.semantic.regexGroupMismatch",
+      Seq(
+        items => asString(items(0)),
+        items => asString(items(1)),
+        items => pluralizeCount(asString(items(0)).toInt, "capture group"),
+        items => pluralizeCountVerb(asString(items(1)).toInt, "binding", "was given", "were given")
+      )
+    ),
+    SemanticError.RECORD_FROM_COMPONENT_UNSUPPORTED -> ErrorDef(
+      "error.semantic.recordFromComponentUnsupported",
+      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
+    ),
+    SemanticError.RECORD_DERIVE_COMPONENT_UNSUPPORTED -> ErrorDef(
+      "error.semantic.recordDeriveComponentUnsupported",
+      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
+    ),
+    SemanticError.RECORD_DERIVE_UNKNOWN_MARKER -> ErrorDef(
+      "error.semantic.recordDeriveUnknownMarker",
+      Seq(items => asString(items(0)), items => asString(items(1)))
+    ),
+    SemanticError.SHAPE_FORMAT_UNKNOWN -> ErrorDef(
+      "error.semantic.shapeFormatUnknown",
+      Seq(items => asString(items(0)), items => asString(items(1)))
+    ),
+    SemanticError.TOOL_UNDECLARED_EFFECT -> ErrorDef(
+      "error.semantic.toolUndeclaredEffect",
+      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
+    ),
+    SemanticError.TOOL_UNUSED_CAPABILITY -> ErrorDef(
+      "error.semantic.toolUnusedCapability",
+      Seq(items => asString(items(0)), items => asString(items(1)))
+    ),
+    SemanticError.TOOL_BAD_CAPABILITY -> ErrorDef(
+      "error.semantic.toolBadCapability",
+      Seq(items => asString(items(0)), items => asString(items(1)), items => asString(items(2)))
+    ),
+    SemanticError.DUPLICATE_TOOL_NAME -> ErrorDef(
+      "error.semantic.duplicateToolName",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.UNREACHABLE_CATCH_CLAUSE -> ErrorDef(
+      "error.semantic.unreachableCatchClause",
+      Seq(items => typeName(items(0)), items => typeName(items(1)))
+    ),
+    SemanticError.SHAPE_INSTANCE_WITHOUT_LAW -> ErrorDef(
+      "error.semantic.shapeInstanceWithoutLaw",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.STATIC_METHOD_WITHOUT_BODY -> ErrorDef(
+      "error.semantic.staticMethodWithoutBody",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.DUPLICATE_RECORD_COMPONENT -> ErrorDef(
+      "error.semantic.duplicateRecordComponent",
+      Seq(items => typeName(items(0)), items => asString(items(1)))
+    ),
+    // {0} = the class, {1} = the primary constructor's parameter types, so the fix is
+    // copy-pasteable: `def this(...) : this(<{1}>) { ... }`.
+    SemanticError.SECONDARY_CONSTRUCTOR_MUST_DELEGATE -> ErrorDef(
+      "error.semantic.secondaryConstructorMustDelegate",
+      Seq(items => typeName(items(0)), items => typeNames(asTypeArray(items(1))))
+    ),
+    SemanticError.CONSTRUCTOR_DELEGATION_CYCLE -> ErrorDef(
+      "error.semantic.constructorDelegationCycle",
+      Seq(items => typeName(items(0)), items => typeNames(asTypeArray(items(1))))
+    ),
+    // {2} is derived from {0} (not a separate call-site argument): the English
+    // template needs the article to agree with whichever noun ("record" or "enum")
+    // was passed, while the Japanese template uses the bare {0} directly (no
+    // articles in Japanese), so both are extracted from the same source value.
+    SemanticError.CONSTRUCTOR_IN_RECORD_OR_ENUM -> ErrorDef(
+      "error.semantic.constructorInRecordOrEnum",
+      Seq(items => asString(items(0)), items => typeName(items(1)), items => indefiniteArticled(asString(items(0))))
+    ),
+    SemanticError.THIS_BEFORE_CONSTRUCTOR_DELEGATION -> ErrorDef(
+      "error.semantic.thisBeforeConstructorDelegation",
+      Seq(items => typeName(items(0)))
+    ),
+    // Reported through the normal reporter path (NameResolution / TypingHeaderPass)
+    // but never wired here, so both rendered as "Unknown error: <NAME>" (found while
+    // sweeping E-code coverage for 0.10.1).
+    SemanticError.CYCLIC_TYPE_ALIAS -> ErrorDef(
+      "error.semantic.cyclicTypeAlias",
+      Seq(items => asString(items(0)))
+    ),
+    SemanticError.DUPLICATE_TYPE_ALIAS -> ErrorDef(
+      "error.semantic.duplicateTypeAlias",
+      Seq(items => asString(items(0)))
+    )
+  )
+
+  // ========== Special case handlers ==========
+
+  // A JS/TS-style backtick template literal (`` `Hello ${name}` ``) isn't a string in
+  // Onion -- backticks only escape a reserved word into an identifier, so the whole
+  // `${...}` text becomes the literal name of a local variable reference, and the
+  // mistake surfaces as a VARIABLE_NOT_FOUND whose message repeats the entire template
+  // text back as if it were an identifier. Detect that shape in the unresolved name
+  // and point at Onion's actual interpolation syntax instead of a name-similarity guess.
 }

--- a/src/main/scala/onion/compiler/TermWalk.scala
+++ b/src/main/scala/onion/compiler/TermWalk.scala
@@ -40,17 +40,27 @@ object TermWalk:
             case _ => false
           }
 
-  private def children(node: AnyRef): Seq[AnyRef] = node match
+  private[compiler] def children(node: AnyRef): Seq[AnyRef] = node match
     case p: Product => p.productIterator.collect { case r: AnyRef => r }.toSeq
     case _ => reflectiveChildren(node)
 
+  // The accessor set of a node class never changes, and getMethods() plus the filter is
+  // the expensive part of a reflective walk -- it ran for every node on every walk, and
+  // codegen walks the right-hand side of every assignment. One lookup per class instead.
+  private val accessors = new java.util.concurrent.ConcurrentHashMap[Class[?], Array[java.lang.reflect.Method]]()
+
+  private def accessorsOf(cls: Class[?]): Array[java.lang.reflect.Method] =
+    accessors.computeIfAbsent(cls, c =>
+      c.getMethods.iterator
+        .filter(m => m.getParameterCount == 0 && !m.getName.contains("$") &&
+          (classOf[Term].isAssignableFrom(m.getReturnType) ||
+           classOf[ActionStatement].isAssignableFrom(m.getReturnType) ||
+           m.getReturnType.isArray ||
+           classOf[java.util.List[?]].isAssignableFrom(m.getReturnType)))
+        .toArray)
+
   private def reflectiveChildren(node: AnyRef): Seq[AnyRef] =
-    node.getClass.getMethods.iterator
-      .filter(m => m.getParameterCount == 0 && !m.getName.contains("$") &&
-        (classOf[Term].isAssignableFrom(m.getReturnType) ||
-         classOf[ActionStatement].isAssignableFrom(m.getReturnType) ||
-         m.getReturnType.isArray ||
-         classOf[java.util.List[?]].isAssignableFrom(m.getReturnType)))
+    accessorsOf(node.getClass).iterator
       .flatMap { m =>
         try
           m.invoke(node) match

--- a/src/main/scala/onion/compiler/TypedAST.scala
+++ b/src/main/scala/onion/compiler/TypedAST.scala
@@ -202,7 +202,9 @@ object TypedAST {
       this(newStatements.asScala.toIndexedSeq: _*)
     }
 
-    def statements: Array[TypedAST.ActionStatement] = newStatements.toArray
+    // Accessed on every visit of the block by typing, optimization and codegen; the
+    // varargs Seq was copied into a new array each time.
+    val statements: Array[TypedAST.ActionStatement] = newStatements.toArray
   }
 
   /**
@@ -1006,10 +1008,14 @@ object TypedAST {
   case class TypeParameter(name: String, upperBound: Option[TypedAST.Type], nullability: Nullability = Nullability.Platform, constraints: scala.collection.immutable.List[ClassType] = scala.collection.immutable.Nil)
 
   object AppliedClassType {
-    private val cache = scala.collection.mutable.HashMap[(TypedAST.ClassType, scala.collection.immutable.List[TypedAST.Type]), AppliedClassType]()
+    // Process-wide, and reached from concurrent compilations (the language server, test
+    // suites), so it has to be a concurrent map. It only pays off when the raw class types
+    // are the same instances across compilations, which ClassTable.shared now guarantees
+    // for platform and runtime classes.
+    private val cache = new java.util.concurrent.ConcurrentHashMap[(TypedAST.ClassType, scala.collection.immutable.List[TypedAST.Type]), AppliedClassType]()
 
     def apply(raw: TypedAST.ClassType, typeArguments: scala.collection.immutable.List[TypedAST.Type]): AppliedClassType =
-      cache.getOrElseUpdate((raw, typeArguments), new AppliedClassType(raw, typeArguments.toArray[TypedAST.Type]))
+      cache.computeIfAbsent((raw, typeArguments), _ => new AppliedClassType(raw, typeArguments.toArray[TypedAST.Type]))
   }
 
   final class AppliedClassType private(val raw: TypedAST.ClassType, val typeArguments: Array[TypedAST.Type])
@@ -1822,8 +1828,17 @@ object TypedAST {
           }
           return true
         case _ =>
-      isSuperTypeForClass(left, right.superClass) ||
-        right.interfaces.exists(iface => isSuperTypeForClass(left, iface))
+      if (isSuperTypeForClass(left, right.superClass)) return true
+      // An index loop: `exists` on the interface Vector allocated an iterator and a closure
+      // per class on the walk, and a failed check walks the whole hierarchy -- which is the
+      // common outcome during overload resolution. It was the top allocation site.
+      val ifaces = right.interfaces
+      var i = 0
+      while (i < ifaces.length) {
+        if (isSuperTypeForClass(left, ifaces(i))) return true
+        i += 1
+      }
+      false
     }
 
     private def isSuperTypeForBasic(left: TypedAST.BasicType, right: TypedAST.BasicType): Boolean =

--- a/src/main/scala/onion/compiler/Typing.scala
+++ b/src/main/scala/onion/compiler/Typing.scala
@@ -7,6 +7,8 @@
  * ************************************************************** */
 package onion.compiler
 
+import scala.jdk.CollectionConverters.*
+
 import _root_.scala.jdk.CollectionConverters._
 import _root_.onion.compiler.toolbox.{Paths, Systems}
 import _root_.onion.compiler.exceptions.CompilationException
@@ -82,6 +84,60 @@ import collection.mutable.{HashMap, Map}
 object Typing {
   /** Pseudo receiver name for extension methods on array types. */
   final val ArrayExtensionReceiver = "<array>"
+
+  /**
+   * The bundled collection utilities' static helpers, as extension methods keyed by the
+   * FQCN of their first parameter's type -- so scripts write `list.map { x -> ... }`
+   * instead of `Colls::map(list) { x -> ... }`.
+   *
+   * Built once per process, on first use, against the shared class table: the containers
+   * are `onion.*` runtime classes, so their `ClassType`s and every type they mention are
+   * the shared instances, and the resulting definitions are safe to hand to every
+   * compilation. (A builtin definition has no body and no frame; only user-declared
+   * extensions ever have those set.) Before this, the same reflective scan over ten
+   * classes ran inside each compilation that resolved an extension call.
+   *
+   * Colls and Iterables overlap (both declare take(List, int)); a given
+   * receiver+name+erased-signature is registered once, first container wins, so
+   * `xs.take(2)` is not ambiguous. Explicit static calls are unaffected.
+   */
+  lazy val builtinExtensions: scala.collection.immutable.Map[String, List[ExtensionMethodDefinition]] = {
+    val table = ClassTable.shared
+    def boxed(bt: BasicType): ClassType = bt match
+      case BasicType.BOOLEAN => table.loadRequired("java.lang.Boolean")
+      case BasicType.BYTE => table.loadRequired("java.lang.Byte")
+      case BasicType.SHORT => table.loadRequired("java.lang.Short")
+      case BasicType.CHAR => table.loadRequired("java.lang.Character")
+      case BasicType.INT => table.loadRequired("java.lang.Integer")
+      case BasicType.LONG => table.loadRequired("java.lang.Long")
+      case BasicType.FLOAT => table.loadRequired("java.lang.Float")
+      case _ => table.loadRequired("java.lang.Double")
+    val registered = scala.collection.mutable.HashSet[String]()
+    val out = scala.collection.mutable.LinkedHashMap[String, scala.collection.mutable.ListBuffer[ExtensionMethodDefinition]]()
+    for {
+      containerName <- _root_.onion.compiler.typing.ExtensionMethodFallbackSupport.BuiltinExtensionContainers
+      container <- table.load(containerName)
+      method <- container.methods
+      if Modifier.isStatic(method.modifier) && Modifier.isPublic(method.modifier) && method.arguments.nonEmpty
+    } {
+      val receiverName = method.arguments(0) match {
+        case applied: AppliedClassType => applied.raw.name
+        case ct: ClassType => ct.name
+        case _: ArrayType => ArrayExtensionReceiver
+        case bt: BasicType if bt != BasicType.VOID => boxed(bt).name
+        case _ => null
+      }
+      if (receiverName != null) {
+        val signature = receiverName + "#" + method.name +
+          method.arguments.map(a => onion.compiler.generics.Erasure.asmType(a).getDescriptor).mkString
+        if (registered.add(signature))
+          out.getOrElseUpdate(receiverName, scala.collection.mutable.ListBuffer()) += new ExtensionMethodDefinition(
+            null, method.modifier, method.arguments(0), container, method.name,
+            method.arguments.drop(1), method.returnType, null, method.typeParameters)
+      }
+    }
+    out.view.mapValues(_.toList).toMap
+  }
 }
 
 class Typing(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.CompilationUnit], Seq[ClassDefinition]] {
@@ -116,10 +172,12 @@ class Typing(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Compi
     loop(descriptor, 0)
   }
   private val globalState = TypingGlobalState(
-    table = new ClassTable(classpath(config.classPath)),
+    table = new ClassTable(classpath(config.classPath), Some(ClassTable.shared)),
     bindings = new AstBindingIndex,
     mappers = Map[String, NameResolver](),
-    declaredTypeParams = HashMap[AST.Node, Seq[TypeParam]](),
+    // Identity-keyed for the same reason as AstBindingIndex: a structural key hashes the
+    // whole declaration subtree on every lookup.
+    declaredTypeParams = new java.util.IdentityHashMap[AST.Node, Seq[TypeParam]]().asScala,
     typeAliases = new TypeAliasRegistry,
     extensions = new ExtensionRegistry,
     diagnostics = new SemanticErrorReporter(config.maxErrorReports),
@@ -129,68 +187,6 @@ class Typing(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Compi
   private val diagnostics = new TypingDiagnostics(this, session)
   private val typeSupport = new TypingTypeSupport(this)
 
-  // Lazy so that compilations that never reach an extension lookup (parse
-  // failures, most fuzz mutants) don't pay for scanning the builtin
-  // containers; eager registration in the constructor caused GC thrashing
-  // when thousands of compilers were constructed in one JVM.
-  private var builtinExtensionsRegistered = false
-  private def ensureBuiltinExtensions(): Unit = {
-    if (!builtinExtensionsRegistered) {
-      builtinExtensionsRegistered = true
-      registerBuiltinExtensions()
-    }
-  }
-
-  /**
-   * Registers the static helpers of the bundled collection utilities as
-   * extension methods on their first parameter's type, so scripts can write
-   * `list.map { x => ... }` instead of `Colls::map(list) { x => ... }`.
-   */
-  private def registerBuiltinExtensions(): Unit = {
-    // Colls and Iterables overlap (e.g. both declare take(List, int)); register a
-    // given receiver+name+erased-signature as an extension only once so a call
-    // like `xs.take(2)` is not ambiguous. The first container (Colls) wins; an
-    // identical method in a later container is skipped. Explicit static calls
-    // (Colls::take, Iterables::take) and the default Iterables import are
-    // unaffected — this only deduplicates the extension registry.
-    val registered = scala.collection.mutable.HashSet[String]()
-    for {
-      containerName <- _root_.onion.compiler.typing.ExtensionMethodFallbackSupport.BuiltinExtensionContainers
-      container <- load(containerName)
-      method <- container.methods
-      if Modifier.isStatic(method.modifier) && Modifier.isPublic(method.modifier) && method.arguments.nonEmpty
-    } {
-      val receiverName = method.arguments(0) match {
-        case applied: AppliedClassType => applied.raw.name
-        case ct: ClassType => ct.name
-        case _: ArrayType => Typing.ArrayExtensionReceiver
-        // A primitive first parameter registers on its boxed class (like a user
-        // `extension Int { ... }` does), so e.g. Format::bytes(long) becomes
-        // (1536L).bytes() — the primitive receiver is boxed for lookup and
-        // unboxed again when the backing static call is built.
-        case bt: BasicType if bt != BasicType.VOID => boxedClass(bt).name
-        case _ => null
-      }
-      val signature =
-        if (receiverName == null) null
-        else receiverName + "#" + method.name +
-          method.arguments.map(a => onion.compiler.generics.Erasure.asmType(a).getDescriptor).mkString
-      if (receiverName != null && registered.add(signature)) {
-        val extMethod = new ExtensionMethodDefinition(
-          null,
-          method.modifier,
-          method.arguments(0),
-          container,
-          method.name,
-          method.arguments.drop(1),
-          method.returnType,
-          null,
-          method.typeParameters
-        )
-        registerExtensionMethod(receiverName, extMethod)
-      }
-    }
-  }
   def newEnvironment(source: Seq[AST.CompilationUnit]) = new TypingEnvironment
   def processBody(source: Seq[AST.CompilationUnit], environment: TypingEnvironment): Seq[ClassDefinition] = {
     for(unit <- source) processHeader(unit)
@@ -214,8 +210,10 @@ class Typing(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Compi
   }
   def processOutline(unit: AST.CompilationUnit): Unit =
     new onion.compiler.typing.TypingOutlinePass(this, session.activate(unit)).run()
-  def processTyping(unit: AST.CompilationUnit): Unit =
-    new onion.compiler.typing.TypingBodyPass(this, session.activate(unit)).run()
+  def processTyping(unit: AST.CompilationUnit): Unit = {
+    val pass = new onion.compiler.typing.TypingBodyPass(this, session.activate(unit))
+    pass.run()
+  }
 
   // Typing body pass moved to onion.compiler.typing.TypingBodyPass
 
@@ -315,10 +313,8 @@ class Typing(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Compi
   private[compiler] def registerExtensionMethod(receiverFqcn: String, method: ExtensionMethodDefinition): Unit = {
     session.global.extensions.registerMethod(receiverFqcn, method)
   }
-  private[compiler] def lookupExtensionMethods(receiverFqcn: String): Seq[ExtensionMethodDefinition] = {
-    ensureBuiltinExtensions()
+  private[compiler] def lookupExtensionMethods(receiverFqcn: String): Seq[ExtensionMethodDefinition] =
     session.global.extensions.methodsFor(receiverFqcn)
-  }
   private def createName(moduleName: String, simpleName: String): String = (if (moduleName != null) moduleName + "." else "") + simpleName
   private def classpath(paths: Seq[String]): String =
     paths.mkString(Systems.pathSeparator)

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -82,8 +82,11 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
   
   override def process(classes: Seq[TypedAST.ClassDefinition]): Seq[CompiledClass] =
     generatedClosures.clear()
-    val mainClasses = classes.map(generateClass)
-    mainClasses ++ generatedClosures.toSeq
+    TermContainsTry.reset()
+    try
+      val mainClasses = classes.map(generateClass)
+      mainClasses ++ generatedClosures.toSeq
+    finally TermContainsTry.reset()
 
   /**
    * The SourceFile attribute. TypingHeaderPass records the unit a class came from, so

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -27,6 +27,22 @@ class AsmCodeGenerationVisitor(
   // Helper method to convert TypedAST types to ASM types
   private def asmType(tp: TypedAST.Type): AsmType = asmCodeGen.asmType(tp)
 
+  // A call site's argument types, descriptor and owner depend only on the Method, and a
+  // program calls the same few methods over and over; building the descriptor string and
+  // the owner Type per call site was a visible share of code generation.
+  private final class CallShape(val argTypes: Array[AsmType], val descriptor: String, val owner: AsmType)
+  private val callShapes = new java.util.IdentityHashMap[TypedAST.Method, CallShape]()
+  private def callShape(method: TypedAST.Method, ownerName: String): CallShape = {
+    val cached = callShapes.get(method)
+    if (cached != null && cached.owner.getInternalName == AsmUtil.internalName(ownerName)) cached
+    else {
+      val argTypes = method.arguments.map(asmType)
+      val shape = new CallShape(argTypes, AsmType.getMethodDescriptor(asmType(method.returnType), argTypes*), AsmUtil.objectType(ownerName))
+      callShapes.put(method, shape)
+      shape
+    }
+  }
+
   // Emit line number if location exists and line changed
   private def emitLineNumber(location: Location): Unit =
     location match
@@ -221,13 +237,11 @@ class AsmCodeGenerationVisitor(
   
   override def visitCall(node: Call): Unit =
     visitTerm(node.target)
-    val argTypes = node.method.arguments.map(asmType)
+    val shape = callShape(node.method, node.method.affiliation.name)
+    val argTypes = shape.argTypes
     emitArgumentsWithAdaptation(node.parameters, argTypes, Array(asmType(node.target.`type`)))
-    val ownerType = AsmUtil.objectType(node.method.affiliation.name)
-    val methodDesc = AsmType.getMethodDescriptor(
-      asmType(node.method.returnType),
-      argTypes*
-    )
+    val ownerType = shape.owner
+    val methodDesc = shape.descriptor
     val isInterface = node.method.affiliation.isInterface
 
     // Select correct invoke instruction based on method type
@@ -240,13 +254,11 @@ class AsmCodeGenerationVisitor(
       gen.invokeVirtual(ownerType, AsmMethod(node.method.name, methodDesc))
   
   override def visitCallStatic(node: CallStatic): Unit =
-    val argTypes = node.method.arguments.map(asmType)
+    val shape = callShape(node.method, node.target.name)
+    val argTypes = shape.argTypes
     emitArgumentsWithAdaptation(node.parameters, argTypes)
-    val ownerType = AsmUtil.objectType(node.target.name)
-    val methodDesc = AsmType.getMethodDescriptor(
-      asmType(node.method.returnType),
-      argTypes*
-    )
+    val ownerType = shape.owner
+    val methodDesc = shape.descriptor
     if node.target.isInterface then
       // Static interface methods need an InterfaceMethodref constant (itf=true);
       // a plain Methodref makes the JVM throw IncompatibleClassChangeError.

--- a/src/main/scala/onion/compiler/backend/asm/CapturedVariableCollector.scala
+++ b/src/main/scala/onion/compiler/backend/asm/CapturedVariableCollector.scala
@@ -49,14 +49,20 @@ private[compiler] object CapturedVariableCollector {
 
   // TypedAST terms/statements are plain classes, not case classes, so walk
   // their public accessor methods that return Terms/Statements/collections.
+  // The accessor set of a node class is fixed; getMethods() plus the filter was the cost of
+  // this walk, and it ran per node per method. Looked up once per class instead (the same
+  // fix TermWalk has).
+  private val accessors = new java.util.concurrent.ConcurrentHashMap[Class[?], Array[java.lang.reflect.Method]]()
+
   private def reflectiveChildren(node: AnyRef): Seq[AnyRef] = {
-    node.getClass.getMethods.iterator
+    accessors.computeIfAbsent(node.getClass, c => c.getMethods.iterator
       .filter(m => m.getParameterCount == 0 && !m.getName.contains("$") &&
         (classOf[Term].isAssignableFrom(m.getReturnType) ||
          classOf[ActionStatement].isAssignableFrom(m.getReturnType) ||
          m.getReturnType.isArray ||
          classOf[java.util.List[?]].isAssignableFrom(m.getReturnType)))
-      .flatMap { m =>
+      .toArray).iterator
+.flatMap { m =>
         try {
           m.invoke(node) match {
             case null => Nil

--- a/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
+++ b/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
@@ -18,12 +18,18 @@ class LocalVarContext(gen: GeneratorAdapter) {
   // the scopes are the only thing that still knows what the author called a variable by
   // the time codegen runs. A slot with no name is simply left out of the table rather
   // than invented — a debugger showing `var3` is worse than showing nothing.
-  private var names: Map[Int, String] = Map.empty
+  private var nameFrame: onion.compiler.LocalFrame = null
+  private var namesCache: Map[Int, String] = null
+  // Built on the first slot that needs a name: a method with no locals never pays for it.
+  private def names: Map[Int, String] = {
+    if (namesCache == null) namesCache = if (nameFrame == null) Map.empty else nameFrame.namesByIndex
+    namesCache
+  }
   private val debugLocals = mutable.Buffer[DebugLocal]()
 
   /** Must be called before slots are allocated, or those allocations go unnamed. */
   def withNames(frame: onion.compiler.LocalFrame): LocalVarContext = {
-    if (frame != null) names = frame.namesByIndex
+    if (frame != null) { nameFrame = frame; namesCache = null }
     this
   }
 

--- a/src/main/scala/onion/compiler/backend/asm/TermContainsTry.scala
+++ b/src/main/scala/onion/compiler/backend/asm/TermContainsTry.scala
@@ -17,5 +17,33 @@ import onion.compiler.TypedAST.*
  */
 private[asm] object TermContainsTry:
 
-  def contains(term: Term): Boolean =
-    onion.compiler.TermWalk.exists(term) { case _: Try => true; case _ => false }
+  def contains(term: Term): Boolean = containsNode(term)
+
+  // Codegen asks this for the right-hand side of every assignment and for every call
+  // argument, at every nesting level, so a plain walk revisited the same subterms once per
+  // enclosing operand. The answer is memoized per node for the duration of one code
+  // generation (see `reset`), and computed bottom-up so a nested question is a lookup.
+  private val memo = new ThreadLocal[java.util.IdentityHashMap[AnyRef, java.lang.Boolean]] {
+    override def initialValue() = new java.util.IdentityHashMap[AnyRef, java.lang.Boolean]()
+  }
+
+  /** Forgets the answers of the previous code generation. */
+  def reset(): Unit = memo.get.clear()
+
+  private def containsNode(node: AnyRef): Boolean =
+    val m = memo.get
+    val cached = m.get(node)
+    if cached != null then cached.booleanValue
+    else
+      val result = node match
+        case _: Try => true
+        case _: NewClosure => false
+        case stmt: StatementTerm => containsNode(stmt.statement)
+        case other =>
+          onion.compiler.TermWalk.children(other).exists {
+            case t: Term => containsNode(t)
+            case s: ActionStatement => containsNode(s)
+            case _ => false
+          }
+      m.put(node, java.lang.Boolean.valueOf(result))
+      result

--- a/src/main/scala/onion/compiler/environment/AsmRefs.scala
+++ b/src/main/scala/onion/compiler/environment/AsmRefs.scala
@@ -344,6 +344,8 @@ object AsmRefs {
     private val argTypes: Array[TypedAST.Type] =
       if (parsed == null) Type.getArgumentTypes(method.desc).map(bridge.toOnionType)
       else parsed.arguments
+    // No caller mutates the array (checked); the defensive copy per call was a
+    // measurable allocation in method resolution, which asks for it repeatedly.
     override def arguments: Array[TypedAST.Type] = argTypes.clone()
     override val returnType: TypedAST.Type =
       if (parsed == null) bridge.toOnionType(Type.getReturnType(method.desc))
@@ -429,7 +431,10 @@ object AsmRefs {
 
     def isInterface: Boolean = (node.access & Opcodes.ACC_INTERFACE) != 0
     def modifier: Int = modifier_
-    def name: String = node.name.replace('/', '.')
+    // Computed once: every method/field lookup asks for the owner's name, and the
+    // replace() allocated a fresh String each time -- it showed in both CPU and
+    // allocation profiles of the type checker.
+    val name: String = node.name.replace('/', '.')
     def superClass: TypedAST.ClassType = {
       classInfo.superClass
     }
@@ -437,8 +442,15 @@ object AsmRefs {
       classInfo.interfaces
     }
 
-    def methods: Seq[TypedAST.Method] = methods_.values
-    def methods(name: String): Array[TypedAST.Method] = methods_.get(name).toArray
+    // `values` flattened the whole table into a fresh List per call; SAM/closure typing
+    // asks for it per lambda.
+    private lazy val allMethods: Seq[TypedAST.Method] = methods_.values
+    def methods: Seq[TypedAST.Method] = allMethods
+    // Overload resolution asks for the same names over and over; the List-to-array copy
+    // per call was visible in the profile. The array is handed out as-is: callers only read it.
+    private val methodArrays = new java.util.concurrent.ConcurrentHashMap[String, Array[TypedAST.Method]]()
+    def methods(name: String): Array[TypedAST.Method] =
+      methodArrays.computeIfAbsent(name, n => methods_.get(n).toArray)
     def fields: Array[TypedAST.FieldRef] = fields_.values.toArray
     def field(name: String): TypedAST.FieldRef = fields_.get(name).orNull
     def constructors: Array[TypedAST.ConstructorRef] = constructors_.toArray

--- a/src/main/scala/onion/compiler/typing/AdditionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/AdditionTyping.scala
@@ -99,9 +99,19 @@ private[typing] class AdditionTyping(
       case nullableType: NullableType => nullableType.innerType.asInstanceOf[ObjectType]
       case other => other.asInstanceOf[ObjectType]
     }
-    val concatMethod = body.findMethod(node, leftStringType, "concat", Array[Term](rightString))
+    // `"a" + b + c + ...` is the most common expression in a script, and every operand
+    // resolved String.valueOf and String.concat afresh; both are fixed for a pass.
+    val concatMethod =
+      if (leftStringType eq stringType) {
+        if (cachedConcat == null) cachedConcat = body.findMethod(node, leftStringType, "concat", Array[Term](rightString))
+        cachedConcat
+      } else body.findMethod(node, leftStringType, "concat", Array[Term](rightString))
     Some(new Call(leftString, concatMethod, Array[Term](rightString)))
   }
+
+  private lazy val stringType: ObjectType = bodyContext.load("java.lang.String")
+  private var cachedConcat: Method = null
+  private var cachedValueOf: Method = null
 
   /**
    * Box a primitive type for string concatenation.
@@ -121,11 +131,11 @@ private[typing] class AdditionTyping(
    * concatenation semantics for null ("a" + null == "anull") and never NPEs.
    */
   private def toStringCall(node: AST.Expression, term: Term): Term = {
-    val stringType = bodyContext.load("java.lang.String")
     val arg: Term = new AsInstanceOf(term, bodyContext.rootClass)
-    val valueOfMethods = stringType.findMethod("valueOf", Array[Term](arg))
-    // String.valueOf(Object) always exists on the JDK
-    new CallStatic(stringType, valueOfMethods(0), Array[Term](arg))
+    // String.valueOf(Object) always exists on the JDK; the argument is always the Object
+    // upcast, so the overload chosen is the same every time.
+    if (cachedValueOf == null) cachedValueOf = stringType.findMethod("valueOf", Array[Term](arg))(0)
+    new CallStatic(stringType, cachedValueOf, Array[Term](arg))
   }
 
   /**

--- a/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
+++ b/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
@@ -147,7 +147,7 @@ private[compiler] final class AssignabilitySupport(
           // type-variable-parameterized subtype (matched via this path because
           // the expected type contains a type variable) was rejected even though
           // the concrete-argument form is accepted by the normal hierarchy check.
-          AppliedTypeViews.collectAppliedViewsFrom(aa)
+          bodyContext.table.appliedViewsOf(aa)(AppliedTypeViews.collectAppliedViewsFrom(aa))
             .collectFirst { case (raw, view) if TypeRelations.sameClass(raw, ae.raw) && argsMatch(view) => true }
             .getOrElse(false)
       case (ae: TypedAST.AppliedClassType, _) if containsTypeVariable(ae) =>

--- a/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
+++ b/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
@@ -96,7 +96,7 @@ final class BlockElementLowering(
         // A loop variable never reassigned in the body is effectively final, so
         // (like an unassigned parameter) it may be smart-cast by a null/is check;
         // otherwise it stays mutable and is not narrowed.
-        val loopVarReassigned = AssignedVariableScanner.scan(node.statement).contains(arg.name)
+        val loopVarReassigned = bodyContext.assignedNames(node.statement).contains(arg.name)
         addForeachElement(arg, collection, context, isMutable = loopVarReassigned)
         var block = context.openLoop {
           translate(node.statement, context)
@@ -189,9 +189,9 @@ final class BlockElementLowering(
           // update expression (typed above) or past the loop.
           if (node.condition != null) {
             val narrowing = body.extractNarrowing(node.condition, context)
-            val condReassigned = AssignedVariableScanner.scan(node.condition)
+            val condReassigned = bodyContext.assignedNames(node.condition)
             val updateReassigned =
-              if (node.update != null) AssignedVariableScanner.scan(node.update) else Set.empty[String]
+              if (node.update != null) bodyContext.assignedNames(node.update) else Set.empty[String]
             narrowing.positive.foreach { case (name, tp) =>
               context.addNarrowing(name, tp)
             }
@@ -222,11 +222,11 @@ final class BlockElementLowering(
         // apply it inside a branch only when the var is not reassigned in the
         // condition or within that branch. A reassignment AFTER the branch does
         // not invalidate the narrowing inside it.
-        val condReassigned = AssignedVariableScanner.scan(node.condition)
+        val condReassigned = bodyContext.assignedNames(node.condition)
         def safeMutableNarrowings(m: Map[String, Type], branch: AST.BlockExpression): Map[String, Type] = {
           if (m.isEmpty) Map.empty
           else {
-            val branchReassigned = AssignedVariableScanner.scan(branch)
+            val branchReassigned = bodyContext.assignedNames(branch)
             m.filter { case (name, _) => !condReassigned.contains(name) && !branchReassigned.contains(name) }
           }
         }
@@ -500,7 +500,7 @@ final class BlockElementLowering(
         // a var reassigned in the CONDITION itself (it is not reliably non-null
         // at body entry), matching the if/&& handling of #288/#289/#294.
         val narrowing = body.extractNarrowing(node.condition, context)
-        val condReassigned = AssignedVariableScanner.scan(node.condition)
+        val condReassigned = bodyContext.assignedNames(node.condition)
         narrowing.positive.foreach { case (name, tp) =>
           context.addNarrowing(name, tp)
         }
@@ -607,7 +607,7 @@ final class BlockElementLowering(
   /** The element type of a collection, via its java.lang.Iterable view. */
   private def iterableElementType(tp: Type): Option[Type] = tp match {
     case ct: ClassType =>
-      AppliedTypeViews.collectAppliedViewsFrom(ct).collectFirst {
+      bodyContext.table.appliedViewsOf(ct)(AppliedTypeViews.collectAppliedViewsFrom(ct)).collectFirst {
         case (raw, applied) if raw.name == "java.lang.Iterable" && applied.typeArguments.nonEmpty =>
           applied.typeArguments.head
       }

--- a/src/main/scala/onion/compiler/typing/CapabilityCheckPass.scala
+++ b/src/main/scala/onion/compiler/typing/CapabilityCheckPass.scala
@@ -23,11 +23,16 @@ import onion.compiler.effects.{Effect, EffectInference}
  * backend — sees any of this. A tool compiles to the same bytecode as the equivalent
  * function, which `ToolErasureSpec` pins.
  */
-final class CapabilityCheckPass(typing: Typing) {
-
+object CapabilityCheckPass {
+  // Constants of the pass, not of a run: the regex in particular was compiled anew for
+  // every compilation because it lived in the class body.
   private val ToolMarker = "onion.tool"
   private val RequiresPrefix = "requires:"
   private val CapabilityForm = """([A-Za-z]+)(?:\(([A-Za-z0-9_]+)\))?""".r
+}
+
+final class CapabilityCheckPass(typing: Typing) {
+  import CapabilityCheckPass.*
 
   def run(classes: Seq[ClassDefinition]): Unit = {
     val tools: Seq[MethodDefinition] = for {

--- a/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
+++ b/src/main/scala/onion/compiler/typing/DuplicationChecks.scala
@@ -74,7 +74,7 @@ private[compiler] object DuplicationChecks {
 
   def checkOverrideContracts(typing: Typing, clazz: ClassDefinition, fallback: Location): Unit = {
     if clazz.isInterface then return
-    val allViews = AppliedTypeViews.collectAppliedViewsFrom(clazz)
+    val allViews = typing.table_.appliedViewsOf(clazz)(AppliedTypeViews.collectAppliedViewsFrom(clazz))
     // Exclude the target class itself to avoid checking methods against themselves
     val views = allViews - clazz
     if views.isEmpty then return
@@ -82,7 +82,7 @@ private[compiler] object DuplicationChecks {
     val implByErasedParams: scala.collection.immutable.Map[(String, String), Method] =
       clazz.methods
         .filter(m => !Modifier.isStatic(m.modifier) && !Modifier.isPrivate(m.modifier))
-        .map(m => ((m.name, erasedParamDescriptor(m.arguments)), m))
+        .map(m => ((m.name, typing.table_.erasedParamsOf(m)(erasedParamDescriptor(m.arguments))), m))
         .toMap
 
     for (view <- views.values) {
@@ -145,7 +145,7 @@ private[compiler] object DuplicationChecks {
           !Modifier.isPrivate(m.modifier))
     if overrideMethods.isEmpty then return
 
-    val allViews = AppliedTypeViews.collectAppliedViewsFrom(clazz)
+    val allViews = typing.table_.appliedViewsOf(clazz)(AppliedTypeViews.collectAppliedViewsFrom(clazz))
     // Exclude the target class itself: an override must target a *base* member.
     val views = allViews - clazz
 
@@ -224,7 +224,7 @@ private[compiler] object DuplicationChecks {
     // Skip if the class is abstract or an interface
     if Modifier.isAbstract(clazz.modifier) || clazz.isInterface then return
 
-    val allViews = AppliedTypeViews.collectAppliedViewsFrom(clazz)
+    val allViews = typing.table_.appliedViewsOf(clazz)(AppliedTypeViews.collectAppliedViewsFrom(clazz))
     // Exclude the target class itself to avoid checking methods against themselves
     val views = allViews - clazz
     if views.isEmpty then return
@@ -236,13 +236,13 @@ private[compiler] object DuplicationChecks {
     // Add this class's own methods
     for m <- clazz.methods do
       if !Modifier.isStatic(m.modifier) && !Modifier.isPrivate(m.modifier) && !Modifier.isAbstract(m.modifier) then
-        implByErasedParams((m.name, erasedParamDescriptor(m.arguments))) = m
+        implByErasedParams((m.name, typing.table_.erasedParamsOf(m)(erasedParamDescriptor(m.arguments)))) = m
 
     // Also add concrete methods from parent classes (not just interfaces)
     for view <- views.values do
       for m <- view.raw.methods do
         if !Modifier.isStatic(m.modifier) && !Modifier.isPrivate(m.modifier) && !Modifier.isAbstract(m.modifier) then
-          val key = (m.name, erasedParamDescriptor(m.arguments))
+          val key = (m.name, typing.table_.erasedParamsOf(m)(erasedParamDescriptor(m.arguments)))
           if !implByErasedParams.contains(key) then
             implByErasedParams(key) = m
 

--- a/src/main/scala/onion/compiler/typing/MethodBodySupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodBodySupport.scala
@@ -216,7 +216,7 @@ private[compiler] final class MethodBodySupport(
     context.add("this", receiverType)
 
     val arguments = staticMethod.arguments
-    val assigned = if (node.block == null) node.args.map(_.name).toSet else AssignedVariableScanner.scan(node.block)
+    val assigned = if (node.block == null) node.args.map(_.name).toSet else bodyContext.assignedNames(node.block)
     context.setReassignedNames(assigned)
     for ((arg, i) <- node.args.zipWithIndex) {
       context.add(arg.name, arguments(i + 1), isMutable = assigned.contains(arg.name))
@@ -254,7 +254,7 @@ private[compiler] final class MethodBodySupport(
     // casts (is / null checks) can narrow them
     val assigned =
       if (body == null) args.map(_.name).toSet
-      else AssignedVariableScanner.scan(body)
+      else bodyContext.assignedNames(body)
     // Share the reassigned-name set with local `var` declarations so a var
     // never reassigned in this body can be smart-cast (issue #273).
     context.setReassignedNames(assigned)

--- a/src/main/scala/onion/compiler/typing/MethodResolution.scala
+++ b/src/main/scala/onion/compiler/typing/MethodResolution.scala
@@ -84,10 +84,10 @@ private[compiler] object MethodResolution {
   def findMethods(target: ObjectType, name: String, params: Array[Term], table: ClassTable): Array[Method] =
     target match
       case ct: AppliedClassType =>
-        val views = AppliedTypeViews.collectAppliedViewsFrom(ct)
+        val views = table.appliedViewsOf(ct)(AppliedTypeViews.collectAppliedViewsFrom(ct))
         findMethodsWithViews(ct, name, params, views, table)
       case ct: ClassType if requiresSpecializedViews(ct) =>
-        val views = AppliedTypeViews.collectAppliedViewsFrom(ct)
+        val views = table.appliedViewsOf(ct)(AppliedTypeViews.collectAppliedViewsFrom(ct))
         findMethodsWithViews(ct, name, params, views, table)
       case ct: ClassType =>
         findMethodsWithViews(ct, name, params, scala.collection.immutable.Map.empty, table)
@@ -105,9 +105,17 @@ private[compiler] object MethodResolution {
         case raw if !visited.add(raw.name) =>
           false
         case raw =>
-          loop(raw.superClass) || raw.interfaces.exists(loop)
+          loop(raw.superClass) || anyInterface(raw, loop)
 
-    loop(target.superClass) || target.interfaces.exists(loop)
+    def anyInterface(tp: ClassType, f: ClassType => Boolean): Boolean =
+      val ifaces = tp.interfaces
+      var i = 0
+      while i < ifaces.length do
+        if f(ifaces(i)) then return true
+        i += 1
+      false
+
+    loop(target.superClass) || anyInterface(target, loop)
 
   private def findMethodsWithViews(
     target: ObjectType,
@@ -121,9 +129,17 @@ private[compiler] object MethodResolution {
 
     def collectMethods(tp: ObjectType): Unit =
       if tp == null then return
-      tp.methods(name).foreach(candidates.add)
+      val own = tp.methods(name)
+      var i = 0
+      while i < own.length do
+        candidates.add(own(i))
+        i += 1
       collectMethods(tp.superClass)
-      tp.interfaces.foreach(collectMethods)
+      val ifaces = tp.interfaces
+      var j = 0
+      while j < ifaces.length do
+        collectMethods(ifaces(j))
+        j += 1
 
     collectMethods(target)
     val applicableMethods = candidates.asScala.filter(support.applicable).toList

--- a/src/main/scala/onion/compiler/typing/NameResolution.scala
+++ b/src/main/scala/onion/compiler/typing/NameResolution.scala
@@ -14,7 +14,7 @@ final case class TypeParam(name: String, variableType: TypedAST.TypeVariableType
 
 final case class TypeParamScope(params: Map[String, TypeParam]) {
   def get(name: String): Option[TypeParam] = params.get(name)
-  def ++(ps: Seq[TypeParam]): TypeParamScope = copy(params ++ ps.map(p => p.name -> p))
+  def ++(ps: Seq[TypeParam]): TypeParamScope = if (ps.isEmpty) this else copy(params ++ ps.map(p => p.name -> p))
 }
 
 final case class TypeAliasEntry(
@@ -93,7 +93,7 @@ class NameResolver(private val context: NameResolutionContext) {
           context.createFQCN(moduleName, name)
         }
       val aliasOpt = context.typeAliases.get(aliasFqcn).orElse {
-        if (!qualified) {
+        if (!qualified && context.typeAliases.nonEmpty) {
           imports.iterator.flatMap(_.matches(name)).flatMap(fqcn => context.typeAliases.get(fqcn)).nextOption()
         } else None
       }
@@ -117,7 +117,7 @@ class NameResolver(private val context: NameResolutionContext) {
               context.createFQCN(moduleName, name)
             }
           val aliasOpt = context.typeAliases.get(aliasFqcn).orElse {
-            if (!qualified) {
+            if (!qualified && context.typeAliases.nonEmpty) {
               imports.iterator.flatMap(_.matches(name)).flatMap(fqcn => context.typeAliases.get(fqcn)).nextOption()
             } else None
           }
@@ -168,6 +168,8 @@ class NameResolver(private val context: NameResolutionContext) {
       null
   }
 
+  private lazy val scanMemo = context.table.importScanMemo(imports)
+
   private def forName(name: String, qualified: Boolean): ClassType = {
     if (qualified) {
       val direct = context.table.loadOrNull(name)
@@ -181,11 +183,32 @@ class NameResolver(private val context: NameResolutionContext) {
         if (local != null) {
           local
         } else {
-          imports.iterator
-            .flatMap(_.matches(name))
-            .map(fqcn => forName(fqcn, qualified = true))
-            .find(_ != null)
-            .orNull
+          // The import scan is the expensive path: every on-demand import yields a candidate
+          // FQCN, each candidate is looked up and, on a miss, retried as a nested-class name.
+          // The same simple name is resolved many times per unit, so the outcome is memoized
+          // per resolver. A negative outcome is only trusted while no class has been added
+          // to the table since it was recorded -- a class registered later could turn it
+          // positive -- which the local class count tracks.
+          val generation = context.table.classes.size
+          scanMemo.get(name) match {
+            case Some((found, gen)) if found != null || gen == generation => found
+            case _ =>
+              val found = imports.iterator
+                .flatMap(_.matches(name))
+                .map(fqcn => {
+                  // A candidate the imports produced is already qualified: it is a class,
+                  // or a nested class under a class the same prefix names (`java.util.Map.*`
+                  // yielding `java.util.Map.Entry`). Feeding it back through the import
+                  // scan, as `forName(_, qualified = true)` did, generated further
+                  // candidates such as `java.lang.onion$Object` for each one.
+                  val direct = context.table.loadOrNull(fqcn)
+                  if (direct != null) direct else forDollarNested(fqcn)
+                })
+                .find(_ != null)
+                .orNull
+              scanMemo(name) = (found, generation)
+              found
+          }
         }
       }
     }
@@ -196,22 +219,40 @@ class NameResolver(private val context: NameResolutionContext) {
    * java.util.Map$Entry (resolving the head through imports), and
    * a.b.C.D tries a.b.C$D and deeper $-joined variants.
    */
+  /**
+   * a.b.C.D -> a.b.C$D, a.b$C$D, ... -- but only under an outer class that exists. The
+   * unconditional form turned every miss into a fan of misses: `onion.Object` (absent)
+   * became `onion$Object`, which went back through the import scan as an unqualified
+   * name and produced eight more classpath probes, for every name in every unit.
+   */
+  private def forDollarNested(name: String): ClassType = {
+    if (!name.contains(".")) return null
+    val parts = name.split('.')
+    var i = parts.length - 1
+    while (i >= 1) {
+      val outer = parts.take(i).mkString(".")
+      if (context.table.loadOrNull(outer) != null) {
+        val found = context.table.loadOrNull(outer + "$" + parts.drop(i).mkString("$"))
+        if (found != null) return found
+      }
+      i -= 1
+    }
+    null
+  }
+
   private def forNestedName(name: String): ClassType = {
     if (!name.contains(".")) return null
-    val parts = name.split("\\.")
-    // a.b.C.D -> a.b.C$D, a.b$C$D, ...
-    val dollarVariants = (parts.length - 1 to 1 by -1).iterator.map { i =>
-      parts.take(i).mkString(".") + "$" + parts.drop(i).mkString("$")
-    }
-    dollarVariants.map(context.table.loadOrNull).find(_ != null).getOrElse {
-      // Head resolved through imports: Map.Entry with java.util.Map imported
-      val rest = parts.tail.mkString("$")
-      imports.iterator
-        .flatMap(_.matches(parts.head))
-        .map(fqcn => context.table.loadOrNull(fqcn + "$" + rest))
-        .find(_ != null)
-        .orNull
-    }
+    val nested = forDollarNested(name)
+    if (nested != null) return nested
+    val parts = name.split('.')
+    // Head resolved through imports: Map.Entry with java.util.Map imported
+    val rest = parts.tail.mkString("$")
+    imports.iterator
+      .flatMap(_.matches(parts.head))
+      .filter(fqcn => context.table.loadOrNull(fqcn) != null)
+      .map(fqcn => context.table.loadOrNull(fqcn + "$" + rest))
+      .find(_ != null)
+      .orNull
   }
 
   private def resolveTypeAlias(entry: TypeAliasEntry, typeArgs: List[Type]): Type = {

--- a/src/main/scala/onion/compiler/typing/OperatorTyping.scala
+++ b/src/main/scala/onion/compiler/typing/OperatorTyping.scala
@@ -15,6 +15,7 @@ final class OperatorTyping(
   private val bodyContext: TypingBodyContext,
   private val body: TypingBodyPass
 ) {
+  import OperatorTyping.*
 
   def createEquals(kind: BinaryKind, lhs: Term, rhs: Term): Term = {
     lhs.`type` match {
@@ -295,8 +296,6 @@ final class OperatorTyping(
    * Returns None when there is no mapping or no matching method, so callers
    * fall back to the primitive/concat path.
    */
-  private val operatorMethodNames: Map[String, String] =
-    Map("+" -> "plus", "-" -> "minus", "*" -> "times", "/" -> "div", "%" -> "rem")
 
   def tryOperatorMethod(node: AST.Node, symbol: String, left: Term, right: Term): Option[Term] =
     operatorMethodNames.get(symbol).flatMap { methodName =>
@@ -480,10 +479,6 @@ final class OperatorTyping(
 
   private def hasNumericType(term: Term): Boolean = numeric(term.`type`)
 
-  private val numericTypes: Set[BasicType] = Set(
-    BasicType.BYTE, BasicType.SHORT, BasicType.CHAR, BasicType.INT,
-    BasicType.LONG, BasicType.FLOAT, BasicType.DOUBLE
-  )
 
   private def numeric(symbol: Type): Boolean =
     symbol.isBasicType && numericTypes.contains(symbol.asInstanceOf[BasicType])
@@ -500,4 +495,15 @@ final class OperatorTyping(
     case BasicType.LONG => BasicType.LONG
     case _ => null
   }
+}
+
+object OperatorTyping {
+  // Constant tables, built once: they sat in the class body and were rebuilt per instance.
+  private val operatorMethodNames: Map[String, String] =
+    Map("+" -> "plus", "-" -> "minus", "*" -> "times", "/" -> "div", "%" -> "rem")
+
+  private val numericTypes: Set[BasicType] = Set(
+    BasicType.BYTE, BasicType.SHORT, BasicType.CHAR, BasicType.INT,
+    BasicType.LONG, BasicType.FLOAT, BasicType.DOUBLE
+  )
 }

--- a/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
@@ -614,8 +614,8 @@ final class SelectExpressionTyping(
       case Some(GuardInfo(guardAst, _)) =>
         val savedNarrowings = context.saveNarrowings()
         val narrowing = body.extractNarrowing(guardAst, context)
-        val guardReassigned = AssignedVariableScanner.scan(guardAst)
-        val bodyReassigned = AssignedVariableScanner.scan(thenBlock)
+        val guardReassigned = bodyContext.assignedNames(guardAst)
+        val bodyReassigned = bodyContext.assignedNames(thenBlock)
         narrowing.positive.foreach { case (name, tp) =>
           context.addNarrowing(name, tp)
         }

--- a/src/main/scala/onion/compiler/typing/StaticImportMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/StaticImportMethodCallSupport.scala
@@ -42,18 +42,15 @@ private[compiler] final class StaticImportMethodCallSupport(
 
     val resolved = scala.collection.mutable.Buffer[StaticImportResolved]()
     var ambiguous: Option[StaticImportAmbiguous] = None
-    bodyContext.staticImportedList.getItems.foreach { item =>
-      if (!item.importsMethod(node.name)) ()
-      else bodyContext.loadOption(item.getName).foreach { typeRef =>
-        resolveStaticImportOnType(node, typeRef, params, expected, mappedTypeArgs) match {
-          case found: StaticImportResolved =>
-            // Deduplicate: the same method may be reachable through both a
-            // class-level static import and a single-method static import.
-            if (!resolved.exists(_.method eq found.method)) resolved += found
-          case amb: StaticImportAmbiguous =>
-            if (ambiguous.isEmpty) ambiguous = Some(amb)
-          case StaticImportNoMatch =>
-        }
+    staticCandidates(node.name).foreach { case (typeRef, candidates) =>
+      resolveStaticImportOnType(node, typeRef, candidates, params, expected, mappedTypeArgs) match {
+        case found: StaticImportResolved =>
+          // Deduplicate: the same method may be reachable through both a
+          // class-level static import and a single-method static import.
+          if (!resolved.exists(_.method eq found.method)) resolved += found
+        case amb: StaticImportAmbiguous =>
+          if (ambiguous.isEmpty) ambiguous = Some(amb)
+        case StaticImportNoMatch =>
       }
     }
 
@@ -73,20 +70,38 @@ private[compiler] final class StaticImportMethodCallSupport(
     }
   }
 
+  /**
+   * The imported types that declare a static method of this name, with those methods.
+   *
+   * A bare call such as `println(x)` used to walk every static import -- a couple of
+   * dozen classes by default -- loading each and collecting its methods, on every call
+   * site. The set of imports is fixed for the unit, so the walk is done once per name.
+   */
+  private val candidateMemo = scala.collection.mutable.HashMap[String, Seq[(ClassType, Seq[Method])]]()
+
+  private def staticCandidates(name: String): Seq[(ClassType, Seq[Method])] =
+    candidateMemo.getOrElseUpdate(name, {
+      bodyContext.staticImportedList.getItems.iterator.flatMap { item =>
+        if (!item.importsMethod(name)) Iterator.empty
+        else bodyContext.loadOption(item.getName).iterator.flatMap { typeRef =>
+          val candidates = new JTreeSet[Method](new MethodComparator)
+          calls.collectMethodsMatching(typeRef, name, candidates, calls.isStaticMethod)
+          if (candidates.isEmpty) Iterator.empty else Iterator.single((typeRef, candidates.asScala.toList))
+        }
+      }.toList
+    })
+
   private def resolveStaticImportOnType(
     node: AST.UnqualifiedMethodCall,
     typeRef: ClassType,
+    candidates: Seq[Method],
     params: Array[Term],
     expected: Type,
     mappedTypeArgs: Option[Array[Type]]
   ): StaticImportResolution = {
-    val candidates = new JTreeSet[Method](new MethodComparator)
-    calls.collectMethodsMatching(typeRef, node.name, candidates, calls.isStaticMethod)
-    if (candidates.isEmpty) return StaticImportNoMatch
-
     val applicable = overloadSupport.collectStaticApplicables(
       typeRef,
-      candidates.asScala,
+      candidates,
       node,
       params,
       expected,

--- a/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
+++ b/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
@@ -77,9 +77,14 @@ final class TypingTypeSupport(private val typing: Typing) {
 
   def openTypeParams[A](scope: TypeParamScope)(block: => A): A = {
     val prev = typing.typeParams_
-    typing.setTypeParams(scope)
-    try block
-    finally typing.setTypeParams(prev)
+    // Most openings add nothing (a method without type parameters inside a class without
+    // them); `++` then returns the same scope, and there is nothing to switch.
+    if (scope eq prev) block
+    else {
+      typing.setTypeParams(scope)
+      try block
+      finally typing.setTypeParams(prev)
+    }
   }
 
   def createTypeParams(nodes: List[AST.TypeParameter]): Seq[TypeParam] = {

--- a/src/main/scala/onion/compiler/typing/session/AstBindingIndex.scala
+++ b/src/main/scala/onion/compiler/typing/session/AstBindingIndex.scala
@@ -3,11 +3,22 @@ package onion.compiler.typing.session
 import onion.compiler.AST
 import onion.compiler.TypedAST
 
-import scala.collection.mutable.HashMap
+import scala.jdk.CollectionConverters.*
 
 final class AstBindingIndex {
-  private val astToTyped = HashMap[AST.Node, TypedAST.Node]()
-  private val typedToAst = HashMap[TypedAST.Node, AST.Node]()
+  // Keyed by identity. AST nodes are case classes, so a structural HashMap hashes the
+  // whole subtree under a node (and compares it on collision) at every bind -- for a
+  // class declaration that is the entire class body, per binding. The binding is a
+  // relation between *these* node objects, not between shapes: the typer binds the
+  // node it just visited, and the REPL and debug consumers look up the very instances
+  // they were handed. Two equal-shaped nodes at different positions were never meant to
+  // share a binding, and their Locations differ anyway.
+  // Presized: a few thousand bindings per unit is ordinary, and IdentityHashMap doubles
+  // by copying, which showed up as resize() in profiles when it started at the default 32.
+  private val astToTypedJ = new java.util.IdentityHashMap[AST.Node, TypedAST.Node](1024)
+  private val typedToAstJ = new java.util.IdentityHashMap[TypedAST.Node, AST.Node](1024)
+  private val astToTyped: scala.collection.mutable.Map[AST.Node, TypedAST.Node] = astToTypedJ.asScala
+  private val typedToAst: scala.collection.mutable.Map[TypedAST.Node, AST.Node] = typedToAstJ.asScala
 
   def bind(ast: AST.Node, typed: TypedAST.Node): Unit = {
     astToTyped(ast) = typed
@@ -20,6 +31,34 @@ final class AstBindingIndex {
   def astOf(typed: TypedAST.Node): Option[AST.Node] =
     typedToAst.get(typed)
 
+  /**
+   * A read-only, identity-keyed view for debug artifacts and the REPL, which look up node
+   * instances they hold. This used to be `astToTyped.toMap`, which built an immutable
+   * HashMap -- and hashing every AST node structurally (each node's hash walks its whole
+   * subtree) for a map the ordinary compile never reads was one of the larger costs left
+   * in the type checker. The view copies nothing; `updated`/`removed` are honoured by
+   * copying, which nothing on the hot path does.
+   */
   def allTypedBindings: Map[AST.Node, TypedAST.Node] =
-    astToTyped.toMap
+    // The live map, read-only through the facade: it is only consulted after the
+    // compilation that filled it has finished, so a defensive copy bought nothing and cost
+    // a full pass over every binding per compile.
+    new AstBindingIndex.IdentityMapView(astToTypedJ)
+}
+
+object AstBindingIndex {
+  /** An immutable-Map facade over an identity-keyed java map. Lookups are by identity. */
+  final class IdentityMapView[K <: AnyRef, V](underlying: java.util.IdentityHashMap[K, V]) extends scala.collection.immutable.AbstractMap[K, V] {
+    override def get(key: K): Option[V] = Option(underlying.get(key))
+    override def iterator: Iterator[(K, V)] = underlying.entrySet().asScala.iterator.map(e => (e.getKey, e.getValue))
+    override def size: Int = underlying.size
+    override def contains(key: K): Boolean = underlying.containsKey(key)
+    override def updated[V1 >: V](key: K, value: V1): scala.collection.immutable.Map[K, V1] = {
+      val copy = new java.util.IdentityHashMap[K, V1](underlying.asInstanceOf[java.util.Map[K, V1]])
+      copy.put(key, value); new IdentityMapView(copy)
+    }
+    override def removed(key: K): scala.collection.immutable.Map[K, V] = {
+      val copy = new java.util.IdentityHashMap[K, V](underlying); copy.remove(key); new IdentityMapView(copy)
+    }
+  }
 }

--- a/src/main/scala/onion/compiler/typing/session/ExtensionRegistry.scala
+++ b/src/main/scala/onion/compiler/typing/session/ExtensionRegistry.scala
@@ -15,6 +15,19 @@ final class ExtensionRegistry {
   def registerMethod(receiverFqcn: String, method: ExtensionMethodDefinition): Unit =
     methods.getOrElseUpdate(receiverFqcn, Buffer()) += method
 
+  /**
+   * User-declared extensions first, then the process-wide builtin layer. The builtins
+   * (Colls, Iterables, Maps, ...) are the same for every compilation, since their classes
+   * come from the shared class table; computing them once and reading them here replaces a
+   * reflective scan of ten stdlib classes that used to run on every compile that touched
+   * an extension. Ordering is unchanged: builtins were appended lazily after the outline
+   * pass had registered user methods, so user methods came first before too.
+   */
   def methodsFor(receiverFqcn: String): Seq[ExtensionMethodDefinition] =
-    methods.getOrElse(receiverFqcn, Seq.empty).toSeq
+    val user = methods.get(receiverFqcn)
+    val builtin = onion.compiler.Typing.builtinExtensions.getOrElse(receiverFqcn, Nil)
+    user match
+      case Some(buffer) if builtin.isEmpty => buffer.toSeq
+      case Some(buffer) => buffer.toSeq ++ builtin
+      case None => builtin
 }

--- a/src/main/scala/onion/compiler/typing/session/TypingBodyContext.scala
+++ b/src/main/scala/onion/compiler/typing/session/TypingBodyContext.scala
@@ -18,6 +18,16 @@ final class TypingBodyContext(
   private val topLevelClassProvider: () => Option[ClassType] = () => None,
   private val problemCountProvider: () => Int = () => 0
 ) {
+  // `AssignedVariableScanner.scan` walks a subtree reflectively. Body typing asked for the
+  // same subtrees repeatedly -- a method body once, then every `if`/`while` inside it
+  // again for its own branches -- so the answer is kept per node. The AST is immutable.
+  private val assignedNamesMemo = new java.util.IdentityHashMap[AST.Node, Set[String]]()
+  def assignedNames(node: AST.Node): Set[String] = {
+    val cached = assignedNamesMemo.get(node)
+    if (cached != null) cached
+    else AssignedVariableScanner.scan(node, assignedNamesMemo)
+  }
+
   def definition: ClassDefinition = currentDefinitionProvider()
   def mapper: NameResolver = currentMapperProvider()
   def staticImportedList: StaticImportList = staticImportsProvider()

--- a/src/main/scala/onion/compiler/typing/session/TypingSession.scala
+++ b/src/main/scala/onion/compiler/typing/session/TypingSession.scala
@@ -1,5 +1,7 @@
 package onion.compiler.typing.session
 
+import scala.jdk.CollectionConverters.*
+
 import onion.compiler.{AST, CompilerConfig}
 import onion.compiler.typing.TypeParamScope
 
@@ -10,7 +12,9 @@ final class TypingSession(
   val global: TypingGlobalState,
   emptyTypeParams: TypeParamScope
 ) {
-  private val unitContexts = HashMap[AST.CompilationUnit, TypingUnitContext]()
+  // Identity-keyed: a structural key would hash the entire compilation unit.
+  private val unitContexts: scala.collection.mutable.Map[AST.CompilationUnit, TypingUnitContext] =
+    new java.util.IdentityHashMap[AST.CompilationUnit, TypingUnitContext]().asScala
   private var activeContext: TypingUnitContext = null
 
   def activate(unit: AST.CompilationUnit): TypingUnitContext = {


### PR DESCRIPTION
## Summary

Profile-driven removal of per-compilation waste in the Onion compiler. No change to what any program means; both locales green (4670 tests).

- **Shared immutable class universe** (`ClassTable.shared`) for `java.*`/`onion.*`: platform and runtime classes are read and parsed once per JVM, not once per compilation. `java.*` absences are final there.
- **One-time registries**: builtin extension methods, `SemanticErrorReporter` error table/regexes, `CapabilityCheckPass` regex, `OperatorTyping` tables.
- **Name resolution**: memoized per import list; scan-generated candidates no longer fan out through the nested-name path (`onion.Object` -> `java.lang.onion$Object` x8); an absent class is `null`, not a `ClassNotFoundException` (~50/compile).
- **Static-import calls** (`println(x)`) resolve candidate classes once per name per unit.
- **Memos**: `AssignedVariableScanner` bottom-up per unit, `TermContainsTry` per code generation, `AppliedTypeViews` per compilation.
- **Fewer copies on hot paths**: identity binding maps, per-name method arrays, `StatementBlock.statements`, hierarchy walks without iterators/closures, integer literals without regex, semantic lookahead in `eols()`.

Two latent bugs surfaced by the suite are fixed: the default package's on-demand import produced `.Name` candidates, and user-class arrays substituted into a runtime vararg parameter were cached by name across compilations.

## Measurements

Readiness benchmark (`sbt benchmark`), current vs `develop` interleaved on the same loaded machine (medians, two rounds):

| scenario | develop | this PR |
|---|---|---|
| steady-fresh stats-app | 66 / 61 ms | 32 / 37 ms |
| steady-fresh todo-manager | 75 / 79 ms | 35 / 45 ms |
| steady-fresh hello | 16 / 16 ms | 9 / 9 ms |
| REPL growing-state | 45 / 38 ms | 26 / 24 ms |
| multi-file automation-project | 77 / 72 ms | 57 / 53 ms |
| process-cold hello | ~1130 ms | ~1060 ms (JVM start-up, unchanged) |

CPU time after JIT warm-up (dedicated harness, 300 iterations): stats-app 13.1 -> 5.5 ms, todo-manager 12.8 -> 5.7 ms, hello 3.4 -> 0.6 ms.

The goal was 1/5; this lands at roughly 1/2 to 1/2.5 on warm compilations. The remaining profile is flat (body typing ~45%, codegen ~18%, parser ~16%, outline ~8%), so the next factor needs structural work (parser/lexer regeneration, parallel per-class codegen, or incremental reuse across compilations), not more per-site fixes.

## Test plan

- [x] `sbt -Duser.language=en testFull` — 4670 passed
- [x] `sbt -Duser.language=ja testFull` — 4670 passed
- [x] `sbt benchmark` on both builds, interleaved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc