### PR TITLE
perf: skip law checking without checks, trim small per-compilation costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Law checking no longer costs anything for programs without laws.** `LawCheckPhase`
+  built a class loader, defined every generated class and reflected over its methods on
+  every compilation, only to find no `law`/`example` to run -- about 15% of a warm
+  compilation. It now scans the class bytes for the check-method name prefixes (a
+  method name is a constant-pool UTF8 entry, so a class without the bytes has no check)
+  and returns before touching a class loader when nothing carries one.
+- Smaller per-compilation costs: classpath entry URLs are cached by path and kind
+  (`File.toURI` stat-ed every entry per compilation); the handwritten lexer computes
+  token positions with a cursor instead of two ints per source character, and shares the
+  images of keywords and operators; the constructor-delegation cycle walk is skipped
+  for classes without a self-delegating constructor; `MethodFinder` returns a lone
+  candidate without filtering and sorting; the assigned-variable scan indexes product
+  elements directly and treats `Location` as a leaf; the LocalVariableTable names come
+  from an array rather than a `Map`.
+
 ## [0.35.0] - 2026-09-02
 
 ### Changed

--- a/src/main/scala/onion/compiler/AssignedVariableScanner.scala
+++ b/src/main/scala/onion/compiler/AssignedVariableScanner.scala
@@ -47,8 +47,14 @@ object AssignedVariableScanner {
       }
       n match {
         case p: Product =>
-          val it = p.productIterator
-          while (it.hasNext) acc = union(acc, visitAny(it.next()))
+          // productElement by index: the iterator form allocated per node and this is the
+          // innermost loop of the walk.
+          val arity = p.productArity
+          var i = 0
+          while (i < arity) {
+            acc = union(acc, visitAny(p.productElement(i)))
+            i += 1
+          }
         case _ =>
       }
       memo.put(n, acc)
