### PR TITLE
feat: an opt-in compile daemon (ONION_DAEMON=1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A compile daemon** (`ONION_DAEMON=1`). `onionc` hands its command line to a resident
+  compiler process -- started on first use, one per user, JDK and Onion installation -- over a
+  Unix domain socket in a user-private directory, and relays its output and exit code. The
+  daemon keeps the JIT-compiled compiler and the shared class universe between runs, exits
+  after 30 minutes idle, and is controlled with `java -cp onion.jar
+  onion.tools.daemon.DaemonClient stop|status`. Whenever it cannot be reached or started,
+  `onionc` compiles in-process as before. Paths in the command line are made absolute by the
+  client, since the daemon has its own working directory.
+
 ## [0.50.0] - 2026-09-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Onion is a statically-typed, object-oriented programming language that compiles 
 - `--no-check-laws` - Do not execute record `law`/`example` clauses (they run at compile time by default; the LSP always has them off)
 - `--law-seed <n>` / `--law-samples <n>` - Control law sampling; a falsified law reports the settings that produced its counterexample
 - `--stacktrace` - Print the raw JVM trace for an uncaught runtime error (the default is a diagnostic-style report with the script's own frames only)
+- `ONION_DAEMON=1` (environment) - `onionc` compiles through a resident daemon (`onion.tools.daemon`), started on first use; falls back to in-process compilation when it cannot be reached. `java -cp onion.jar onion.tools.daemon.DaemonClient stop|status` controls it
 
 ## High-Level Architecture
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -98,6 +98,27 @@ ONION_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5
 `ONION_DEBUG_STARTUP=1` stops the launcher silencing the JVM's class-sharing messages,
 which is how to find out why an archive is being ignored.
 
+### The compile daemon
+
+Every `onionc` run starts a JVM, loads the compiler and compiles it just-in-time before it
+gets to your file. With `ONION_DAEMON=1`, `onionc` instead hands the command line to a
+resident compiler process — started on first use, one per user, JDK and Onion
+installation — and relays its output and exit code. The daemon keeps the warmed-up
+compiler between runs, so a typical single-file compile takes a fraction of the time:
+
+```bash
+export ONION_DAEMON=1
+onionc Hello.on            # starts the daemon the first time, then reuses it
+```
+
+The daemon stops itself after 30 minutes without work; `java -cp onion.jar
+onion.tools.daemon.DaemonClient stop` (or `status`) controls it by hand. It listens on a
+Unix domain socket in a directory only you can read (`$XDG_RUNTIME_DIR` or the temp
+directory; override with `ONION_DAEMON_SOCKET`), needs Java 16 or later for that, and
+whenever it cannot be reached or started `onionc` simply compiles in-process as before.
+`ONION_DAEMON_JAVA_OPTS` adds JVM flags to the daemon itself. Running a script with
+`onion` is not routed through the daemon (the program runs in your own process).
+
 ## IDE Setup
 
 ### Visual Studio Code

--- a/docs/ja/getting-started/installation.md
+++ b/docs/ja/getting-started/installation.md
@@ -98,6 +98,27 @@ ONION_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5
 `ONION_DEBUG_STARTUP=1` を設定すると、ランチャが抑止している JVM のクラス共有メッセージが
 表示されます。アーカイブが使われない理由はこれで分かります。
 
+### コンパイルデーモン
+
+`onionc` は毎回 JVM を起動し、コンパイラを読み込み、JIT で温めてからようやくファイルを
+コンパイルします。`ONION_DAEMON=1` を設定すると、`onionc` はコマンドラインを常駐の
+コンパイラプロセス（初回に自動起動、ユーザー・JDK・Onion のインストールごとに 1 つ）へ
+渡し、その出力と終了コードを中継します。デーモンは温まったコンパイラを実行間で保持する
+ので、典型的な 1 ファイルのコンパイルはずっと短い時間で終わります。
+
+```bash
+export ONION_DAEMON=1
+onionc Hello.on            # 初回はデーモンを起動し、以後はそれを再利用する
+```
+
+デーモンは 30 分仕事が無ければ自分で終了します。手動では `java -cp onion.jar
+onion.tools.daemon.DaemonClient stop`（または `status`）で操作できます。待ち受けは自分
+だけが読めるディレクトリ（`$XDG_RUNTIME_DIR` または一時ディレクトリ。
+`ONION_DAEMON_SOCKET` で上書き可）の Unix ドメインソケットで、Java 16 以降が必要です。
+デーモンに到達・起動できないときは、`onionc` はこれまでどおりプロセス内でコンパイル
+します。`ONION_DAEMON_JAVA_OPTS` はデーモン自身の JVM フラグです。`onion` による
+スクリプト実行はデーモンを経由しません（プログラムは自分のプロセスで動きます）。
+
 ## IDEセットアップ
 
 ### Visual Studio Code

--- a/src/main/scala/onion/tools/CompilerFrontend.scala
+++ b/src/main/scala/onion/tools/CompilerFrontend.scala
@@ -32,21 +32,31 @@ object CompilerFrontend {
   private def printError(message: String): Unit = System.err.println(message)
 
   def main(args: Array[String]): Unit = {
+    // With ONION_DAEMON set, the command line goes to the resident compile daemon (see
+    // onion.tools.daemon.DaemonClient); when the daemon cannot be reached, compile here.
+    val viaDaemon =
+      if (onion.tools.daemon.DaemonClient.enabledByEnvironment && !args.exists(a => a == "-h" || a == "--help" || a == "-v" || a == "--version"))
+        onion.tools.daemon.DaemonClient.compile(args)
+      else None
+    val exitCode = viaDaemon.getOrElse(runCommandLine(args))
+    if (exitCode != 0) System.exit(exitCode)
+  }
+
+  /** `main` without the exit: runs a complete `onionc` command line and returns its exit code. */
+  def runCommandLine(args: Array[String]): Int = {
     // Handle help and version flags early
     if (args.exists(a => a == "-h" || a == "--help")) {
       new CompilerFrontend().printUsage()
-      return
+      return 0
     }
     if (args.exists(a => a == "-v" || a == "--version")) {
       println(s"Onion Compiler version $VERSION")
-      return
+      return 0
     }
     val verbose = args.exists(_ == "--verbose")
     val filteredArgs = args.filterNot(_ == "--verbose")
-    try {
-      val exitCode = new CompilerFrontend().run(filteredArgs, verbose)
-      if (exitCode != 0) System.exit(exitCode)
-    } catch {
+    try new CompilerFrontend().run(filteredArgs, verbose)
+    catch {
       case e: ScriptException => throw e.getCause
     }
   }

--- a/src/main/scala/onion/tools/daemon/DaemonClient.scala
+++ b/src/main/scala/onion/tools/daemon/DaemonClient.scala
@@ -1,0 +1,164 @@
+package onion.tools.daemon
+
+import java.io.{DataInputStream, DataOutputStream, File}
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.{Channels, SocketChannel}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import java.security.MessageDigest
+import scala.util.control.NonFatal
+
+/**
+ * The client side of the compile daemon. `onionc` uses it when `ONION_DAEMON` is set to
+ * anything but `0`/`off`/`false`: the command line is sent to a resident [[OnionDaemon]]
+ * (started on first use, one per user, JDK and Onion installation) and its output and exit
+ * code are relayed. Whenever the daemon cannot be reached or started, the caller compiles
+ * in-process as before -- the daemon is only ever a shortcut.
+ *
+ * Paths in the command line are made absolute here, because the daemon has a different
+ * working directory: source files, `-d` and `-classpath` entries, and the defaults for the
+ * latter two (`.`) when they are absent.
+ *
+ * `java -cp onion.jar onion.tools.daemon.DaemonClient stop|status` controls the daemon.
+ */
+object DaemonClient {
+
+  /** Whether `onionc` should try the daemon, per the `ONION_DAEMON` environment variable. */
+  def enabledByEnvironment: Boolean = {
+    val v = System.getenv("ONION_DAEMON")
+    v != null && !Set("", "0", "off", "false", "no").contains(v.trim.toLowerCase)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val code = args.headOption match {
+      case Some("stop") => control("stop")
+      case Some("status") => control("ping")
+      case Some("start") => if (ensureRunning(socketPath())) 0 else 1
+      case _ =>
+        System.err.println("usage: DaemonClient start|stop|status")
+        2
+    }
+    System.exit(code)
+  }
+
+  /** Runs an `onionc` command line through the daemon; None when that is not possible. */
+  def compile(args: Array[String]): Option[Int] =
+    try {
+      val socket = socketPath()
+      if (!ensureRunning(socket)) None
+      else {
+        val cwd = Paths.get("").toAbsolutePath
+        val response = request(socket, DaemonProtocol.Request("compile", cwd.toString, absolutize(args, cwd)))
+        System.out.print(response.out)
+        System.err.print(response.err)
+        System.out.flush(); System.err.flush()
+        Some(response.exitCode)
+      }
+    } catch { case NonFatal(_) => None }
+
+  private def control(command: String): Int = {
+    val socket = socketPath()
+    if (!Files.exists(socket)) { println("onion daemon: not running"); return if (command == "ping") 1 else 0 }
+    try {
+      val r = request(socket, DaemonProtocol.Request(command, "", Array.empty))
+      print(r.out); System.err.print(r.err)
+      r.exitCode
+    } catch {
+      case NonFatal(_) =>
+        // A stale socket file: the daemon died without cleaning up.
+        try Files.deleteIfExists(socket) catch { case NonFatal(_) => () }
+        println("onion daemon: not running")
+        if (command == "ping") 1 else 0
+    }
+  }
+
+  /** The command line with every path made absolute against `cwd` (see the class comment). */
+  private[daemon] def absolutize(args: Array[String], cwd: Path): Array[String] = {
+    val out = scala.collection.mutable.ArrayBuffer[String]()
+    var sawOutput = false
+    var sawClasspath = false
+    var i = 0
+    while (i < args.length) {
+      val a = args(i)
+      a match {
+        case "-d" if i + 1 < args.length =>
+          sawOutput = true
+          out += a += abs(args(i + 1), cwd); i += 1
+        case "-classpath" if i + 1 < args.length =>
+          sawClasspath = true
+          out += a += args(i + 1).split(File.pathSeparator).map(abs(_, cwd)).mkString(File.pathSeparator); i += 1
+        case "-encoding" | "-maxErrorReport" | "-super" | "--Wno" | "--warn" | "--law-seed" | "--law-samples" |
+             "--profile-format" if i + 1 < args.length =>
+          out += a += args(i + 1); i += 1
+        case "--profile-output" if i + 1 < args.length =>
+          val target = args(i + 1)
+          out += a += (if (target == "stderr" || target == "stdout") target else abs(target, cwd)); i += 1
+        case _ if !a.startsWith("-") => out += abs(a, cwd)
+        case _ => out += a
+      }
+      i += 1
+    }
+    if (!sawOutput) out += "-d" += cwd.toString
+    if (!sawClasspath) out += "-classpath" += cwd.toString
+    out.toArray
+  }
+
+  private def abs(p: String, cwd: Path): String =
+    if (p.isEmpty) p else try cwd.resolve(p).normalize().toString catch { case NonFatal(_) => p }
+
+  /** One socket per user, JDK and Onion class path, in a directory only the user can read. */
+  def socketPath(): Path = {
+    val explicit = System.getenv("ONION_DAEMON_SOCKET")
+    if (explicit != null && explicit.nonEmpty) return Paths.get(explicit)
+    val runtimeDir = Option(System.getenv("XDG_RUNTIME_DIR")).filter(_.nonEmpty).getOrElse(System.getProperty("java.io.tmpdir"))
+    val user = System.getProperty("user.name", "onion")
+    val key = System.getProperty("java.class.path", "") + "|" + System.getProperty("java.version", "") + "|" + System.getProperty("java.home", "")
+    val digest = MessageDigest.getInstance("SHA-256").digest(key.getBytes(StandardCharsets.UTF_8))
+    val hash = digest.take(6).map(b => f"${b & 0xff}%02x").mkString
+    Paths.get(runtimeDir, s"onion-daemon-$user", s"$hash.sock")
+  }
+
+  /** Connects to the daemon, starting it first if needed; false when it cannot be reached. */
+  private def ensureRunning(socket: Path): Boolean = {
+    if (canConnect(socket)) return true
+    try Files.deleteIfExists(socket) catch { case NonFatal(_) => () }
+    start(socket)
+    val deadline = System.currentTimeMillis() + 8000
+    while (System.currentTimeMillis() < deadline) {
+      if (canConnect(socket)) return true
+      Thread.sleep(25)
+    }
+    false
+  }
+
+  private def canConnect(socket: Path): Boolean =
+    Files.exists(socket) && {
+      try { val ch = SocketChannel.open(UnixDomainSocketAddress.of(socket)); ch.close(); true }
+      catch { case NonFatal(_) => false }
+    }
+
+  /** Launches the daemon JVM with this JVM's java and class path, detached, logging to a file next to the socket. */
+  private def start(socket: Path): Unit = {
+    Files.createDirectories(socket.getParent)
+    val java = Paths.get(System.getProperty("java.home"), "bin", if (File.separatorChar == '\\') "java.exe" else "java").toString
+    val extra = Option(System.getenv("ONION_DAEMON_JAVA_OPTS")).filter(_.nonEmpty).map(_.trim.split("\\s+").toList).getOrElse(Nil)
+    val command = List(java, "-XX:+UseParallelGC", "-Xss16m") ++ extra ++
+      List("-cp", System.getProperty("java.class.path"), "onion.tools.daemon.OnionDaemon", socket.toString, OnionDaemon.DefaultIdleMillis.toString)
+    val log = socket.resolveSibling(socket.getFileName.toString.stripSuffix(".sock") + ".log").toFile
+    val builder = new ProcessBuilder(command*)
+    builder.redirectErrorStream(true)
+    builder.redirectOutput(ProcessBuilder.Redirect.appendTo(log))
+    builder.redirectInput(ProcessBuilder.Redirect.from(new File(if (File.separatorChar == '\\') "NUL" else "/dev/null")))
+    builder.start()
+  }
+
+  private[daemon] def request(socket: Path, req: DaemonProtocol.Request): DaemonProtocol.Response = {
+    val channel = SocketChannel.open(UnixDomainSocketAddress.of(socket))
+    try {
+      val out = new DataOutputStream(Channels.newOutputStream(channel))
+      val in = new DataInputStream(Channels.newInputStream(channel))
+      DaemonProtocol.writeRequest(out, req)
+      DaemonProtocol.readResponse(in)
+    } finally channel.close()
+  }
+}

--- a/src/main/scala/onion/tools/daemon/DaemonProtocol.scala
+++ b/src/main/scala/onion/tools/daemon/DaemonProtocol.scala
@@ -1,0 +1,64 @@
+package onion.tools.daemon
+
+import java.io.{DataInputStream, DataOutputStream}
+import java.nio.charset.StandardCharsets
+
+/**
+ * The wire format between [[DaemonClient]] and [[OnionDaemon]]: length-prefixed UTF-8
+ * strings over a Unix domain socket.
+ *
+ * Request: `command`, `cwd`, then `n` and `n` arguments. Commands are `compile` (the
+ * arguments are an `onionc` command line, with every path already absolute), `ping` and
+ * `stop`. Response: exit code, then captured standard output and standard error.
+ */
+private[daemon] object DaemonProtocol {
+  final case class Request(command: String, cwd: String, args: Array[String])
+  final case class Response(exitCode: Int, out: String, err: String)
+
+  def writeString(out: DataOutputStream, s: String): Unit = {
+    val bytes = s.getBytes(StandardCharsets.UTF_8)
+    out.writeInt(bytes.length)
+    out.write(bytes)
+  }
+
+  def readString(in: DataInputStream): String = {
+    val n = in.readInt()
+    if (n < 0 || n > (1 << 26)) throw new java.io.IOException(s"bad length $n")
+    val bytes = new Array[Byte](n)
+    in.readFully(bytes)
+    new String(bytes, StandardCharsets.UTF_8)
+  }
+
+  def writeRequest(out: DataOutputStream, r: Request): Unit = {
+    writeString(out, r.command)
+    writeString(out, r.cwd)
+    out.writeInt(r.args.length)
+    r.args.foreach(writeString(out, _))
+    out.flush()
+  }
+
+  def readRequest(in: DataInputStream): Request = {
+    val command = readString(in)
+    val cwd = readString(in)
+    val n = in.readInt()
+    if (n < 0 || n > 100000) throw new java.io.IOException(s"bad argument count $n")
+    val args = new Array[String](n)
+    var i = 0
+    while (i < n) { args(i) = readString(in); i += 1 }
+    Request(command, cwd, args)
+  }
+
+  def writeResponse(out: DataOutputStream, r: Response): Unit = {
+    out.writeInt(r.exitCode)
+    writeString(out, r.out)
+    writeString(out, r.err)
+    out.flush()
+  }
+
+  def readResponse(in: DataInputStream): Response = {
+    val code = in.readInt()
+    val out = readString(in)
+    val err = readString(in)
+    Response(code, out, err)
+  }
+}

--- a/src/main/scala/onion/tools/daemon/OnionDaemon.scala
+++ b/src/main/scala/onion/tools/daemon/OnionDaemon.scala
@@ -1,0 +1,132 @@
+package onion.tools.daemon
+
+import onion.tools.CompilerFrontend
+
+import java.io.{ByteArrayOutputStream, DataInputStream, DataOutputStream, PrintStream}
+import java.net.{StandardProtocolFamily, UnixDomainSocketAddress}
+import java.nio.channels.{Channels, ServerSocketChannel, SocketChannel}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.util.control.NonFatal
+
+/**
+ * The compile daemon: a resident JVM that runs `onionc` command lines sent to it over a
+ * Unix domain socket, so the JIT-compiled compiler and the shared class universe are reused
+ * across invocations instead of being rebuilt by a fresh JVM each time.
+ *
+ * One request at a time. Standard output and error are captured per request and sent back
+ * with the exit code; the daemon exits after `idleMillis` without a request, or on `stop`.
+ * The socket file lives in a directory only the user can read, and is removed on exit.
+ *
+ * Started on demand by [[DaemonClient]]; not meant to be run by hand, but
+ * `java -cp onion.jar onion.tools.daemon.OnionDaemon <socket-path> [idle-millis]` works.
+ */
+object OnionDaemon {
+  val DefaultIdleMillis: Long = 30L * 60 * 1000
+
+  def main(args: Array[String]): Unit = {
+    if (args.isEmpty) {
+      System.err.println("usage: OnionDaemon <socket-path> [idle-millis]")
+      System.exit(2)
+    }
+    val idle = if (args.length > 1) args(1).toLong else DefaultIdleMillis
+    serve(Path.of(args(0)), idle)
+    System.exit(0)
+  }
+
+  /** Serves until `stop` or `idleMillis` of inactivity. `ready` runs once the socket accepts connections. */
+  def serve(socket: Path, idleMillis: Long, ready: () => Unit = () => ()): Unit = {
+    Files.createDirectories(socket.getParent)
+    restrictToOwner(socket.getParent)
+    Files.deleteIfExists(socket)
+    val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+    server.bind(UnixDomainSocketAddress.of(socket))
+    restrictToOwner(socket)
+    @volatile var lastActivity = System.currentTimeMillis()
+    @volatile var stopping = false
+    val watchdog = new Thread(() => {
+      try {
+        while (!stopping) {
+          Thread.sleep(math.min(idleMillis, 60000L))
+          if (!stopping && System.currentTimeMillis() - lastActivity > idleMillis) {
+            stopping = true
+            server.close() // makes accept() throw, ending the loop below
+          }
+        }
+      } catch { case _: InterruptedException => () }
+    }, "onion-daemon-idle")
+    watchdog.setDaemon(true)
+    watchdog.start()
+    ready()
+    try {
+      while (!stopping) {
+        val channel = try server.accept() catch { case _: java.nio.channels.AsynchronousCloseException | _: java.nio.channels.ClosedChannelException => null }
+        if (channel == null) stopping = true
+        else {
+          lastActivity = System.currentTimeMillis()
+          try {
+            if (!handle(channel)) stopping = true
+          } catch { case NonFatal(_) => () }
+          finally { try channel.close() catch { case NonFatal(_) => () } }
+          lastActivity = System.currentTimeMillis()
+        }
+      }
+    } finally {
+      stopping = true
+      try server.close() catch { case NonFatal(_) => () }
+      try Files.deleteIfExists(socket) catch { case NonFatal(_) => () }
+    }
+  }
+
+  /** Handles one connection; false when the client asked the daemon to stop. */
+  private def handle(channel: SocketChannel): Boolean = {
+    val in = new DataInputStream(Channels.newInputStream(channel))
+    val out = new DataOutputStream(Channels.newOutputStream(channel))
+    val request = DaemonProtocol.readRequest(in)
+    request.command match {
+      case "ping" =>
+        DaemonProtocol.writeResponse(out, DaemonProtocol.Response(0, "pong\n", ""))
+        true
+      case "stop" =>
+        DaemonProtocol.writeResponse(out, DaemonProtocol.Response(0, "stopped\n", ""))
+        false
+      case "compile" =>
+        DaemonProtocol.writeResponse(out, compile(request.args))
+        true
+      case other =>
+        DaemonProtocol.writeResponse(out, DaemonProtocol.Response(2, "", s"unknown daemon command: $other\n"))
+        true
+    }
+  }
+
+  /** Runs one `onionc` command line with its output captured. Serialized: the streams are process-wide. */
+  private[daemon] def compile(args: Array[String]): DaemonProtocol.Response = synchronized {
+    val outBytes = new ByteArrayOutputStream()
+    val errBytes = new ByteArrayOutputStream()
+    val outStream = new PrintStream(outBytes, true, StandardCharsets.UTF_8)
+    val errStream = new PrintStream(errBytes, true, StandardCharsets.UTF_8)
+    val previousOut = System.out
+    val previousErr = System.err
+    System.setOut(outStream)
+    System.setErr(errStream)
+    val code =
+      try Console.withOut(outStream) { Console.withErr(errStream) { CompilerFrontend.runCommandLine(args) } }
+      catch {
+        case NonFatal(e) =>
+          errStream.println(s"onion daemon: internal error: $e")
+          -1
+      } finally {
+        System.setOut(previousOut)
+        System.setErr(previousErr)
+      }
+    outStream.flush(); errStream.flush()
+    DaemonProtocol.Response(code, outBytes.toString(StandardCharsets.UTF_8), errBytes.toString(StandardCharsets.UTF_8))
+  }
+
+  private def restrictToOwner(path: Path): Unit =
+    try {
+      import java.nio.file.attribute.PosixFilePermissions
+      val perms = if (Files.isDirectory(path)) "rwx------" else "rw-------"
+      Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(perms))
+    } catch { case NonFatal(_) => () } // not a POSIX file system (Windows): the user directory is private anyway
+}

--- a/src/test/scala/onion/tools/daemon/DaemonSpec.scala
+++ b/src/test/scala/onion/tools/daemon/DaemonSpec.scala
@@ -1,0 +1,67 @@
+package onion.tools.daemon
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+import java.util.concurrent.CountDownLatch
+
+/**
+ * The compile daemon end to end, in-process: a server on a temporary socket, requests
+ * through the client's wire code, a compile that produces class files, a compile that
+ * fails with diagnostics relayed, and `stop`.
+ */
+class DaemonSpec extends AnyFunSpec with Matchers {
+
+  private def unixSocketsSupported: Boolean =
+    try { java.nio.channels.ServerSocketChannel.open(java.net.StandardProtocolFamily.UNIX).close(); true }
+    catch { case _: Throwable => false }
+
+  private def withDaemon[A](body: Path => A): A = {
+    val dir = Files.createTempDirectory("onion-daemon-spec")
+    val socket = dir.resolve("d.sock")
+    val ready = new CountDownLatch(1)
+    val server = new Thread(() => OnionDaemon.serve(socket, 60000L, () => ready.countDown()), "daemon-under-test")
+    server.setDaemon(true)
+    server.start()
+    ready.await()
+    try body(socket)
+    finally {
+      try DaemonClient.request(socket, DaemonProtocol.Request("stop", "", Array.empty)) catch { case _: Throwable => () }
+      server.join(10000)
+    }
+  }
+
+  describe("the compile daemon") {
+    it("answers ping, compiles a file to class files, relays diagnostics, and stops") {
+      assume(unixSocketsSupported, "Unix domain sockets are not available on this platform")
+      withDaemon { socket =>
+        val pong = DaemonClient.request(socket, DaemonProtocol.Request("ping", "", Array.empty))
+        pong.exitCode shouldBe 0
+        pong.out.trim shouldBe "pong"
+
+        val work = Files.createTempDirectory("onion-daemon-work")
+        val source = work.resolve("Hello.on")
+        Files.writeString(source, "IO::println(\"hello from the daemon\")\n")
+        val out = work.resolve("out")
+        val args = DaemonClient.absolutize(Array("Hello.on", "-d", "out"), work)
+        val ok = DaemonClient.request(socket, DaemonProtocol.Request("compile", work.toString, args))
+        withClue(ok.err) { ok.exitCode shouldBe 0 }
+        Files.exists(out.resolve("HelloMain.class")) shouldBe true
+
+        Files.writeString(source, "val x: Int = \"not an int\"\n")
+        val bad = DaemonClient.request(socket, DaemonProtocol.Request("compile", work.toString, args))
+        bad.exitCode should not be 0
+        bad.err should include ("E0")
+      }
+    }
+
+    it("makes source, -d and -classpath paths absolute and supplies the defaults") {
+      val cwd = Path.of("/work/dir")
+      val args = DaemonClient.absolutize(Array("--warn", "off", "a.on", "sub/b.on"), cwd)
+      args.toList shouldBe List("--warn", "off", "/work/dir/a.on", "/work/dir/sub/b.on", "-d", "/work/dir", "-classpath", "/work/dir")
+      val explicit = DaemonClient.absolutize(Array("-d", "out", "-classpath", "lib/a.jar:/abs/b.jar", "x.on"), cwd)
+      explicit.toList shouldBe List("-d", "/work/dir/out", "-classpath", "/work/dir/lib/a.jar:/abs/b.jar", "/work/dir/x.on")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

An opt-in compile daemon, toward the "compile time 1/2" goal, where in-compiler work had reached the measurement floor (v0.45 -> v0.50: about 17% fewer instructions).

With `ONION_DAEMON=1`, `onionc` hands its command line to a resident compiler process and relays its output and exit code. The daemon is started on first use (one per user, JDK and Onion installation), listens on a Unix domain socket in a user-private directory (`$XDG_RUNTIME_DIR` or the temp directory; `ONION_DAEMON_SOCKET` overrides), keeps the JIT-compiled compiler and the shared class universe between runs, handles one request at a time with its output captured per request, exits after 30 minutes idle, and is controlled with `java -cp onion.jar onion.tools.daemon.DaemonClient stop|status`. Whenever it cannot be reached or started, `onionc` compiles in-process exactly as before -- the daemon is only ever a shortcut. The client makes every path in the command line absolute (sources, `-d`, `-classpath`, and the `.` defaults of the latter two), since the daemon has its own working directory. Running a script with `onion` is not routed through it (the program runs in the user's process).

No launcher changes: the switch lives in `CompilerFrontend.main`, so the distribution launchers and the ones `install.sh` writes both pick it up.

## Numbers (fat jar with the launcher's CDS archive and flags, warm daemon)

| | in-process | via daemon |
|---|---|---|
| `onionc run/StatsApp.on` | 0.83-0.87 s | 0.17-0.27 s |
| `onionc run/TodoApp.on` | -- | 0.15-0.19 s |
| `onionc run/Hello.on` | 0.36-0.48 s | 0.12-0.22 s |

The first call after a cold start takes about 1.9 s (it launches the daemon and warms it on that file).

## Verification

- `DaemonSpec`: a server on a temporary socket answers ping, compiles a file to class files, relays the diagnostics of a failing compile, and stops; the path normalization is checked separately.
- Full suite green in both locales (`testFull`, en and ja).
- Documented in `docs/getting-started/installation.md` (and the Japanese translation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc
