### PR TITLE
docs(colls): document List flatMap/bind/zip/groupBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`Colls::flatMap`/`bind`/`zip`/`groupBy` on `List`.** `docs/reference/stdlib.md` and its
+  Japanese translation never mentioned these four `List` extension methods in the Colls
+  Module section -- a whole-file coverage guard missed the gap because `Option`, `Result`,
+  `Future`, `Outcome`, and `Maps` happen to document their own same-named methods
+  elsewhere in the file. Documented all four (`bind` as the `do[List]` alias for
+  `flatMap`) and added a scoped regression test that checks the Colls section itself.
+
 ## [0.51.0] - 2026-09-03
 
 ### Added

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1573,6 +1573,8 @@ Colls::emptyMap()                       // 空の Map
 ```onion
 xs.concat(ys)                     // xs の要素に続けて ys の要素
 [[1, 2], [3, 4]].flatten()        // [1, 2, 3, 4] - ネストを1段階解消
+xs.flatMap { x -> [x, x] }        // 各要素をリストに写してから1段階平坦化する
+                                   // （bind はその別名で、do[List] { x <- xs; ... } が使う）
 xs.partition { x -> x > 1 }       // [matching, nonMatching] - 2つの List
 xs.toSet()                        // xs の要素から作った Set
 xs.distinct()                     // 重複を除去、最初に出現した順を保持
@@ -1583,6 +1585,8 @@ xs.head()                         // 先頭要素、空ならnull（first の別
 xs.tail()                         // 先頭要素を除いた残り（空リストでは例外）
 xs.takeWhile { x -> x < 3 }       // 述語を満たす先頭の連続部分
 xs.dropWhile { x -> x < 3 }       // その先頭の連続部分を取り除いた残り
+xs.zip(ys)                        // [[x0, y0], [x1, y1], ...] - ペアのList、短い方に合わせて切り詰め
+xs.groupBy { x -> x % 2 }         // キーごとの要素の List を値に持つ Map
 xs.mkString(", ")                 // "1, 2, 3" - 要素を文字列として連結（join は別名）
 Colls::isNotEmpty(xs)             // true - isEmpty の否定
 m.filterMap { k, v -> k == "name" }   // 条件に合うエントリだけの Map

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1561,6 +1561,8 @@ into a pipeline like the rest of `Colls`:
 ```onion
 xs.concat(ys)                     // elements of xs followed by elements of ys
 [[1, 2], [3, 4]].flatten()        // [1, 2, 3, 4] - one level of nesting removed
+xs.flatMap { x -> [x, x] }        // maps each element to a list, then flattens one level
+                                   // (bind is an alias, used by do[List] { x <- xs; ... })
 xs.partition { x -> x > 1 }       // [matching, nonMatching] - two Lists
 xs.toSet()                        // Set built from xs's elements
 xs.distinct()                     // duplicates removed, first-seen order preserved
@@ -1571,6 +1573,8 @@ xs.head()                         // first element, or null if empty (alias for 
 xs.tail()                         // all but the first element (throws on an empty list)
 xs.takeWhile { x -> x < 3 }       // longest leading run matching the predicate
 xs.dropWhile { x -> x < 3 }       // xs with that leading run removed
+xs.zip(ys)                        // [[x0, y0], [x1, y1], ...] - pairs, truncated to the shorter list
+xs.groupBy { x -> x % 2 }         // Map from key to the List of elements with that key
 xs.mkString(", ")                 // "1, 2, 3" - joins elements into a String (join is an alias)
 Colls::isNotEmpty(xs)             // true - the negation of isEmpty
 m.filterMap { k, v -> k == "name" }   // Map with only the matching entries

--- a/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
@@ -63,4 +63,36 @@ class CollsDocCoverageSpec extends AnyFunSpec {
     assert(read("docs/ja/reference/stdlib.md").contains("Colls"),
       "docs/ja/reference/stdlib.md's overview table should mention Colls")
   }
+
+  /**
+   * `flatMap`/`bind`/`zip`/`groupBy` on `List` are real `onion.Colls` members (caught by
+   * the two whole-file checks above only by accident, because `Option`/`Result`/`Future`/
+   * `Outcome`/`Maps` happen to document their own same-named methods elsewhere in the
+   * file). Pin their presence in the Colls section itself so that coincidence is not the
+   * only thing standing between this file and a real gap.
+   */
+  private def collsSection(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toIndexedSeq
+    val start = lines.indexWhere(_.contains(heading))
+    assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+    val rest = lines.drop(start + 1)
+    val end = rest.indexWhere(_.startsWith("## "))
+    (if (end < 0) rest else rest.take(end)).mkString("\n")
+  }
+
+  private val listMonadAndPairingNames = Set("flatMap", "bind", "zip", "groupBy")
+
+  it("docs/reference/stdlib.md's Colls Module section documents List flatMap/bind/zip/groupBy") {
+    val doc = collsSection(read("docs/reference/stdlib.md"), "## Colls Module")
+    val missing = listMonadAndPairingNames -- documentedNames(doc, listMonadAndPairingNames)
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md's Colls Module section is missing: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md's Colls section documents List flatMap/bind/zip/groupBy") {
+    val doc = collsSection(read("docs/ja/reference/stdlib.md"), "## Colls モジュール")
+    val missing = listMonadAndPairingNames -- documentedNames(doc, listMonadAndPairingNames)
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md's Colls section is missing: ${missing.toSeq.sorted.mkString(", ")}")
+  }
 }


### PR DESCRIPTION
## Summary
- `onion.Colls::flatMap`/`bind`/`zip`/`groupBy` are real, callable `List` extension methods (`xs.flatMap { ... }`, `xs.bind(f)`, `xs.zip(ys)`, `xs.groupBy { ... }`), but neither `docs/reference/stdlib.md` nor its Japanese translation ever mentioned them in the Colls Module section.
- The existing `CollsDocCoverageSpec` whole-file scan missed the gap because `Option`/`Result`/`Future`/`Outcome`/`Maps` happen to document their own same-named methods elsewhere in the file — the bare words were "found" but not in the right place.
- Documented all four in both languages (`bind` as the `do[List]` alias for `flatMap`) and added a regression test scoped to the Colls section itself so this class of gap can't hide behind an unrelated module's docs again.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] New tests in `CollsDocCoverageSpec` confirmed red before the doc fix, green after (verified via `git stash`)
- [x] Manually ran `xs.flatMap`, `xs.bind`, `xs.zip`, `xs.groupBy` through `onion.tools.ScriptRunner` to confirm they work as documented
- [x] Full suite green: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5027 succeeded, 0 failed, 1 canceled (pre-existing, opt-in `ProjectDistributionSpec` smoke test gated behind `-Donion.dist.path`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk1Lg9n1Jfy4BngQH8pYnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk1Lg9n1Jfy4BngQH8pYnt)_