### PR TITLE
docs(proc): document Proc::runIn/execIn and Result::failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Yaml.YamlParseException` also carries `getLine()` — the 1-based line number where parsing
   gave up — alongside the usual `message()`, mirroring `Json.JsonParseException::getPosition`.
   A new `YamlParseExceptionLineSpec` exercises both accessors via `shell.run`.
+- **`Proc::runIn`/`Proc::execIn` and `Proc.Result::failed`.** `docs/reference/stdlib.md` and
+  its Japanese translation showed `Proc::capture`/`Proc::run`/`Proc::exec`/`Proc::captureIn`
+  and said the "...In variants set the working directory" (plural), but never actually showed
+  `Proc::runIn`/`Proc::execIn`, and `Proc.Result::failed()` was missing alongside the other
+  `Result` accessors. A new `ProcDocCoverageSpec` guards the full `Proc`/`Proc.Result` member
+  set against both files going forward.
 
 ## [0.46.0] - 2026-09-03
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1516,10 +1516,12 @@ val out2 = Csv::stringifyWithHeader(recs)     // records -> CSV（parseWithHeade
 スクリプト向けのプロセス実行（`onion.Proc`）:
 
 ```onion
-val r = Proc::capture("git", "status")  // r.status() / r.stdout() / r.stderr() / r.succeeded()
+val r = Proc::capture("git", "status")  // r.status() / r.stdout() / r.stderr() / r.succeeded() / r.failed()
 Proc::run("ls", "-la")                  // stdout を String で取得（失敗時は例外）
 Proc::exec("make", "build")             // 終了コード、出力はそのまま素通し
 Proc::captureIn("/tmp", "ls")           // ...In 系は作業ディレクトリを指定
+Proc::runIn("/tmp", "ls")               // run と同様だが、指定した作業ディレクトリで実行
+Proc::execIn("/tmp", "make", "build")   // exec と同様だが、指定した作業ディレクトリで実行
 ```
 
 ## Args モジュール

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1504,10 +1504,12 @@ Text::table([["Name", "Dept"], ["Alice", "Eng"], ["Bob", "Sales"]])
 Process execution for scripting (`onion.Proc`):
 
 ```onion
-val r = Proc::capture("git", "status")  // r.status() / r.stdout() / r.stderr() / r.succeeded()
+val r = Proc::capture("git", "status")  // r.status() / r.stdout() / r.stderr() / r.succeeded() / r.failed()
 Proc::run("ls", "-la")                  // stdout as String (throws on failure)
 Proc::exec("make", "build")             // exit code, output passes through
 Proc::captureIn("/tmp", "ls")           // ...In variants set the working directory
+Proc::runIn("/tmp", "ls")               // like run, but in the given working directory
+Proc::execIn("/tmp", "make", "build")   // like exec, but in the given working directory
 ```
 
 ## Args Module

--- a/src/test/scala/onion/compiler/tools/ProcDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ProcDocCoverageSpec.scala
@@ -1,0 +1,60 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Proc` module docs.
+ *
+ * `onion.Proc` exposes `capture`/`captureIn`/`run`/`runIn`/`exec`/`execIn` plus instance
+ * methods on the `Result` type `capture`/`captureIn` return. docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md showed `capture`/`run`/`exec`/`captureIn` and, on `Result`,
+ * only `status`/`stdout`/`stderr`/`succeeded` -- `runIn`, `execIn`, and `Result.failed()`
+ * were all real, callable members with no mention anywhere in either file, even though the
+ * doc text says "...In variants set the working directory" (plural) without ever showing
+ * `runIn`/`execIn` themselves.
+ *
+ * `Object` overrides (`toString`, `equals`, `hashCode`, ...) are excluded: they carry no
+ * Proc-specific behavior worth documenting.
+ */
+class ProcDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => s"\\b${java.util.regex.Pattern.quote(n)}\\b".r.findFirstIn(doc).isDefined)
+
+  private val objectOverrides = Set("toString", "equals", "hashCode", "wait", "notify", "notifyAll", "getClass")
+
+  private def staticNames(c: Class[?]): Set[String] =
+    c.getDeclaredMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(m => java.lang.reflect.Modifier.isPublic(m.getModifiers))
+      .map(_.getName)
+      .toSet
+
+  private def instanceNames(c: Class[?]): Set[String] =
+    c.getDeclaredMethods
+      .filterNot(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(m => java.lang.reflect.Modifier.isPublic(m.getModifiers))
+      .map(_.getName)
+      .filterNot(objectOverrides.contains)
+      .toSet
+
+  private lazy val actualNames: Set[String] =
+    staticNames(classOf[onion.Proc]) ++ instanceNames(classOf[onion.Proc.Result])
+
+  it("actual onion.Proc (and Result) exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Proc found no members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Proc member") {
+    val missing = actualNames -- documentedNames(read("docs/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/reference/stdlib.md is missing Proc members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Proc member") {
+    val missing = actualNames -- documentedNames(read("docs/ja/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/ja/reference/stdlib.md is missing Proc members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md` and its Japanese translation showed `Proc::capture`/`Proc::run`/`Proc::exec`/`Proc::captureIn` and said the "...In variants set the working directory" (plural), but never actually showed `Proc::runIn`/`Proc::execIn` themselves, and `Proc.Result::failed()` was missing alongside the other `Result` accessors (`status`/`stdout`/`stderr`/`succeeded`).
- Added the missing examples to both docs.
- Added a new `ProcDocCoverageSpec` (mirroring the existing `TimingDocCoverageSpec`/`ConcurrentDocCoverageSpec` pattern) that reflects over `onion.Proc`/`onion.Proc.Result`'s public members and guards that every member name appears in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.

## Test plan

- [x] TDD: wrote `ProcDocCoverageSpec` first, confirmed it failed (`execIn`, `runIn` missing) before the doc fix
- [x] Fixed both docs, confirmed `ProcDocCoverageSpec` passes
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5023 succeeded, 0 failed, 1 canceled (pre-existing, opt-in-only `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPeqnzSHuGXsEeijXvPUbB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPeqnzSHuGXsEeijXvPUbB)_