### PR TITLE
docs(io): document IO::input alongside IO::readln

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`IO::input`.** `docs/reference/stdlib.md` and its Japanese translation documented
+  `IO::readln(prompt)` and `IO::readLine()` but never mentioned `IO::input(prompt)` — a
+  fully public sibling method that `readln(prompt)` is itself implemented in terms of. A
+  new `IODocCoverageSpec` guards its presence in both files going forward.
 - **`Yaml.YamlParseException::getLine`.** `docs/reference/stdlib.md` and its Japanese
   translation documented `Yaml::parse`/`Yaml::stringify` but never mentioned that a caught
   `Yaml.YamlParseException` also carries `getLine()` — the 1-based line number where parsing

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -59,6 +59,13 @@ val name: String = IO::readln("名前は？ ")
 IO::println("こんにちは、" + name)
 ```
 
+`IO::input(prompt)` はこの名前で直接呼び出せる同じ操作 -- `readln(prompt)` は
+内部で `input` を呼び出す実装：
+
+```onion
+val name: String = IO::input("名前は？ ")
+```
+
 ### IO::readLine
 
 標準入力から1行読み取り、入力の終端では `null` を返す。プロンプトなしの

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -59,6 +59,13 @@ val name: String = IO::readln("What's your name? ")
 IO::println("Hello, " + name)
 ```
 
+`IO::input(prompt)` is the same operation callable directly by that name --
+`readln(prompt)` is implemented in terms of it:
+
+```onion
+val name: String = IO::input("What's your name? ")
+```
+
 ### IO::readLine
 
 Read a line from standard input, or `null` at end of input. `IO::readln()` (no

--- a/src/test/scala/onion/compiler/tools/IODocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IODocCoverageSpec.scala
@@ -1,0 +1,37 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `IO` module docs.
+ *
+ * `onion.IO::input(prompt)` is a fully public stdlib method -- `readln(prompt)`
+ * is itself implemented as `return input(prompt);`, so it's a real, independently
+ * callable sibling of the documented `IO::readln(prompt)`, not a private helper.
+ * docs/reference/stdlib.md and its Japanese translation document `IO::readln`
+ * and `IO::readLine` but never mention `IO::input` at all.
+ */
+class IODocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def mentionsInput(doc: String): Boolean =
+    "IO::input".r.findFirstIn(doc).isDefined
+
+  it("actual onion.IO declares a public static input(String) method (sanity check)") {
+    val method = classOf[onion.IO].getDeclaredMethod("input", classOf[String])
+    assert(java.lang.reflect.Modifier.isStatic(method.getModifiers))
+    assert(java.lang.reflect.Modifier.isPublic(method.getModifiers))
+  }
+
+  it("docs/reference/stdlib.md mentions IO::input") {
+    assert(mentionsInput(read("docs/reference/stdlib.md")),
+      "docs/reference/stdlib.md never mentions IO::input")
+  }
+
+  it("docs/ja/reference/stdlib.md mentions IO::input") {
+    assert(mentionsInput(read("docs/ja/reference/stdlib.md")),
+      "docs/ja/reference/stdlib.md never mentions IO::input")
+  }
+}


### PR DESCRIPTION
## Summary
- `IO::input(prompt)` is a fully public stdlib method — `IO::readln(prompt)` is itself implemented as `return input(prompt);` — but neither `docs/reference/stdlib.md` nor its Japanese translation ever mentioned it.
- Added a short cross-reference to `IO::input` right after the existing `IO::readln` example in both language versions.
- Added `IODocCoverageSpec` to guard `IO::input`'s presence in both docs going forward, following the existing `*DocCoverageSpec` pattern (e.g. `TimingDocCoverageSpec`, `NetDocCoverageSpec`).
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.IODocCoverageSpec"` — red before the doc fix, green after
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5020 tests, 0 failed (1 pre-existing, unrelated cancellation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AwBrb89eBMfhPVnhiXX3g

---
_Generated by [Claude Code](https://claude.ai/code/session_012AwBrb89eBMfhPVnhiXX3g)_