### PR TITLE
docs(stdlib): document onion.Colls's undocumented factories and list/set/map utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`onion.Colls`'s factories and list/set/map utilities.** `docs/reference/stdlib.md` and
+  its Japanese translation only ever documented a handful of `Colls`'s members; `setOf`,
+  `mapOf`/`mutableMapOf`/`entry`, `emptyList`/`emptySet`/`emptyMap`, `mutableSetOf`,
+  `rangeWithStep`, and the `concat`/`flatten`/`partition`/`toSet`/`distinct`/`slice`/
+  `sorted`/`sortedByDescending`/`head`/`tail`/`takeWhile`/`dropWhile`/`mkString`/
+  `isNotEmpty`/`filterMap` list-and-map utilities were undiscoverable without reading
+  `src/main/java/onion/Colls.java`. A new `CollsDocCoverageSpec` guards every public
+  `onion.Colls` member against both files going forward.
+
 ## [0.45.0] - 2026-09-03
 
 ### Changed

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1498,9 +1498,48 @@ parsed.positional()                     // オプション以外の引数の Lis
 Colls::listOf("a", "b", "c")            // 不変の List
 Colls::mutableListOf(1, 2, 3)           // ArrayList
 Colls::range(0, 5)                      // List [0,1,2,3,4]
+Colls::rangeWithStep(0, 10, 2)          // List [0,2,4,6,8]
 Colls::sortedBy(people) { p -> p.age() }
 // map/filter/reduce/fold のパイプラインは List/Iterable/配列の拡張メソッド:
 // xs.map { x -> x * 2 }.filter { x -> x > 0 }
+```
+
+### 追加のファクトリ: Set・Map・空のコレクション
+
+```onion
+Colls::setOf("a", "b", "c")             // 不変の Set（反復順序は保証されない）
+Colls::mutableSetOf(1, 2, 3)            // HashSet
+
+Colls::entry("name", "Alice")           // mapOf/mutableMapOf 用の Map.Entry
+Colls::mapOf(Colls::entry("name", "Alice"), Colls::entry("age", "30"))   // 不変の Map、挿入順を保持
+Colls::mutableMapOf(Colls::entry("x", 1))                               // HashMap
+
+Colls::emptyList()                      // []
+Colls::emptySet()                       // 空の Set
+Colls::emptyMap()                       // 空の Map
+```
+
+### List・Set・Map のユーティリティ
+
+`Colls` の他のメソッドと同様、最初の引数（list/map）に対する拡張メソッドとしても
+呼び出せ、パイプラインとして連結できる:
+
+```onion
+xs.concat(ys)                     // xs の要素に続けて ys の要素
+[[1, 2], [3, 4]].flatten()        // [1, 2, 3, 4] - ネストを1段階解消
+xs.partition { x -> x > 1 }       // [matching, nonMatching] - 2つの List
+xs.toSet()                        // xs の要素から作った Set
+xs.distinct()                     // 重複を除去、最初に出現した順を保持
+xs.slice(0, 2)                    // [0, 2) の部分リスト、範囲内にクランプ
+xs.sorted()                       // 昇順の新しい List（要素は Comparable である必要がある）
+xs.sortedByDescending { x -> x }  // sortedBy と同様だが降順
+xs.head()                         // 先頭要素、空ならnull（first の別名）
+xs.tail()                         // 先頭要素を除いた残り（空リストでは例外）
+xs.takeWhile { x -> x < 3 }       // 述語を満たす先頭の連続部分
+xs.dropWhile { x -> x < 3 }       // その先頭の連続部分を取り除いた残り
+xs.mkString(", ")                 // "1, 2, 3" - 要素を文字列として連結（join は別名）
+Colls::isNotEmpty(xs)             // true - isEmpty の否定
+m.filterMap { k, v -> k == "name" }   // 条件に合うエントリだけの Map
 ```
 
 ### バッチ化・ウィンドウ化・セレクタ集計

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1485,9 +1485,48 @@ Collection factories and pipelines (`onion.Colls`):
 Colls::listOf("a", "b", "c")            // immutable List
 Colls::mutableListOf(1, 2, 3)           // ArrayList
 Colls::range(0, 5)                      // List [0,1,2,3,4]
+Colls::rangeWithStep(0, 10, 2)          // List [0,2,4,6,8]
 Colls::sortedBy(people) { p -> p.age() }
 // map/filter/reduce/fold pipelines are extension methods on
 // List/Iterable/arrays: xs.map { x -> x * 2 }.filter { x -> x > 0 }
+```
+
+### More factories: sets, maps, and empty collections
+
+```onion
+Colls::setOf("a", "b", "c")             // immutable Set (iteration order unspecified)
+Colls::mutableSetOf(1, 2, 3)            // HashSet
+
+Colls::entry("name", "Alice")           // a Map.Entry, for mapOf/mutableMapOf
+Colls::mapOf(Colls::entry("name", "Alice"), Colls::entry("age", "30"))   // immutable Map, insertion order preserved
+Colls::mutableMapOf(Colls::entry("x", 1))                               // HashMap
+
+Colls::emptyList()                      // []
+Colls::emptySet()                       // empty Set
+Colls::emptyMap()                       // empty Map
+```
+
+### List, set, and map utilities
+
+Also usable as extension methods on their first (list/map) argument, chaining
+into a pipeline like the rest of `Colls`:
+
+```onion
+xs.concat(ys)                     // elements of xs followed by elements of ys
+[[1, 2], [3, 4]].flatten()        // [1, 2, 3, 4] - one level of nesting removed
+xs.partition { x -> x > 1 }       // [matching, nonMatching] - two Lists
+xs.toSet()                        // Set built from xs's elements
+xs.distinct()                     // duplicates removed, first-seen order preserved
+xs.slice(0, 2)                    // sublist [0, 2), clamped into range
+xs.sorted()                       // new List, ascending (elements must be Comparable)
+xs.sortedByDescending { x -> x }  // like sortedBy, but descending
+xs.head()                         // first element, or null if empty (alias for first)
+xs.tail()                         // all but the first element (throws on an empty list)
+xs.takeWhile { x -> x < 3 }       // longest leading run matching the predicate
+xs.dropWhile { x -> x < 3 }       // xs with that leading run removed
+xs.mkString(", ")                 // "1, 2, 3" - joins elements into a String (join is an alias)
+Colls::isNotEmpty(xs)             // true - the negation of isEmpty
+m.filterMap { k, v -> k == "name" }   // Map with only the matching entries
 ```
 
 ### Batching, windowing, and selector aggregation

