### PR TITLE
docs(stdlib): document Db::connect(url) overload and Conn::isClosed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Stats::sumInt(...)` in an actual example — `sumLong` never appeared as a real call in
   either file. A new `StatsDocCoverageSpec` guards every public `onion.Stats` member against
   both files going forward.
+- **`Db::connect`'s single-argument overload and `Conn::isClosed`.** `docs/reference/stdlib.md`
+  and its Japanese translation only ever showed the 3-argument `Db::connect(url, user, password)`
+  call and `db.close()` — the credential-less `Db::connect(url)` overload (for databases needing
+  none, e.g. SQLite/H2) and `db.isClosed()` (alongside `close()`, as `Concurrent`'s Channel docs
+  already pair `close()`/`isClosed()`) never appeared in either file. A new `DbDocCoverageSpec`
+  guards both overloads and `isClosed()` against both files going forward.
 
 ## [0.45.0] - 2026-09-03
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1950,8 +1950,12 @@ db.transaction((conn) -> {
   conn.update("UPDATE accounts SET balance = balance + ? WHERE id = ?", 100, 2)
 })
 
+db.isClosed()   // db.close() を呼ぶまでは false
 db.close()
 ```
+
+`Db::connect(url)` には認証情報が不要なデータベース（SQLite、H2 など）向けの引数 1 つの形式
+もあります。`Db::connect("jdbc:sqlite:local.db")` は `Db::connect(url, null, null)` と同じです。
 
 値は常に**バインド**され、SQL 文字列に埋め込まれることはありません。`WHERE name = ?` は
 どんな名前でも安全で、うっかり文字列連結してしまう余地がそもそもありません。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1942,8 +1942,12 @@ db.transaction((conn) -> {
   conn.update("UPDATE accounts SET balance = balance + ? WHERE id = ?", 100, 2)
 })
 
+db.isClosed()   // false until db.close() is called
 db.close()
 ```
+
+`Db::connect(url)` also has a credential-less, one-argument form for databases that need
+none (SQLite, H2): `Db::connect("jdbc:sqlite:local.db")` is `Db::connect(url, null, null)`.
 
 Values are always **bound**, never pasted into the SQL, so `WHERE name = ?` is safe with
 any name and there is no way to build the string by accident.

--- a/src/test/scala/onion/compiler/tools/DbDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/DbDocCoverageSpec.scala
@@ -1,0 +1,59 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Db` module docs.
+ *
+ * `onion.Db::connect` is overloaded: the 3-arg `connect(url, user, password)` and a
+ * credential-less `connect(url)` that delegates to it with null user/password (for
+ * databases needing no credentials, e.g. SQLite/H2). `onion.Db.Conn::isClosed` is also
+ * a real, callable member alongside `close()`. docs/reference/stdlib.md and its Japanese
+ * translation only ever showed the 3-arg `connect` call and `db.close()`, never the
+ * single-arg `connect` overload or `isClosed()` -- even though `Concurrent`'s Channel
+ * docs pair `close()`/`isClosed()` explicitly.
+ */
+class DbDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def hasSingleArgConnectCall(doc: String): Boolean =
+    """Db::connect\([^,)]+\)""".r.findFirstIn(doc).isDefined
+
+  private def hasIsClosedCall(doc: String): Boolean =
+    doc.contains("db.isClosed()")
+
+  it("actual onion.Db::connect has both a single-arg and a 3-arg overload (sanity check)") {
+    val arities = classOf[onion.Db].getDeclaredMethods
+      .filter(_.getName == "connect")
+      .map(_.getParameterCount)
+      .toSet
+    assert(arities == Set(1, 3), s"expected connect/1 and connect/3 overloads, found arities: ${arities.toSeq.sorted}")
+  }
+
+  it("actual onion.Db.Conn exposes isClosed (sanity check)") {
+    val hasIsClosed = classOf[onion.Db.Conn].getDeclaredMethods.exists(_.getName == "isClosed")
+    assert(hasIsClosed, "reflection on onion.Db.Conn found no isClosed method -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md demonstrates the single-arg Db::connect(url) overload") {
+    assert(hasSingleArgConnectCall(read("docs/reference/stdlib.md")),
+      "docs/reference/stdlib.md never shows a single-arg Db::connect(url) call")
+  }
+
+  it("docs/ja/reference/stdlib.md demonstrates the single-arg Db::connect(url) overload") {
+    assert(hasSingleArgConnectCall(read("docs/ja/reference/stdlib.md")),
+      "docs/ja/reference/stdlib.md never shows a single-arg Db::connect(url) call")
+  }
+
+  it("docs/reference/stdlib.md documents Conn::isClosed()") {
+    assert(hasIsClosedCall(read("docs/reference/stdlib.md")),
+      "docs/reference/stdlib.md never shows db.isClosed()")
+  }
+
+  it("docs/ja/reference/stdlib.md documents Conn::isClosed()") {
+    assert(hasIsClosedCall(read("docs/ja/reference/stdlib.md")),
+      "docs/ja/reference/stdlib.md never shows db.isClosed()")
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md` and its Japanese translation only ever showed the 3-argument `Db::connect(url, user, password)` call and `db.close()` — the credential-less `Db::connect(url)` overload (for databases needing none, e.g. SQLite/H2) and `db.isClosed()` never appeared in either file, even though the analogous `Concurrent` Channel docs already pair `close()`/`isClosed()`.
- Adds a short example/prose note for both to both doc files.
- Adds `DbDocCoverageSpec` (TDD: confirmed red before the doc changes, green after) guarding both against regressing, following the established `*DocCoverageSpec` pattern used for `Timing`, `Regex`, `Stats`, etc.
- Notes the change in `CHANGELOG.md` under `[Unreleased] / Documentation`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.DbDocCoverageSpec'` — red before the doc edits, green after.
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5005 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GYAUdvkpABATzkbnaVMQd

---
_Generated by [Claude Code](https://claude.ai/code/session_011GYAUdvkpABATzkbnaVMQd)_