### PR TITLE
test: add runtime regression test for @TailRecursive mutual-recursion TCO

### DIFF
--- a/src/test/scala/onion/compiler/tools/TailCallOptimizationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TailCallOptimizationSpec.scala
@@ -70,6 +70,41 @@ class TailCallOptimizationSpec extends AbstractShellSpec {
       assert(Shell.Success("6") == result)
     }
 
+    it("optimizes a @TailRecursive mutual-recursion group (no stack overflow at depth 1000000)") {
+      // MutualRecursionOptimization rewrites an all-private, matching-signature
+      // @TailRecursive group into a state machine (see
+      // src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala).
+      // IneffectiveTailRecursiveWarningSpec only checks that W0016 fires or not at
+      // compile time; this checks the optimized bytecode is actually correct at runtime.
+      val result = shell.run(
+        """
+          |class Parity {
+          |private:
+          |  @TailRecursive
+          |  def isEven(n: Int): Boolean {
+          |    if n == 0 { return true }
+          |    return isOdd(n - 1)
+          |  }
+          |  @TailRecursive
+          |  def isOdd(n: Int): Boolean {
+          |    if n == 0 { return false }
+          |    return isEven(n - 1)
+          |  }
+          |public:
+          |  def check(n: Int): Boolean = isEven(n)
+          |}
+          |
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Boolean = new Parity().check(1000000)
+          |}
+          |""".stripMargin,
+        "MutualTailRecursiveDepth.on",
+        Array()
+      )
+      assert(Shell.Success(true) == result)
+    }
+
     it("optimizes a zero-argument static method without crashing") {
       val result = shell.run(
         """


### PR DESCRIPTION
## Summary

- `MutualRecursionOptimization` rewrites an all-private, matching-signature `@TailRecursive` group into a state machine so deep mutual recursion doesn't overflow the JVM stack (`src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala`), and it's a real, working, documented feature (`docs/compiler/tail-call-optimization.md`).
- The only existing coverage was `IneffectiveTailRecursiveWarningSpec`, which checks the W0016 diagnostic fires/doesn't fire at **compile time only** — it never executes the generated bytecode. `TailCallOptimizationSpec`'s existing "no stack overflow at depth 100000" runtime check only covers **direct self-recursion** (`TailCallOptimization`), not the mutual-recursion state-machine path.
- So the mutual-recursion transform's actual runtime correctness (does the generated bytecode avoid the extra stack frames, does it return the right value at depth) was unverified by any test — a regression there would only have surfaced as a production `StackOverflowError` or a silently wrong return value, not a test failure.
- Adds one test to `TailCallOptimizationSpec.scala` following the existing pattern: a private `isEven`/`isOdd` pair annotated `@TailRecursive`, called at depth 1,000,000, asserting the correct `Shell.Success(true)` result.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly *TailCallOptimizationSpec'` — 5/5 pass, new test included
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4707 succeeded, 0 failed, 1 pre-existing environment-conditional cancellation unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPZo6oyWZ7D3z4XbLoqSTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPZo6oyWZ7D3z4XbLoqSTA)_