--- a/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
@@ -1,0 +1,66 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Colls` module docs.
+ *
+ * `onion.Colls` is a large factory/pipeline module (`Colls::listOf`, `Colls::setOf`,
+ * `Colls::chunked`, ...), but docs/reference/stdlib.md and docs/ja/reference/stdlib.md only
+ * ever documented a handful of its members -- most Colls operations are meant to be called
+ * as List/Map/Set extension methods (`xs.map { ... }`, not `Colls::map(xs, ...)`), so this
+ * guard looks for each member name anywhere in the file rather than requiring the
+ * `Colls::name` static-call spelling (contrast `OnionMathDocCoverageSpec`, whose module has
+ * no such extension-method form).
+ *
+ * Arity-suffixed overload-resolution helpers (`listOf0`, `setOf3`, `mapOf1`,
+ * `mutableSetOf2`, ...) exist only so the compiler can dispatch a call written as
+ * `Colls::listOf(a, b, c)` -- Onion code never spells the suffixed name -- so they are
+ * excluded from the guard; the varargs name they back (`listOf`, `setOf`, `mapOf`,
+ * `mutableSetOf`) is still required.
+ */
+class CollsDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => s"\\b${java.util.regex.Pattern.quote(n)}\\b".r.findFirstIn(doc).isDefined)
+
+  private val arityOverloadHelper = """^(?:listOf|setOf|mapOf|mutableSetOf)\d+$""".r
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Colls]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+      .filterNot(arityOverloadHelper.matches)
+    methodNames.toSet
+  }
+
+  it("actual onion.Colls exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Colls found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Colls member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"), actualNames)
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Colls:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Colls member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"), actualNames)
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Colls:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Colls in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Colls"),
+      "docs/reference/stdlib.md's overview table should mention Colls")
+    assert(read("docs/ja/reference/stdlib.md").contains("Colls"),
+      "docs/ja/reference/stdlib.md's overview table should mention Colls")
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Colls` is a large factory/pipeline module, but `docs/reference/stdlib.md` and its Japanese translation only ever documented a handful of its members.
- Adds documentation for the previously-undocumented factories (`setOf`, `mapOf`/`mutableMapOf`/`entry`, `emptyList`/`emptySet`/`emptyMap`, `mutableSetOf`, `rangeWithStep`) and list/map utilities (`concat`, `flatten`, `partition`, `toSet`, `distinct`, `slice`, `sorted`, `sortedByDescending`, `head`, `tail`, `takeWhile`, `dropWhile`, `mkString`, `isNotEmpty`, `filterMap`) in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- Adds `CollsDocCoverageSpec` (mirroring the existing `OnionMathDocCoverageSpec` pattern) so a future addition to `onion.Colls` fails the build instead of silently staying undocumented. Arity-suffixed overload-resolution helpers (`listOf0`, `setOf3`, `mapOf1`, `mutableSetOf2`, ...) are excluded since Onion code never spells those names directly.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.
- All new doc examples were verified against a real `onion` run (compiled and executed) before being written down.

## Test plan

- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.CollsDocCoverageSpec onion.compiler.tools.StdlibDocCollsBatchingAggregationParitySpec"` — green
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4965 passed, 0 failed, 1 cancelled (the gated distribution smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tV8otAbijE4HHcJWRcaGn

---
_Generated by [Claude Code](https://claude.ai/code/session_016tV8otAbijE4HHcJWRcaGn)_