### PR TITLE
docs(ja): document Json::stringifyPretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Json::stringifyPretty`.** `docs/reference/stdlib.md` showed both
+  `Json::stringify(obj) / Json::stringifyPretty(obj)`, but its Japanese translation's
+  equivalent example only ever called the plain `Json::stringify`, never mentioning the
+  pretty-printing sibling at all. A new `JsonDocCoverageSpec` guards its presence in both
+  files going forward.
 - **`Timing::measure`'s labeled overload.** `docs/reference/stdlib.md` and its Japanese
   translation showed `Timing::measure(fn)` and both `Timing::measureVoid` forms, but never
   the labeled `Timing::measure(label, fn)` overload sitting right next to `measureVoid`'s

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1041,6 +1041,7 @@ val age = Json::getInt(obj, "age")                     // 3
 val m = Json::object()                                  // 空の Map
 m.put("x", 1)
 val text = Json::stringify(m)                           // {"x":1}
+val pretty = Json::stringifyPretty(m)                   // インデント付きで整形
 val a = Json::array()                                   // 空の List（JSON 配列値の構築に使う）
 ```
 

--- a/src/test/scala/onion/compiler/tools/JsonDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/JsonDocCoverageSpec.scala
@@ -1,0 +1,36 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Json` module docs.
+ *
+ * `onion.Json::stringify` is overloaded with a pretty-printing sibling,
+ * `stringifyPretty`, that indents the output. docs/reference/stdlib.md shows
+ * both (`Json::stringify(obj) / Json::stringifyPretty(obj)`), but its Japanese
+ * translation only ever showed the plain `Json::stringify(m)` call -- never
+ * `stringifyPretty` at all.
+ */
+class JsonDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def hasStringifyPretty(doc: String): Boolean =
+    doc.contains("Json::stringifyPretty")
+
+  it("actual onion.Json exposes stringifyPretty (sanity check)") {
+    val hasStringifyPretty = classOf[onion.Json].getDeclaredMethods.exists(_.getName == "stringifyPretty")
+    assert(hasStringifyPretty, "reflection on onion.Json found no stringifyPretty method -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents Json::stringifyPretty") {
+    assert(hasStringifyPretty(read("docs/reference/stdlib.md")),
+      "docs/reference/stdlib.md never shows Json::stringifyPretty")
+  }
+
+  it("docs/ja/reference/stdlib.md documents Json::stringifyPretty") {
+    assert(hasStringifyPretty(read("docs/ja/reference/stdlib.md")),
+      "docs/ja/reference/stdlib.md never shows Json::stringifyPretty")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md`'s Json module example shows both `Json::stringify(obj)` and `Json::stringifyPretty(obj)`, but the Japanese translation's equivalent example only ever called the plain `Json::stringify` — `stringifyPretty` (a real, callable method on `onion.Json`) was never mentioned in the Japanese docs at all.
- Adds the missing example line (`val pretty = Json::stringifyPretty(m)`) to `docs/ja/reference/stdlib.md`, mirroring the English doc.
- Adds `JsonDocCoverageSpec`, following the established `*DocCoverageSpec` pattern used elsewhere in this repo (e.g. `TimingDocCoverageSpec`, `NetDocCoverageSpec`, `DbDocCoverageSpec`) to guard `stringifyPretty`'s presence in both doc files going forward.
- One `CHANGELOG.md` entry under `[Unreleased] / Documentation`.

## Test plan

- [x] `JsonDocCoverageSpec` written first and confirmed red (Japanese doc check failed) before the doc fix.
- [x] `JsonDocCoverageSpec` green after the fix.
- [x] Full suite green locally under both locales:
  - `sbt shutdown && SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5014 succeeded, 0 failed, 1 canceled (pre-existing, environment-conditional, unrelated to this change)
  - `sbt shutdown && SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` → same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2UFntYjhtpZ72AjNpSKhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2UFntYjhtpZ72AjNpSKhx)_