### PR TITLE
fix: add a syntax hint for JavaScript/TypeScript-style `for (const x of arr)` loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A syntax hint for JavaScript/TypeScript-style `for (const x of arr)` loops.**
+  Onion's `for` clauses aren't parenthesized and have no `of` form, so this mistake
+  previously fell through to the generic C-style-for hint (which suggested adding
+  semicolons that don't belong in a foreach-shaped loop) or, for the `const` spelling
+  specifically, the unrelated `const`-declaration hint. `SyntaxHintClassifier` now
+  recognizes `for (const|let|var x of expr)` (and the bare `for (x of expr)` form) and
+  points at `foreach x: Type in expr { ... }` instead.
+
 ### Documentation
 
 - **`onion.Option`'s and `onion.Result`'s full instance-method sets.** `docs/reference/stdlib.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,7 @@ These are frequently confused with other languages. **Always check these:**
 | `case Circle(r):` unsupported? | ✓ correct - record destructuring patterns work, also `case x when guard:` |
 | `for (int i = 0; ...)` | `for var i: Int = 0; ...` - no parentheses |
 | `for i in 0..10` (other langs) | `foreach i: Int in 0..10` - ranges: `a..b` inclusive, `a..<b` exclusive |
+| `for (const x of arr) { }` (JS/TS) | `foreach x: Type in arr { }` - no `for (... of ...)` |
 | `i += 1`, `i -= 1`, `i++` | ✓ correct - compound assignment and `++`/`--` work as statements |
 | `while (x = read()) != null` | ✓ correct - assignment in condition with parens |
 

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -147,6 +147,7 @@ error.parsing.hint.catch_parens=Hint: a `catch` clause's variable isn't parenthe
 error.parsing.hint.c_style_for=Hint: a `for` loop's clauses aren't parenthesized — write `for var i: Int = 0; i < 10; i++ { ... }`, not `for (int i = 0; i < 10; i++) { ... }`.
 error.parsing.hint.for_each_destructure=Hint: `for` doesn''t destructure or iterate a collection — that''s `foreach`''s job — write `foreach ({0}) in {1} '{' ... '}'`, not `for ({0}) in {1}`.
 error.parsing.hint.java_style_enhanced_for=Hint: Onion''s enhanced-for is `foreach` — write `foreach {0}: {1} in {2} '{' ... '}'`, not `for ({1} {0} : {2}) '{' ... '}'`.
+error.parsing.hint.js_style_for_of=Hint: Onion has no JavaScript-style `for (... of ...)` — write `foreach {0}: Type in {1} '{' ... '}'`, not `for (const {0} of {1}) '{' ... '}'`.
 error.parsing.hint.java_style_import=Hint: imports are wrapped in braces — write `import { java.util.List }`, not `import java.util.List;`.
 error.parsing.hint.java_style_import_alias=Hint: an import''s alias is named with `as`, not `=` — write `{0} as {1}`, not `{1} = {0}`.
 error.parsing.hint.java_style_constructor=Hint: a constructor is declared with `def this`, not by naming a method after the class — write `def this(...) { ... }`, not `public ClassName(...) { ... }`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -147,6 +147,7 @@ error.parsing.hint.catch_parens=ヒント: `catch` 節の変数は丸かっこ�
 error.parsing.hint.c_style_for=ヒント: `for` ループの各節は丸かっこで囲みません — `for (int i = 0; i < 10; i++) { ... }` ではなく `for var i: Int = 0; i < 10; i++ { ... }` と書いてください。
 error.parsing.hint.for_each_destructure=ヒント: `for` はコレクションを分配・反復できません — それは `foreach` の役目です — `for ({0}) in {1}` ではなく `foreach ({0}) in {1} '{' ... '}'` と書いてください。
 error.parsing.hint.java_style_enhanced_for=ヒント: Onion の拡張for文は `foreach` です — `for ({1} {0} : {2}) '{' ... '}'` ではなく `foreach {0}: {1} in {2} '{' ... '}'` と書いてください。
+error.parsing.hint.js_style_for_of=ヒント: Onion に JavaScript スタイルの `for (... of ...)` はありません — `for (const {0} of {1}) '{' ... '}'` ではなく `foreach {0}: Type in {1} '{' ... '}'` と書いてください。
 error.parsing.hint.java_style_import=ヒント: import は波かっこで囲みます — `import java.util.List;` ではなく `import { java.util.List }` と書いてください。
 error.parsing.hint.java_style_import_alias=ヒント: import のエイリアスは `=` ではなく `as` で指定します — `{1} = {0}` ではなく `{0} as {1}` と書いてください。
 error.parsing.hint.java_style_constructor=ヒント: コンストラクタはクラス名と同じメソッドではなく `def this` で宣言します — `public ClassName(...) { ... }` ではなく `def this(...) { ... }` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -99,6 +99,14 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*for\s*\(\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)+)\s*in\s+([^{]+?)\)\s*\{?\s*$""".r
   private val JavaStyleEnhancedForLoop =
     """^\s*for\s*\(\s*(?:final\s+)?([A-Za-z_][\w.\[\],\s]*\??)\s+([A-Za-z_]\w*)\s*:\s*(.+?)\s*\)\s*\{?\s*$""".r
+  // A JavaScript/TypeScript-style `for (const x of arr)` (or `let`/`var`, or no
+  // declarator at all) -- unlike JavaStyleEnhancedForLoop's `Type name : expr` shape,
+  // `of` isn't followed by a colon, so it never collides with that rule, but it still
+  // matches the generic CStyleForLoop fallback below (which assumes the C-style
+  // three-clause counting loop and would suggest adding semicolons that don't belong
+  // here), so this must be tried first.
+  private val JsStyleForOfLoop =
+    """^\s*for\s*\(\s*(?:const|let|var)?\s*([A-Za-z_]\w*)\s+of\s+(.+?)\s*\)\s*\{?\s*$""".r
   private val ForeachParenMistake = """\bforeach\s*\(""".r
   private val JavaStyleImport = """^\s*import\s+(?!\{)\S""".r
   private val JavaStyleImportAlias =
@@ -197,6 +205,13 @@ private[compiler] object SyntaxHintClassifier {
     found match {
       case "<:" =>
         hint("error.parsing.hint.old_conforms")
+      // A JS/TS `for (const x of arr)` fails right at `const` itself (`for (`
+      // parses as the start of a C-style clause, which never accepts `const`),
+      // so the generic const-declaration hint below would otherwise win before
+      // the sourceLine-based JsStyleForOfLoop case further down ever runs.
+      case "const" if JsStyleForOfLoop.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = JsStyleForOfLoop.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.js_style_for_of", matched.group(1), matched.group(2).trim)
       case "const" =>
         hint("error.parsing.hint.js_style_const")
       case "$" =>
@@ -325,6 +340,10 @@ private[compiler] object SyntaxHintClassifier {
       case _ if JavaStyleEnhancedForLoop.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleEnhancedForLoop.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_enhanced_for", matched.group(2), matched.group(1).trim, matched.group(3).trim)
+      // A JS/TS `for (const x of arr)` also matches CStyleForLoop, so keep this first.
+      case _ if JsStyleForOfLoop.findFirstMatchIn(sourceLine).isDefined =>
+        val matched = JsStyleForOfLoop.findFirstMatchIn(sourceLine).get
+        hint("error.parsing.hint.js_style_for_of", matched.group(1), matched.group(2).trim)
       case _ if CStyleForLoop.findFirstMatchIn(sourceLine).isDefined =>
         hint("error.parsing.hint.c_style_for")
       case _ if JavaStyleImport.findFirstMatchIn(sourceLine).isDefined =>

--- a/src/test/scala/onion/compiler/JsStyleForOfHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/JsStyleForOfHintI18nSpec.scala
@@ -1,0 +1,68 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The JS/TS-style for-of hint (`SyntaxHintClassifier`'s `JsStyleForOfLoop`
+ * case, for `for (const x of coll) { ... }`) must resolve through the
+ * bilingual `error.parsing.hint.*` bundle in both locales, like every other
+ * hint in that match -- see JavaStyleEnhancedForHintI18nSpec for the same
+ * pattern.
+ */
+class JsStyleForOfHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.js_style_for_of"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  private def compileFailureMessages(forOfClause: String): String = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      s"""
+        |class Main {
+        |public:
+        |  static def main(args: String[]): void {
+        |    val arr: List = ["a", "b"]
+        |    $forOfClause {
+        |      IO::println(x)
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+  }
+
+  // The substituted variable/collection text is literal source text, identical
+  // in both bundles, so these assertions hold regardless of the JVM's default
+  // locale.
+  it("fires for a JS-style `for (const x of arr) { ... }` loop") {
+    val msgs = compileFailureMessages("for (const x of arr)")
+    assert(msgs.contains("foreach x: Type in arr"), s"expected the hint's `foreach` example, got: $msgs")
+  }
+
+  it("fires for a `for (let x of arr) { ... }` loop") {
+    val msgs = compileFailureMessages("for (let x of arr)")
+    assert(msgs.contains("foreach x: Type in arr"), s"expected the hint's `foreach` example, got: $msgs")
+  }
+
+  it("fires for a `for (x of arr) { ... }` loop with no declarator keyword") {
+    val msgs = compileFailureMessages("for (x of arr)")
+    assert(msgs.contains("foreach x: Type in arr"), s"expected the hint's `foreach` example, got: $msgs")
+  }
+}

--- a/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
+++ b/src/test/scala/onion/compiler/parser/SyntaxHintClassifierSpec.scala
@@ -96,6 +96,56 @@ class SyntaxHintClassifierSpec extends AnyFunSpec with Matchers {
       hint.arguments shouldBe Seq("entry", "Map.Entry[String, Int]", "map.entrySet()")
     }
 
+    it("prefers JS-style for-of advice over generic C-style-for advice") {
+      val hint = classify(
+        found = "x",
+        sourceLine = "for (const x of arr) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.js_style_for_of"
+      hint.arguments shouldBe Seq("x", "arr")
+    }
+
+    it("recognizes a `let`-declared for-of loop over a call-expression collection") {
+      val hint = classify(
+        found = "item",
+        sourceLine = "for (let item of getItems()) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.js_style_for_of"
+      hint.arguments shouldBe Seq("item", "getItems()")
+    }
+
+    it("recognizes a for-of loop with no declarator keyword") {
+      val hint = classify(
+        found = "x",
+        sourceLine = "for (x of arr) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.js_style_for_of"
+      hint.arguments shouldBe Seq("x", "arr")
+    }
+
+    it("prefers for-of advice over the generic const-declaration hint when found is `const`") {
+      val hint = classify(
+        found = "const",
+        sourceLine = "for (const x of arr) {"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.js_style_for_of"
+      hint.arguments shouldBe Seq("x", "arr")
+    }
+
+    it("keeps the generic const-declaration hint for an ordinary `const` statement") {
+      val hint = classify(
+        found = "const",
+        sourceLine = "const x = 1;"
+      )
+
+      hint.messageKey shouldBe "error.parsing.hint.js_style_const"
+      hint.arguments shouldBe empty
+    }
+
     it("captures Java-style import alias arguments in Onion order") {
       val hint = classify(
         found = "=",


### PR DESCRIPTION
## Summary

- Onion's `for` clauses aren't parenthesized and have no `of` form. A JS/TS-style `for (const x of arr)` (or `let`/`var`, or no declarator at all) previously fell through to the generic C-style-for hint — which wrongly suggests adding semicolons to what is really a foreach-shaped loop — or, for the `const` spelling specifically, to the unrelated `const`-declaration hint (the parser fails right at the `const` token itself, before the source-line-based classifier rules run).
- `SyntaxHintClassifier` now recognizes `for (const|let|var x of expr)` and the bare `for (x of expr)` form, and points at `foreach x: Type in expr { ... }` instead, in both English and Japanese.
- Adds bilingual `error.parsing.hint.js_style_for_of` messages, unit tests in `SyntaxHintClassifierSpec`, and an end-to-end i18n spec (`JsStyleForOfHintI18nSpec`) covering all three declarator variants through the real compiler pipeline (both the fast-path and JavaCC-fallback parsers).
- Documents the new hint in `CLAUDE.md`'s common-mistakes table and in `CHANGELOG.md`.

## Test plan

- [x] `sbt -Duser.language=en testOnly onion.compiler.parser.SyntaxHintClassifierSpec onion.compiler.JsStyleForOfHintI18nSpec onion.compiler.JavaStyleEnhancedForHintI18nSpec onion.compiler.SwitchStatementHintI18nSpec onion.compiler.parser.ControlFlowSyntaxHintsSpec` — all green
- [x] Same spec re-run with `-Donion.parser.javacc=true` to force the JavaCC-only path — all green
- [x] `sbt shutdown && sbt -Duser.language=en testFull` — 4981 succeeded, 0 failed, 1 cancelled (the known `-Donion.dist.path`-gated distribution smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQXXkWSVuVRUkstwQpC7yg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQXXkWSVuVRUkstwQpC7yg)_