### PR TITLE
perf: no exceptions on the law-check class path, one sub-parser per file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- No exceptions on two ordinary paths: `OnionClassLoader` defines the classes it carries
+  directly instead of delegating to the parent first (a `ClassNotFoundException` per
+  generated class on every law-checked compilation and script run), and the string
+  interpolation sub-parser is reused across a file's `#{...}` fragments instead of being
+  constructed -- lookahead tables and a stack-trace-filling `LookaheadSuccess` -- per
+  fragment.
 - **Classes are generated in parallel.** Each class's code generation only reads the typed
   structures, so the classes of one compilation are emitted on the common pool when there
   are at least two; per-class state (closure counter, closure classes, visitor cache) is

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -30,6 +30,27 @@ public class JJOnionParser implements Parser {
   private int mset; // used for semantic lookahead
 
   // ========== Error Recovery Support ==========
+  /**
+   * The sub-parser for `#{...}` fragments, reused across the fragments of this parser:
+   * constructing a JJOnionParser allocates its lookahead tables and a LookaheadSuccess
+   * (an Error, with a stack trace) every time, and a file has one fragment per
+   * interpolated value. ReInit resets the generated state; the user state is reset here.
+   */
+  private JJOnionParser cachedInterpolationParser = null;
+
+  private JJOnionParser interpolationParser(String text) {
+    if (cachedInterpolationParser == null) {
+      cachedInterpolationParser = new JJOnionParser(new OnionLexer(text));
+    } else {
+      cachedInterpolationParser.ReInit(new OnionLexer(text));
+      cachedInterpolationParser.states.clear();
+      cachedInterpolationParser.errorRecoveryMode = false;
+      cachedInterpolationParser.collectedErrors.clear();
+      cachedInterpolationParser.mset = 0;
+    }
+    return cachedInterpolationParser;
+  }
+
   private boolean errorRecoveryMode = false;
   private ArrayList<ParseError> collectedErrors = new ArrayList<ParseError>();
   private int maxErrors = 10; // Maximum number of errors to collect before giving up
@@ -910,7 +931,7 @@ public class JJOnionParser implements Parser {
       // Parse the expression inside, padded so positions match the file
       String exprStr = str.substring(interpStart + 2, interpEnd - 1);
       String padding = interpolationPadding(str, interpStart + 2, loc, 1);
-      JJOnionParser exprParser = new JJOnionParser(new OnionLexer(padding + exprStr));
+      JJOnionParser exprParser = interpolationParser(padding + exprStr);
       try {
         AST.Expression expr = exprParser.term();
         append(expressions, expr);
@@ -979,7 +1000,7 @@ public class JJOnionParser implements Parser {
       // Parse the expression inside, padded so positions match the file
       String exprStr = str.substring(interpStart + 2, interpEnd - 1);
       String padding = interpolationPadding(str, interpStart + 2, loc, 3);
-      JJOnionParser exprParser = new JJOnionParser(new OnionLexer(padding + exprStr));
+      JJOnionParser exprParser = interpolationParser(padding + exprStr);
       try {
         AST.Expression expr = exprParser.term();
         append(expressions, expr);

--- a/src/main/scala/onion/compiler/OnionClassLoader.scala
+++ b/src/main/scala/onion/compiler/OnionClassLoader.scala
@@ -26,6 +26,21 @@ class OnionClassLoader @throws(classOf[MalformedURLException]) (parent: ClassLoa
 
   classes.foreach(k => loadClass(k.className))
 
+  // A class this loader carries is defined here directly. Delegating to the parent first
+  // (the default) made the parent throw ClassNotFoundException for every one of them --
+  // a stack trace per generated class, on every law-checked compilation and script run.
+  @throws(classOf[ClassNotFoundException])
+  protected override def loadClass(name: String, resolve: Boolean): Class[?] =
+    getClassLoadingLock(name).synchronized {
+      val loaded = findLoadedClass(name)
+      val result =
+        if (loaded != null) loaded
+        else if (pendingClasses.contains(name)) findClass(name)
+        else super.loadClass(name, false)
+      if (resolve) resolveClass(result)
+      result
+    }
+
   @throws(classOf[ClassNotFoundException])
   protected override def findClass(name: String): Class[?] =
     pendingClasses.remove(name) match {


### PR DESCRIPTION
## Summary

Two exception sources that a JFR exception profile over the whole `run/` corpus showed on ordinary compilations:

- **`OnionClassLoader`** loaded each class it carries parent-first, so the parent threw `ClassNotFoundException` (with a stack trace) for every generated class on every law-checked compilation and every script run. It now defines its own classes directly (child-first for the pending set, parent for everything else).
- **String interpolation** constructed a `JJOnionParser` per `#{...}` fragment: lookahead tables plus a `LookaheadSuccess` (an `Error`, so `fillInStackTrace`) each time. One sub-parser per parser is reused via `ReInit` with the user state (`states`, error recovery, `mset`) reset.

Corpus counts per compilation: `LookaheadSuccess` constructions ~50 -> ~5, `ClassNotFoundException` 6 -> 0. Whole-corpus CPU vs v0.36.0 (with #1072-#1074 included): 1252/1325 -> 1049/1073 ms per iteration.

## Test plan

- [x] interpolation, law/example, shape, sample, script-runner and shell specs (347) pass
- [ ] full suites both locales (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc