### PR TITLE
docs: document Rand::nextLong's bounded overload (EN/JA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`Rand::nextLong(bound)` (bounded overload) documented.** `docs/reference/stdlib.md`
+  and its Japanese translation covered the bounded overloads of `Rand::nextInt` and
+  `Rand::nextDouble` but not the equivalent `Rand::nextLong(bound)` -- the doc-coverage
+  test only checked method *names*, so the already-documented zero-arg `Rand::nextLong()`
+  masked the missing bounded form. Added the missing subsection to both docs and
+  strengthened `StdlibDocRandModuleParitySpec` to check bounded-overload coverage, not
+  just name coverage.
+
 ## [0.52.0] - 2026-09-03
 
 ### Changed

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -732,6 +732,14 @@ val percent: Int = Rand::nextInt(100)     // 0から99
 val d20: Int = Rand::nextInt(1, 21)       // 1から20（min, 排他的max）
 ```
 
+### Rand::nextLong（範囲指定）
+
+範囲内の乱数longを生成：
+
+```onion
+val bigId: Long = Rand::nextLong(1000000L)   // 0から999999
+```
+
 ### Rand::nextDouble（範囲指定）
 
 ```onion

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -981,6 +981,14 @@ val percent: Int = Rand::nextInt(100)     // 0 to 99
 val d20: Int = Rand::nextInt(1, 21)       // 1 to 20 (min, exclusive max)
 ```
 
+### Rand::nextLong (bounded)
+
+Generate a random long in a range:
+
+```onion
+val bigId: Long = Rand::nextLong(1000000L)   // 0 to 999999
+```
+
 ### Rand::nextDouble (bounded)
 
 ```onion

--- a/src/test/scala/onion/compiler/tools/StdlibDocRandModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocRandModuleParitySpec.scala
@@ -26,6 +26,12 @@ class StdlibDocRandModuleParitySpec extends AnyFunSpec {
     "choice", "shuffle", "sample", "uuid"
   )
 
+  // nextInt/nextLong/nextDouble each have a bounded overload beyond the zero-arg
+  // form already covered by `methods` above; a name-only `contains` check can't
+  // tell the zero-arg mention from the bounded one, so check the bounded heading
+  // each sibling documents under.
+  private val boundedMethods = Seq("nextInt", "nextLong", "nextDouble")
+
   it("mentions every public onion.Rand method in the English Rand Module section") {
     val en = sectionUnder(read("docs/reference/stdlib.md"), "## Rand Module")
     methods.foreach { name =>
@@ -41,6 +47,24 @@ class StdlibDocRandModuleParitySpec extends AnyFunSpec {
       assert(ja.contains(s"Rand::$name"),
         s"docs/ja/reference/stdlib.md's Rand モジュール section doesn't mention Rand::$name, " +
         "a public onion.Rand method")
+    }
+  }
+
+  it("documents the bounded overload of every Rand method that has one, in English") {
+    val en = sectionUnder(read("docs/reference/stdlib.md"), "## Rand Module")
+    boundedMethods.foreach { name =>
+      assert(en.contains(s"### Rand::$name (bounded)"),
+        s"docs/reference/stdlib.md's Rand Module section doesn't document the bounded " +
+        s"overload of Rand::$name (expected a '### Rand::$name (bounded)' subsection)")
+    }
+  }
+
+  it("documents the bounded overload of every Rand method that has one, in Japanese") {
+    val ja = sectionUnder(read("docs/ja/reference/stdlib.md"), "## Rand モジュール")
+    boundedMethods.foreach { name =>
+      assert(ja.contains(s"### Rand::$name（範囲指定）"),
+        s"docs/ja/reference/stdlib.md's Rand モジュール section doesn't document the bounded " +
+        s"overload of Rand::$name (expected a '### Rand::$name（範囲指定）' subsection)")
     }
   }
 }


### PR DESCRIPTION
## Summary

- `Rand::nextInt` and `Rand::nextDouble` both document their bounded overload in `docs/reference/stdlib.md` (and the Japanese translation), but `Rand::nextLong(bound)` (`src/main/java/onion/Rand.java:55-57`) was undocumented in both.
- The existing `StdlibDocRandModuleParitySpec` doc-coverage guard only checked method *names*, so the already-documented zero-arg `Rand::nextLong()` masked the missing bounded overload.
- Added a `### Rand::nextLong (bounded)` subsection to both docs (matching the style of its `nextInt`/`nextDouble` siblings), and strengthened the parity spec with two new assertions that check bounded-overload coverage specifically (written first, confirmed red, then made green by the doc fix).
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `StdlibDocRandModuleParitySpec` written to fail before the doc fix (confirmed red), passes after (confirmed green)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5030 succeeded, 0 failed, 1 cancelled (the gated distribution smoke test), 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvAviqydqun7GNfVw7Hd87

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvAviqydqun7GNfVw7Hd87)_