### PR TITLE
perf: fewer allocations in the scanners, the lexer and codegen locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fewer allocations on the compile path (each below measurement noise on the corpus): the
+  captured-variable and return scanners keep one visitor function per walk instead of
+  eta-expanding one per node; the handwritten lexer shares its never-read character stream
+  and hands out one `String` per distinct identifier per file; codegen's local-variable
+  context keeps slots in an array and its index sets in bit sets, and a closure's captured
+  variables are found by a linear scan instead of a tuple-keyed map.
+
 ## [0.49.0] - 2026-09-03
 
 ### Changed

--- a/src/main/scala/onion/compiler/CapturedVariableScanner.scala
+++ b/src/main/scala/onion/compiler/CapturedVariableScanner.scala
@@ -162,13 +162,17 @@ object CapturedVariableScanner {
   private def findClosures(node: AST.Node): List[AST.ClosureExpression] = {
     val result = mutable.ListBuffer[AST.ClosureExpression]()
 
+    // One function object for the whole walk: passing the local `visit` as an argument
+    // eta-expanded it into a new lambda at every node.
+    var visitF: AST.Node => Unit = null
     def visit(n: AST.Node): Unit = n match {
       case closure: AST.ClosureExpression =>
         result += closure
         // Don't descend into nested closures - they will be handled separately
       case _ =>
-        visitChildren(n)(visit)
+        visitChildren(n)(visitF)
     }
+    visitF = visit
 
     visit(node)
     result.toList
@@ -194,6 +198,7 @@ object CapturedVariableScanner {
     // closure are visible in the declaring closure.
     val capturedByNested = mutable.Set[String]()
 
+    var visitF: AST.Node => Unit = null
     def visit(n: AST.Node): Unit = {
       n match {
         case id: AST.Id =>
@@ -224,8 +229,9 @@ object CapturedVariableScanner {
 
         case _ =>
       }
-      visitChildren(n)(visit)
+      visitChildren(n)(visitF)
     }
+    visitF = visit
 
     visit(node)
     // Exclude variables that are both locally declared AND not captured by any

--- a/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
+++ b/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
@@ -10,9 +10,22 @@ import scala.collection.mutable
 final case class DebugLocal(slot: Int, name: String, descriptor: String)
 
 class LocalVarContext(gen: GeneratorAdapter) {
-  private val indexMap = mutable.Map[Int, Int]()
-  private val parameterSet = mutable.Set[Int]()
-  private val boxedSet = mutable.Set[Int]()
+  // Typed-AST index -> JVM slot, and two index sets, as flat structures: a boxed
+  // `Map[Int, Int]` and two `Set[Int]`s were consulted for every local read and write.
+  private var slots: Array[Int] = new Array[Int](16)
+  java.util.Arrays.fill(slots, -1)
+  private val parameterSet = new java.util.BitSet()
+  private val boxedSet = new java.util.BitSet()
+  private def setSlot(typedIndex: Int, slot: Int): Unit = {
+    if (typedIndex >= slots.length) {
+      val grown = java.util.Arrays.copyOf(slots, math.max(slots.length * 2, typedIndex + 1))
+      java.util.Arrays.fill(grown, slots.length, grown.length, -1)
+      slots = grown
+    }
+    slots(typedIndex) = slot
+  }
+  private def slotOrMinusOne(typedIndex: Int): Int =
+    if (typedIndex >= 0 && typedIndex < slots.length) slots(typedIndex) else -1
 
   // Debug info. Names come from the frame, because `LocalBinding` does not carry one and
   // the scopes are the only thing that still knows what the author called a variable by
@@ -42,41 +55,48 @@ class LocalVarContext(gen: GeneratorAdapter) {
       debugLocals += DebugLocal(slot, name, tp.getDescriptor)
     }
 
-  def slotOf(typedIndex: Int): Option[Int] = indexMap.get(typedIndex)
+  def slotOf(typedIndex: Int): Option[Int] = {
+    val slot = slotOrMinusOne(typedIndex)
+    if (slot < 0) None else Some(slot)
+  }
 
-  def getOrAllocateSlot(typedIndex: Int, tp: AsmType): Int =
-    indexMap.get(typedIndex) match {
-      case Some(slot) => slot
-      case None =>
-        val slot = gen.newLocal(tp)
-        indexMap(typedIndex) = slot
-        recordDebug(typedIndex, slot, tp)
-        slot
+  def getOrAllocateSlot(typedIndex: Int, tp: AsmType): Int = {
+    val existing = slotOrMinusOne(typedIndex)
+    if (existing >= 0) existing
+    else {
+      val slot = gen.newLocal(tp)
+      setSlot(typedIndex, slot)
+      recordDebug(typedIndex, slot, tp)
+      slot
     }
+  }
 
   def allocateSlot(typedIndex: Int, tp: AsmType): Int = {
     val slot = gen.newLocal(tp)
-    indexMap(typedIndex) = slot
+    setSlot(typedIndex, slot)
     recordDebug(typedIndex, slot, tp)
     slot
   }
 
-  def isParameter(typedIndex: Int): Boolean = parameterSet.contains(typedIndex)
+  def isParameter(typedIndex: Int): Boolean = typedIndex >= 0 && parameterSet.get(typedIndex)
 
-  def isBoxed(typedIndex: Int): Boolean = boxedSet.contains(typedIndex)
+  def isBoxed(typedIndex: Int): Boolean = typedIndex >= 0 && boxedSet.get(typedIndex)
 
-  def markAsBoxed(typedIndex: Int): Unit = boxedSet += typedIndex
+  def markAsBoxed(typedIndex: Int): Unit = boxedSet.set(typedIndex)
 
   /**
     * Register JVM parameter slots. Slot0 is `this` for instance methods.
     */
   def withParameters(isStatic: Boolean, argTypes: Array[AsmType]): LocalVarContext = {
-    val startSlot = if isStatic then 0 else 1
-    argTypes.zipWithIndex.foldLeft(startSlot) { case (slot, (tp, i)) =>
-      indexMap(i) = slot
-      parameterSet += i
+    var slot = if isStatic then 0 else 1
+    var i = 0
+    while (i < argTypes.length) {
+      val tp = argTypes(i)
+      setSlot(i, slot)
+      parameterSet.set(i)
       recordDebug(i, slot, tp)
-      slot + tp.getSize
+      slot += tp.getSize
+      i += 1
     }
     this
   }
@@ -95,7 +115,7 @@ class LocalVarContext(gen: GeneratorAdapter) {
       // Order is irrelevant here; `entries` sorted a fresh array per method.
       for (binding <- frame.allBindings) {
         if (binding.isBoxed) {
-          boxedSet += binding.index
+          boxedSet.set(binding.index)
         }
       }
     }
@@ -108,13 +128,18 @@ class ClosureLocalVarContext(
   val closureClassName: String,
   val capturedVars: Seq[onion.compiler.ClosureLocalBinding]
 ) extends LocalVarContext(gen) {
-  // Use (frameIndex, index) as key to handle nested closures correctly
-  private val capturedByKey: Map[(Int, Int), onion.compiler.ClosureLocalBinding] =
-    capturedVars.map(b => (b.frameIndex, b.index) -> b).toMap
-
-  // Also maintain index-only lookup for backward compatibility with non-nested cases
-  private val capturedByIndex: Map[Int, onion.compiler.ClosureLocalBinding] =
-    capturedVars.filter(_.frameIndex == 0).map(b => b.index -> b).toMap
+  // A closure captures a handful of variables; a linear scan over an array beats a map
+  // keyed by a (frame, index) tuple that had to be allocated for every local read.
+  private val capturedArray: Array[onion.compiler.ClosureLocalBinding] = capturedVars.toArray
+  private def find(frameIndex: Int, typedIndex: Int): onion.compiler.ClosureLocalBinding = {
+    var i = 0
+    while (i < capturedArray.length) {
+      val b = capturedArray(i)
+      if (b.frameIndex == frameIndex && b.index == typedIndex) return b
+      i += 1
+    }
+    null
+  }
 
   def capturedFieldName(frameIndex: Int, typedIndex: Int): String = s"captured_${frameIndex}_$typedIndex"
 
@@ -122,13 +147,13 @@ class ClosureLocalVarContext(
     capturedFieldName(binding.frameIndex, binding.index)
 
   def capturedBinding(frameIndex: Int, typedIndex: Int): Option[onion.compiler.ClosureLocalBinding] =
-    capturedByKey.get((frameIndex, typedIndex))
+    Option(find(frameIndex, typedIndex))
 
-  def capturedBinding(typedIndex: Int): Option[onion.compiler.ClosureLocalBinding] = capturedByIndex.get(typedIndex)
+  def capturedBinding(typedIndex: Int): Option[onion.compiler.ClosureLocalBinding] = Option(find(0, typedIndex))
 
-  def isCapturedVariable(frameIndex: Int, typedIndex: Int): Boolean = capturedByKey.contains((frameIndex, typedIndex))
+  def isCapturedVariable(frameIndex: Int, typedIndex: Int): Boolean = find(frameIndex, typedIndex) != null
 
-  def isCapturedVariable(typedIndex: Int): Boolean = capturedByIndex.contains(typedIndex)
+  def isCapturedVariable(typedIndex: Int): Boolean = find(0, typedIndex) != null
 
   override def getOrAllocateSlot(typedIndex: Int, tp: AsmType): Int =
     capturedBinding(typedIndex) match {

--- a/src/main/scala/onion/compiler/parser/OnionLexer.scala
+++ b/src/main/scala/onion/compiler/parser/OnionLexer.scala
@@ -28,7 +28,7 @@ import onion.compiler.parser.{JJOnionParserConstants as K}
  *    that starts nothing is an `ERROR` token rather than an exception.
  */
 final class OnionLexer(text: String)
-  extends JJOnionParserTokenManager(new JavaCharStream(new java.io.StringReader(""), 1, 1, 1)):
+  extends JJOnionParserTokenManager(OnionLexer.unusedStream):
 
   import OnionLexer.*
 
@@ -244,12 +244,42 @@ final class OnionLexer(text: String)
   private def make(kind: Int, start: Int, end: Int): Token =
     // Keywords and operators have one spelling; their image is the shared constant.
     val fixed = fixedImages(kind)
-    val t = Token.newToken(kind, if fixed != null then fixed else new String(chars, start, end - start))
+    val image =
+      if fixed != null then fixed
+      else if kind == K.ID then internedIdentifier(start, end)
+      else new String(chars, start, end - start)
+    val t = Token.newToken(kind, image)
     t.beginLine = lineAt(start)
     t.beginColumn = columnAt(start)
     t.endLine = lineAt(end - 1)
     t.endColumn = columnAt(end - 1)
     t
+
+  // Identifiers repeat within a file (`i`, `x`, `println`, the same locals over and over);
+  // a small open-addressing table hands the same String back instead of a copy per token.
+  private val identTable = new Array[String](512)
+  private def internedIdentifier(start: Int, end: Int): String =
+    val len = end - start
+    var h = 0
+    var i = start
+    while i < end do
+      h = h * 31 + chars(i)
+      i += 1
+    var slot = h & (identTable.length - 1)
+    var probes = 0
+    while probes < 4 do
+      val existing = identTable(slot)
+      if existing == null then
+        val fresh = new String(chars, start, len)
+        identTable(slot) = fresh
+        return fresh
+      if existing.length == len then
+        var j = 0
+        while j < len && existing.charAt(j) == chars(start + j) do j += 1
+        if j == len then return existing
+      slot = (slot + 1) & (identTable.length - 1)
+      probes += 1
+    new String(chars, start, len)
 
   private def blockCommentEnd(from: Int): Int =
     var i = from
@@ -578,6 +608,11 @@ final class OnionLexer(text: String)
   extension [A](a: A) private inline def tap(f: A => Unit): A = { f(a); a }
 
 object OnionLexer:
+  // The generated token manager wants a character stream, but this lexer never reads it (it
+  // scans `text` itself). One shared, never-advanced stream instead of an 8 KiB buffer per
+  // lexer -- and a lexer is built per file and per interpolated expression.
+  private val unusedStream: JavaCharStream = new JavaCharStream(new java.io.StringReader(""), 1, 1, 1)
+
   private val TabSize = 8
   private val DEFAULT = 0
   private val IN_STATEMENT = 1

--- a/src/main/scala/onion/compiler/typing/ReturnNodeDetector.scala
+++ b/src/main/scala/onion/compiler/typing/ReturnNodeDetector.scala
@@ -126,14 +126,17 @@ private[typing] object ReturnNodeDetector {
         ()
     }
 
+    // One function object for the whole walk (passing the local def eta-expanded a lambda per node).
+    var visitF: AST.Node => Unit = null
     def visit(n: AST.Node): Unit = n match {
       case _: AST.ReturnExpression =>
         found = true
       case _: AST.ClosureExpression =>
         () // do not inspect nested closures
       case _ =>
-        visitChildren(n)(visit)
+        visitChildren(n)(visitF)
     }
+    visitF = visit
 
     visit(node)
     found


### PR DESCRIPTION
## Summary

Allocation removals on the compile path, each below measurement noise on the whole corpus (user instructions within 2% of v0.49.0), kept because they only remove work:

- the captured-variable and return scanners keep one visitor function per walk (passing the local `def` eta-expanded a lambda per node);
- the handwritten lexer shares its never-read `JavaCharStream` (an 8 KiB buffer per lexer, and a lexer per file and per interpolated expression) and interns identifier images per file through a small open-addressing table;
- codegen's `LocalVarContext` keeps typed-index-to-slot in an array and its parameter/boxed sets in `BitSet`s instead of boxed `Map[Int, Int]`/`Set[Int]`, and `ClosureLocalVarContext` finds captured variables by a linear scan instead of a `(frame, index)`-tuple-keyed map allocated per local read.

Tokens (259/259 files, 523k tokens) and ASTs (258/259) still match the generated parser exactly.

## Verification

Full suite green in both locales (`testFull`, en and ja; 5023 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc
