### PR TITLE
refactor(typing): replace non-local return with boundary/break in extension bidirectional call

### DIFF
--- a/src/main/scala/onion/compiler/typing/ExtensionMethodFallbackSupport.scala
+++ b/src/main/scala/onion/compiler/typing/ExtensionMethodFallbackSupport.scala
@@ -3,6 +3,8 @@ package onion.compiler.typing
 import onion.compiler.*
 import onion.compiler.TypedAST.*
 import onion.compiler.toolbox.Boxing
+import scala.util.boundary
+import scala.util.boundary.break
 
 private[compiler] final class ExtensionMethodFallbackSupport(
   typing: Typing,
@@ -148,7 +150,7 @@ private[compiler] final class ExtensionMethodFallbackSupport(
     context: LocalContext,
     expected: Type,
     untypedClosureIndices: Set[Int]
-  ): Option[Term] = {
+  ): Option[Term] = boundary {
     val name = node.name
     val args = node.args.toArray
 
@@ -156,7 +158,7 @@ private[compiler] final class ExtensionMethodFallbackSupport(
     for (i <- args.indices if !untypedClosureIndices.contains(i)) {
       calls.typed(args(i), context) match {
         case Some(term) => preliminaryParams(i) = term
-        case None => return None
+        case None => break(None)
       }
     }
 


### PR DESCRIPTION
## Summary

- `ExtensionMethodFallbackSupport.tryExtensionMethodCallBidirectional` used a bare `return None` inside a `for` loop to short-circuit typing of a preliminary argument. Scala 3 flags this as a deprecated non-local return ("Non local returns are no longer supported; use `boundary` and `boundary.break` in `scala.util` instead" — this was a real compiler warning at build time).
- Rewrote the method body as `boundary { ... }` with `break(None)` replacing the `return None`, exactly as the compiler warning suggests. No behavior change — pure control-flow refactor.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4711 tests, 0 failed, 1 canceled (pre-existing), all passed.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 4711 tests, 0 failed, 1 canceled (pre-existing), all passed.
- [x] Verified the "Non local returns are no longer supported" warning no longer appears on a clean recompile of the changed file.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Q1S5LpgH3j1ZAjMBJ5G3cH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1S5LpgH3j1ZAjMBJ5G3cH)_