### PR TITLE
perf: small fixed-cost removals in typing, codegen and source reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Smaller fixed costs in typing and codegen (each below measurement noise on the corpus,
+  kept because they only remove work): a class's method lists are cached until a member is
+  added; single-argument applied types are cached by that argument's identity instead of a
+  list hash; every remaining candidate collection uses the memoized per-compilation candidate
+  array; the codegen call-shape cache compares owner names instead of converting one per call
+  and carries the ASM method handle; a source file is read and decoded in one step; a `#{name}`
+  interpolation builds its identifier directly instead of running a sub-parser.
+
 ## [0.48.0] - 2026-09-03
 
 ### Changed

--- a/src/main/scala/onion/compiler/MultiTable.scala
+++ b/src/main/scala/onion/compiler/MultiTable.scala
@@ -13,7 +13,12 @@ class MultiTable[E <: Named] extends Iterable[E] {
   // table for every name ever asked of every class, `size` on `Object` included.
   private[this] final val mapping = new mutable.HashMap[String, List[E]]
 
+  // `values` is asked for on every method lookup over a user class; it is rebuilt only
+  // after an `add`.
+  private[this] var cachedValues: List[E] = null
+
   def add(entry: E): Boolean = {
+    cachedValues = null
     mapping.get(entry.name) match {
       case Some(v) =>
         mapping(entry.name) = v :+ entry
@@ -26,6 +31,9 @@ class MultiTable[E <: Named] extends Iterable[E] {
 
   def get(key: String): Seq[E] = mapping.getOrElse(key, Nil)
 
-  def values: Seq[E] = mapping.values.toList.flatten
+  def values: Seq[E] = {
+    if (cachedValues == null) cachedValues = mapping.values.toList.flatten
+    cachedValues
+  }
   def iterator: Iterator[E] = values.iterator
 }

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -59,14 +59,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * every other line keeps its original line number. On any other line `#!` is
    * left for the lexer to reject rather than being silently skipped (issue #262).
    */
-  private def stripShebang(reader: Reader): String = {
-    val sb = new StringBuilder
-    val buf = new Array[Char](4096)
-    try {
-      var n = reader.read(buf)
-      while (n != -1) { sb.appendAll(buf, 0, n); n = reader.read(buf) }
-    } finally reader.close()
-    val text = sb.toString
+  private def stripShebang(text: String): String = {
     if (text.startsWith("#!")) {
       val nl = text.indexOf('\n')
       if (nl < 0) "" else text.substring(nl)
@@ -79,7 +72,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
     problems: ArrayBuffer[CompileError]
   ): Unit = {
     try {
-      val sourceText = stripShebang(source.openReader())
+      val sourceText = stripShebang(source.readText())
 
       // Fast path: the handwritten parser. It produces the same AST as the JavaCC parser
       // for every program the latter accepts, and gives up (Fail) on anything else, in which

--- a/src/main/scala/onion/compiler/TypedAST.scala
+++ b/src/main/scala/onion/compiler/TypedAST.scala
@@ -430,7 +430,12 @@ object TypedAST {
       this.isResolutionComplete = isInResolution
     }
 
+    // Per-name method arrays, as AsmClassType keeps: overload resolution asks for the same
+    // names over and over, and the table-to-array copy per call showed in the profile.
+    private var methodArrays: java.util.HashMap[String, Array[TypedAST.Method]] = null
+
     def add(method: TypedAST.Method): Unit = {
+      methodArrays = null
       methods_.add(method)
     }
 
@@ -444,7 +449,16 @@ object TypedAST {
     def addDefaultConstructor: Unit =
       constructors_ += ConstructorDefinition.newDefaultConstructor(this)
 
-    def methods(name: String): Array[TypedAST.Method] = methods_.get(name).toArray(using methodTag)
+    def methods(name: String): Array[TypedAST.Method] = {
+      if (methodArrays == null) methodArrays = new java.util.HashMap[String, Array[TypedAST.Method]]()
+      val cached = methodArrays.get(name)
+      if (cached != null) cached
+      else {
+        val fresh = methods_.get(name).toArray(using methodTag)
+        methodArrays.put(name, fresh)
+        fresh
+      }
+    }
 
     def field(name: String): TypedAST.FieldRef = fields_.get(name).orNull
 
@@ -1036,8 +1050,24 @@ object TypedAST {
     // a (raw, list) tuple hashed the raw type's name and allocated the tuple on every
     // lookup, and this is asked for every written type annotation.
     private val cache = new java.util.concurrent.ConcurrentHashMap[TypedAST.ClassType, java.util.concurrent.ConcurrentHashMap[scala.collection.immutable.List[TypedAST.Type], AppliedClassType]]()
+    // Most applied types have one argument (List[String], Function1[...]'s aside); those are
+    // keyed by that argument's identity, which hashes in O(1), instead of by the list, whose
+    // hash walks its elements on every lookup.
+    private val cache1 = new java.util.concurrent.ConcurrentHashMap[TypedAST.ClassType, java.util.concurrent.ConcurrentHashMap[TypedAST.Type, AppliedClassType]]()
 
     def apply(raw: TypedAST.ClassType, typeArguments: scala.collection.immutable.List[TypedAST.Type]): AppliedClassType =
+      if typeArguments.nonEmpty && typeArguments.tail.isEmpty then
+        var perRaw1 = cache1.get(raw)
+        if perRaw1 == null then
+          perRaw1 = new java.util.concurrent.ConcurrentHashMap[TypedAST.Type, AppliedClassType]()
+          val winner = cache1.putIfAbsent(raw, perRaw1)
+          if winner != null then perRaw1 = winner
+        val arg = typeArguments.head
+        val cached1 = perRaw1.get(arg)
+        if cached1 != null then return cached1
+        val fresh1 = new AppliedClassType(raw, Array[TypedAST.Type](arg))
+        val winner1 = perRaw1.putIfAbsent(arg, fresh1)
+        return if winner1 == null then fresh1 else winner1
       var perRaw = cache.get(raw)
       if perRaw == null then
         perRaw = new java.util.concurrent.ConcurrentHashMap[scala.collection.immutable.List[TypedAST.Type], AppliedClassType]()
@@ -1813,6 +1843,8 @@ object TypedAST {
     private def isSuperTypeForClass(left: TypedAST.ClassType, right: TypedAST.ClassType): Boolean = {
       if (right == null) return false
       if (left eq right) return true
+      // Identity maps on purpose: a hashed map would call the types' hashCode, which for an
+      // applied type is not identity-based (measured slower than the walk it replaces).
       val memo = subtypeMemo.get
       var byRight = memo.get(left)
       if (byRight == null) {

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -361,7 +361,7 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
   private def codeMethod(cw: ClassWriter, node: MethodDefinition, className: String): Unit =
     var access = toAsmModifier(node.modifier)
     if (node.isVararg) access |= Opcodes.ACC_VARARGS
-    val argTypes = node.arguments.map(asmType)
+    val argTypes = node.arguments.map(asmType)(using AsmUtil.asmTypeTag)
     val returnType = asmType(node.returnType)
     val exceptions = if (node.throwsTypes.isEmpty) null
                      else node.throwsTypes.map(t => AsmUtil.internalName(t.name))

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -30,14 +30,17 @@ class AsmCodeGenerationVisitor(
   // A call site's argument types, descriptor and owner depend only on the Method, and a
   // program calls the same few methods over and over; building the descriptor string and
   // the owner Type per call site was a visible share of code generation.
-  private final class CallShape(val argTypes: Array[AsmType], val descriptor: String, val owner: AsmType)
+  private final class CallShape(val argTypes: Array[AsmType], val descriptor: String, val owner: AsmType, val ownerName: String, val asmMethod: AsmMethod)
   private val callShapes = new java.util.IdentityHashMap[TypedAST.Method, CallShape]()
   private def callShape(method: TypedAST.Method, ownerName: String): CallShape = {
     val cached = callShapes.get(method)
-    if (cached != null && cached.owner.getInternalName == AsmUtil.internalName(ownerName)) cached
+    // Compared by the owner's source name (the same string instance nearly always): the
+    // internal-name conversion this used to do on every hit allocated a string per call.
+    if (cached != null && (cached.ownerName eq ownerName) || (cached != null && cached.ownerName == ownerName)) cached
     else {
       val argTypes = method.arguments.map(asmType)(using AsmUtil.asmTypeTag)
-      val shape = new CallShape(argTypes, AsmType.getMethodDescriptor(asmType(method.returnType), argTypes*), AsmUtil.objectType(ownerName))
+      val descriptor = AsmType.getMethodDescriptor(asmType(method.returnType), argTypes*)
+      val shape = new CallShape(argTypes, descriptor, AsmUtil.objectType(ownerName), ownerName, new AsmMethod(method.name, descriptor))
       callShapes.put(method, shape)
       shape
     }
@@ -247,19 +250,21 @@ class AsmCodeGenerationVisitor(
     visitTerm(node.target)
     val shape = callShape(node.method, node.method.affiliation.name)
     val argTypes = shape.argTypes
-    emitArgumentsWithAdaptation(node.parameters, argTypes, Array(asmType(node.target.`type`)))
+    val pendingReceiver = new Array[AsmType](1)
+    pendingReceiver(0) = asmType(node.target.`type`)
+    emitArgumentsWithAdaptation(node.parameters, argTypes, pendingReceiver)
     val ownerType = shape.owner
     val methodDesc = shape.descriptor
     val isInterface = node.method.affiliation.isInterface
 
     // Select correct invoke instruction based on method type
     if isInterface then
-      gen.invokeInterface(ownerType, AsmMethod(node.method.name, methodDesc))
+      gen.invokeInterface(ownerType, shape.asmMethod)
     else
       // Since JEP 181 (class file v55+) invokevirtual is legal for private
       // instance methods within a nest, which lets closures (nest members)
       // call the host's private methods
-      gen.invokeVirtual(ownerType, AsmMethod(node.method.name, methodDesc))
+      gen.invokeVirtual(ownerType, shape.asmMethod)
   
   override def visitCallStatic(node: CallStatic): Unit =
     val shape = callShape(node.method, node.target.name)
@@ -272,7 +277,7 @@ class AsmCodeGenerationVisitor(
       // a plain Methodref makes the JVM throw IncompatibleClassChangeError.
       gen.visitMethodInsn(Opcodes.INVOKESTATIC, ownerType.getInternalName, node.method.name, methodDesc, true)
     else
-      gen.invokeStatic(ownerType, AsmMethod(node.method.name, methodDesc))
+      gen.invokeStatic(ownerType, shape.asmMethod)
   
   override def visitCallSuper(node: CallSuper): Unit =
     visitTerm(node.target)
@@ -319,18 +324,17 @@ class AsmCodeGenerationVisitor(
     // Non-null path: call the method. The target survives the null check on
     // the stack (the dup'd copy IFNULL consumed was the other one), so it is
     // a pending operand across the arguments just like visitCall's receiver.
-    val argTypes = node.method.arguments.map(asmType)
-    emitArgumentsWithAdaptation(node.parameters, argTypes, Array(asmType(node.target.`type`)))
-    val ownerType = AsmUtil.objectType(node.method.affiliation.name)
-    val methodDesc = AsmType.getMethodDescriptor(
-      asmType(node.method.returnType),
-      argTypes*
-    )
+    val shape = callShape(node.method, node.method.affiliation.name)
+    val argTypes = shape.argTypes
+    val pendingReceiver = new Array[AsmType](1)
+    pendingReceiver(0) = asmType(node.target.`type`)
+    emitArgumentsWithAdaptation(node.parameters, argTypes, pendingReceiver)
+    val ownerType = shape.owner
     val isInterface = node.method.affiliation.isInterface
     if isInterface then
-      gen.invokeInterface(ownerType, AsmMethod(node.method.name, methodDesc))
+      gen.invokeInterface(ownerType, shape.asmMethod)
     else
-      gen.invokeVirtual(ownerType, AsmMethod(node.method.name, methodDesc))
+      gen.invokeVirtual(ownerType, shape.asmMethod)
 
     // Box primitive return type if needed (safe call always returns nullable)
     node.method.returnType match

--- a/src/main/scala/onion/compiler/parser/OnionParser.scala
+++ b/src/main/scala/onion/compiler/parser/OnionParser.scala
@@ -2399,6 +2399,21 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     }
   }
 
+  /** An ASCII identifier that is not a keyword: what the lexer would turn into a single ID token. */
+  private def isPlainIdentifier(text: String): Boolean = {
+    val n = text.length
+    if (n == 0 || n >= 32) return false
+    val c0 = text.charAt(0)
+    if (!((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z') || c0 == '_')) return false
+    var i = 1
+    while (i < n) {
+      val c = text.charAt(i)
+      if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_')) return false
+      i += 1
+    }
+    OnionLexer.keywordKind(text.toCharArray, 0, n) == -1
+  }
+
   /** `parseInterpolatedString` / `parseMultiLineInterpolatedString` of the grammar. */
   private def interpolated(loc: Location, whole: String, quoteLen: Int): AST.Expression = {
     val str = whole.substring(quoteLen, whole.length - quoteLen)
@@ -2432,9 +2447,16 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
         if (braceCount > 0) throw fail
         val exprStr = str.substring(interpStart + 2, interpEnd - 1)
         val (line, col) = interpolationOrigin(str, interpStart + 2, loc, quoteLen)
-        val sub = new OnionParser(exprStr, line - 1, col - 1)
-        val expr = try sub.term() catch { case _: Exception => throw fail }
-        needsBodyRewrite |= sub.needsBodyRewrite
+        // `#{name}` is most interpolations; a plain identifier needs no sub-parser (and its
+        // lexer). Anything else is parsed as a term at its position in the enclosing file.
+        val expr =
+          if (isPlainIdentifier(exprStr)) AST.Id(Location(line, col, line, col + exprStr.length - 1), exprStr)
+          else {
+            val sub = new OnionParser(exprStr, line - 1, col - 1)
+            val parsed = try sub.term() catch { case _: Exception => throw fail }
+            needsBodyRewrite |= sub.needsBodyRewrite
+            parsed
+          }
         expressions += expr
         start = interpEnd
         pos = interpEnd

--- a/src/main/scala/onion/compiler/source/FileSource.scala
+++ b/src/main/scala/onion/compiler/source/FileSource.scala
@@ -7,4 +7,9 @@ import java.io.Reader
 class FileSource(val name: String) extends SourceHandle {
   override def openReader(): Reader =
     Inputs.newReader(name)
+
+  // One read and one decode, under the same default charset `openReader()` (a FileReader)
+  // uses; the reader path decoded through a small buffer into a StringBuilder.
+  override def readText(): String =
+    new String(java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(name)), java.nio.charset.Charset.defaultCharset())
 }

--- a/src/main/scala/onion/compiler/source/SourceHandle.scala
+++ b/src/main/scala/onion/compiler/source/SourceHandle.scala
@@ -5,4 +5,16 @@ import java.io.Reader
 trait SourceHandle {
   def openReader(): Reader
   def name: String
+
+  /** The whole text. The default drains `openReader()`; a file-backed source decodes its bytes in one step. */
+  def readText(): String = {
+    val reader = openReader()
+    val sb = new java.lang.StringBuilder
+    val buf = new Array[Char](1 << 16)
+    try {
+      var n = reader.read(buf)
+      while (n != -1) { sb.append(buf, 0, n); n = reader.read(buf) }
+    } finally reader.close()
+    sb.toString
+  }
 }

--- a/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
@@ -119,15 +119,14 @@ final class MethodCallTyping(
     candidates: JTreeSet[Method],
     filter: Method => Boolean
   ): Unit = {
-    def collect(currentType: ObjectType): Unit = {
-      if (currentType == null) return
-      currentType.methods(name).foreach { method =>
-        if (filter(method)) candidates.add(method)
-      }
-      collect(currentType.superClass)
-      currentType.interfaces.foreach(collect)
+    // The hierarchy walk is memoized per (receiver, name) for the compilation; only the
+    // filter is applied here.
+    val all = MethodResolution.candidatesOf(sourceType, name, typing.table_)
+    var i = 0
+    while (i < all.length) {
+      if (filter(all(i))) candidates.add(all(i))
+      i += 1
     }
-    collect(sourceType)
   }
 
   /** Filter for instance (non-static) methods */

--- a/src/main/scala/onion/compiler/typing/session/AstBindingIndex.scala
+++ b/src/main/scala/onion/compiler/typing/session/AstBindingIndex.scala
@@ -15,7 +15,7 @@ final class AstBindingIndex {
   // share a binding, and their Locations differ anyway.
   // Presized: a few thousand bindings per unit is ordinary, and IdentityHashMap doubles
   // by copying, which showed up as resize() in profiles when it started at the default 32.
-  private val astToTypedJ = new java.util.IdentityHashMap[AST.Node, TypedAST.Node](8192)
+  private val astToTypedJ = new java.util.IdentityHashMap[AST.Node, TypedAST.Node](1024)
   private val astToTyped: scala.collection.mutable.Map[AST.Node, TypedAST.Node] = astToTypedJ.asScala
 
   // One put per typed node. The reverse direction used to be a second identity map


### PR DESCRIPTION
## Summary

Small fixed-cost removals, each individually below measurement noise on the whole corpus (user instructions within 2% of v0.48.0); kept because they only remove work and simplify a few paths:

- class method lists are cached until a member is added (`MultiTable.values`, `ClassDefinition.methods(name)` arrays);
- single-argument applied types are cached by that argument's identity instead of a list hash;
- every remaining candidate collection (`collectMethodsMatching`) uses the memoized per-compilation candidate array;
- the codegen call-shape cache compares owner names instead of converting one to an internal name per call, and carries the ASM `Method` handle (safe calls use the shape too);
- `SourceHandle.readText()` reads and decodes a file in one step; `Parsing` uses it;
- a `#{name}` interpolation builds its `Id` directly instead of running a sub-parser and lexer (both parsers still build identical ASTs over the corpus, 258/259).

Two things were tried and dropped in this batch: a `findMethod` memo keyed by argument-type identity (no measurable gain) and a per-type `ConcurrentHashMap` subtype memo (slower than the identity map it replaced, because an applied type's `hashCode` is not identity-based).

## Verification

Full suite green in both locales (`testFull`, en and ja; 5023 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc
