### PR TITLE
Add diagnostic hint for a leading access modifier before a type declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diagnostic for a Java/C#/Kotlin-style access modifier before a type declaration
+  (`public class Foo`, `private record Point(...)`, `protected interface Shape`).**
+  None of `public`/`private`/`protected` are reserved words in Onion (they only mean
+  something after `:` inside a class body's access sections), so this common habit
+  from other languages previously parsed as a bare leading token, with the actual
+  declaration keyword landing in a generic "expecting class, record, def, ..." parse
+  error and nothing connecting it back to the mistake. `SyntaxHintClassifier` now
+  recognizes the shape directly and points at the fix: drop the modifier and declare
+  members under a `public:`/`private:`/`protected:` section inside the body instead.
+  Pinned by new `AccessModifierBeforeDeclarationHintI18nSpec`.
+
 - **Diagnostic for a Kotlin-style `companion object` nested inside a class.** `companion`
   isn't a reserved word, so `companion object { ... }` previously parsed as a bare
   identifier statement followed by a stray `object` token, falling through to the

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -188,6 +188,7 @@ error.parsing.hint.missing_call_parens=Hint: a call''s arguments need parenthese
 error.parsing.hint.rust_style_macro_call=Hint: Onion has no Rust-style `{0}!(...)` macro call — Onion has no macros at all — call `{0}(...)` directly, without the `!`.
 error.parsing.hint.java_style_final_local=Hint: Onion has no Java-style `final` local variable — every `val` is already immutable, so declare it with `val` instead — write `val {1}: {0} = ...`, not `final {0} {1} = ...`.
 error.parsing.hint.instanceof_not_supported=Hint: Onion has no Java-style `instanceof` operator — use the `is` type-check operator instead (also usable as `case x is Type:` in `select`) — write `{0} is {1}`, not `{0} instanceof {1}`.
+error.parsing.hint.access_modifier_before_declaration=Hint: Onion has no Java/C#/Kotlin-style access modifier before a type declaration — access is controlled by `public:`/`private:`/`protected:` sections inside the body instead. Drop `{0}` and declare the members under the right section — write `class Foo '{'public: ...'}'`, not `{0} class Foo '{' ... '}'`.
 error.semantic.toolUndeclaredEffect=tool `{0}` performs `{1}` here (calling {2}) but does not declare it. Add `{1}` to its `requires '{' ... '}'` clause.
 error.semantic.toolUnusedCapability=tool `{0}` declares capability `{1}` but nothing in its body can perform it. Remove `{1}` from the requires clause.
 error.semantic.toolBadCapability=tool `{0}` has an invalid capability `{1}`: {2}

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -188,6 +188,7 @@ error.parsing.hint.missing_call_parens=ヒント: 呼び出しの引数にはか
 error.parsing.hint.rust_style_macro_call=ヒント: Onion に Rust 風の `{0}!(...)` マクロ呼び出しはありません — Onion にマクロという概念自体がありません — `!` を外して `{0}(...)` と直接呼び出してください。
 error.parsing.hint.java_style_final_local=ヒント: Onion に Java 風の `final` ローカル変数はありません — `val` はもともと不変なので、代わりに `val` で宣言してください — `final {0} {1} = ...` ではなく `val {1}: {0} = ...` と書いてください。
 error.parsing.hint.instanceof_not_supported=ヒント: Onion に Java 風の `instanceof` 演算子はありません — 代わりに型検査演算子 `is` を使ってください（`select` の中では `case x is Type:` としても使えます）— `{0} instanceof {1}` ではなく `{0} is {1}` と書いてください。
+error.parsing.hint.access_modifier_before_declaration=ヒント: Onion に Java/C#/Kotlin 風の型宣言前のアクセス修飾子はありません — アクセス制御は本体内の `public:`/`private:`/`protected:` セクションで行います。`{0}` を外し、正しいセクションの下でメンバーを宣言してください — `{0} class Foo '{' ... '}'` ではなく `class Foo '{'public: ...'}'` と書いてください。
 error.semantic.toolUndeclaredEffect=tool `{0}` はここで `{1}` を行います（{2} の呼び出し）が、宣言されていません。`requires '{' ... '}'` 節に `{1}` を追加してください。
 error.semantic.toolUnusedCapability=tool `{0}` は capability `{1}` を宣言していますが、本体がそれを行うことはありません。requires 節から `{1}` を削除してください。
 error.semantic.toolBadCapability=tool `{0}` の capability `{1}` は不正です: {2}

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -204,6 +204,15 @@ private[compiler] object SyntaxHintClassifier {
       case "instanceof" if InstanceofExpression.findFirstMatchIn(sourceLine).isDefined =>
         val matched = InstanceofExpression.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.instanceof_not_supported", matched.group(1), matched.group(2))
+      // A Java/C#/Kotlin-style access modifier written before a type declaration
+      // (`public class Foo`, `private record Point(...)`, ...). None of the three
+      // words are reserved (they only mean something after `:` inside a class body),
+      // so each parses as a bare leading token with the declaration keyword landing
+      // in the same "expecting class/record/..." token set this fires from -- keep
+      // this ahead of the generic reserved-word-as-identifier case below, which
+      // never applies here since a declaration keyword isn't `<ID>`.
+      case ("public" | "private" | "protected") if expected.contains("\"class\"") =>
+        hint("error.parsing.hint.access_modifier_before_declaration", found)
       case _ if JavaStyleImplements.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleImplements.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_implements", matched.group(1), matched.group(2).trim)

--- a/src/test/scala/onion/compiler/AccessModifierBeforeDeclarationHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/AccessModifierBeforeDeclarationHintI18nSpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The Java/C#/Kotlin-style leading access-modifier hint (`SyntaxHintClassifier`'s
+ * `public`/`private`/`protected` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in that
+ * match -- see CompanionObjectDeclarationHintI18nSpec for the same pattern.
+ */
+class AccessModifierBeforeDeclarationHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.access_modifier_before_declaration"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("fires for a Java/C#/Kotlin-style `public class` declaration") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |public class Greeter {
+        |public:
+        |  static def main(args: String[]): Int = 0
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The hint's `public:` example text is literal, identical in both bundles,
+    // so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("public:"), s"expected the access-modifier hint, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -230,6 +230,48 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       ).map(_.messageKey) should not be Some("error.parsing.hint.instanceof_not_supported")
     }
 
+    it("recognizes a Java/C#/Kotlin-style `public` modifier before a class declaration") {
+      val hint = classify(
+        found = "public",
+        expected = "\"abstract\", \"class\", \"record\", \"def\"",
+        sourceLine = "public class Foo {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.access_modifier_before_declaration"
+      hint.arguments shouldBe Seq("public")
+    }
+
+    it("recognizes a `private` modifier before a record declaration") {
+      val hint = classify(
+        found = "private",
+        expected = "\"abstract\", \"class\", \"record\", \"def\"",
+        sourceLine = "private record Point(x: Int, y: Int)"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.access_modifier_before_declaration"
+      hint.arguments shouldBe Seq("private")
+    }
+
+    it("recognizes a `protected` modifier before an interface declaration") {
+      val hint = classify(
+        found = "protected",
+        expected = "\"abstract\", \"class\", \"record\", \"def\"",
+        sourceLine = "protected interface Shape {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.access_modifier_before_declaration"
+      hint.arguments shouldBe Seq("protected")
+    }
+
+    it("does not flag `public` when it isn't followed by a stray type-declaration expectation") {
+      SyntaxHintClassifier.classify(
+        found = "public",
+        expected = "\":\"",
+        context = "",
+        sourceLine = "public"
+      ).map(_.messageKey) should not be Some("error.parsing.hint.access_modifier_before_declaration")
+    }
+
     it("recognizes a Python/Rust/TypeScript-style `-> Type` return type arrow") {
       val hint = classify(
         found = "->",


### PR DESCRIPTION
## Summary

- `public class Foo`, `private record Point(...)`, `protected interface Shape` (the Java/C#/Kotlin habit of an access modifier before a type declaration) had no dedicated diagnostic. None of `public`/`private`/`protected` are reserved words in Onion — they only mean something after `:` inside a class body's access sections — so the modifier parsed as a bare leading token and the actual declaration keyword landed in a generic `expecting "abstract", "class", "record", "def", ...` parse error, with nothing connecting it back to the mistake.
- `SyntaxHintClassifier` now recognizes the shape directly and points at the fix: drop the modifier and declare members under a `public:`/`private:`/`protected:` section inside the body instead. Bilingual (en/ja).
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] New `SyntaxHintClassifierSpec` cases for `public class`, `private record`, `protected interface`, and a negative case confirming a legitimate `public:` access-section label is not misflagged.
- [x] New `AccessModifierBeforeDeclarationHintI18nSpec` asserting the hint resolves (and differs) in both the English and Japanese message bundles, and fires end-to-end through the real compiler.
- [x] `HintMessageKeyCoverageSpec` / `MessageBundleKeyParitySpec` pass (no orphaned/missing bundle keys).
- [x] Full suite, English locale: 4706/4706 green (1 pre-existing, unrelated cancellation).
- [x] Full suite, Japanese locale: 4706/4706 green (same pre-existing cancellation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADv5piiYiSW4zD2UNfspoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADv5piiYiSW4zD2UNfspoC)_