### PR TITLE
docs(regex): document onion.Regex::matchGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real, callable members with no mention anywhere in either file. A new
   `ConcurrentDocCoverageSpec` guards every public `onion.Concurrent`/`Pool`/`Counter`/`Lock`/
   `Channel` member against both files going forward.
+- **`onion.Regex::matchGroups`.** `docs/reference/stdlib.md` and its Japanese translation
+  documented `matches`/`find`/`findAll`/`findFirst`/`groups`/`groupsAll`/`replace`/
+  `replaceFirst`/`split`/`quote`/`isValid`, but never mentioned `matchGroups` — the anchored,
+  whole-string match that backs the `case re"..." (a, b):` select pattern. A new
+  `RegexDocCoverageSpec` guards every public `onion.Regex` member against both files going
+  forward.
 
 ## [0.45.0] - 2026-09-03
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1987,6 +1987,20 @@ Regex::quote(literal): String    // 特殊文字をエスケープ
 Regex::isValid(pattern): Boolean
 ```
 
+### アンカー付きマッチ
+
+```
+Regex::matchGroups(input, pattern): List[String]
+```
+
+`input` **全体**が `pattern` にマッチしたときだけマッチしたとみなし（`find`/`findAll`
+のようにどこかにマッチすれば良いのではなくアンカー付き）、マッチしなければ `null` を
+返す。マッチした場合はキャプチャグループを返す(インデックス0がグループ1)。マッチに
+参加しなかったグループは `null` ではなく `""` になる。これは `case re"..." (a, b):`
+という select パターン（CLAUDE.md の「Regex literals」を参照）を支える基本操作で、
+コンパイラはアンカー付き正規表現パターンを `matchGroups` 呼び出しと null チェックに
+脱糖する。
+
 ### Pattern リテラルのオーバーロード
 
 `re"..."` リテラルは `String` ではなく `java.util.regex.Pattern` にコンパイルされます。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1979,6 +1979,19 @@ Regex::quote(literal): String    // Escape special characters
 Regex::isValid(pattern): Boolean
 ```
 
+### Anchored match
+
+```
+Regex::matchGroups(input, pattern): List[String]
+```
+
+Matches only if the **whole** `input` matches `pattern` (anchored, unlike `find`/
+`findAll`, which match anywhere); returns `null` otherwise. On a match, returns the
+capture groups (index 0 is group 1); a group that did not participate in the match
+yields `""` rather than `null`. This is the primitive behind the `case re"..." (a, b):`
+select pattern (see "Regex literals" in CLAUDE.md) — the compiler desugars an anchored
+regex pattern into a `matchGroups` call plus a null check.
+
 ### Pattern literal overloads
 
 A `re"..."` literal compiles to a `java.util.regex.Pattern`, not a `String`.

--- a/src/test/scala/onion/compiler/tools/RegexDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RegexDocCoverageSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Regex` module docs.
+ *
+ * `onion.Regex` exposes only static factories. docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md document `matches`/`find`/`findAll`/`findFirst`/`groups`/
+ * `groupsAll`/`replace`/`replaceFirst`/`split`/`quote`/`isValid`, but never mention
+ * `matchGroups` -- the anchored, whole-string match used to desugar the `case re"..."
+ * (a, b):` select pattern described in CLAUDE.md -- anywhere in either file.
+ *
+ * `Object` overrides (`toString`, `equals`, `hashCode`, ...) are excluded: they carry no
+ * Regex-specific behavior worth documenting.
+ */
+class RegexDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => s"\\b${java.util.regex.Pattern.quote(n)}\\b".r.findFirstIn(doc).isDefined)
+
+  private val objectOverrides = Set("toString", "equals", "hashCode", "wait", "notify", "notifyAll", "getClass")
+
+  private def staticNames(c: Class[?]): Set[String] =
+    c.getDeclaredMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(m => java.lang.reflect.Modifier.isPublic(m.getModifiers))
+      .map(_.getName)
+      .filterNot(objectOverrides.contains)
+      .toSet
+
+  private lazy val actualNames: Set[String] = staticNames(classOf[onion.Regex])
+
+  it("actual onion.Regex exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Regex found no members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Regex member") {
+    val missing = actualNames -- documentedNames(read("docs/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/reference/stdlib.md is missing Regex members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Regex member") {
+    val missing = actualNames -- documentedNames(read("docs/ja/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/ja/reference/stdlib.md is missing Regex members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Regex::matchGroups` — the anchored, whole-string match that backs the `case re"..." (a, b):` select pattern — was never mentioned in `docs/reference/stdlib.md` or its Japanese translation, even though every other public `Regex` member (`matches`/`find`/`findAll`/`findFirst`/`groups`/`groupsAll`/`replace`/`replaceFirst`/`split`/`quote`/`isValid`) was documented.
- Added a "Anchored match" / "アンカー付きマッチ" subsection to both stdlib docs explaining `matchGroups`'s semantics (whole-input match required, `null` on no match, unmatched groups yield `""`) and its relationship to the `case re"..."` select-pattern feature.
- Added `RegexDocCoverageSpec` (mirroring `ConcurrentDocCoverageSpec`/`CollsDocCoverageSpec`) to guard `onion.Regex`'s full public API against both doc files going forward.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan

- [x] TDD: `RegexDocCoverageSpec` written first, confirmed red (missing `matchGroups` in both files), then green after the doc edits.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4987 tests, all green (1 canceled, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QRbqiqcZYjnZEiNk54AKW

---
_Generated by [Claude Code](https://claude.ai/code/session_017QRbqiqcZYjnZEiNk54AKW)_