### PR TITLE
docs(json): document JsonParseException::getPosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Json.JsonParseException::getPosition`.** `docs/reference/stdlib.md` and its Japanese
+  translation mentioned `Json.JsonParseException` only as the thing `Json::parseOrNull`
+  avoids throwing, never documenting that a caught instance also carries `getPosition()` —
+  the character offset where parsing gave up — alongside the usual `message()`. A new
+  `JsonParseExceptionPositionSpec` exercises both accessors via `shell.run`.
 - **`onion.Option`'s and `onion.Result`'s full instance-method sets.** `docs/reference/stdlib.md`
   and its Japanese translation documented only part of each interface — `isDefined`/`isEmpty`/`get`/
   `orElseThrow`/`forEach` were missing from `Option`, and `isOk`/`isErr`/`get`/`getError`/

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1071,6 +1071,17 @@ v["users"][0]["name"].asString()
 val obj = Json::parseOrNull("not json")   // 例外を投げず null
 ```
 
+不正入力の失敗をその場で処理したい場合、`Json.JsonParseException` は通常の `message()` に加えて
+`getPosition()`（パースを諦めた位置の文字オフセット）を持っています:
+
+```onion
+try {
+  Json::parse("{bad json")
+} catch e: Json.JsonParseException {
+  IO::println(e.message() + " at offset " + e.getPosition())
+}
+```
+
 `Json::asObject(obj)` と `Json::asArray(obj)` は素の `Map`/`List` 表現に対する型安全なキャストです。
 実行時の型が一致していれば `Map`/`List` にキャストした値を、そうでなければ `null` を返します。
 `Json::get`・`Json::parse`・`Json::parseOrNull` が `Object` を返した後、Map/List として

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1228,6 +1228,18 @@ another "absent" case rather than an error to handle separately:
 val obj = Json::parseOrNull("not json")   // null, no exception
 ```
 
+When you do want to handle a malformed-input failure, `Json.JsonParseException` carries
+`getPosition()` — the character offset into the input where parsing gave up — in addition
+to the usual `message()`:
+
+```onion
+try {
+  Json::parse("{bad json")
+} catch e: Json.JsonParseException {
+  IO::println(e.message() + " at offset " + e.getPosition())
+}
+```
+
 `Json::asObject(obj)` and `Json::asArray(obj)` are type-safe casts on the plain
 `Map`/`List` representation: each returns its argument cast to `Map`/`List` when the
 runtime type matches, or `null` otherwise. They're handy after `Json::get`, `Json::parse`,

--- a/src/test/scala/onion/compiler/tools/JsonParseExceptionPositionSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JsonParseExceptionPositionSpec.scala
@@ -1,0 +1,44 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `Json.JsonParseException` carries the character offset where parsing gave up via
+ * `getPosition()`, in addition to the usual `message()` — documented in
+ * docs/reference/stdlib.md and docs/ja/reference/stdlib.md but never exercised by a
+ * `shell.run` test case.
+ */
+class JsonParseExceptionPositionSpec extends AbstractShellSpec {
+  it("getPosition() reports the offset where parsing failed") {
+    val result = shell.run(
+      """
+        | static def main(args: String[]): Int {
+        |   try {
+        |     Json::parse("{bad json")
+        |     return -1
+        |   } catch e: Json.JsonParseException {
+        |     return e.getPosition()
+        |   }
+        | }
+      """.stripMargin, "None", Array())
+    assert(Shell.Success(1) == result)
+  }
+
+  it("message() and getPosition() are both usable on the caught exception") {
+    val result = shell.run(
+      """
+        | static def main(args: String[]): String {
+        |   try {
+        |     Json::parse("not json")
+        |     return "no exception"
+        |   } catch e: Json.JsonParseException {
+        |     return e.message() + "|" + e.getPosition()
+        |   }
+        | }
+      """.stripMargin, "None", Array())
+    assert(result match {
+      case Shell.Success(s: String) => s.contains("|0")
+      case _ => false
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- `Json.JsonParseException` was only ever mentioned in `docs/reference/stdlib.md` (and its
  Japanese translation) as the thing `Json::parseOrNull` avoids throwing — a caught
  instance's `getPosition()` (the character offset where parsing gave up) was never
  documented, even though it's a real, public, callable accessor alongside `message()`.
- Documented `getPosition()` in both `docs/reference/stdlib.md` and
  `docs/ja/reference/stdlib.md`, right after the existing `Json::parseOrNull` paragraph.
- Added `JsonParseExceptionPositionSpec` (execution coverage via `shell.run`) exercising
  both `getPosition()` and `message()` on a caught `Json.JsonParseException`.
- Noted the change under `[Unreleased] / Documentation` in `CHANGELOG.md`.

## Test plan

- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.JsonParseExceptionPositionSpec'` — 2/2 passed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4989 succeeded, 0 failed, 1 canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqhBk17sxf3FFx6y8fNruL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqhBk17sxf3FFx6y8fNruL)_