### PR TITLE
docs(yaml): document Yaml.YamlParseException::getLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`Yaml.YamlParseException::getLine`.** `docs/reference/stdlib.md` and its Japanese
+  translation documented `Yaml::parse`/`Yaml::stringify` but never mentioned that a caught
+  `Yaml.YamlParseException` also carries `getLine()` — the 1-based line number where parsing
+  gave up — alongside the usual `message()`, mirroring `Json.JsonParseException::getPosition`.
+  A new `YamlParseExceptionLineSpec` exercises both accessors via `shell.run`.
+
 ## [0.46.0] - 2026-09-03
 
 ### Added

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1128,6 +1128,17 @@ scalar の型推論規則（Json と同一）:
 不正な入力に対しては `Yaml.YamlParseException` を投げます。`derive!(Yaml)` の
 `fromYaml` はこれを捕捉して代わりに `null` を返します。
 
+不正入力の失敗をその場で処理したい場合、`Yaml.YamlParseException` は通常の `message()` に加えて
+`getLine()`（パースを諦めた行番号、1始まり）を持っています:
+
+```onion
+try {
+  Yaml::parse("no colon here")
+} catch e: Yaml.YamlParseException {
+  IO::println(e.message() + " at line " + e.getLine())
+}
+```
+
 ### Yaml::stringify
 
 `Map`（または scalar）を YAML の flat block-mapping 文字列にシリアライズします:

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1285,6 +1285,18 @@ Scalar type inference rules (identical to `Json`):
 Throws `Yaml.YamlParseException` on malformed input; `derive!(Yaml)`'s
 `fromYaml` catches this and returns `null` instead.
 
+When you do want to handle a malformed-input failure, `Yaml.YamlParseException` carries
+`getLine()` — the 1-based line number where parsing gave up — in addition to the usual
+`message()`:
+
+```onion
+try {
+  Yaml::parse("no colon here")
+} catch e: Yaml.YamlParseException {
+  IO::println(e.message() + " at line " + e.getLine())
+}
+```
+
 ### Yaml::stringify
 
 Serialize a `Map` (or scalar) to a YAML flat block-mapping string:

--- a/src/test/scala/onion/compiler/tools/YamlParseExceptionLineSpec.scala
+++ b/src/test/scala/onion/compiler/tools/YamlParseExceptionLineSpec.scala
@@ -1,0 +1,59 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `Yaml.YamlParseException` carries the line number where parsing gave up via
+ * `getLine()`, in addition to the usual `message()` -- documented in
+ * docs/reference/stdlib.md and docs/ja/reference/stdlib.md but never exercised by a
+ * `shell.run` test case.
+ */
+class YamlParseExceptionLineSpec extends AbstractShellSpec {
+  it("getLine() reports the line number where parsing failed") {
+    val result = shell.run(
+      """
+        | static def main(args: String[]): Int {
+        |   try {
+        |     Yaml::parse("no colon here")
+        |     return -1
+        |   } catch e: Yaml.YamlParseException {
+        |     return e.getLine()
+        |   }
+        | }
+      """.stripMargin, "None", Array())
+    assert(Shell.Success(1) == result)
+  }
+
+  it("getLine() reports the failing line, not the first, on a later bad line") {
+    val result = shell.run(
+      """
+        | static def main(args: String[]): Int {
+        |   try {
+        |     Yaml::parse("name: Alice\nage: 30\nno colon here")
+        |     return -1
+        |   } catch e: Yaml.YamlParseException {
+        |     return e.getLine()
+        |   }
+        | }
+      """.stripMargin, "None", Array())
+    assert(Shell.Success(3) == result)
+  }
+
+  it("message() and getLine() are both usable on the caught exception") {
+    val result = shell.run(
+      """
+        | static def main(args: String[]): String {
+        |   try {
+        |     Yaml::parse("no colon here")
+        |     return "no exception"
+        |   } catch e: Yaml.YamlParseException {
+        |     return e.message() + "|" + e.getLine()
+        |   }
+        | }
+      """.stripMargin, "None", Array())
+    assert(result match {
+      case Shell.Success(s: String) => s.contains("|1")
+      case _ => false
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md` and its Japanese translation documented `Yaml::parse`/`Yaml::stringify` but never mentioned that a caught `Yaml.YamlParseException` also carries `getLine()` — the 1-based line number where parsing gave up — alongside the usual `message()`. The Java source's own doc comment says it "mirrors `Json.JsonParseException` in shape", and that accessor (`getPosition()`) was already documented for `Json` — this brings `Yaml` to parity.
- Added `YamlParseExceptionLineSpec` (mirrors `JsonParseExceptionPositionSpec`) to exercise `getLine()`/`message()` via `shell.run`.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5017 tests, 0 failed, 1 cancelled (known distribution smoke test), all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCCuoxBAUFGrUSVUNVVDeL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCCuoxBAUFGrUSVUNVVDeL)_