### PR TITLE
fix: detect Scala-style postfix `match` expressions in syntax hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for Kruskal's minimum-spanning-tree algorithm. `docs/quality-bar.md` (en/ja) updated
   to the new sample counts (248 total, 188 large programs).
 
+### Fixed
+
+- **Diagnostic for a Scala-style postfix `match` expression (`value match { case ... }`).**
+  `match` isn't a reserved word, so this parsed as a complete statement (`value`)
+  followed by a stray second one (`match { ... }`), falling through to the generic
+  "missing call parentheses" hint (suggesting the nonsensical `value match(...)`) even
+  though the existing `error.parsing.hint.match_not_supported` message already claimed
+  to cover Scala's `match` -- only Rust's prefix `match value { ... }` shape actually
+  triggered it. `ControlFlowSyntaxHints` now recognizes the postfix shape too and
+  points at the same `select` fix. Pinned by a new case in `MatchStatementHintI18nSpec`.
+
 ## [0.42.0] - 2026-09-03
 
 ### Changed

--- a/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
+++ b/src/main/scala/onion/compiler/parser/ControlFlowSyntaxHints.scala
@@ -5,6 +5,15 @@ private[compiler] object ControlFlowSyntaxHints {
   private val LeadingSwitchStatement = """^\s*switch\b""".r
   private val LeadingWhenStatement = """^\s*when\b""".r
   private val LeadingMatchStatement = """^\s*match\b""".r
+  // Scala/OCaml's actual `match` shape is postfix (`value match { case ... }`),
+  // unlike Rust's prefix `match value { ... }` above -- `match` isn't a reserved
+  // word, so `value` parses as a complete statement on its own and the following
+  // `match` reads as a stray second statement, which also matches the generic
+  // missing-call-parens fallback (suggesting the nonsensical `value match(...)`
+  // reading `match` as a call target); keep this ahead of that case. Requires
+  // at least one token before `match` so a genuine leading `match {` (handled
+  // above) is never double-matched here.
+  private val PostfixMatchExpression = """^\s*\S.*?\bmatch\s*\{\s*$""".r
   private val DefaultCaseLabel = """^\s*default\s*:""".r
   private val ElifStatement = """\belif\b""".r
   private val ElsifStatement = """\belsif\b""".r
@@ -59,6 +68,8 @@ private[compiler] object ControlFlowSyntaxHints {
     } else if (found == "when" && LeadingWhenStatement.findFirstMatchIn(sourceLine).isDefined) {
       hint("error.parsing.hint.when_not_supported")
     } else if (LeadingMatchStatement.findFirstMatchIn(sourceLine).isDefined) {
+      hint("error.parsing.hint.match_not_supported")
+    } else if (found == "match" && PostfixMatchExpression.findFirstMatchIn(sourceLine).isDefined) {
       hint("error.parsing.hint.match_not_supported")
     } else if (DefaultCaseLabel.findFirstMatchIn(sourceLine).isDefined) {
       hint("error.parsing.hint.default_case_not_supported")

--- a/src/test/scala/onion/compiler/MatchStatementHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/MatchStatementHintI18nSpec.scala
@@ -52,4 +52,26 @@ class MatchStatementHintI18nSpec extends AnyFunSpec with Diagrams {
     // assertion holds regardless of the JVM's default locale.
     assert(msgs.contains("select"), s"expected the hint's `select` suggestion, got: $msgs")
   }
+
+  it("fires for a Scala-style postfix `expr match { ... }` expression") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val x: Int = 1
+        |    x match {
+        |      case 1:
+        |        IO::println("one")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    assert(msgs.contains("select"), s"expected the hint's `select` suggestion, got: $msgs")
+  }
 }

--- a/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
+++ b/src/test/scala/onion/compiler/parser/ControlFlowSyntaxHintsSpec.scala
@@ -10,6 +10,7 @@ class ControlFlowSyntaxHintsSpec extends AnyFunSpec with Matchers {
         ("value", "switch value {", "error.parsing.hint.switch_not_supported"),
         ("when", "when value {", "error.parsing.hint.when_not_supported"),
         ("value", "match value {", "error.parsing.hint.match_not_supported"),
+        ("match", "value match {", "error.parsing.hint.match_not_supported"),
         (":", "default:", "error.parsing.hint.default_case_not_supported"),
         ("condition", "} elif condition {", "error.parsing.hint.elif_not_supported"),
         ("unless", "unless done {", "error.parsing.hint.unless_not_supported"),


### PR DESCRIPTION
## Summary
- `error.parsing.hint.match_not_supported` already says Onion has no "Rust/Scala/OCaml-style `match` expression", but `ControlFlowSyntaxHints` only ever detected Rust's prefix shape (`match value { ... }`). Scala's actual postfix shape (`value match { case ... }`) fell through to the generic "missing call parentheses" hint instead, since `match` isn't a reserved word and parses as a stray second statement after `value`.
- Added a `PostfixMatchExpression` pattern to `ControlFlowSyntaxHints` so the postfix shape is recognized too and points at the same `select` fix, in both English and Japanese message bundles (no new message keys — reuses the existing `match_not_supported` key, which already describes both shapes correctly).
- Added a case to `ControlFlowSyntaxHintsSpec` and a new end-to-end case to `MatchStatementHintI18nSpec` covering the postfix form; both were verified red before the fix and green after.
- Noted the fix in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.parser.ControlFlowSyntaxHintsSpec onion.compiler.MatchStatementHintI18nSpec'` — red before the fix, green after
- [x] Manually verified via `sbt runScript` on a `value match { case 1: ... }` snippet in both English and Japanese locales
- [x] Full suite: `sbt shutdown && sbt -Duser.language=en testFull` — 4711 passed / 0 failed / 1 canceled (known distribution smoke test)
- [x] Full suite: `sbt shutdown && sbt -Duser.language=ja testFull` — 4711 passed / 0 failed / 1 canceled (same)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DusacGxkcu6h2tpr6Movn3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DusacGxkcu6h2tpr6Movn3)_