@@ -56,6 +62,7 @@ object AssignedVariableScanner {
     }
 
     def visitAny(any: Any): Set[String] = any match {
+      case _: String | _: java.lang.Number | _: java.lang.Boolean | _: Location | null => Set.empty
       case n: AST.Node => visitNode(n)
       case s: Iterable[_] =>
         var acc: Set[String] = Set.empty

--- a/src/main/scala/onion/compiler/LocalFrame.scala
+++ b/src/main/scala/onion/compiler/LocalFrame.scala
@@ -49,6 +49,15 @@ class LocalFrame(val parent: LocalFrame) {
   def namesByIndex: Map[Int, String] =
     allScopes.iterator.flatMap(_.bindingEntries.map { case (name, binding) => binding.index -> name }).toMap
 
+  /** The same relation as `namesByIndex` as an array (null = no name), which is what codegen needs. */
+  def namesArray: Array[String] = {
+    var max = -1
+    allScopes.foreach(_.bindingEntries.foreach { case (_, b) => if (b.index > max) max = b.index })
+    val names = new Array[String](max + 1)
+    allScopes.foreach(_.bindingEntries.foreach { case (name, b) => if (b.index >= 0) names(b.index) = name })
+    names
+  }
+
   def entries: Seq[LocalBinding] = {
     // Per method at codegen and for closures; the HashSet-per-scope merge it replaced
     // showed on the profile.

--- a/src/main/scala/onion/compiler/TypedAST.scala
+++ b/src/main/scala/onion/compiler/TypedAST.scala
@@ -1341,6 +1341,8 @@ object TypedAST {
       find(methods, target, name, arguments)
       // Java-style phasing: a fixed-arity match beats vararg matches
       val all = methods.asScala.toArray
+      // Zero or one candidate needs no filtering or sorting; that is the common case.
+      if (all.length <= 1) return all
       val candidates = {
         val fixedArity = all.filter(m => !m.isVararg || matcher.matches(m.arguments, arguments))
         if (fixedArity.nonEmpty) fixedArity else all

--- a/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
+++ b/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
@@ -19,10 +19,10 @@ class LocalVarContext(gen: GeneratorAdapter) {
   // the time codegen runs. A slot with no name is simply left out of the table rather
   // than invented — a debugger showing `var3` is worse than showing nothing.
   private var nameFrame: onion.compiler.LocalFrame = null
-  private var namesCache: Map[Int, String] = null
+  private var namesCache: Array[String] = null
   // Built on the first slot that needs a name: a method with no locals never pays for it.
-  private def names: Map[Int, String] = {
-    if (namesCache == null) namesCache = if (nameFrame == null) Map.empty else nameFrame.namesByIndex
+  private def names: Array[String] = {
+    if (namesCache == null) namesCache = if (nameFrame == null) Array.empty else nameFrame.namesArray
     namesCache
   }
   private val debugLocals = mutable.Buffer[DebugLocal]()
@@ -36,7 +36,9 @@ class LocalVarContext(gen: GeneratorAdapter) {
   def declaredLocals: Seq[DebugLocal] = debugLocals.toSeq
 
   private def recordDebug(typedIndex: Int, slot: Int, tp: AsmType): Unit =
-    names.get(typedIndex).foreach { name =>
+    val table = names
+    val name = if (typedIndex >= 0 && typedIndex < table.length) table(typedIndex) else null
+    Option(name).foreach { name =>
       debugLocals += DebugLocal(slot, name, tp.getDescriptor)
     }
 

--- a/src/main/scala/onion/compiler/environment/ClassFileTable.scala
+++ b/src/main/scala/onion/compiler/environment/ClassFileTable.scala
@@ -21,10 +21,18 @@ class ClassFileTable(classPathString: String) {
   private val bytesCache = new ConcurrentHashMap[String, Option[Array[Byte]]]()
 
   private def createClassLoader(classPath: String): ClassLoader = {
+    // `File.toURI` stats the path to decide on a trailing slash (directory vs jar), on
+    // every entry of every compilation. The URL depends only on the path and that one
+    // bit, so it is cached by both; the bit is still checked each time, so a directory
+    // created after the first compilation is picked up.
     val urls =
       classPath.split(File.pathSeparator, -1).iterator
         .filter(_.nonEmpty)
-        .map(path => new File(path).toURI.toURL)
+        .map { path =>
+          val file = new File(path)
+          val key = if (file.isDirectory) path + File.separator else path
+          ClassFileTable.urls.computeIfAbsent(key, _ => file.toURI.toURL)
+        }
         .toArray
     ExplicitClasspathClassLoader(
       urls,
@@ -57,4 +65,8 @@ class ClassFileTable(classPathString: String) {
     bytesCache.putIfAbsent(className, loaded)
     loaded.orNull
   }
+}
+
+object ClassFileTable {
+  private val urls = new ConcurrentHashMap[String, java.net.URL]()
 }

--- a/src/main/scala/onion/compiler/parser/OnionLexer.scala
+++ b/src/main/scala/onion/compiler/parser/OnionLexer.scala
@@ -35,10 +35,51 @@ final class OnionLexer(text: String)
   // ---------------------------------------------------------------- decoded input
 
   private val length: Int = text.length
-  private val chars: Array[Char] = new Array[Char](length)
-  private val lines: Array[Int] = new Array[Int](length)
-  private val cols: Array[Int] = new Array[Int](length)
-  private val n: Int = decode()
+  // A source without a `\u` escape -- nearly all of them -- is scanned in place and its
+  // positions are computed by a cursor that follows the tokens (they are emitted in order),
+  // instead of two ints per character up front. The escape path keeps the eager tables,
+  // because a decoded char's position is not a function of its index alone.
+  private val fast: Boolean = text.indexOf("\\u") < 0
+  private val chars: Array[Char] = if fast then text.toCharArray else new Array[Char](length)
+  private val lines: Array[Int] = if fast then null else new Array[Int](length)
+  private val cols: Array[Int] = if fast then null else new Array[Int](length)
+  private val n: Int = if fast then length else decode()
+
+  // The position cursor of the fast path: the line/column JavaCharStream would have
+  // recorded for chars(cursorIndex), advanced with the same rules as `decode`.
+  private var cursorIndex = -1
+  private var cursorLine = 1
+  private var cursorColumn = 0
+  private var cursorPrevCR = false
+  private var cursorPrevLF = false
+
+  private def advanceTo(index: Int): Unit =
+    if index < cursorIndex then
+      cursorIndex = -1; cursorLine = 1; cursorColumn = 0; cursorPrevCR = false; cursorPrevLF = false
+    while cursorIndex < index do
+      cursorIndex += 1
+      val c = chars(cursorIndex)
+      cursorColumn += 1
+      if cursorPrevLF then
+        cursorPrevLF = false
+        cursorColumn = 1
+        cursorLine += 1
+      else if cursorPrevCR then
+        cursorPrevCR = false
+        if c == '\n' then cursorPrevLF = true
+        else
+          cursorColumn = 1
+          cursorLine += 1
+      c match
+        case '\r' => cursorPrevCR = true
+        case '\n' => cursorPrevLF = true
+        case '\t' =>
+          cursorColumn -= 1
+          cursorColumn += TabSize - (cursorColumn % TabSize)
+        case _ =>
+
+  private def lineAt(index: Int): Int = if fast then { advanceTo(index); cursorLine } else lines(index)
+  private def columnAt(index: Int): Int = if fast then { advanceTo(index); cursorColumn } else cols(index)
 
   private var pos: Int = 0
   private var pendingSpecial: Token = null
@@ -190,19 +231,21 @@ final class OnionLexer(text: String)
     val t = Token.newToken(K.EOF, "")
     // JavaCC reports the position of the last character it consumed.
     if n > 0 then
-      t.beginLine = lines(n - 1); t.beginColumn = cols(n - 1)
-      t.endLine = lines(n - 1); t.endColumn = cols(n - 1)
+      t.beginLine = lineAt(n - 1); t.beginColumn = columnAt(n - 1)
+      t.endLine = t.beginLine; t.endColumn = t.beginColumn
     else
       t.beginLine = 0; t.beginColumn = 0; t.endLine = 0; t.endColumn = 0
     t
 
   /** A token covering `[start, end)` of the decoded input. */
   private def make(kind: Int, start: Int, end: Int): Token =
-    val t = Token.newToken(kind, new String(chars, start, end - start))
-    t.beginLine = lines(start)
-    t.beginColumn = cols(start)
-    t.endLine = lines(end - 1)
-    t.endColumn = cols(end - 1)
+    // Keywords and operators have one spelling; their image is the shared constant.
+    val fixed = fixedImages(kind)
+    val t = Token.newToken(kind, if fixed != null then fixed else new String(chars, start, end - start))
+    t.beginLine = lineAt(start)
+    t.beginColumn = columnAt(start)
+    t.endLine = lineAt(end - 1)
+    t.endColumn = columnAt(end - 1)
     t
 
   private def blockCommentEnd(from: Int): Int =
@@ -553,6 +596,16 @@ object OnionLexer:
     m.put("void", K.K_VOID)
     m.put("Unit", K.K_VOID)
     m
+
+  /** The image of each single-spelling token (keywords, operators); null for the rest. */
+  private val fixedImages: Array[String] =
+    val a = new Array[String](K.tokenImage.length)
+    var kind = K.K_ABSTRACT
+    while kind <= K.SAFE_INDEX do
+      val image = K.tokenImage(kind)
+      if image.length >= 2 && image.charAt(0) == '"' then a(kind) = image.substring(1, image.length - 1)
+      kind += 1
+    a
 
   private def keywordKind(word: String): Int =
     val k = keywords.get(word)

--- a/src/main/scala/onion/compiler/typing/DeclarationBodySupport.scala
+++ b/src/main/scala/onion/compiler/typing/DeclarationBodySupport.scala
@@ -75,6 +75,8 @@ private[compiler] final class DeclarationBodySupport(
    */
   private def reportDelegationCycles(node: AST.ClassDeclaration, definition: ClassDefinition): Unit = {
     val ctors = definition.constructors.collect { case c: ConstructorDefinition => c }
+    // A cycle needs a self-delegating constructor; without one there is nothing to walk.
+    if (!ctors.exists(c => c.superInitializer != null && c.superInitializer.selfDelegation)) return
     def target(c: ConstructorDefinition): Option[ConstructorDefinition] =
       Option(c.superInitializer).filter(_.selfDelegation).flatMap { init =>
         ctors.find(sibling => sibling.getArgs.toSeq == init.arguments.toSeq)

--- a/src/main/scala/onion/compiler/verification/CheckMethodIndex.scala
+++ b/src/main/scala/onion/compiler/verification/CheckMethodIndex.scala
@@ -42,6 +42,33 @@ private[verification] object CheckMethodIndex {
    * Never throws: a class file this phase cannot parse must not fail the build on its
    * own, it just yields no position and the diagnostic degrades to what it printed before.
    */
+  private val LawNeedle = "onion$$law$$".getBytes("UTF-8")
+  private val ExampleNeedle = "onion$$example$$".getBytes("UTF-8")
+
+  /**
+   * Whether the class can carry a check at all: a check is a method whose name starts with
+   * one of the two prefixes, and a method name is a UTF8 constant-pool entry, so a class
+   * without either byte sequence has none. A byte scan is far cheaper than the ClassReader
+   * pass `read` makes, and nearly every class fails it.
+   */
+  def mayHaveChecks(bytes: Array[Byte]): Boolean =
+    contains(bytes, LawNeedle) || contains(bytes, ExampleNeedle)
+
+  private def contains(hay: Array[Byte], needle: Array[Byte]): Boolean = {
+    val first = needle(0)
+    val last = hay.length - needle.length
+    var i = 0
+    while (i <= last) {
+      if (hay(i) == first) {
+        var j = 1
+        while (j < needle.length && hay(i + j) == needle(j)) j += 1
+        if (j == needle.length) return true
+      }
+      i += 1
+    }
+    false
+  }
+
   def read(bytes: Array[Byte]): CheckMethodIndex =
     try {
       var source: Option[String] = None

--- a/src/main/scala/onion/compiler/verification/LawCheckPhase.scala
+++ b/src/main/scala/onion/compiler/verification/LawCheckPhase.scala
@@ -34,6 +34,11 @@ final class LawCheckPhase(config: CompilerConfig)
 
   def run(classes: Seq[CompiledClass], ctx: PhaseContext): Seq[CompiledClass] = {
     if (!config.checkLaws) return classes
+    // Most programs declare no law or example. Reading the check index first (a cheap scan
+    // of the class bytes) avoids building a class loader and defining every generated class
+    // just to discover there is nothing to run -- which was ~15% of a warm compilation.
+    val indexes = classes.collect { case cc if CheckMethodIndex.mayHaveChecks(cc.content) => cc -> CheckMethodIndex.read(cc.content) }
+    if (!indexes.exists(_._2.hasChecks)) return classes
     // Same parent CL as Shell.run so synthesized methods resolve the onion stdlib.
     val loader = new OnionClassLoader(classOf[OnionClassLoader].getClassLoader, config.classPath, classes)
     val errors = ArrayBuffer.empty[CompileError]
@@ -41,10 +46,9 @@ final class LawCheckPhase(config: CompilerConfig)
     val previous = thread.getContextClassLoader
     thread.setContextClassLoader(loader)
     try {
-      for (cc <- classes) {
+      for ((cc, index) <- indexes) {
         // initialize=false: don't run static initializers (top-level side effects) just to
         // scan for check methods; invoking a check lazily initializes only that record class.
-        val index = CheckMethodIndex.read(cc.content)
         val clazz = try Class.forName(cc.className, false, loader) catch { case _: Throwable => null }
         if (clazz != null) {
           for (m <- clazz.getDeclaredMethods if isBooleanStatic(m)) {


### PR DESCRIPTION
## Summary

- **Law checking costs nothing for programs without laws.** `LawCheckPhase` created an `OnionClassLoader`, defined every generated class and reflected over its methods on every compilation, just to find no `law`/`example`: ~15% of a warm compilation. It now scans class bytes for the check-method name prefixes (a method name is a constant-pool UTF8 entry) and returns before touching a class loader when nothing carries one.
- Classpath entry URLs cached by path and kind (`File.toURI` stat-ed each entry per compilation).
- Handwritten lexer: token positions from a cursor instead of two ints per source char; keyword/operator images shared. Token golden still zero differences (455k tokens, plus a `\u`-escape case).
- Constructor-delegation cycle walk skipped without a self-delegating constructor; `MethodFinder` returns a lone candidate directly; assigned-variable scan indexes product elements and treats `Location` as a leaf; LocalVariableTable names from an array.

## Measurements

Readiness benchmark, same machine, interleaved with the v0.35.0 jar: stats-app 12.4 -> 11.4 ms, todo-manager 18.3 -> 15.6 ms, hello 2.9 -> 2.5 ms, REPL 9.6 -> 8.3 ms. In-process CPU on StatsApp after warm-up: 6.5 -> 5.3 ms, of which LawCheck 0.88 -> 0.02 ms.

## Test plan

- [x] `sbt -Duser.language=en testFull` — 4707 passed
- [x] `sbt -Duser.language=ja testFull` — 4707 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc