### PR TITLE
test: add fast-path/JavaCC parser AST parity spec

### DIFF
--- a/src/test/scala/onion/compiler/FastPathParserParitySpec.scala
+++ b/src/test/scala/onion/compiler/FastPathParserParitySpec.scala
@@ -1,0 +1,44 @@
+package onion.compiler
+
+import onion.compiler.parser.{JJOnionParser, OnionParser}
+
+import java.io.{File, StringReader}
+import org.scalatest.funspec.AnyFunSpec
+import scala.io.Source
+
+/**
+ * The handwritten recursive-descent parser (`onion.compiler.parser.OnionParser`) is meant to
+ * produce the identical AST to the JavaCC parser for every program the latter accepts, falling
+ * back (`OnionParser.Fail`) on anything it cannot handle -- see CLAUDE.md's Parsing section.
+ * Nothing else in the suite checks that claim directly: the default test run only exercises the
+ * fast path (it is tried first and normally succeeds), and CI never sets
+ * `-Donion.parser.javacc=true` to run the JavaCC parser alone. A fast-path bug that still
+ * returns a *different* tree instead of failing would compile silently -- exactly the
+ * miscompilation risk the project's quality bar treats as a blocker -- without this test.
+ */
+class FastPathParserParitySpec extends AnyFunSpec {
+
+  private def samples: Seq[File] =
+    Option(new File("run").listFiles()).getOrElse(Array.empty[File]).toSeq
+      .filter(_.getName.endsWith(".on"))
+      .sortBy(_.getName)
+
+  describe("the handwritten fast-path parser matches the JavaCC parser") {
+    val files = samples
+
+    it("finds the sample programs") {
+      assert(files.nonEmpty, "no .on samples found under run/")
+    }
+
+    files.foreach { f =>
+      it(s"run/${f.getName}: fast-path AST equals the JavaCC AST when both accept it") {
+        val code = Source.fromFile(f, "UTF-8").mkString
+        val fast = try Some(OnionParser.parse(code)) catch { case _: OnionParser.Fail => None }
+        fast.foreach { fastUnit =>
+          val jjUnit = new JJOnionParser(new StringReader(code)).unit()
+          assert(fastUnit == jjUnit, s"run/${f.getName}: fast-path AST diverged from the JavaCC AST")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- The handwritten fast-path parser (`onion.compiler.parser.OnionParser`) is meant to produce the identical AST to the JavaCC parser for every program the latter accepts (see CLAUDE.md's Parsing section), falling back (`OnionParser.Fail`) on anything it can't handle.
- Nothing in the suite checked that claim directly: the default test run only exercises the fast path (it's tried first and normally succeeds), and CI never sets `-Donion.parser.javacc=true` to exercise the JavaCC parser. A fast-path bug that returned a *different* tree instead of failing would compile silently — exactly the miscompilation risk the project's quality bar treats as a release blocker.
- `FastPathParserParitySpec` parses every `run/*.on` sample with both parsers and asserts structural AST equality whenever the fast path accepts it.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.FastPathParserParitySpec'` — 249/249 pass (248 samples currently agree between the two parsers).
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4960 tests, 0 failed, 1 canceled (pre-existing env-gated smoke test), all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TA2dLbTZTm31twAvhDrH8

---
_Generated by [Claude Code](https://claude.ai/code/session_012TA2dLbTZTm31twAvhDrH8)_