### PR TITLE
docs: document Future::fromCompletableFuture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole-string match that backs the `case re"..." (a, b):` select pattern. A new
   `RegexDocCoverageSpec` guards every public `onion.Regex` member against both files going
   forward.
+- **`Future::fromCompletableFuture`.** `docs/reference/stdlib.md` and its Japanese translation
+  documented `f.underlying()` (Future -> Java `CompletableFuture`) under "Conversions" but never
+  its inverse, `Future::fromCompletableFuture` (Java `CompletableFuture` -> Future) — the way to
+  wrap a Java async API's result for use with Onion's `map`/`flatMap`/`await`/`do` notation. A new
+  `FutureDocCoverageSpec` guards every public `onion.Future` member against both files going
+  forward.
 
 ## [0.45.0] - 2026-09-03
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1007,6 +1007,10 @@ val f: Future[Int] = Future::successful(42)
 f.toOption()   // Option[Int] - Some(42) または None（ブロックする）
 f.toResult()   // Result[Int, Throwable]（ブロックする）
 f.underlying() // 相互運用のための Java CompletableFuture
+
+// 逆方向: Java の CompletableFuture を Future でラップする
+val cf: java.util.concurrent.CompletableFuture[Int] = someJavaApi()
+val wrapped: Future[Int] = Future::fromCompletableFuture(cf)
 ```
 
 ### Do記法サポート

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -931,6 +931,10 @@ val f: Future[Int] = Future::successful(42)
 f.toOption()  // Option[Int] - Some(42) or None (blocks)
 f.toResult()  // Result[Int, Throwable] (blocks)
 f.underlying() // Java CompletableFuture for interop
+
+// The reverse direction: wrap a Java CompletableFuture as a Future
+val cf: java.util.concurrent.CompletableFuture[Int] = someJavaApi()
+val wrapped: Future[Int] = Future::fromCompletableFuture(cf)
 ```
 
 ### Do Notation Support

--- a/src/test/scala/onion/compiler/tools/FutureDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FutureDocCoverageSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Future` module docs.
+ *
+ * `onion.Future` pairs `underlying()` (Future -> Java `CompletableFuture`, documented
+ * under "Conversions") with `Future::fromCompletableFuture` (Java `CompletableFuture` ->
+ * Future) for the reverse direction, but only the former ever appeared in
+ * docs/reference/stdlib.md or docs/ja/reference/stdlib.md.
+ *
+ * `Object` overrides (`toString`, `equals`, `hashCode`, ...) are excluded: they carry no
+ * Future-specific behavior worth documenting.
+ */
+class FutureDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => s"\\b${java.util.regex.Pattern.quote(n)}\\b".r.findFirstIn(doc).isDefined)
+
+  private val objectOverrides = Set("toString", "equals", "hashCode", "wait", "notify", "notifyAll", "getClass")
+
+  private def staticNames(c: Class[?]): Set[String] =
+    c.getDeclaredMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(m => java.lang.reflect.Modifier.isPublic(m.getModifiers))
+      .map(_.getName)
+      .toSet
+
+  private def instanceNames(c: Class[?]): Set[String] =
+    c.getDeclaredMethods
+      .filterNot(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(m => java.lang.reflect.Modifier.isPublic(m.getModifiers))
+      .map(_.getName)
+      .filterNot(objectOverrides.contains)
+      .toSet
+
+  private lazy val actualNames: Set[String] =
+    staticNames(classOf[onion.Future[?]]) ++ instanceNames(classOf[onion.Future[?]])
+
+  it("actual onion.Future exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Future found no members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Future member") {
+    val missing = actualNames -- documentedNames(read("docs/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/reference/stdlib.md is missing Future members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Future member") {
+    val missing = actualNames -- documentedNames(read("docs/ja/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/ja/reference/stdlib.md is missing Future members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary
- `f.underlying()` (Future -> Java `CompletableFuture`) was documented under "Conversions" in `docs/reference/stdlib.md` and its Japanese translation, but the inverse factory, `Future::fromCompletableFuture` (Java `CompletableFuture` -> Future), was never mentioned in either file.
- Added a short example to both docs showing the round trip.
- Added `FutureDocCoverageSpec`, following the existing `OptionResultDocCoverageSpec`/`CollsDocCoverageSpec`/`ConcurrentDocCoverageSpec`/`RegexDocCoverageSpec` pattern, to reflectively guard every public `onion.Future` member against both doc files going forward.
- Noted the fix under `[Unreleased]` in `CHANGELOG.md`.

## Test plan
- [x] `FutureDocCoverageSpec` fails (red) before the docs change, confirming it catches the gap
- [x] `FutureDocCoverageSpec` passes (green) after the docs change
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 4992 succeeded, 0 failed, 1 pre-existing unrelated cancellation (distribution-packaging journey test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKVVZHrz1LmJt4dTjsToAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKVVZHrz1LmJt4dTjsToAC)_