### PR TITLE
feat: run onion script.on through the compile daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`onion script.on` uses the compile daemon too** (`ONION_DAEMON=1`): the daemon compiles
+  the script and hands the classes and class path back, and the program runs in the caller's
+  process as always. `ScriptRunner.run` is split into `prepare` (parse options, compile,
+  report) and `execute` for this; behaviour without the daemon is unchanged.
+
 ## [0.51.0] - 2026-09-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Onion is a statically-typed, object-oriented programming language that compiles 
 - `--no-check-laws` - Do not execute record `law`/`example` clauses (they run at compile time by default; the LSP always has them off)
 - `--law-seed <n>` / `--law-samples <n>` - Control law sampling; a falsified law reports the settings that produced its counterexample
 - `--stacktrace` - Print the raw JVM trace for an uncaught runtime error (the default is a diagnostic-style report with the script's own frames only)
-- `ONION_DAEMON=1` (environment) - `onionc` compiles through a resident daemon (`onion.tools.daemon`), started on first use; falls back to in-process compilation when it cannot be reached. `java -cp onion.jar onion.tools.daemon.DaemonClient stop|status` controls it
+- `ONION_DAEMON=1` (environment) - `onionc` and `onion script.on` compile through a resident daemon (`onion.tools.daemon`), started on first use; a script's classes come back and run in the caller's process; falls back to in-process compilation when the daemon cannot be reached. `java -cp onion.jar onion.tools.daemon.DaemonClient stop|status` controls it
 
 ## High-Level Architecture
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -116,8 +116,9 @@ onion.tools.daemon.DaemonClient stop` (or `status`) controls it by hand. It list
 Unix domain socket in a directory only you can read (`$XDG_RUNTIME_DIR` or the temp
 directory; override with `ONION_DAEMON_SOCKET`), needs Java 16 or later for that, and
 whenever it cannot be reached or started `onionc` simply compiles in-process as before.
-`ONION_DAEMON_JAVA_OPTS` adds JVM flags to the daemon itself. Running a script with
-`onion` is not routed through the daemon (the program runs in your own process).
+`ONION_DAEMON_JAVA_OPTS` adds JVM flags to the daemon itself. `onion script.on` uses it
+too: the daemon compiles and hands the classes back, and the program itself runs in your
+own process, as always.
 
 ## IDE Setup
 

--- a/docs/ja/getting-started/installation.md
+++ b/docs/ja/getting-started/installation.md
@@ -116,8 +116,9 @@ onion.tools.daemon.DaemonClient stop`（または `status`）で操作できま�
 だけが読めるディレクトリ（`$XDG_RUNTIME_DIR` または一時ディレクトリ。
 `ONION_DAEMON_SOCKET` で上書き可）の Unix ドメインソケットで、Java 16 以降が必要です。
 デーモンに到達・起動できないときは、`onionc` はこれまでどおりプロセス内でコンパイル
-します。`ONION_DAEMON_JAVA_OPTS` はデーモン自身の JVM フラグです。`onion` による
-スクリプト実行はデーモンを経由しません（プログラムは自分のプロセスで動きます）。
+します。`ONION_DAEMON_JAVA_OPTS` はデーモン自身の JVM フラグです。`onion script.on` も
+デーモンを使います。コンパイルはデーモンが行ってクラスを返し、プログラム自体はこれまで
+どおり自分のプロセスで動きます。
 
 ## IDEセットアップ
 

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -24,6 +24,9 @@ import onion.tools.option._
  *
  */
 object ScriptRunner {
+  /** What `execute` needs after a successful compile: the script's name, the class path and classes, and the script's own arguments. */
+  final case class Prepared(scriptName: String, classPath: Seq[String], classes: Seq[CompiledClass], scriptArgs: Array[String])
+
   val VERSION = OnionVersion.value
 
   private def conf(optionName: String, requireArgument: Boolean) = OptionConfig(optionName, requireArgument)
@@ -74,8 +77,18 @@ object ScriptRunner {
     // wrote (issue #450). Render it like a diagnostic instead; --stacktrace keeps the
     // untouched trace for when the JVM detail is the point.
     val wantTrace = prefix.exists(_ == STACKTRACE)
+    val runnerArgs = filteredArgs.filterNot(_ == STACKTRACE)
     try {
-      new ScriptRunner().run(filteredArgs.filterNot(_ == STACKTRACE), verbose)
+      // With ONION_DAEMON set, the compile happens in the resident daemon and only the run
+      // happens here (the program must run in the user's own process). When the daemon
+      // cannot be reached, everything happens here as before.
+      val viaDaemon =
+        if (onion.tools.daemon.DaemonClient.enabledByEnvironment) onion.tools.daemon.DaemonClient.compileScript(runnerArgs) else None
+      viaDaemon match {
+        case Some(Left(exitCode)) => exitCode
+        case Some(Right(prepared)) => new ScriptRunner().execute(prepared)
+        case None => new ScriptRunner().run(runnerArgs, verbose)
+      }
     }
     catch {
       case e: ScriptException =>
@@ -188,32 +201,43 @@ class ScriptRunner {
     conf(SHOW_EFFECTS, false)
   )
 
-  def run(commandLine: Array[String], verbose: Boolean = false): Int = {
+  def run(commandLine: Array[String], verbose: Boolean = false): Int =
+    prepare(commandLine, verbose) match {
+      case Left(exitCode) => exitCode
+      case Right(prepared) => execute(prepared)
+    }
+
+  /**
+   * The compile half of `run`: option parsing, compilation, diagnostics and profile output.
+   * Returns the exit code when there is nothing to run, else what `execute` needs. Split out
+   * so the compile daemon can do this half in its own process and hand the classes back.
+   */
+  def prepare(commandLine: Array[String], verbose: Boolean = false): Either[Int, ScriptRunner.Prepared] = {
     if (commandLine.isEmpty) {
       printUsage()
-      return -1
+      return Left(-1)
     }
     // Runner options end at the script file; everything after it goes to the
     // script verbatim (so script flags like --count are never parsed here).
     val si = ScriptRunner.scriptIndex(commandLine)
     if (si >= commandLine.length) {
       printUsage()
-      return -1
+      return Left(-1)
     }
     val runnerLine = commandLine.take(si + 1)
     val passThroughArgs = commandLine.drop(si + 1)
     parser.parse(runnerLine) match {
       case failure@ParseFailure(_, _) =>
         printFailure(failure)
-        return -1
+        return Left(-1)
       case success@ParseSuccess(_, _) =>
         val params = success.arguments
         if (params.isEmpty) {
           printUsage()
-          return -1
+          return Left(-1)
         }
         createConfig(success, verbose) match {
-          case None => -1
+          case None => Left(-1)
           case Some(config) =>
             val scriptArgs = passThroughArgs
             val result = compile(config, Array(params.head))
@@ -227,22 +251,24 @@ class ScriptRunner {
                 System.err.println(me.render)
               }
             }
-            if (result.hasErrors) {
-              -1
-            } else {
-              // Expose the script's file name so auto-CLI usage messages read
-              // `usage: myscript.on <arg>` instead of the literal `<script>`.
-              System.setProperty("onion.cli.script", new java.io.File(params.head).getName)
-              new Shell(classOf[OnionClassLoader].getClassLoader, config.classPath).run(result.classes, scriptArgs) match {
-                // main's returned Int is the documented exit code (docs/guide/tools.md's
-                // "Failures are exit codes ... return 1 from main"); a void main (or any
-                // other return type) has no such meaning, so it keeps exiting 0.
-                case Shell.Success(value: java.lang.Integer) => value.intValue()
-                case Shell.Success(_) => 0
-                case Shell.Failure(code) => code
-              }
-            }
+            if (result.hasErrors) Left(-1)
+            else Right(ScriptRunner.Prepared(new java.io.File(params.head).getName, config.classPath, result.classes, scriptArgs))
         }
+    }
+  }
+
+  /** The run half of `run`: executes compiled classes in this process. */
+  def execute(prepared: ScriptRunner.Prepared): Int = {
+    // Expose the script's file name so auto-CLI usage messages read
+    // `usage: myscript.on <arg>` instead of the literal `<script>`.
+    System.setProperty("onion.cli.script", prepared.scriptName)
+    new Shell(classOf[OnionClassLoader].getClassLoader, prepared.classPath).run(prepared.classes, prepared.scriptArgs) match {
+      // main's returned Int is the documented exit code (docs/guide/tools.md's
+      // "Failures are exit codes ... return 1 from main"); a void main (or any
+      // other return type) has no such meaning, so it keeps exiting 0.
+      case Shell.Success(value: java.lang.Integer) => value.intValue()
+      case Shell.Success(_) => 0
+      case Shell.Failure(code) => code
     }
   }
 

--- a/src/main/scala/onion/tools/daemon/DaemonClient.scala
+++ b/src/main/scala/onion/tools/daemon/DaemonClient.scala
@@ -56,6 +56,63 @@ object DaemonClient {
       }
     } catch { case NonFatal(_) => None }
 
+  /**
+   * The compile half of `onion` through the daemon: Some(Left(code)) when the daemon answered
+   * but there is nothing to run (a compile error, `--help`...), Some(Right(prepared)) when the
+   * classes came back, None when the daemon is not available. Runner options before the
+   * script get their paths made absolute; the script's own arguments are passed verbatim.
+   */
+  def compileScript(args: Array[String]): Option[Either[Int, onion.tools.ScriptRunner.Prepared]] =
+    try {
+      val socket = socketPath()
+      if (!ensureRunning(socket)) None
+      else {
+        val cwd = Paths.get("").toAbsolutePath
+        val si = onion.tools.ScriptRunner.scriptIndex(args)
+        if (si >= args.length) return None // no script: let the in-process runner print usage
+        val runner = absolutizeRunnerOptions(args.take(si), cwd) :+ abs(args(si), cwd)
+        val sent = runner ++ args.drop(si + 1)
+        val channel = SocketChannel.open(UnixDomainSocketAddress.of(socket))
+        try {
+          val out = new DataOutputStream(Channels.newOutputStream(channel))
+          val in = new DataInputStream(Channels.newInputStream(channel))
+          DaemonProtocol.writeRequest(out, DaemonProtocol.Request("compile-script", cwd.toString, sent))
+          val response = DaemonProtocol.readResponse(in)
+          System.out.print(response.out)
+          System.err.print(response.err)
+          System.out.flush(); System.err.flush()
+          if (response.exitCode != 0) Some(Left(response.exitCode))
+          else {
+            val bundle = DaemonProtocol.readBundle(in)
+            Some(Right(onion.tools.ScriptRunner.Prepared(bundle.scriptName, bundle.classPath.toSeq, bundle.classes.toSeq, args.drop(si + 1))))
+          }
+        } finally channel.close()
+      }
+    } catch { case NonFatal(_) => None }
+
+  /** `-classpath` entries made absolute and the `.` default supplied; other runner options pass through. */
+  private[daemon] def absolutizeRunnerOptions(options: Array[String], cwd: Path): Array[String] = {
+    val out = scala.collection.mutable.ArrayBuffer[String]()
+    var sawClasspath = false
+    var i = 0
+    while (i < options.length) {
+      val a = options(i)
+      if (a == "-classpath" && i + 1 < options.length) {
+        sawClasspath = true
+        out += a += options(i + 1).split(File.pathSeparator).map(abs(_, cwd)).mkString(File.pathSeparator); i += 1
+      } else if ((a == "-encoding" || a == "-maxErrorReport" || a == "-super" || a == "--Wno" || a == "--warn" ||
+                  a == "--law-seed" || a == "--law-samples" || a == "--profile-format") && i + 1 < options.length) {
+        out += a += options(i + 1); i += 1
+      } else if (a == "--profile-output" && i + 1 < options.length) {
+        val target = options(i + 1)
+        out += a += (if (target == "stderr" || target == "stdout") target else abs(target, cwd)); i += 1
+      } else out += a
+      i += 1
+    }
+    if (!sawClasspath) out += "-classpath" += cwd.toString
+    out.toArray
+  }
+
   private def control(command: String): Int = {
     val socket = socketPath()
     if (!Files.exists(socket)) { println("onion daemon: not running"); return if (command == "ping") 1 else 0 }

--- a/src/main/scala/onion/tools/daemon/DaemonProtocol.scala
+++ b/src/main/scala/onion/tools/daemon/DaemonProtocol.scala
@@ -55,6 +55,43 @@ private[daemon] object DaemonProtocol {
     out.flush()
   }
 
+  /** After a `compile-script` response: the classes to run and the class path they were compiled against. */
+  final case class ClassBundle(scriptName: String, classPath: Array[String], classes: Array[onion.compiler.CompiledClass])
+
+  def writeBundle(out: DataOutputStream, b: ClassBundle): Unit = {
+    writeString(out, b.scriptName)
+    out.writeInt(b.classPath.length)
+    b.classPath.foreach(writeString(out, _))
+    out.writeInt(b.classes.length)
+    b.classes.foreach { c =>
+      writeString(out, c.className)
+      writeString(out, if (c.outputPath == null) "" else c.outputPath)
+      out.writeInt(c.content.length)
+      out.write(c.content)
+    }
+    out.flush()
+  }
+
+  def readBundle(in: DataInputStream): ClassBundle = {
+    val scriptName = readString(in)
+    val cp = Array.fill(in.readInt())(readString(in))
+    val n = in.readInt()
+    if (n < 0 || n > 100000) throw new java.io.IOException(s"bad class count $n")
+    val classes = new Array[onion.compiler.CompiledClass](n)
+    var i = 0
+    while (i < n) {
+      val name = readString(in)
+      val path = readString(in)
+      val len = in.readInt()
+      if (len < 0 || len > (1 << 28)) throw new java.io.IOException(s"bad class size $len")
+      val bytes = new Array[Byte](len)
+      in.readFully(bytes)
+      classes(i) = onion.compiler.CompiledClass(name, if (path.isEmpty) null else path, bytes)
+      i += 1
+    }
+    ClassBundle(scriptName, cp, classes)
+  }
+
   def readResponse(in: DataInputStream): Response = {
     val code = in.readInt()
     val out = readString(in)

--- a/src/main/scala/onion/tools/daemon/OnionDaemon.scala
+++ b/src/main/scala/onion/tools/daemon/OnionDaemon.scala
@@ -93,14 +93,40 @@ object OnionDaemon {
       case "compile" =>
         DaemonProtocol.writeResponse(out, compile(request.args))
         true
+      case "compile-script" =>
+        val (response, bundle) = compileScript(request.args)
+        DaemonProtocol.writeResponse(out, response)
+        if (bundle != null) DaemonProtocol.writeBundle(out, bundle)
+        true
       case other =>
         DaemonProtocol.writeResponse(out, DaemonProtocol.Response(2, "", s"unknown daemon command: $other\n"))
         true
     }
   }
 
+  /**
+   * The compile half of an `onion` script run (see ScriptRunner.prepare): the classes come
+   * back to the client, which runs them. The bundle is null when there is nothing to run.
+   */
+  private[daemon] def compileScript(args: Array[String]): (DaemonProtocol.Response, DaemonProtocol.ClassBundle) = synchronized {
+    var bundle: DaemonProtocol.ClassBundle = null
+    val response = captured { () =>
+      val verbose = args.contains("--verbose")
+      new onion.tools.ScriptRunner().prepare(args.filterNot(_ == "--verbose"), verbose) match {
+        case Left(code) => code
+        case Right(prepared) =>
+          bundle = DaemonProtocol.ClassBundle(prepared.scriptName, prepared.classPath.toArray, prepared.classes.toArray)
+          0
+      }
+    }
+    (response, bundle)
+  }
+
   /** Runs one `onionc` command line with its output captured. Serialized: the streams are process-wide. */
-  private[daemon] def compile(args: Array[String]): DaemonProtocol.Response = synchronized {
+  private[daemon] def compile(args: Array[String]): DaemonProtocol.Response =
+    captured(() => CompilerFrontend.runCommandLine(args))
+
+  private def captured(body: () => Int): DaemonProtocol.Response = synchronized {
     val outBytes = new ByteArrayOutputStream()
     val errBytes = new ByteArrayOutputStream()
     val outStream = new PrintStream(outBytes, true, StandardCharsets.UTF_8)
@@ -110,7 +136,7 @@ object OnionDaemon {
     System.setOut(outStream)
     System.setErr(errStream)
     val code =
-      try Console.withOut(outStream) { Console.withErr(errStream) { CompilerFrontend.runCommandLine(args) } }
+      try Console.withOut(outStream) { Console.withErr(errStream) { body() } }
       catch {
         case NonFatal(e) =>
           errStream.println(s"onion daemon: internal error: $e")

--- a/src/test/scala/onion/tools/daemon/DaemonSpec.scala
+++ b/src/test/scala/onion/tools/daemon/DaemonSpec.scala
@@ -56,6 +56,29 @@ class DaemonSpec extends AnyFunSpec with Matchers {
       }
     }
 
+    it("compiles a script for the client to run, returning its classes and class path") {
+      assume(unixSocketsSupported, "Unix domain sockets are not available on this platform")
+      withDaemon { socket =>
+        val work = Files.createTempDirectory("onion-daemon-script")
+        val source = work.resolve("Greet.on")
+        Files.writeString(source, "def main(name: String): Int {\n  IO::println(\"hi \" + name)\n  return 3\n}\n")
+        val runner = DaemonClient.absolutizeRunnerOptions(Array.empty, work) :+ source.toString
+        val channel = java.nio.channels.SocketChannel.open(java.net.UnixDomainSocketAddress.of(socket))
+        try {
+          val out = new java.io.DataOutputStream(java.nio.channels.Channels.newOutputStream(channel))
+          val in = new java.io.DataInputStream(java.nio.channels.Channels.newInputStream(channel))
+          DaemonProtocol.writeRequest(out, DaemonProtocol.Request("compile-script", work.toString, runner :+ "world"))
+          val response = DaemonProtocol.readResponse(in)
+          withClue(response.err) { response.exitCode shouldBe 0 }
+          val bundle = DaemonProtocol.readBundle(in)
+          bundle.scriptName shouldBe "Greet.on"
+          bundle.classPath.toList shouldBe List(work.toString)
+          bundle.classes.map(_.className) should contain ("GreetMain")
+          bundle.classes.forall(_.content.length > 0) shouldBe true
+        } finally channel.close()
+      }
+    }
+
     it("makes source, -d and -classpath paths absolute and supplies the defaults") {
       val cwd = Path.of("/work/dir")
       val args = DaemonClient.absolutize(Array("--warn", "off", "a.on", "sub/b.on"), cwd)


### PR DESCRIPTION
## Summary

Follow-up to #1105: `onion script.on` goes through the compile daemon too. With `ONION_DAEMON=1`, the daemon parses the runner options, compiles the script and reports diagnostics exactly as the in-process runner would (its output is relayed), then hands back the classes and the class path; the client runs them in its own process with the same `Shell` as before, so the program's I/O, exit code and arguments are untouched. When the daemon cannot be reached, everything happens in-process as before.

`ScriptRunner.run` is split into `prepare` (option parsing, compilation, diagnostics, profile) and `execute` (run the classes) for this; `run` is `prepare` followed by `execute`, so behaviour without the daemon is unchanged. The wire protocol gains a `compile-script` command whose response is followed by a class bundle. Runner options before the script get their `-classpath` entries made absolute (and the `.` default supplied); the script's own arguments are passed verbatim.

## Numbers (fat jar with the launcher's CDS archive and flags, warm daemon)

| | in-process | via daemon |
|---|---|---|
| `onion run/StatsApp.on` | 0.61-0.67 s | 0.17-0.21 s |
| `onion run/Hello.on` | 0.27-0.31 s | 0.12-0.13 s |

## Verification

- `DaemonSpec` gains a `compile-script` case: the bundle names the script, carries the class path and the compiled classes.
- Full suite green in both locales (`testFull`, en and ja).
- Docs updated (installation guide, English and Japanese; CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc
