### PR TITLE
perf: handwritten lexer and explicit parser lookaheads (parsing 3.5x faster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Parsing is about 3.5x faster** (the whole `run/` corpus, 247 files: 365 -> 105 ms of CPU
+  after warm-up), which takes the parser from ~16% of a warm compilation to ~5%.
+  - **A handwritten lexer** (`OnionLexer`) replaces the JavaCC-generated token manager. It
+    is a drop-in subclass of it, so the generated parser, `onion fmt` and the language
+    server's semantic tokens use it unchanged, and it produces a byte-identical token
+    stream: kinds, images, positions, comment special-token chains, the two lexical
+    states, Java unicode escapes and tab columns exactly as `JavaCharStream` recorded
+    them, the `return"x"` keyword re-cut. Pinned by a golden comparison over 455k tokens.
+    Under the parser most source is lexed in `IN_STATEMENT`, and the generated NFA for that
+    state was about five times slower than for `DEFAULT`; the two differ only in whether a
+    newline is an `EOL`, so one scanner with a flag does the same work.
+  - **The grammar's implicit one-token scans are gone.** JavaCC cannot compute a first set
+    through a choice that carries semantic lookahead, so the catch-all alternatives of
+    `expression`, `argument_expr`, `unary_prefix`, `primary`, and the optionals in `terms`,
+    `block`, `block_elements` and `unit` were each decided by a syntactic scan that
+    descended the whole precedence chain for one token -- roughly half of parse time.
+    They are now explicit token checks (`LOOKAHEAD({ true })`, `getToken(1).kind != RPAREN`).
+    The `Type::member` alternatives of `primary` (eleven unbounded type scans per primary)
+    and the `( ... ) ->` lambda alternative sit behind a cheap token peek, guarded so the
+    peek never runs during a syntactic scan (it would lex ahead in the wrong lexical state).
+    ASTs are identical to before over all 258 programs in `run/` and `src/test/run/`.
+  - Syntax hints now classify against the **full** expected-token list. The classifier read
+    the four-item user-facing summary, so which hint fired depended on the order JavaCC
+    happened to record choice points in -- a grammar change moved `;` to fifth place and
+    silently switched off sixteen hints. The message users see is unchanged.
+
 ### Fixed
 
 - **Diagnostic for a Java/C#/Kotlin-style access modifier before a type declaration

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -42,12 +42,19 @@ public class JJOnionParser implements Parser {
     public final int column;
     public final String found;
     public final String expected;
+    /** Every expected token, untruncated: what the hint classifier reads (see Parsing). */
+    public final String expectedAll;
 
     public ParseError(int line, int column, String found, String expected) {
+      this(line, column, found, expected, expected);
+    }
+
+    public ParseError(int line, int column, String found, String expected, String expectedAll) {
       this.line = line;
       this.column = column;
       this.found = found;
       this.expected = expected;
+      this.expectedAll = expectedAll;
     }
 
     @Override
@@ -92,6 +99,10 @@ public class JJOnionParser implements Parser {
    * @return true if parsing should continue, false if should stop
    */
   private boolean collectError(Token errorToken, String expected) {
+    return collectError(errorToken, expected, expected);
+  }
+
+  private boolean collectError(Token errorToken, String expected, String expectedAll) {
     if (!errorRecoveryMode) {
       return false; // Don't collect, let normal exception handling occur
     }
@@ -100,7 +111,8 @@ public class JJOnionParser implements Parser {
       errorToken.beginLine,
       errorToken.beginColumn,
       errorToken.image,
-      expected
+      expected,
+      expectedAll
     ));
 
     return collectedErrors.size() < maxErrors;
@@ -170,6 +182,58 @@ public class JJOnionParser implements Parser {
    * position, the next token is "." or "?.". Lets a method chain span lines.
    * Pure token peeking (no consumption).
    */
+  /**
+   * Whether a `Type::` shape lies ahead, mirroring the receivers static_access_primary()
+   * accepts: an identifier with optional dotted qualification, a `#<...>` name, or a boxed
+   * primitive keyword; then an optional bracketed type-argument list; then `::`. It must
+   * say yes whenever one of those alternatives would match, because the choice commits.
+   */
+  private boolean staticAccessAhead() {
+    int k = 1;
+    int kind = getToken(1).kind;
+    if (kind == ID) {
+      while (getToken(k + 1).kind == DOT && getToken(k + 2).kind == ID) k += 2;
+    } else if (kind == FQCN || kind == K_BYTE || kind == K_SHORT || kind == K_CHAR || kind == K_INT
+               || kind == K_LONG || kind == K_FLOAT || kind == K_DOUBLE || kind == K_BOOLEAN) {
+      // a single-token receiver
+    } else return false;
+    if (getToken(k + 1).kind == LBRACKET) {
+      int depth = 0;
+      k++;
+      for (; k <= 4096; k++) {
+        int t = getToken(k).kind;
+        if (t == LBRACKET) depth++;
+        else if (t == RBRACKET) { depth--; if (depth == 0) break; }
+        else if (t == EOF) return false;
+      }
+      if (depth != 0) return false;
+    }
+    return getToken(k + 1).kind == COLON2;
+  }
+
+  /** Whether the next token can begin a block element: anything but a closer or `case`/`else`. */
+  private boolean blockElementFollows() {
+    int k = getToken(1).kind;
+    return k != RBRACE && k != EOF && k != K_CASE && k != K_ELSE;
+  }
+
+  /** Whether the tokens ahead are `( ... )`, balanced, followed (after newlines) by `->`. */
+  private boolean arrowAfterParenAhead() {
+    if (getToken(1).kind != LPAREN) return false;
+    int depth = 0;
+    int k = 1;
+    for (; k <= 4096; k++) {
+      int kind = getToken(k).kind;
+      if (kind == LPAREN) depth++;
+      else if (kind == RPAREN) { depth--; if (depth == 0) break; }
+      else if (kind == EOF) return false;
+    }
+    if (depth != 0) return false;
+    k++;
+    while (getToken(k).kind == EOL) k++;
+    return getToken(k).kind == ARROW;
+  }
+
   private boolean dotContinuationFollows() {
     int i = 1;
     while (getToken(i).kind == EOL) i++;
@@ -392,6 +456,14 @@ public class JJOnionParser implements Parser {
   /**
    * Summarize the expected tokens of a ParseException for collected errors.
    */
+  /** All expected token images, comma-separated, in JavaCC's order; no truncation. */
+  private String expectedAll(ParseException e) {
+    if (e.expectedTokenSequences == null || e.expectedTokenSequences.length == 0) return "valid token";
+    java.util.LinkedHashSet<String> seen = new java.util.LinkedHashSet<String>();
+    for (int[] seq : e.expectedTokenSequences) if (seq.length > 0) seen.add(e.tokenImage[seq[0]]);
+    return seen.isEmpty() ? "valid token" : String.join(", ", seen);
+  }
+
   private String expectedSummary(ParseException e) {
     if (e.expectedTokenSequences == null || e.expectedTokenSequences.length == 0) {
       return "valid token";
@@ -838,7 +910,7 @@ public class JJOnionParser implements Parser {
       // Parse the expression inside, padded so positions match the file
       String exprStr = str.substring(interpStart + 2, interpEnd - 1);
       String padding = interpolationPadding(str, interpStart + 2, loc, 1);
-      JJOnionParser exprParser = new JJOnionParser(new java.io.StringReader(padding + exprStr));
+      JJOnionParser exprParser = new JJOnionParser(new OnionLexer(padding + exprStr));
       try {
         AST.Expression expr = exprParser.term();
         append(expressions, expr);
@@ -907,7 +979,7 @@ public class JJOnionParser implements Parser {
       // Parse the expression inside, padded so positions match the file
       String exprStr = str.substring(interpStart + 2, interpEnd - 1);
       String padding = interpolationPadding(str, interpStart + 2, loc, 3);
-      JJOnionParser exprParser = new JJOnionParser(new java.io.StringReader(padding + exprStr));
+      JJOnionParser exprParser = new JJOnionParser(new OnionLexer(padding + exprStr));
       try {
         AST.Expression expr = exprParser.term();
         append(expressions, expr);
@@ -1228,13 +1300,13 @@ AST.CompilationUnit unit() :{
 }{
   [module=module_decl()]
   [imports=import_decl()]
-  (
+  ( LOOKAHEAD({ getToken(1).kind != EOF })
     try {
       top=top_level() {append(tops, top);}
     } catch (ParseException e) {
       if (!errorRecoveryMode) { throw e; }
       Token errorToken = (e.currentToken != null && e.currentToken.next != null) ? e.currentToken.next : token;
-      if (!collectError(errorToken, expectedSummary(e))) { throw e; }
+      if (!collectError(errorToken, expectedSummary(e), expectedAll(e))) { throw e; }
       if (!skipToToplevelSyncPoint()) {
         // EOF reached while recovering: return what we have, errors are collected
         return new AST.CompilationUnit(p(1, 1), null, module, imports, toList(tops));
@@ -1489,7 +1561,7 @@ AST.TypeDeclaration type_decl(int modifiers) :{AST.TypeDeclaration ty = null;}{
 }
 
 AST.BlockExpression block():{Token t; List<AST.BlockElement> elements = (List<AST.BlockElement>)AST.NIL(); AST.BlockExpression s;}{
-  t="{" eols() [elements=block_elements()] eols() "}" {return new AST.BlockExpression(p(t), elements);}
+  t="{" eols() [ LOOKAHEAD({ getToken(1).kind != RBRACE }) elements=block_elements() ] eols() "}" {return new AST.BlockExpression(p(t), elements);}
 }
 
 List<AST.BlockElement> block_elements():{ AST.BlockElement element; ArrayBuffer<AST.BlockElement> elements = new ArrayBuffer<AST.BlockElement>(); }{
@@ -1502,7 +1574,7 @@ List<AST.BlockElement> block_elements():{ AST.BlockElement element; ArrayBuffer<
   // after such an element is tokenized as an EOL and would otherwise stall the
   // next element. In the DEFAULT lexer state (ordinary statement blocks) EOLs are
   // skipped, so this eols() is a harmless no-op there.
-  (element=block_element() { append(elements, element); } eols())+ {return toList(elements);}
+  ( LOOKAHEAD({ blockElementFollows() }) element=block_element() { append(elements, element); } eols() )+ {return toList(elements);}
 }
 
 int modifiers():{ mset = 0; Token t = null, last = null; }{
@@ -2393,7 +2465,7 @@ AST.SelectExpression select_expression() :{
     )*
     eols()
     [LOOKAHEAD({la("else")})
-      t2="else" ":" eols() { ss = (List<AST.BlockElement>)AST.NIL(); } [ss=block_elements()] { elseBlock = new AST.BlockExpression(p(t2), ss); }
+      t2="else" ":" eols() { ss = (List<AST.BlockElement>)AST.NIL(); } [ LOOKAHEAD({ blockElementFollows() }) ss=block_elements() ] { elseBlock = new AST.BlockExpression(p(t2), ss); }
     ]
   eols() "}" {
     return new AST.SelectExpression(p(t1), e1, toList(branches), elseBlock);
@@ -2469,7 +2541,7 @@ AST.Expression expression() :{AST.Expression e;}{
 | e=return_expression()      {return e;}
 | e=synchronized_expression() {return e;}
 | e=foreach_expression()      {return e;}
-| e=assignable()             {return e;}
+| LOOKAHEAD({ true }) e=assignable() {return e;}
 }
 
 AST.Expression term() :{AST.Expression e;}{
@@ -2478,6 +2550,8 @@ AST.Expression term() :{AST.Expression e;}{
 
 AST.Expression assignable() :{Token t; AST.Expression a, b; }{
   a=pipeline()
+  // Two tokens on purpose: `x => y` must fail at the `=`, not after consuming it, for the
+  // old-arrow hint to see the `=>`.
   [ LOOKAHEAD(2)
     ( t="="  eols() b=expression() {a = new AST.Assignment(span(a, b), a, b);}
     | t="+=" eols() b=expression() {a = new AST.AdditionAssignment(span(a, b), a, b);}
@@ -2512,7 +2586,7 @@ AST.Expression pipeline() :{Token t; AST.Expression a, b; }{
 
 AST.Expression logical_or() :{Token t; AST.Expression a, b; }{
   a=logical_and()
-  ( LOOKAHEAD(2)
+  ( LOOKAHEAD(1)
     ( t="||" eols() b=logical_and() {a = new AST.LogicalOr(span(a, b), a, b);}
     | t="?:" eols() ( b=throw_expression() | b=return_expression() | b=logical_and() ) {a = new AST.Elvis(span(a, b), a, b);}
     )
@@ -2521,24 +2595,24 @@ AST.Expression logical_or() :{Token t; AST.Expression a, b; }{
 }
 
 AST.Expression logical_and() :{Token t; AST.Expression a, b; }{
-  a=bit_or() (LOOKAHEAD(2) t="&&" eols() b=bit_or() {a = new AST.LogicalAnd(span(a, b), a, b);})* {return a;}
+  a=bit_or() (LOOKAHEAD(1) t="&&" eols() b=bit_or() {a = new AST.LogicalAnd(span(a, b), a, b);})* {return a;}
 }
 
 AST.Expression bit_or() :{Token t; AST.Expression a, b; }{
-  a=xor() (LOOKAHEAD(2) t="|" eols() b=xor() {a = new AST.BitOr(span(a, b), a, b);})* {return a;}
+  a=xor() (LOOKAHEAD(1) t="|" eols() b=xor() {a = new AST.BitOr(span(a, b), a, b);})* {return a;}
 }
 
 AST.Expression xor() :{Token t; AST.Expression a, b;}{
-  a = bit_and() (LOOKAHEAD(2) t="^" eols() b=bit_and() {a = new AST.XOR(span(a, b), a, b);})* {return a;}
+  a = bit_and() (LOOKAHEAD(1) t="^" eols() b=bit_and() {a = new AST.XOR(span(a, b), a, b);})* {return a;}
 }
 
 AST.Expression bit_and() :{Token t; AST.Expression a, b; }{
-  a=equal() (LOOKAHEAD(2) t = "&" eols() b=equal() {a = new AST.BitAnd(span(a, b), a, b);})* {return a;}
+  a=equal() (LOOKAHEAD(1) t = "&" eols() b=equal() {a = new AST.BitAnd(span(a, b), a, b);})* {return a;}
 }
 
 AST.Expression equal() :{ Token t; AST.Expression a, b; }{
   a=comparative()
-  ( LOOKAHEAD(2)
+  ( LOOKAHEAD(1)
     ( t="===" eols() b=comparative() {a= new AST.ReferenceEqual(span(a, b), a, b);}
     | t="!==" eols() b=comparative() {a= new AST.ReferenceNotEqual(span(a, b), a, b);}
     | t="=="  eols() b=comparative() {a= new AST.Equal(span(a, b), a, b);}
@@ -2549,7 +2623,7 @@ AST.Expression equal() :{ Token t; AST.Expression a, b; }{
 
 AST.Expression comparative() : { Token t; AST.Expression a, b; AST.TypeNode type; }{
   a=range_expr()
-  ( LOOKAHEAD(2)
+  ( LOOKAHEAD(1)
     ( t=<LTEQ> eols() b=range_expr() {a = new AST.LessOrEqual(span(a, b), a, b);}
     | t=<GTEQ> eols() b=range_expr() {a = new AST.GreaterOrEqual(span(a, b), a, b);}
     | t="<"  eols() b=range_expr() {a = new AST.LessThan(span(a, b), a, b);}
@@ -2564,7 +2638,7 @@ AST.Expression comparative() : { Token t; AST.Expression a, b; AST.TypeNode type
 // foreach works without further compiler support.
 AST.Expression range_expr() :{Token t; AST.Expression a, b;}{
   a=bit_shift()
-  [ LOOKAHEAD(2)
+  [ LOOKAHEAD(1)
     ( t="..<" eols() b=bit_shift() { a = rangeNew(p(t), a, b, false); }
     | t=".." eols() b=bit_shift() { a = rangeNew(p(t), a, b, true); }
     )
@@ -2574,7 +2648,7 @@ AST.Expression range_expr() :{Token t; AST.Expression a, b;}{
 
 AST.Expression bit_shift() :{Token t; AST.Expression e1, e2;}{
   e1=additive()
-( LOOKAHEAD(2)
+( LOOKAHEAD(1)
   ( t="<<" eols() e2=additive()    {e1 = new AST.MathLeftShift(span(e1, e2), e1, e2);}
   | t=">>" eols() e2=additive()    {e1 = new AST.MathRightShift(span(e1, e2), e1, e2);}
   | t=">>>"eols() e2=additive()    {e1 = new AST.LogicalRightShift(span(e1, e2), e1, e2);}
@@ -2584,7 +2658,7 @@ AST.Expression bit_shift() :{Token t; AST.Expression e1, e2;}{
 
 AST.Expression additive() :{Token t; AST.Expression e1, e2;}{
   e1=unary_prefix()
-( LOOKAHEAD(2)
+( LOOKAHEAD(1)
   ( t="+" eols() e2=unary_prefix() {e1 = new AST.Addition(span(e1, e2), e1, e2);}
   | t="-" eols() e2=unary_prefix() {e1 = new AST.Subtraction(span(e1, e2), e1, e2);}
   )
@@ -2596,13 +2670,13 @@ AST.Expression unary_prefix() :{Token t; AST.Expression e;}{
 | t="-" e=unary_prefix() {e = new AST.Negate(p(t), e);}
 | t="!" e=unary_prefix() {e = new AST.Not(p(t), e);}
 | t=<BN> e=unary_prefix() {e = new AST.BitNot(p(t), e);}
-| e=multitive()
+| LOOKAHEAD({ true }) e=multitive()
 ) {return e;}
 }
 
 AST.Expression multitive() :{Token t; AST.Expression e1, e2;}{
   e1=primary_suffix()
-( LOOKAHEAD(2)
+( LOOKAHEAD(1)
   ( t="*" eols() e2=mul_operand()  {e1 = new AST.Multiplication(span(e1, e2), e1, e2);}
   | t="/" eols() e2=mul_operand()  {e1 = new AST.Division(span(e1, e2), e1, e2);}
   | t="%" eols() e2=mul_operand()  {e1 = new AST.Modulo(span(e1, e2), e1, e2);}
@@ -2699,7 +2773,8 @@ AST.Expression safe_access_suffix(AST.Expression e) : {
     ) { return e; }
 }
 
-AST.Expression primary() : {
+/** The `Type::member` forms of primary, reached only when staticAccessAhead() holds. */
+AST.Expression static_access_primary() : {
   Token n = null, t; AST.TypeNode ty = null; AST.Expression e;
   List<AST.Expression> es = (List<AST.Expression>)AST.NIL();
   List<AST.Argument> args = (List<AST.Argument>)AST.NIL();
@@ -2707,14 +2782,7 @@ AST.Expression primary() : {
   AST.BlockExpression body;
   AST.ClosureExpression tl = null;
 }{
-  LOOKAHEAD( "super" eols() "." eols() id() type_arguments() "(" )
-    t="super" eols() "." eols() n=id() tas=type_arguments() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
-    { es = AST.appendToList(es, tl); return new AST.SuperMethodCall(p(t), c(n), es, tas); }
-| t="super" eols() "." eols() n=id() [LOOKAHEAD(2) "(" es=terms() ")"]
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
-    { es = AST.appendToList(es, tl); return new AST.SuperMethodCall(through(n), c(n), es); }
-| LOOKAHEAD( class_type() type_arguments() "::" ) ty=class_type() tas=type_arguments() t="::" n=id() "(" es=terms() ")"
+  LOOKAHEAD( class_type() type_arguments() "::" ) ty=class_type() tas=type_arguments() t="::" n=id() "(" es=terms() ")"
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.TraitMethodCall(through(n), ty, tas, c(n), es); }
 | LOOKAHEAD( boxed_class_type() "::" id() type_arguments() "(" ) ty=boxed_class_type() t="::" n=id() tas=type_arguments() "(" es=terms() ")"
@@ -2740,7 +2808,49 @@ AST.Expression primary() : {
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es); }
 | LOOKAHEAD(2) ty=class_type() t="::" n=id()                        {return new AST.StaticMemberSelection(p(t), ty, c(n));}
-| LOOKAHEAD( id() type_arguments() "(" ) t=id() tas=type_arguments() "(" es=terms() ")"
+| LOOKAHEAD({ true }) e=primary_rest() {return e;}
+}
+
+/** A `(`: a lambda when lambda_head() parses, else a parenthesised term. */
+AST.Expression lambda_or_paren() : { AST.Expression e; }{
+  LOOKAHEAD( lambda_head() ) e=arrow_anonymous_function() {return e;}
+| "(" eols() e=term() eols() ")" {return e;}
+}
+
+AST.Expression primary() : {
+  Token n = null, t; AST.TypeNode ty = null; AST.Expression e;
+  List<AST.Expression> es = (List<AST.Expression>)AST.NIL();
+  List<AST.Argument> args = (List<AST.Argument>)AST.NIL();
+  List<AST.TypeNode> tas = (List<AST.TypeNode>)AST.NIL();
+  AST.BlockExpression body;
+  AST.ClosureExpression tl = null;
+}{
+  LOOKAHEAD( "super" eols() "." eols() id() type_arguments() "(" )
+    t="super" eols() "." eols() n=id() tas=type_arguments() "(" es=terms() ")"
+    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    { es = AST.appendToList(es, tl); return new AST.SuperMethodCall(p(t), c(n), es, tas); }
+| t="super" eols() "." eols() n=id() [LOOKAHEAD(2) "(" es=terms() ")"]
+    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    { es = AST.appendToList(es, tl); return new AST.SuperMethodCall(through(n), c(n), es); }
+// Every alternative below needs a `::` after a type. Peeking for that first spares the
+// full syntactic type scans -- eleven of them, per primary -- on the common case.
+// During a syntactic scan the guard is skipped (a peek there would lex ahead in the
+// wrong lexical state); static_access_primary() then falls through to primary_rest(),
+// which is exactly the old alternative order.
+| LOOKAHEAD({ jj_lookingAhead || staticAccessAhead() }) e=static_access_primary() {return e;}
+| LOOKAHEAD({ true }) e=primary_rest() {return e;}
+}
+
+/** The alternatives of primary after the `Type::` forms. */
+AST.Expression primary_rest() : {
+  Token n = null, t; AST.TypeNode ty = null; AST.Expression e;
+  List<AST.Expression> es = (List<AST.Expression>)AST.NIL();
+  List<AST.Argument> args = (List<AST.Argument>)AST.NIL();
+  List<AST.TypeNode> tas = (List<AST.TypeNode>)AST.NIL();
+  AST.BlockExpression body;
+  AST.ClosureExpression tl = null;
+}{
+  LOOKAHEAD( id() type_arguments() "(" ) t=id() tas=type_arguments() "(" es=terms() ")"
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.UnqualifiedMethodCall(through(t), c(t), es, tas); }
 | LOOKAHEAD(2) t=id() "(" es=terms() ")"
@@ -2749,7 +2859,9 @@ AST.Expression primary() : {
 | LOOKAHEAD(2, id() <ARROW>) e=arrow_anonymous_function()                 {return e;}
 | LOOKAHEAD(1) t=id()                                               {return new AST.Id(p(t), c(t));}
 | {enterDefault();} t="[" eols() e=bracket_literal_rest(t) {leaveDefault();} {return e;}
-| LOOKAHEAD( lambda_head() ) e=arrow_anonymous_function()                 {return e;}
+// A parenthesised lambda is `( ... ) ->`; matching the parenthesis by depth is a token peek,
+// where lambda_head() re-parsed the whole parenthesised expression on every `(`.
+| LOOKAHEAD({ jj_lookingAhead || arrowAfterParenAhead() }) e=lambda_or_paren() {return e;}
 | LOOKAHEAD("do" "[") e=do_expression()                                   {return e;}
 | LOOKAHEAD("new" raw_type() "[" "]" "{") t="new" ty=raw_type() "[" "]" "{" eols() es=terms() "}"
     { return new AST.NewArrayWithValues(p(t), ty, es); }
@@ -2799,13 +2911,15 @@ AST.Expression primary() : {
 AST.Expression argument_expr() :{Token n; AST.Expression e;}{
   LOOKAHEAD(2, id() "=")
     n=id() "=" eols() e=term()  {return new AST.NamedArgument(p(n), c(n), e);}
-  | e=term()                    {return e;}
+  | LOOKAHEAD({ true }) e=term()  {return e;}
 }
 
 List<AST.Expression> terms() :{AST.Expression arg; ArrayBuffer<AST.Expression> args = new ArrayBuffer<AST.Expression>();}{
   // eols() before each argument and at the end lets argument lists span
   // multiple lines: f(\n a,\n b\n)
-  [eols() arg=argument_expr() {append(args, arg);} ("," eols() arg=argument_expr() {append(args, arg);})* eols()] {
+  // Leading newlines are consumed before the choice: with them inside the optional, JavaCC
+  // had to run a syntactic scan (through the nullable eols()) to decide it at every call.
+  eols() [ LOOKAHEAD({ getToken(1).kind != RPAREN }) arg=argument_expr() {append(args, arg);} ("," eols() arg=argument_expr() {append(args, arg);})* eols()] {
     return toList(args);
   }
 }
@@ -2918,7 +3032,7 @@ AST.ClosureExpression trailing_lambda() :{
   AST.TypeNode ty = null;
 }{
   {enterDefault();}
-  t="{" eols() args=lambda_args(false) eols() <ARROW> eols() [stmts=block_elements()] eols() "}" {
+  t="{" eols() args=lambda_args(false) eols() <ARROW> eols() [ LOOKAHEAD({ getToken(1).kind != RBRACE }) stmts=block_elements() ] eols() "}" {
     body = new AST.BlockExpression(p(t), stmts);
     ty = new AST.TypeNode(p(t), new AST.ReferenceType("onion.Function" + args.size(), true), true);
     leaveDefault();

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -7,6 +7,7 @@ import java.io.{IOException, Reader, StringReader}
 import _root_.onion.compiler.toolbox.Message
 import _root_.onion.compiler.exceptions.CompilationException
 import _root_.onion.compiler.parser.{
+  OnionLexer,
   ExpectedTokenFormatter,
   JJOnionParser,
   ParseException,
@@ -78,8 +79,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
   ): Unit = {
     try {
       val sourceText = stripShebang(source.openReader())
-      val reader = new StringReader(sourceText)
-      val parser = new JJOnionParser(reader)
+      val parser = new JJOnionParser(new OnionLexer(sourceText))
 
       // Enable error recovery mode to collect multiple errors
       parser.enableErrorRecovery(maxErrorsPerFile)
@@ -104,8 +104,6 @@ class Parsing(config: CompilerConfig) extends AnyRef
           }
           // Then add the final error that stopped parsing
           addParseException(e, source.name, sourceText, problems)
-      } finally {
-        reader.close()
       }
     } catch {
       case e: IOException =>
@@ -133,7 +131,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
           error.found,
           error.expected,
           sourceContext.context,
-          sourceContext.sourceLine
+          sourceContext.sourceLine,
+          error.expectedAll
         )
       )
     }
@@ -155,6 +154,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
     } else {
       val error = e.currentToken.next
       val expected = ExpectedTokenFormatter.format(e.expectedTokenSequences, e.tokenImage)
+      val expectedAll = ExpectedTokenFormatter.formatAll(e.expectedTokenSequences, e.tokenImage)
       val sourceContext = SourceContext.at(sourceText, error.beginLine, error.beginColumn)
       problems += CompileError(
         fileName,
@@ -163,7 +163,8 @@ class Parsing(config: CompilerConfig) extends AnyRef
           error.image,
           expected,
           sourceContext.context,
-          sourceContext.sourceLine
+          sourceContext.sourceLine,
+          expectedAll
         )
       )
     }
@@ -174,7 +175,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * (complete strings lex as a single STRING token); report it as such
    * instead of listing unrelated expected tokens.
    */
-  private def syntaxErrorMessage(found: String, expected: String, context: String = "", sourceLine: String = ""): String = {
+  private def syntaxErrorMessage(found: String, expected: String, context: String = "", sourceLine: String = "", expectedAll: String = null): String = {
     // At EOF the expected-token list is a large, unhelpful dump; report the real
     // problem (an unclosed block/paren) instead.
     if (found == null || found.isEmpty) return Message("error.parsing.unexpected_eof")
@@ -182,7 +183,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
       if (found == "\"") Message("error.parsing.unterminated_string")
       else Message("error.parsing.syntax_error", displayTokenImage(found), expected)
     val hint = SyntaxHintClassifier
-      .classify(found, expected, context, sourceLine)
+      .classify(found, if (expectedAll == null) expected else expectedAll, context, sourceLine)
       .map(renderSyntaxHint)
       .getOrElse("")
     if (hint.isEmpty) base else base + " " + hint

--- a/src/main/scala/onion/compiler/parser/ExpectedTokenFormatter.scala
+++ b/src/main/scala/onion/compiler/parser/ExpectedTokenFormatter.scala
@@ -6,6 +6,20 @@ private[compiler] object ExpectedTokenFormatter {
   private val Fallback = "valid token"
 
   /** Render the first token of each JavaCC expected-token sequence. */
+  /**
+   * Every expected token, untruncated, for the hint classifier. The user-facing `format`
+   * shows the first four, and which four those are depends on the order JavaCC recorded
+   * its choice points in -- a detail a grammar change moves around, and one no hint
+   * should hinge on.
+   */
+  def formatAll(expectedTokenSequences: Array[Array[Int]], tokenImages: Array[String]): String = {
+    if (expectedTokenSequences == null || expectedTokenSequences.isEmpty) return Fallback
+    val expectedSet = LinkedHashSet[String]()
+    for (sequence <- expectedTokenSequences)
+      if (sequence != null && sequence.nonEmpty) expectedSet += tokenImages(sequence(0))
+    if (expectedSet.isEmpty) Fallback else expectedSet.mkString(", ")
+  }
+
   def format(expectedTokenSequences: Array[Array[Int]], tokenImages: Array[String]): String = {
     if (expectedTokenSequences == null || expectedTokenSequences.isEmpty) {
       return Fallback

--- a/src/main/scala/onion/compiler/parser/OnionLexer.scala
+++ b/src/main/scala/onion/compiler/parser/OnionLexer.scala
@@ -1,0 +1,559 @@
+package onion.compiler.parser
+
+import onion.compiler.parser.{JJOnionParserConstants as K}
+
+/**
+ * A handwritten replacement for the JavaCC-generated token manager.
+ *
+ * It produces the same token stream as `JJOnionParserTokenManager` -- kinds, images,
+ * positions, special-token chains, and the two lexical states -- and is a drop-in for it:
+ * it extends the generated class so the generated parser, which holds a
+ * `JJOnionParserTokenManager`, accepts it unchanged.
+ *
+ * Why it exists: under the parser most of the source is lexed in `IN_STATEMENT`, and the
+ * generated NFA for that state ran about five times slower than the one for `DEFAULT`,
+ * which made lexing more than half of the parse time. The two states differ only in
+ * whether a newline is skipped or becomes an `EOL` token, so one scanner with a flag does
+ * the same work at the speed of a switch on the current character.
+ *
+ * Fidelity notes, each pinned by the token-golden comparison over `run/` and `src/test/run/`:
+ *  - Java unicode escapes are decoded before scanning, with `JavaCharStream`'s
+ *    backslash-parity rule and its column bookkeeping (`column += 4` per escape, tab stops
+ *    of 8), because the build generates the parser with `JAVA_UNICODE_ESCAPE=true`.
+ *  - Maximal munch, ties to the earlier-declared token: `//` beats `/=`, keywords beat `ID`,
+ *    `re"`/`file"`/`http"` beat the generic scheme string.
+ *  - A scheme string whose prefix is a keyword (`return"x"`) is re-cut into the keyword
+ *    followed by a string, exactly as the grammar's one lexical action does.
+ *  - A token that fails part-way falls back to its longest accepted prefix, and a character
+ *    that starts nothing is an `ERROR` token rather than an exception.
+ */
+final class OnionLexer(text: String)
+  extends JJOnionParserTokenManager(new JavaCharStream(new java.io.StringReader(""), 1, 1, 1)):
+
+  import OnionLexer.*
+
+  // ---------------------------------------------------------------- decoded input
+
+  private val length: Int = text.length
+  private val chars: Array[Char] = new Array[Char](length)
+  private val lines: Array[Int] = new Array[Int](length)
+  private val cols: Array[Int] = new Array[Int](length)
+  private val n: Int = decode()
+
+  private var pos: Int = 0
+  private var pendingSpecial: Token = null
+
+  /**
+   * Replays `JavaCharStream.readChar` over the raw text: unicode escapes become one char,
+   * every char gets the line/column the stream would have recorded for it.
+   */
+  private def decode(): Int =
+    var line = 1
+    var column = 0
+    var prevCR = false
+    var prevLF = false
+    var out = 0
+    var i = 0
+
+    // Exactly UpdateLineColumn, minus the buffer bookkeeping.
+    def update(c: Char): Unit =
+      column += 1
+      if prevLF then
+        prevLF = false
+        column = 1
+        line += 1
+      else if prevCR then
+        prevCR = false
+        if c == '\n' then prevLF = true
+        else
+          column = 1
+          line += 1
+      c match
+        case '\r' => prevCR = true
+        case '\n' => prevLF = true
+        case '\t' =>
+          column -= 1
+          column += TabSize - (column % TabSize)
+        case _ =>
+
+    def emit(c: Char, l: Int, col: Int): Unit =
+      chars(out) = c
+      lines(out) = l
+      cols(out) = col
+      out += 1
+
+    while i < length do
+      val c = text.charAt(i)
+      if c == '\\' then
+        var j = i
+        var count = 0
+        while j < length && text.charAt(j) == '\\' do
+          count += 1
+          j += 1
+        if j < length && text.charAt(j) == 'u' && (count & 1) == 1 then
+          // An odd run of backslashes and a `u`: the escape. Every backslash and the `u`
+          // pass through UpdateLineColumn; the decoded char takes the position recorded
+          // for the last backslash; the preceding backslashes stay literal.
+          var lastLine = 0
+          var lastCol = 0
+          var k = 0
+          while k < count do
+            update('\\')
+            if k < count - 1 then emit('\\', line, column)
+            else
+              lastLine = line
+              lastCol = column
+            k += 1
+          update('u')
+          j += 1
+          while j < length && text.charAt(j) == 'u' do
+            column += 1
+            j += 1
+          if j + 4 > length then
+            throw new Error("Invalid escape character at line " + line + " column " + column + ".")
+          var value = 0
+          var h = 0
+          while h < 4 do
+            value = (value << 4) | hexval(text.charAt(j + h), line, column)
+            h += 1
+          column += 4
+          emit(value.toChar, lastLine, lastCol)
+          i = j + 4
+        else
+          var k = 0
+          while k < count do
+            update('\\')
+            emit('\\', line, column)
+            k += 1
+          i = j
+      else
+        update(c)
+        emit(c, line, column)
+        i += 1
+    out
+
+  private def hexval(c: Char, line: Int, column: Int): Int =
+    if c >= '0' && c <= '9' then c - '0'
+    else if c >= 'a' && c <= 'f' then c - 'a' + 10
+    else if c >= 'A' && c <= 'F' then c - 'A' + 10
+    else throw new Error("Invalid escape character at line " + line + " column " + column + ".")
+
+  // ---------------------------------------------------------------- state
+
+  override def SwitchTo(lexState: Int): Unit =
+    if lexState >= 2 || lexState < 0 then
+      throw new TokenMgrError(
+        "Error: Ignoring invalid lexical state : " + lexState + ". State unchanged.",
+        TokenMgrError.INVALID_LEXICAL_STATE)
+    curLexState = lexState
+
+  // ---------------------------------------------------------------- driver
+
+  override def getNextToken(): Token =
+    pendingSpecial = null
+    while true do
+      if pos >= n then return finish(eofToken())
+      val c = chars(pos)
+      if c == ' ' || c == '\t' || c == '\f' then pos += 1
+      else if c == '\n' || c == '\r' then
+        val start = pos
+        pos += 1
+        if c == '\r' && pos < n && chars(pos) == '\n' then pos += 1
+        if curLexState == IN_STATEMENT then return finish(make(K.EOL, start, pos))
+      else if c == '/' && pos + 1 < n && chars(pos + 1) == '/' then
+        val start = pos
+        pos += 2
+        while pos < n && chars(pos) != '\n' && chars(pos) != '\r' do pos += 1
+        special(make(K.LINE_COMMENT, start, pos))
+      else if c == '/' && pos + 1 < n && chars(pos + 1) == '*' then
+        val end = blockCommentEnd(pos + 2)
+        if end < 0 then return finish(make(K.SLASH, pos, pos + 1).tap(_ => pos += 1))
+        special(make(K.MULTI_LINE_COMMENT, pos, end))
+        pos = end
+      else
+        return finish(scanToken())
+    null // unreachable
+
+  private def special(t: Token): Unit =
+    if pendingSpecial == null then pendingSpecial = t
+    else
+      t.specialToken = pendingSpecial
+      pendingSpecial.next = t
+      pendingSpecial = t
+
+  private def finish(t: Token): Token =
+    t.specialToken = pendingSpecial
+    pendingSpecial = null
+    t
+
+  private def eofToken(): Token =
+    val t = Token.newToken(K.EOF, "")
+    // JavaCC reports the position of the last character it consumed.
+    if n > 0 then
+      t.beginLine = lines(n - 1); t.beginColumn = cols(n - 1)
+      t.endLine = lines(n - 1); t.endColumn = cols(n - 1)
+    else
+      t.beginLine = 0; t.beginColumn = 0; t.endLine = 0; t.endColumn = 0
+    t
+
+  /** A token covering `[start, end)` of the decoded input. */
+  private def make(kind: Int, start: Int, end: Int): Token =
+    val t = Token.newToken(kind, new String(chars, start, end - start))
+    t.beginLine = lines(start)
+    t.beginColumn = cols(start)
+    t.endLine = lines(end - 1)
+    t.endColumn = cols(end - 1)
+    t
+
+  private def blockCommentEnd(from: Int): Int =
+    var i = from
+    while i + 1 < n do
+      if chars(i) == '*' && chars(i + 1) == '/' then return i + 2
+      i += 1
+    -1
+
+  // ---------------------------------------------------------------- tokens
+
+  private def scanToken(): Token =
+    val start = pos
+    val c = chars(pos)
+    if isIdentStart(c) then identifierOrScheme(start)
+    else if c >= '0' && c <= '9' then number(start)
+    else if c == '.' then
+      if pos + 1 < n && chars(pos + 1) >= '0' && chars(pos + 1) <= '9' then number(start)
+      else operator(start)
+    else if c == '"' then
+      if pos + 2 < n && chars(pos + 1) == '"' && chars(pos + 2) == '"' then
+        val end = multiLineStringEnd(start + 3)
+        if end >= 0 then emit(K.MULTI_LINE_STRING, start, end)
+        else
+          // `"""` with no close: `""` is an empty STRING, and the third quote starts over.
+          emit(K.STRING, start, start + 2)
+      else
+        val end = stringEnd(start + 1)
+        if end >= 0 then emit(K.STRING, start, end) else emit(K.ERROR, start, start + 1)
+    else if c == '\'' then
+      val end = characterEnd(start + 1)
+      if end >= 0 then emit(K.CHARACTER, start, end) else emit(K.ERROR, start, start + 1)
+    else if c == '`' then
+      var i = start + 1
+      while i < n && chars(i) != '`' do i += 1
+      if i < n && i > start + 1 then emit(K.QUOTED_ID, start, i + 1)
+      else emit(K.BACK_QUOTE, start, start + 1)
+    else if c == '#' then
+      val end = fqcnEnd(start + 1)
+      if end >= 0 then emit(K.FQCN, start, end) else emit(K.SHARP, start, start + 1)
+    else if c == '@' then
+      var i = start + 1
+      while i < n && isIdentPart(chars(i)) do i += 1
+      if i > start + 1 then emit(K.ANNOTATION, start, i) else emit(K.ERROR, start, start + 1)
+    else operator(start)
+
+  private def emit(kind: Int, start: Int, end: Int): Token =
+    pos = end
+    make(kind, start, end)
+
+  private def identifierOrScheme(start: Int): Token =
+    var i = start + 1
+    while i < n && isIdentPart(chars(i)) do i += 1
+    val word = new String(chars, start, i - start)
+    val kw = keywordKind(word)
+    if i < n && chars(i) == '"' then
+      val end = rawStringEnd(i + 1)
+      if end >= 0 then
+        // A scheme string is the longest match. If its prefix is a keyword the grammar's
+        // lexical action gives the string back and emits the keyword alone.
+        if kw != -1 then return emit(kw, start, i)
+        val kind = word match
+          case "re" => K.RE_STRING
+          case "file" => K.FILE_STRING
+          case "http" => K.HTTP_STRING
+          case _ => K.SCHEME_STRING
+        return emit(kind, start, end)
+    emit(if kw != -1 then kw else K.ID, start, i)
+
+  /** `( ~["\"","\\","\n","\r"] | "\\" ~["\n","\r"] )* "\""` from `from`; the index after the close, or -1. */
+  private def rawStringEnd(from: Int): Int =
+    var i = from
+    while i < n do
+      val c = chars(i)
+      if c == '"' then return i + 1
+      if c == '\n' || c == '\r' then return -1
+      if c == '\\' then
+        if i + 1 >= n || chars(i + 1) == '\n' || chars(i + 1) == '\r' then return -1
+        i += 2
+      else i += 1
+    -1
+
+  private def multiLineStringEnd(from: Int): Int =
+    var i = from
+    while i + 2 < n do
+      if chars(i) == '"' && chars(i + 1) == '"' && chars(i + 2) == '"' then return i + 3
+      i += 1
+    -1
+
+  /**
+   * The STRING body from `from` (just after the opening quote): the index after the closing
+   * quote of the longest accepted match, or -1. The only branch point is `#{`, which may be
+   * an interpolation or a literal `#` followed by `{`; the NFA keeps both alive, so both are
+   * tried and the longer accepted end wins.
+   */
+  private def stringEnd(from: Int): Int =
+    var i = from
+    while i < n do
+      val c = chars(i)
+      c match
+        case '"' => return i + 1
+        case '\n' | '\r' => return -1
+        case '\\' =>
+          val next = escapeEnd(i, allowHash = true)
+          if next < 0 then return -1
+          i = next
+        case '#' =>
+          if i + 1 < n && chars(i + 1) == '{' then
+            val bodyEnd = interpBodyEnd(i + 2)
+            val viaInterp = if bodyEnd >= 0 then stringEnd(bodyEnd) else -1
+            val viaPlain = stringEnd(i + 1)
+            return math.max(viaInterp, viaPlain)
+          i += 1
+        case _ => i += 1
+    -1
+
+  /** After `#{`: INTERP_BODY then `}`; returns the index after `}` or -1. */
+  private def interpBodyEnd(from: Int): Int =
+    var i = from
+    var depth = 0
+    while i < n do
+      val c = chars(i)
+      c match
+        case '}' =>
+          if depth == 0 then return i + 1
+          depth -= 1
+          i += 1
+        case '{' =>
+          if depth == 1 then return -1
+          depth += 1
+          i += 1
+        case '"' =>
+          val end = interpStringEnd(i + 1)
+          if end < 0 then return -1
+          i = end
+        case '\n' | '\r' => return -1
+        case _ => i += 1
+    -1
+
+  /** INTERP_STRING body: `( ~["\"","\\","\n","\r"] | "\\" ~["\n","\r"] )* "\""`. */
+  private def interpStringEnd(from: Int): Int = rawStringEnd(from)
+
+  /**
+   * An escape starting at the backslash at `i` (inside CHARACTER or STRING): the index after
+   * it, or -1 when it is not one of the accepted forms.
+   */
+  private def escapeEnd(i: Int, allowHash: Boolean): Int =
+    if i + 1 >= n then return -1
+    val c = chars(i + 1)
+    c match
+      case 'n' | 't' | 'b' | 'r' | 'f' | '\\' | '\'' | '"' => i + 2
+      case '#' if allowHash => i + 2
+      case _ if c >= '0' && c <= '7' =>
+        var j = i + 2
+        val max = if c <= '3' then 3 else 2
+        var count = 1
+        while count < max && j < n && chars(j) >= '0' && chars(j) <= '7' do
+          j += 1
+          count += 1
+        j
+      case _ => -1
+
+  private def characterEnd(from: Int): Int =
+    if from >= n then return -1
+    val c = chars(from)
+    if c == '\\' then
+      // Octal escapes are greedy in the regex, but the whole token still needs the closing
+      // quote; try the longest digit run first and fall back to shorter ones.
+      val d = if from + 1 < n then chars(from + 1) else '\u0000'
+      if d >= '0' && d <= '7' then
+        var count = 1
+        val max = if d <= '3' then 3 else 2
+        while count < max && from + 1 + count < n && chars(from + 1 + count) >= '0' && chars(from + 1 + count) <= '7' do count += 1
+        var k = count
+        while k >= 1 do
+          val close = from + 1 + k
+          if close < n && chars(close) == '\'' then return close + 1
+          k -= 1
+        -1
+      else
+        val next = escapeEnd(from, allowHash = false)
+        if next >= 0 && next < n && chars(next) == '\'' then next + 1 else -1
+    else if c == '\'' || c == '\n' || c == '\r' then -1
+    else if from + 1 < n && chars(from + 1) == '\'' then from + 2
+    else -1
+
+  private def fqcnEnd(from: Int): Int =
+    if from >= n || chars(from) != '<' then return -1
+    var i = from + 1
+    var expectId = true
+    while true do
+      if expectId then
+        if i < n && isIdentStart(chars(i)) then
+          i += 1
+          while i < n && isIdentPart(chars(i)) do i += 1
+          expectId = false
+        else return -1
+      else if i < n && chars(i) == '.' then
+        i += 1
+        expectId = true
+      else if i < n && chars(i) == '>' then return i + 1
+      else return -1
+    -1
+
+  // ---------------------------------------------------------------- numbers
+
+  private def number(start: Int): Token =
+    val intEnd = integerEnd(start)
+    val floatEnd = floatEnd0(start)
+    if floatEnd > intEnd then emit(K.FLOAT, start, floatEnd)
+    else emit(K.INTEGER, start, intEnd)
+
+  private def isDigit(c: Char): Boolean = c >= '0' && c <= '9'
+  private def isHex(c: Char): Boolean = isDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+
+  /** End of the longest INTEGER match at `start`, or `start` if none. */
+  private def integerEnd(start: Int): Int =
+    val c = chars(start)
+    var i = start
+    if c >= '1' && c <= '9' then
+      i += 1
+      while i < n && (isDigit(chars(i)) || chars(i) == '_') do i += 1
+    else if c == '0' then
+      if start + 2 < n && (chars(start + 1) == 'x' || chars(start + 1) == 'X') && isHex(chars(start + 2)) then
+        i = start + 3
+        while i < n && (isHex(chars(i)) || chars(i) == '_') do i += 1
+      else if start + 2 < n && chars(start + 1) == 'b' && (chars(start + 2) == '0' || chars(start + 2) == '1') then
+        i = start + 3
+        while i < n && (chars(i) == '0' || chars(i) == '1' || chars(i) == '_') do i += 1
+      else
+        i = start + 1
+        while i < n && ((chars(i) >= '0' && chars(i) <= '7') || chars(i) == '_') do i += 1
+    else return start
+    if i < n && (chars(i) == 'B' || chars(i) == 'S' || chars(i) == 'L') then i + 1 else i
+
+  /** End of the longest FLOAT match at `start`, or -1 if none. */
+  private def floatEnd0(start: Int): Int =
+    var best = -1
+    var i = start
+    if chars(start) == '.' then
+      i = digitsEnd(start + 1)
+      if i == start + 1 then return -1
+      best = withExponentAndSuffix(i, exponentRequired = false, suffixRequired = false)
+      return best
+    // [0-9][0-9_]*
+    i = digitsEnd(start)
+    // alt1: "." [0-9][0-9_]* (EXP)? ([FfDd])?
+    if i < n && chars(i) == '.' && i + 1 < n && isDigit(chars(i + 1)) then
+      val j = digitsEnd(i + 1)
+      best = math.max(best, withExponentAndSuffix(j, exponentRequired = false, suffixRequired = false))
+    // alt3: EXP ([FfDd])?
+    best = math.max(best, withExponentAndSuffix(i, exponentRequired = true, suffixRequired = false))
+    // alt4: (EXP)? [FfDd]
+    best = math.max(best, withExponentAndSuffix(i, exponentRequired = false, suffixRequired = true))
+    best
+
+  /** `[0-9][0-9_]*` from `from` (first char must be a digit); returns the end, or `from` if none. */
+  private def digitsEnd(from: Int): Int =
+    if from >= n || !isDigit(chars(from)) then return from
+    var i = from + 1
+    while i < n && (isDigit(chars(i)) || chars(i) == '_') do i += 1
+    i
+
+  private def withExponentAndSuffix(from: Int, exponentRequired: Boolean, suffixRequired: Boolean): Int =
+    var i = from
+    var hasExp = false
+    if i < n && (chars(i) == 'e' || chars(i) == 'E') then
+      var j = i + 1
+      if j < n && (chars(j) == '+' || chars(j) == '-') then j += 1
+      if j < n && isDigit(chars(j)) then
+        while j < n && isDigit(chars(j)) do j += 1
+        i = j
+        hasExp = true
+    if exponentRequired && !hasExp then return -1
+    val hasSuffix = i < n && (chars(i) == 'f' || chars(i) == 'F' || chars(i) == 'd' || chars(i) == 'D')
+    if suffixRequired && !hasSuffix then return -1
+    if hasSuffix then i + 1 else i
+
+  // ---------------------------------------------------------------- operators
+
+  private def operator(start: Int): Token =
+    val c = chars(start)
+    val c1 = if start + 1 < n then chars(start + 1) else '\u0000'
+    val c2 = if start + 2 < n then chars(start + 2) else '\u0000'
+    val c3 = if start + 3 < n then chars(start + 3) else '\u0000'
+    inline def tok(kind: Int, len: Int): Token = emit(kind, start, start + len)
+    c match
+      case '+' => if c1 == '+' then tok(K.PLUSPLUS, 2) else if c1 == '=' then tok(K.ADDEQ, 2) else tok(K.PLUS, 1)
+      case '-' => if c1 == '-' then tok(K.MINUSMINUS, 2) else if c1 == '=' then tok(K.SUBEQ, 2) else if c1 == '>' then tok(K.ARROW, 2) else tok(K.MINUS, 1)
+      case '*' => if c1 == '=' then tok(K.MULEQ, 2) else tok(K.STAR, 1)
+      case '/' => if c1 == '=' then tok(K.DIVEQ, 2) else tok(K.SLASH, 1)
+      case '%' => if c1 == '=' then tok(K.MODEQ, 2) else tok(K.PERC, 1)
+      case '<' =>
+        if c1 == '<' then (if c2 == '=' then tok(K.LSHIFTEQ, 3) else tok(K.L2S, 2))
+        else if c1 == '=' then tok(K.LTEQ, 2)
+        else if c1 == '-' then tok(K.LARROW, 2)
+        else if c1 == ':' then tok(K.SUBTYPE, 2)
+        else tok(K.LT, 1)
+      case '>' =>
+        if c1 == '>' then
+          if c2 == '>' then (if c3 == '=' then tok(K.URSHIFTEQ, 4) else tok(K.R3S, 3))
+          else if c2 == '=' then tok(K.RSHIFTEQ, 3)
+          else tok(K.R2S, 2)
+        else if c1 == '=' then tok(K.GTEQ, 2)
+        else tok(K.GT, 1)
+      case '=' => if c1 == '=' then (if c2 == '=' then tok(K.REFEQ, 3) else tok(K.EQ, 2)) else tok(K.ASSIGN, 1)
+      case '!' => if c1 == '=' then (if c2 == '=' then tok(K.REFNOTEQ, 3) else tok(K.NOTEQ, 2)) else if c1 == '!' then tok(K.NOT_NULL, 2) else tok(K.NOT, 1)
+      case '&' => if c1 == '&' then tok(K.AND, 2) else if c1 == '=' then tok(K.ANDEQ, 2) else tok(K.AMP, 1)
+      case '|' => if c1 == '|' then tok(K.OR, 2) else if c1 == '=' then tok(K.OREQ, 2) else if c1 == '>' then tok(K.PIPELINE, 2) else tok(K.BAR, 1)
+      case '^' => if c1 == '=' then tok(K.XOREQ, 2) else tok(K.EOR, 1)
+      case '~' => tok(K.BN, 1)
+      case ':' => if c1 == ':' then tok(K.COLON2, 2) else tok(K.COLON, 1)
+      case ';' => tok(K.SEMI, 1)
+      case '.' =>
+        if c1 == '.' then (if c2 == '.' then tok(K.ELLIPSIS, 3) else if c2 == '<' then tok(K.DOTDOT_LT, 3) else tok(K.DOTDOT, 2))
+        else tok(K.DOT, 1)
+      case '{' => tok(K.LBRACE, 1)
+      case '}' => tok(K.RBRACE, 1)
+      case '(' => tok(K.LPAREN, 1)
+      case ')' => tok(K.RPAREN, 1)
+      case ',' => tok(K.COMMA, 1)
+      case '[' => tok(K.LBRACKET, 1)
+      case ']' => tok(K.RBRACKET, 1)
+      case '?' => if c1 == ':' then tok(K.ELVIS, 2) else if c1 == '.' then tok(K.SAFE_ACCESS, 2) else if c1 == '[' then tok(K.SAFE_INDEX, 2) else tok(K.QUESTION, 1)
+      case _ => tok(K.ERROR, 1)
+
+  extension [A](a: A) private inline def tap(f: A => Unit): A = { f(a); a }
+
+object OnionLexer:
+  private val TabSize = 8
+  private val DEFAULT = 0
+  private val IN_STATEMENT = 1
+
+  private def isIdentStart(c: Char): Boolean =
+    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+
+  private def isIdentPart(c: Char): Boolean =
+    isIdentStart(c) || (c >= '0' && c <= '9')
+
+  /** Keyword image -> kind, from the generated constant table; `void` and `Unit` share K_VOID. */
+  private val keywords: java.util.HashMap[String, Integer] =
+    val m = new java.util.HashMap[String, Integer]()
+    var kind = K.K_ABSTRACT
+    while kind <= K.K_WHILE do
+      val image = K.tokenImage(kind)
+      if image.length >= 2 && image.charAt(0) == '"' then m.put(image.substring(1, image.length - 1), kind)
+      kind += 1
+    m.put("void", K.K_VOID)
+    m.put("Unit", K.K_VOID)
+    m
+
+  private def keywordKind(word: String): Int =
+    val k = keywords.get(word)
+    if k == null then -1 else k.intValue

--- a/src/main/scala/onion/tools/doc/DocModel.scala
+++ b/src/main/scala/onion/tools/doc/DocModel.scala
@@ -2,7 +2,7 @@ package onion.tools.doc
 
 import java.io.StringReader
 import onion.compiler.AST
-import onion.compiler.parser.JJOnionParser
+import onion.compiler.parser.{JJOnionParser, OnionLexer}
 
 /** A documented member (method, field, or constructor) within a type. */
 final case class DocMember(
@@ -37,7 +37,7 @@ object DocModel {
    * @param sourceName a display name for the file (used in the model)
    */
   def fromSource(sourceText: String, sourceName: String): DocFile = {
-    val parser = new JJOnionParser(new StringReader(sourceText))
+    val parser = new JJOnionParser(new OnionLexer(sourceText))
     parser.enableErrorRecovery(100)
     val unit = parser.unit()
     val comments = scanDocComments(sourceText)

--- a/src/main/scala/onion/tools/format/OnionFormatter.scala
+++ b/src/main/scala/onion/tools/format/OnionFormatter.scala
@@ -2,7 +2,7 @@ package onion.tools.format
 
 import java.io.StringReader
 
-import onion.compiler.parser.{JJOnionParserConstants as K, JJOnionParserTokenManager, JavaCharStream, Token}
+import onion.compiler.parser.{JJOnionParserConstants as K, OnionLexer, Token}
 
 import scala.collection.mutable
 
@@ -172,7 +172,7 @@ object OnionFormatter:
   private def lex(source: String): Seq[Lexeme] =
     val raw = mutable.Buffer[Token]()
     val comments = mutable.Set[Token]()
-    val manager = new JJOnionParserTokenManager(new JavaCharStream(new StringReader(source)))
+    val manager = new OnionLexer(source)
     var token = manager.getNextToken()
     var done = false
     while !done do
@@ -240,7 +240,7 @@ object OnionFormatter:
   /** Every token and comment image, in order — the invariant a format must not disturb. */
   def signature(source: String): Seq[(Int, String)] =
     val out = mutable.Buffer[(Int, String)]()
-    val manager = new JJOnionParserTokenManager(new JavaCharStream(new StringReader(source)))
+    val manager = new OnionLexer(source)
     var token = manager.getNextToken()
     var done = false
     while !done do

--- a/src/main/scala/onion/tools/lsp/OnionSemanticTokens.scala
+++ b/src/main/scala/onion/tools/lsp/OnionSemanticTokens.scala
@@ -2,7 +2,7 @@ package onion.tools.lsp
 
 import java.io.StringReader
 
-import onion.compiler.parser.{JJOnionParserConstants as K, JJOnionParserTokenManager, JavaCharStream, Token}
+import onion.compiler.parser.{JJOnionParserConstants as K, OnionLexer, Token}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -219,7 +219,7 @@ object OnionSemanticTokens:
   private def tokens(content: String): Seq[(Token, Boolean)] =
     val out = mutable.Buffer[(Token, Boolean)]()
     try
-      val manager = new JJOnionParserTokenManager(new JavaCharStream(new StringReader(content)))
+      val manager = new OnionLexer(content)
       var token = manager.getNextToken()
       var done = false
       while !done do


### PR DESCRIPTION
## Summary

Second step of the compile-time work (after #1063): the parser. Parsing the whole `run/` corpus (247 files) drops from 365 ms to 105 ms of CPU after warm-up, taking the parser from ~16% of a warm compilation to ~5%.

- **Handwritten lexer** `OnionLexer`, a drop-in subclass of the generated token manager (the generated parser, `onion fmt` and LSP semantic tokens use it unchanged). Byte-identical token stream, pinned by a golden over 455k tokens: kinds, images, positions, comment special-token chains, both lexical states, `JavaCharStream` unicode-escape and tab-column bookkeeping, the `return"x"` keyword re-cut. The generated `IN_STATEMENT` NFA ran ~5x slower than `DEFAULT` while the states differ only in whether a newline is `EOL`.
- **Explicit lookaheads in the grammar.** JavaCC cannot compute a first set through a choice with semantic lookahead, so the catch-all alternatives of `expression`/`argument_expr`/`unary_prefix`/`primary` and the optionals in `terms`/`block`/`block_elements`/`unit` were decided by implicit `jj_2_N(1)` scans that walked the full precedence chain for one token: about half of parse time. They are explicit token checks now. The eleven unbounded `Type::member` scans and the `( ... ) ->` scan in `primary` sit behind a token peek, guarded with `jj_lookingAhead` so a peek never lexes ahead in the wrong lexical state during a syntactic scan (that bug surfaced as lost `EOL`s and is documented in the grammar).
- **Syntax hints classify against the full expected-token list.** The classifier read the four-item user-facing summary; the grammar change moved `;` to fifth place and silently disabled sixteen hints. Collected errors now carry `expectedAll`; user-visible messages are unchanged.

ASTs (`--dump-ast`) are identical to `develop` over all 258 programs in `run/` and `src/test/run/`. JavaCC's five pre-existing choice-conflict warnings are unchanged.

## Measurements

Readiness benchmark, quiet machine, this branch vs the v0.33 jar (before #1063):

| scenario | v0.33 | this PR |
|---|---|---|
| steady-fresh stats-app | 34.9 ms | 14.0 ms |
| steady-fresh todo-manager | 42.6 ms | 19.2 ms |
| steady-fresh hello | 6.8 ms | 3.6 ms |
| REPL growing-state | 21.9 ms | 10.9 ms |
| process-cold hello | 618 ms | 600 ms |

## Test plan

- [x] token golden: 258 files, 455,132 tokens, zero differences
- [x] AST dumps identical to baseline over 258 programs
- [x] `sbt -Duser.language=en testFull` — 4683 passed
- [x] `sbt -Duser.language=ja testFull` — 4683 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc