### PR TITLE
perf: skip body rewriting for units without do-notation or trait calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Rewriting no longer copies method bodies that have nothing to rewrite.** The only
+  body-level transforms are do-notation desugaring and trait-method-call lowering; the
+  parser records whether a unit contains either, and for the (common) units that do not,
+  Rewriting returns bodies as parsed instead of rebuilding every node. Declaration-level
+  rewriting (records, enums, tools, dictionaries) is unchanged.
+
 ## [0.40.0] - 2026-09-03
 
 ### Changed

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -51,6 +51,9 @@ public class JJOnionParser implements Parser {
     return cachedInterpolationParser;
   }
 
+  /** Set when a do-expression or trait method call is parsed; see AST.CompilationUnit.needsBodyRewrite. */
+  boolean needsBodyRewrite = false;
+
   private boolean errorRecoveryMode = false;
   private ArrayList<ParseError> collectedErrors = new ArrayList<ParseError>();
   private int maxErrors = 10; // Maximum number of errors to collect before giving up
@@ -934,6 +937,7 @@ public class JJOnionParser implements Parser {
       JJOnionParser exprParser = interpolationParser(padding + exprStr);
       try {
         AST.Expression expr = exprParser.term();
+        needsBodyRewrite |= exprParser.needsBodyRewrite;
         append(expressions, expr);
       } catch (Exception e) {
         throw new ParseException("Invalid expression in string interpolation: " + exprStr + " at " + loc);
@@ -1003,6 +1007,7 @@ public class JJOnionParser implements Parser {
       JJOnionParser exprParser = interpolationParser(padding + exprStr);
       try {
         AST.Expression expr = exprParser.term();
+        needsBodyRewrite |= exprParser.needsBodyRewrite;
         append(expressions, expr);
       } catch (Exception e) {
         throw new ParseException("Invalid expression in string interpolation: " + exprStr + " at " + loc);
@@ -1330,11 +1335,11 @@ AST.CompilationUnit unit() :{
       if (!collectError(errorToken, expectedSummary(e), expectedAll(e))) { throw e; }
       if (!skipToToplevelSyncPoint()) {
         // EOF reached while recovering: return what we have, errors are collected
-        return new AST.CompilationUnit(p(1, 1), null, module, imports, toList(tops));
+        return new AST.CompilationUnit(p(1, 1), null, module, imports, toList(tops), needsBodyRewrite);
       }
     }
   )+ <EOF> {
-    return new AST.CompilationUnit(p(1, 1),  null, module, imports, toList(tops));
+    return new AST.CompilationUnit(p(1, 1),  null, module, imports, toList(tops), needsBodyRewrite);
   }
 }
 
@@ -2805,7 +2810,7 @@ AST.Expression static_access_primary() : {
 }{
   LOOKAHEAD( class_type() type_arguments() "::" ) ty=class_type() tas=type_arguments() t="::" n=id() "(" es=terms() ")"
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
-    { es = AST.appendToList(es, tl); return new AST.TraitMethodCall(through(n), ty, tas, c(n), es); }
+    { es = AST.appendToList(es, tl); needsBodyRewrite = true; return new AST.TraitMethodCall(through(n), ty, tas, c(n), es); }
 | LOOKAHEAD( boxed_class_type() "::" id() type_arguments() "(" ) ty=boxed_class_type() t="::" n=id() tas=type_arguments() "(" es=terms() ")"
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es, tas); }
@@ -3008,6 +3013,7 @@ AST.DoExpression do_expression() :{
   {enterDefault();}
   t="do" "[" monadType=type() "]" "{" eols() stmts=do_clauses() eols() "}" {
     leaveDefault();
+    needsBodyRewrite = true;
     return new AST.DoExpression(p(t), monadType, stmts);
   }
 }

--- a/src/main/scala/onion/compiler/AST.scala
+++ b/src/main/scala/onion/compiler/AST.scala
@@ -103,7 +103,14 @@ object AST {
   case class Argument(location: Location, name: String, typeRef: TypeNode, defaultValue: Expression = null, isVararg: Boolean = false) extends Node
   case class CompilationUnit(
     location: Location, sourceFile: String/*nullable*/, module: ModuleDeclaration/*nullable*/,
-    imports: ImportClause, toplevels: List[Toplevel]) extends Node
+    imports: ImportClause, toplevels: List[Toplevel],
+    /**
+     * Whether any body of this unit contains a construct the Rewriting phase transforms
+     * (do-notation, a trait method call). The parser records it; when false, Rewriting
+     * leaves method bodies as they are instead of copying every node. Defaults to true
+     * so a unit built anywhere else is still rewritten.
+     */
+    needsBodyRewrite: Boolean = true) extends Node
   case class ModuleDeclaration(location: Location, name: String) extends Node
   case class ImportClause(
     location: Location,

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -162,7 +162,12 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
 
   private var topLevelExampleCount: Int = 0
 
+  // See AST.CompilationUnit.needsBodyRewrite: the only body-level transforms are do-notation
+  // and trait method calls, and most units have neither.
+  private var bodyRewriteNeeded: Boolean = true
+
   def rewrite(unit: AST.CompilationUnit): AST.CompilationUnit = {
+    bodyRewriteNeeded = unit.needsBodyRewrite
     checkInstanceCoherence(unit.toplevels)
     val newToplevels = Buffer.empty[AST.Toplevel]
     for (top <- unit.toplevels) top match {
@@ -1231,12 +1236,13 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
   }
 
   def rewriteBlockExpression(block: AST.BlockExpression): AST.BlockExpression = {
+    if (!bodyRewriteNeeded) return block
     if (block == null) return null
     val newElements = block.elements.map(rewriteBlockElement)
     block.copy(elements = newElements)
   }
 
-  def rewriteBlockElement(element: AST.BlockElement): AST.BlockElement = element match {
+  def rewriteBlockElement(element: AST.BlockElement): AST.BlockElement = if (!bodyRewriteNeeded) element else element match {
     case AST.LocalVariableDeclaration(loc, modifiers, name, typeRef, init) =>
       val rewrittenInit = init match {
         // `val r: M[E] = do[M] { ... }` — thread the declared element type E into
@@ -1262,7 +1268,7 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
       empty
   }
 
-  def rewriteExpression(expr: AST.Expression): AST.Expression = expr match {
+  def rewriteExpression(expr: AST.Expression): AST.Expression = if (!bodyRewriteNeeded) expr else expr match {
     // Do notation desugaring - the main transformation
     case doExpr: AST.DoExpression => desugarDoExpression(doExpr)
     case AST.RetStatement(loc, e) => AST.RetStatement(loc, rewriteExpression(e))


### PR DESCRIPTION
## Summary

The Rewriting phase rebuilt every node of every method body, but its only body-level transforms are do-notation desugaring and `TraitMethodCall` lowering (everything else it does is declaration-level: records, ADT enums, tools, dictionaries).

- The parser records whether a unit contains a `do` expression or a trait method call (`AST.CompilationUnit.needsBodyRewrite`, propagated from interpolation sub-parsers). It defaults to `true`, so a unit constructed anywhere but the parser is still rewritten.
- When false, `rewriteBlockExpression` / `rewriteBlockElement` / `rewriteExpression` return their input; the declaration-level rewriting runs as before.

## Measurements

Whole `run/` corpus: Rewriting 44 -> 24 ms per iteration; total CPU vs v0.36.0 1246/1193 -> 996/1059 ms (this branch includes #1072-#1075).

## Test plan

- [x] rewriting, do-notation, trait, interpolation, instance, sample and doc-example specs (660) pass
- [ ] full suites both locales (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc