### PR TITLE
docs(stdlib): document Stats::sumLong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrap a Java async API's result for use with Onion's `map`/`flatMap`/`await`/`do` notation. A new
   `FutureDocCoverageSpec` guards every public `onion.Future` member against both files going
   forward.
+- **`Stats::sumLong`.** `docs/reference/stdlib.md` and its Japanese translation mentioned
+  `sumInt`/`sumLong` together in prose ("keep integer precision") but only ever showed
+  `Stats::sumInt(...)` in an actual example — `sumLong` never appeared as a real call in
+  either file. A new `StatsDocCoverageSpec` guards every public `onion.Stats` member against
+  both files going forward.
 
 ## [0.45.0] - 2026-09-03
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1316,6 +1316,9 @@ Stats::sum(xs)       // 100.0      Stats::sumInt(xs)   // 100
 Stats::average(xs)   // 25.0       Stats::median(xs)   // 25.0
 Stats::min(xs) / Stats::max(xs)    // 10.0 / 40.0
 Stats::variance(xs) / Stats::stddev(xs)
+
+val ys: List[Long] = [10L, 20L, 30L, 40L]
+Stats::sumLong(ys)   // 100L   （Long: 整数精度を保持）
 ```
 
 メソッド呼び出しの形でも使えます（実際のコードではこちらが自然です）。ただし

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1429,6 +1429,9 @@ Stats::sum(xs)       // 100.0      Stats::sumInt(xs)   // 100
 Stats::average(xs)   // 25.0       Stats::median(xs)   // 25.0
 Stats::min(xs) / Stats::max(xs)    // 10.0 / 40.0
 Stats::variance(xs) / Stats::stddev(xs)
+
+val ys: List[Long] = [10L, 20L, 30L, 40L]
+Stats::sumLong(ys)   // 100L   (Long, exact precision)
 ```
 
 These are also reachable as method calls, which is the form most code reaches

--- a/src/test/scala/onion/compiler/tools/StatsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StatsDocCoverageSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Stats` module docs.
+ *
+ * `onion.Stats` is a default-imported stdlib module (`Stats::sum`, `Stats::sumLong`,
+ * `Stats::median`, ...) with its own section in docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md, but `sumLong` was only ever mentioned in prose
+ * ("`sumInt`/`sumLong` keep integer precision") and never shown as an actual
+ * `Stats::sumLong(...)` call — every public member is checked here against both
+ * files so a future addition to onion.Stats fails the build instead of silently
+ * staying undocumented.
+ */
+class StatsDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Stats::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Stats]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    methodNames.toSet
+  }
+
+  it("actual onion.Stats exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Stats found no static members — the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Stats member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Stats:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Stats member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Stats:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Stats in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Stats"),
+      "docs/reference/stdlib.md's overview table should mention Stats")
+    assert(read("docs/ja/reference/stdlib.md").contains("Stats"),
+      "docs/ja/reference/stdlib.md's overview table should mention Stats")
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md` and its Japanese translation mentioned `sumInt`/`sumLong` together in prose ("keep integer precision") but only ever showed `Stats::sumInt(...)` in an actual runnable example — `Stats::sumLong` never appeared as a real call in either file.
- Added a `Stats::sumLong(ys)` example to both docs, next to the existing `Stats::sum`/`sumInt` example block.
- Added `StatsDocCoverageSpec`, following the existing `*DocCoverageSpec` pattern (`OnionMathDocCoverageSpec`, `CollsDocCoverageSpec`, `ConcurrentDocCoverageSpec`, `RegexDocCoverageSpec`, `FutureDocCoverageSpec`, `OptionResultDocCoverageSpec`), reflecting `onion.Stats`'s public static members and asserting every one is documented in both language files. Confirmed red before the doc fix, green after.
- Noted the fix under `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.StatsDocCoverageSpec'` — red before the docs fix (missing `sumLong`), green after
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — full suite green (673 suites, 4996 succeeded, 0 failed, 1 canceled — the pre-existing `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path` to be set, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lrc6W8xXhQ6bydwhBspFvu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lrc6W8xXhQ6bydwhBspFvu)_