### PR TITLE
perf: less bookkeeping per typed node and per call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Less bookkeeping per typed node and per call site: the applied-type cache is keyed by
+  raw class identity then argument list (no tuple, no name hashing); the per-compilation
+  candidate memos are nested maps rather than tuple-keyed; extension-method candidates are
+  memoized per (receiver type, name); the bridge emitter indexes a class's methods by
+  name instead of scanning them for every method of every generic supertype; the
+  named-method existence test walks with an early exit instead of collecting a candidate
+  set; `MethodResolutionSupport` creates its caches on first use; `openTypeParams` and
+  `LocalFrame.open` are inlined so their blocks are no longer closures; the reflective
+  child walk fills one buffer instead of chaining iterators.
+
 ## [0.37.0] - 2026-09-03
 
 ### Changed

--- a/src/main/scala/onion/compiler/ClassTable.scala
+++ b/src/main/scala/onion/compiler/ClassTable.scala
@@ -93,14 +93,29 @@ class ClassTable(classPath: String, parent: Option[ClassTable] = None) {
    * Per-compilation memo of the overload candidates of (receiver type, method name): the
    * hierarchy walk that collects them is the same at every call site of that pair.
    */
-  private val candidateMemo = new java.util.HashMap[(TypedAST.ObjectType, String), Array[TypedAST.Method]]()
+  private val candidateMemo = new java.util.IdentityHashMap[TypedAST.ObjectType, java.util.HashMap[String, Array[TypedAST.Method]]]()
   def methodCandidatesOf(target: TypedAST.ObjectType, name: String)(compute: => Array[TypedAST.Method]): Array[TypedAST.Method] = {
-    val key = (target, name)
-    val cached = candidateMemo.get(key)
+    var byName = candidateMemo.get(target)
+    if (byName == null) { byName = new java.util.HashMap[String, Array[TypedAST.Method]](); candidateMemo.put(target, byName) }
+    val cached = byName.get(name)
     if (cached != null) cached
     else {
       val fresh = compute
-      candidateMemo.put(key, fresh)
+      byName.put(name, fresh)
+      fresh
+    }
+  }
+
+  /** Per-compilation memo of the extension methods named `name` visible from a receiver type. */
+  private val extensionMemo = new java.util.IdentityHashMap[TypedAST.ObjectType, java.util.HashMap[String, Seq[onion.compiler.TypedAST.ExtensionMethodDefinition]]]()
+  def extensionCandidatesOf(target: TypedAST.ObjectType, name: String)(compute: => Seq[onion.compiler.TypedAST.ExtensionMethodDefinition]): Seq[onion.compiler.TypedAST.ExtensionMethodDefinition] = {
+    var byName = extensionMemo.get(target)
+    if (byName == null) { byName = new java.util.HashMap[String, Seq[onion.compiler.TypedAST.ExtensionMethodDefinition]](); extensionMemo.put(target, byName) }
+    val cached = byName.get(name)
+    if (cached != null) cached
+    else {
+      val fresh = compute
+      byName.put(name, fresh)
       fresh
     }
   }

--- a/src/main/scala/onion/compiler/LocalFrame.scala
+++ b/src/main/scala/onion/compiler/LocalFrame.scala
@@ -23,7 +23,7 @@ class LocalFrame(val parent: LocalFrame) {
 
   allScopes += scope
 
-  def open[A](block: => A): A = {
+  inline def open[A](inline block: A): A = {
     try {
       scope = new LocalScope(scope)
       allScopes += scope

--- a/src/main/scala/onion/compiler/TermWalk.scala
+++ b/src/main/scala/onion/compiler/TermWalk.scala
@@ -60,13 +60,29 @@ object TermWalk:
         .toArray)
 
   private def reflectiveChildren(node: AnyRef): Seq[AnyRef] =
-    accessorsOf(node.getClass).iterator
-      .flatMap { m =>
-        try
-          m.invoke(node) match
-            case null => Nil
-            case arr: Array[?] => arr.toSeq.collect { case r: AnyRef => r }
-            case list: java.util.List[?] => scala.jdk.CollectionConverters.ListHasAsScala(list).asScala.toSeq.collect { case r: AnyRef => r }
-            case other: AnyRef => Seq(other)
-        catch case _: Throwable => Nil
-      }.toSeq
+    // One buffer, filled by index: the iterator/flatMap/toSeq chain it replaces allocated
+    // several collections per node on every walk.
+    val methods = accessorsOf(node.getClass)
+    val out = new scala.collection.mutable.ArrayBuffer[AnyRef](methods.length)
+    var i = 0
+    while i < methods.length do
+      try
+        methods(i).invoke(node) match
+          case null =>
+          case arr: Array[?] =>
+            var j = 0
+            while j < arr.length do
+              arr(j) match
+                case r: AnyRef => out += r
+                case _ =>
+              j += 1
+          case list: java.util.List[?] =>
+            val it = list.iterator()
+            while it.hasNext do
+              it.next() match
+                case r: AnyRef => out += r
+                case _ =>
+          case other: AnyRef => out += other
+      catch case _: Throwable => ()
+      i += 1
+    out.toSeq

--- a/src/main/scala/onion/compiler/TypedAST.scala
+++ b/src/main/scala/onion/compiler/TypedAST.scala
@@ -1012,10 +1012,23 @@ object TypedAST {
     // suites), so it has to be a concurrent map. It only pays off when the raw class types
     // are the same instances across compilations, which ClassTable.shared now guarantees
     // for platform and runtime classes.
-    private val cache = new java.util.concurrent.ConcurrentHashMap[(TypedAST.ClassType, scala.collection.immutable.List[TypedAST.Type]), AppliedClassType]()
+    // Two levels: the raw class by identity, then the argument list. A single map keyed by
+    // a (raw, list) tuple hashed the raw type's name and allocated the tuple on every
+    // lookup, and this is asked for every written type annotation.
+    private val cache = new java.util.concurrent.ConcurrentHashMap[TypedAST.ClassType, java.util.concurrent.ConcurrentHashMap[scala.collection.immutable.List[TypedAST.Type], AppliedClassType]]()
 
     def apply(raw: TypedAST.ClassType, typeArguments: scala.collection.immutable.List[TypedAST.Type]): AppliedClassType =
-      cache.computeIfAbsent((raw, typeArguments), _ => new AppliedClassType(raw, typeArguments.toArray[TypedAST.Type]))
+      var perRaw = cache.get(raw)
+      if perRaw == null then
+        perRaw = new java.util.concurrent.ConcurrentHashMap[scala.collection.immutable.List[TypedAST.Type], AppliedClassType]()
+        val winner = cache.putIfAbsent(raw, perRaw)
+        if winner != null then perRaw = winner
+      val cached = perRaw.get(typeArguments)
+      if cached != null then cached
+      else
+        val fresh = new AppliedClassType(raw, typeArguments.toArray[TypedAST.Type])
+        val winner = perRaw.putIfAbsent(typeArguments, fresh)
+        if winner == null then fresh else winner
   }
 
   final class AppliedClassType private(val raw: TypedAST.ClassType, val typeArguments: Array[TypedAST.Type])

--- a/src/main/scala/onion/compiler/Typing.scala
+++ b/src/main/scala/onion/compiler/Typing.scala
@@ -334,7 +334,7 @@ class Typing(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Compi
   private[compiler] def mapFromDeclared(typeNode: AST.TypeNode, mapper: NameResolver): Option[Type] =
     typeSupport.mapFrom(typeNode, mapper, banRaw = true)
 
-  private[compiler] def openTypeParams[A](scope: TypeParamScope)(block: => A): A =
+  private[compiler] inline def openTypeParams[A](scope: TypeParamScope)(inline block: A): A =
     typeSupport.openTypeParams(scope)(block)
 
   private[compiler] def createTypeParams(nodes: List[AST.TypeParameter]): Seq[TypeParam] =

--- a/src/main/scala/onion/compiler/backend/asm/BridgeMethodEmitter.scala
+++ b/src/main/scala/onion/compiler/backend/asm/BridgeMethodEmitter.scala
@@ -21,9 +21,13 @@ final class BridgeMethodEmitter(private val codegen: AsmCodeGeneration) {
     // a method declared at several levels of the generic hierarchy (e.g. addLast
     // on both List and SequencedCollection) yields a single bridge instead of a
     // duplicate (which would be a ClassFormatError).
-    val emitted = scala.collection.mutable.HashSet.from(classDef.methods.map { m =>
+    val ownMethods = classDef.methods // one copy: `methods` builds a fresh Seq per call
+    val emitted = scala.collection.mutable.HashSet.from(ownMethods.map { m =>
       (m.name, methodDesc(m.returnType, m.arguments))
     })
+    // Indexed by name: the search below ran over every method of the class for every
+    // method of every generic supertype, with per-argument compatibility checks.
+    val ownByName = ownMethods.groupBy(_.name)
 
     for source <- sources do
       val subst: Map[String, TypedAST.Type] =
@@ -35,9 +39,9 @@ final class BridgeMethodEmitter(private val codegen: AsmCodeGeneration) {
         if Modifier.isStatic(rawMethod.modifier) || Modifier.isPrivate(rawMethod.modifier) then
           ()
         else
-          val specializedArgs = rawMethod.arguments.map(substituteClassParams)
-          val implOpt = classDef.methods.find { m =>
-            m.name == rawMethod.name &&
+          val sameName = ownByName.getOrElse(rawMethod.name, Nil)
+          val specializedArgs = if sameName.isEmpty then null else rawMethod.arguments.map(substituteClassParams)
+          val implOpt = if sameName.isEmpty then None else sameName.find { m =>
             m.arguments.length == specializedArgs.length &&
             m.arguments.indices.forall(i => isBridgeCompatible(m.arguments(i), specializedArgs(i)))
           }

--- a/src/main/scala/onion/compiler/typing/ExtensionMethodFallbackSupport.scala
+++ b/src/main/scala/onion/compiler/typing/ExtensionMethodFallbackSupport.scala
@@ -231,6 +231,14 @@ private[compiler] final class ExtensionMethodFallbackSupport(
   private def collectExtensionMethods(
     targetType: ObjectType,
     name: String
+  ): Seq[ExtensionMethodDefinition] =
+    // The receiver hierarchy walk and the per-type name filter depend only on the
+    // (receiver type, name) pair; user extensions are all registered before body typing.
+    typing.table_.extensionCandidatesOf(targetType, name)(collectExtensionMethodsUncached(targetType, name))
+
+  private def collectExtensionMethodsUncached(
+    targetType: ObjectType,
+    name: String
   ): Seq[ExtensionMethodDefinition] = {
     val result = scala.collection.mutable.LinkedHashSet.empty[ExtensionMethodDefinition]
 

--- a/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
@@ -89,6 +89,29 @@ final class MethodCallTyping(
   ): Option[ResolvedMethodInvocation] =
     methodInvocationBuilderSupport.resolveInvocation(node, method, params, typeArgs, classSubst, expected)
 
+  /** Whether any method of `name` accepted by `filter` exists in the hierarchy: the walk of
+    * `collectMethodsMatching` with an early exit and no candidate set. */
+  private[typing] def existsMethodMatching(sourceType: ObjectType, name: String, filter: Method => Boolean): Boolean = {
+    def walk(currentType: ObjectType): Boolean = {
+      if (currentType == null) return false
+      val own = currentType.methods(name)
+      var i = 0
+      while (i < own.length) {
+        if (filter(own(i))) return true
+        i += 1
+      }
+      if (walk(currentType.superClass)) return true
+      val ifaces = currentType.interfaces
+      var j = 0
+      while (j < ifaces.length) {
+        if (walk(ifaces(j))) return true
+        j += 1
+      }
+      false
+    }
+    walk(sourceType)
+  }
+
   /** Collects methods matching the filter from a type hierarchy into candidates set */
   private[typing] def collectMethodsMatching(
     sourceType: ObjectType,

--- a/src/main/scala/onion/compiler/typing/MethodResolutionSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodResolutionSupport.scala
@@ -10,9 +10,21 @@ private[compiler] final class MethodResolutionSupport(
   params: Array[Term],
   table: ClassTable
 ) {
-  private val specializedArgsCache = HashMap[Method, Array[Type]]()
-  private val methodArgsWithTypeParamsCache = HashMap[Method, Array[Type]]()
-  private val viewSubstCache = HashMap[ClassType, scala.collection.immutable.Map[String, Type]]()
+  // Created on first use: a support object is built per call site, and most call sites
+  // never touch all three. (Plain null checks -- a `lazy val` here measurably slowed the
+  // hot path.)
+  private var specializedArgsCache0: HashMap[Method, Array[Type]] = null
+  private def specializedArgsCache: HashMap[Method, Array[Type]] =
+    if specializedArgsCache0 == null then specializedArgsCache0 = HashMap[Method, Array[Type]]()
+    specializedArgsCache0
+  private var methodArgsWithTypeParamsCache0: HashMap[Method, Array[Type]] = null
+  private def methodArgsWithTypeParamsCache: HashMap[Method, Array[Type]] =
+    if methodArgsWithTypeParamsCache0 == null then methodArgsWithTypeParamsCache0 = HashMap[Method, Array[Type]]()
+    methodArgsWithTypeParamsCache0
+  private var viewSubstCache0: HashMap[ClassType, scala.collection.immutable.Map[String, Type]] = null
+  private def viewSubstCache: HashMap[ClassType, scala.collection.immutable.Map[String, Type]] =
+    if viewSubstCache0 == null then viewSubstCache0 = HashMap[ClassType, scala.collection.immutable.Map[String, Type]]()
+    viewSubstCache0
   private val emptySubst = scala.collection.immutable.Map.empty[String, Type]
 
   def specializedArgs(method: Method): Array[Type] =

--- a/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
+++ b/src/main/scala/onion/compiler/typing/TypingTypeSupport.scala
@@ -75,7 +75,7 @@ final class TypingTypeSupport(private val typing: Typing) {
       case _ =>
     }
 
-  def openTypeParams[A](scope: TypeParamScope)(block: => A): A = {
+  inline def openTypeParams[A](scope: TypeParamScope)(inline block: A): A = {
     val prev = typing.typeParams_
     // Most openings add nothing (a method without type parameters inside a class without
     // them); `++` then returns the same scope, and there is nothing to switch.

--- a/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
@@ -120,11 +120,8 @@ private[compiler] final class UnqualifiedMethodCallSupport(
     }
   }
 
-  private def hasNamedMethod(targetType: ClassType, name: String, filter: Method => Boolean): Boolean = {
-    val candidates = new JTreeSet[Method](new MethodComparator)
-    calls.collectMethodsMatching(targetType, name, candidates, filter)
-    !candidates.isEmpty
-  }
+  private def hasNamedMethod(targetType: ClassType, name: String, filter: Method => Boolean): Boolean =
+    calls.existsMethodMatching(targetType, name, filter) // an existence test: no candidate set, early exit
 
   /**
    * Bidirectional-inference entry for an unqualified call whose arguments include


### PR DESCRIPTION
## Summary

Follow-up to #1072 on the type checker and backend, all local changes:

- Applied-type cache keyed by raw class identity, then the argument list (the tuple key hashed the class name and allocated per lookup, on every written type annotation).
- Per-compilation memos (overload candidates, extension candidates) as nested identity/name maps instead of tuple keys; extension-method candidates memoized per (receiver type, name).
- Bridge emitter indexes the class's methods by name (it scanned them for every method of every generic supertype, with per-argument compatibility checks).
- `hasNamedMethod` walks the hierarchy with an early exit instead of collecting a `TreeSet`.
- `MethodResolutionSupport` caches created on first use (plain null checks; a `lazy val` here measurably slowed the hot path).
- `openTypeParams` / `LocalFrame.open` inlined so the block is no longer a `Function0`; the reflective child walk fills one buffer.

## Measurements

Whole `run/` corpus in one JVM, CPU time, interleaved with v0.36.0: type checking 686/711 -> 635/638 ms per iteration. Against the v0.33 baseline the corpus now compiles in 1292 ms vs 4443 ms (about 3.5x).

## Test plan

- [x] `sbt -Duser.language=en testFull` — 4707 passed
- [x] `sbt -Duser.language=ja testFull` — 4707 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc