### PR TITLE
docs(stdlib): document onion.Option's and onion.Result's full instance-method sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`onion.Option`'s and `onion.Result`'s full instance-method sets.** `docs/reference/stdlib.md`
+  and its Japanese translation documented only part of each interface — `isDefined`/`isEmpty`/`get`/
+  `orElseThrow`/`forEach` were missing from `Option`, and `isOk`/`isErr`/`get`/`getError`/
+  `getOrThrow`/`forEach`/`forEachError` were missing from `Result`. A new
+  `OptionResultDocCoverageSpec` guards both interfaces' full member sets against both files
+  going forward.
 - **`onion.Colls`'s factories and list/set/map utilities.** `docs/reference/stdlib.md` and
   its Japanese translation only ever documented a handful of `Colls`'s members; `setOf`,
   `mapOf`/`mutableMapOf`/`entry`, `emptyList`/`emptySet`/`emptyMap`, `mutableSetOf`,

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -862,9 +862,11 @@ val timeNanos: Long = Timing::time(() -> { return expensiveOperation(); })
 `onion.Option`で提供。
 
 - `Option::some(value)` / `Option::none()` / `Option::of(value)`
+- `opt.isDefined()` / `opt.isEmpty()` / `opt.get()` — `get()` は `None` の場合 `NoSuchElementException` を投げる
 - `opt.getOrElse(defaultValue)` / `opt.orElseGet(() -> default)` / `opt.orNull()`
+- `opt.orElseThrow()` / `opt.orElseThrow(() -> customException)`
 - `opt.orElse(otherOption)`
-- `opt.map(f)` / `opt.flatMap(f)` / `opt.filter(predicate)`
+- `opt.map(f)` / `opt.flatMap(f)` / `opt.filter(predicate)` / `opt.forEach(action)`
 - `opt.contains(value)` / `opt.exists(predicate)`
 - `opt.fold(() -> ifEmpty, v -> ifPresent)` — 単一の値へ畳み込む
 - `opt.toList()` — 0個または1個の要素のリスト
@@ -875,8 +877,11 @@ val timeNanos: Long = Timing::time(() -> { return expensiveOperation(); })
 
 - `Result::ok(value)` / `Result::err(error)`
 - `Result::ofNullable(value, errorIfNull)` / `Result::trying(operation)`
+- `res.isOk()` / `res.isErr()` / `res.get()` / `res.getError()` — `get()` は `Err` で、`getError()` は `Ok` で例外を投げる
 - `res.map(f)` / `res.mapError(f)` / `res.flatMap(f)` / `res.toOption()`
 - `res.getOrElse(default)` / `res.orElseGet(() -> default)` / `res.orNull()`
+- `res.getOrThrow()` / `res.getOrThrow(e -> customException)` — エラーを（`Throwable` でなければラップして）投げる、またはマッピングした例外を投げる
+- `res.forEach(action)` / `res.forEachError(action)`
 - `res.fold(e -> ifErr, v -> ifOk)` — 単一の値へ畳み込む
 - `res.recover(e -> value)` / `res.recoverWith(e -> otherResult)` — `Err` を回復
 - `res.exists(predicate)` / `res.toList()`

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -786,9 +786,11 @@ Access iteration utilities for collections and arrays:
 Provided via `onion.Option`.
 
 - `Option::some(value)` / `Option::none()` / `Option::of(value)`
+- `opt.isDefined()` / `opt.isEmpty()` / `opt.get()` — `get()` throws `NoSuchElementException` on `None`
 - `opt.getOrElse(defaultValue)` / `opt.orElseGet(() -> default)` / `opt.orNull()`
+- `opt.orElseThrow()` / `opt.orElseThrow(() -> customException)`
 - `opt.orElse(otherOption)`
-- `opt.map(f)` / `opt.flatMap(f)` / `opt.filter(predicate)`
+- `opt.map(f)` / `opt.flatMap(f)` / `opt.filter(predicate)` / `opt.forEach(action)`
 - `opt.contains(value)` / `opt.exists(predicate)`
 - `opt.fold(() -> ifEmpty, v -> ifPresent)` — collapse to a single value
 - `opt.toList()` — zero- or one-element list
@@ -799,8 +801,11 @@ Provided via `onion.Result`.
 
 - `Result::ok(value)` / `Result::err(error)`
 - `Result::ofNullable(value, errorIfNull)` / `Result::trying(operation)`
+- `res.isOk()` / `res.isErr()` / `res.get()` / `res.getError()` — `get()` throws on `Err`, `getError()` throws on `Ok`
 - `res.map(f)` / `res.mapError(f)` / `res.flatMap(f)` / `res.toOption()`
 - `res.getOrElse(default)` / `res.orElseGet(() -> default)` / `res.orNull()`
+- `res.getOrThrow()` / `res.getOrThrow(e -> customException)` — throws the error (wrapped if not a `Throwable`) or a mapped exception
+- `res.forEach(action)` / `res.forEachError(action)`
 - `res.fold(e -> ifErr, v -> ifOk)` — collapse to a single value
 - `res.recover(e -> value)` / `res.recoverWith(e -> otherResult)` — rescue an `Err`
 - `res.exists(predicate)` / `res.toList()`

--- a/src/test/scala/onion/compiler/tools/OptionResultDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/OptionResultDocCoverageSpec.scala
@@ -1,0 +1,64 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Option`/`Result` module docs.
+ *
+ * `onion.Option` and `onion.Result` are sealed interfaces whose instance methods are
+ * declared directly on the interface (and implemented in the `Some`/`None`/`Ok`/`Err`
+ * records), so reflection on the interface class itself finds the full member set.
+ * docs/reference/stdlib.md and docs/ja/reference/stdlib.md documented only a subset of
+ * each -- `isDefined`/`isEmpty`/`get`/`orElseThrow`/`forEach`/`bind` for Option and
+ * `isOk`/`isErr`/`get`/`getError`/`getOrThrow`/`forEach`/`forEachError`/`bind` for
+ * Result were all real, callable methods with no mention anywhere in either file.
+ */
+class OptionResultDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => s"\\b${java.util.regex.Pattern.quote(n)}\\b".r.findFirstIn(doc).isDefined)
+
+  private def instanceMethodNames(c: Class[?]): Set[String] =
+    c.getDeclaredMethods
+      .filterNot(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .map(_.getName)
+      .toSet
+
+  private lazy val optionNames: Set[String] = instanceMethodNames(classOf[onion.Option[?]])
+  private lazy val resultNames: Set[String] = instanceMethodNames(classOf[onion.Result[?, ?]])
+
+  it("actual onion.Option exposes the names this guard assumes (sanity check)") {
+    assert(optionNames.nonEmpty, "reflection on onion.Option found no instance members -- the scan has rotted")
+  }
+
+  it("actual onion.Result exposes the names this guard assumes (sanity check)") {
+    assert(resultNames.nonEmpty, "reflection on onion.Result found no instance members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Option member") {
+    val doc = read("docs/reference/stdlib.md")
+    val missing = optionNames -- documentedNames(doc, optionNames)
+    assert(missing.isEmpty, s"docs/reference/stdlib.md is missing Option members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Option member") {
+    val doc = read("docs/ja/reference/stdlib.md")
+    val missing = optionNames -- documentedNames(doc, optionNames)
+    assert(missing.isEmpty, s"docs/ja/reference/stdlib.md is missing Option members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Result member") {
+    val doc = read("docs/reference/stdlib.md")
+    val missing = resultNames -- documentedNames(doc, resultNames)
+    assert(missing.isEmpty, s"docs/reference/stdlib.md is missing Result members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Result member") {
+    val doc = read("docs/ja/reference/stdlib.md")
+    val missing = resultNames -- documentedNames(doc, resultNames)
+    assert(missing.isEmpty, s"docs/ja/reference/stdlib.md is missing Result members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md` and its Japanese translation only ever documented part of
  `onion.Option`'s and `onion.Result`'s instance-method sets, even though both are common,
  user-facing types.
- `Option` was missing `isDefined`/`isEmpty`/`get`/`orElseThrow` (both overloads)/`forEach`.
- `Result` was missing `isOk`/`isErr`/`get`/`getError`/`getOrThrow` (both overloads)/`forEach`/
  `forEachError`.
- Added `OptionResultDocCoverageSpec` (modeled on the existing `CollsDocCoverageSpec`), which
  reflects on the `Option`/`Result` interfaces' declared instance methods and asserts every
  member name appears somewhere in each doc file, so future additions can't drift silently.
- Documented one CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4971 succeeded,
      0 failed, 1 canceled (pre-existing, unrelated `ProjectDistributionSpec` environmental skip),
      0 ignored. All tests passed.
- [x] New `OptionResultDocCoverageSpec` confirmed red before the doc edits, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2xY9mRGwKQZEc8rtzDqoU

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2xY9mRGwKQZEc8rtzDqoU)_