### PR TITLE
test: guard E0079's full effect-vocabulary sentence against Effect.all drift

### DIFF
--- a/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ErrorCodeDocCoverageSpec.scala
@@ -157,4 +157,25 @@ class ErrorCodeDocCoverageSpec extends AnyFunSpec {
   it("the Japanese E0079 section names every effect that takes a parameter argument") {
     checkParameterizedEffects("docs/ja/reference/error-codes.md")
   }
+
+  // The E0079 section also states the *full* effect vocabulary (all nine names, not
+  // just the ones that take a parameter) as a prose sentence in both docs. Nothing
+  // tied that sentence to `Effect.all` -- the same drift risk `checkParameterizedEffects`
+  // above already guards for the parameterized subset, one list over.
+
+  private def checkEffectVocabulary(docPath: String): Unit = {
+    val names = onion.compiler.effects.Effect.all.map(_.name)
+    assert(names.nonEmpty, "no effects found in Effect.all -- the scan has rotted")
+    val e0079 = section(read(docPath), "E0079")
+    val missing = names.filterNot(e0079.contains)
+    assert(missing.isEmpty, s"$docPath E0079 section does not mention effect(s): ${missing.mkString(", ")}")
+  }
+
+  it("the English E0079 section names every effect in the vocabulary") {
+    checkEffectVocabulary("docs/reference/error-codes.md")
+  }
+
+  it("the Japanese E0079 section names every effect in the vocabulary") {
+    checkEffectVocabulary("docs/ja/reference/error-codes.md")
+  }
 }


### PR DESCRIPTION
## Summary
- `ErrorCodeDocCoverageSpec` already ties several `docs/reference/error-codes.md` / `docs/ja/reference/error-codes.md` whitelists (E0063 derive markers, E0076 shape formats, E0061/E0062/E0081 scalar types, and E0079's *parameterized*-effect subset) to their single source of truth in the compiler.
- The E0079 section's full nine-name effect vocabulary sentence (`read write net exec env clock rand console unknown`) in both language docs was still untied to `Effect.all` (`src/main/scala/onion/compiler/effects/Effect.scala`) — nothing today is broken, but a future effect addition could silently leave that sentence stale in one or both docs, the same drift class the file's other checks already guard against.
- Adds `checkEffectVocabulary`, mirroring the existing `checkParameterizedEffects` pattern, plus one English and one Japanese assertion.

Test-only change; no production code or documented behavior modified.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4694 succeeded, 0 failed, 1 canceled (pre-existing, network-dependent distribution test unrelated to this change), all green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYgk9ghe4XvDw2uucjEjiL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYgk9ghe4XvDw2uucjEjiL)_