### PR TITLE
docs: list all stdlib modules in CLAUDE.md / CLAUDE_ja.md, add completeness guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   strengthened `StdlibDocRandModuleParitySpec` to check bounded-overload coverage, not
   just name coverage.
 
+- **CLAUDE.md's and CLAUDE_ja.md's Standard Library summaries were missing 21 of the
+  ~38 documented `onion.*` stdlib modules** (`Colls`, `Iterables`, `Maps`, `Sets`,
+  `Text`, `OnionMath`, `Stats`, `Format`, `Yaml`, `Csv`, `Config`, `Codec`, `Hash`,
+  `Outcome`, `Defect`, `Origin`, `Shape`, `Shapes`, `Scalars`, `Proc`, `Args`) --
+  the existing drift guard only checked that *listed* names were real, not that the
+  list was complete. Added the missing bullets to both files and extended
+  `StdlibDocDriftSpec` with a completeness check against the "Modules at a glance"
+  table in `docs/reference/stdlib.md`.
+
 ## [0.52.0] - 2026-09-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,22 @@ All phases extend `Processor[A, B]` trait and can be composed using `andThen()`:
 - `Concurrent` - Thread pools, counters, locks, channels
 - `Net` - TCP sockets (connect, listen)
 - `Server` - Minimal HTTP server (routing, request/response)
+- `Proc` - Subprocess execution (run, capture)
+- `Args` - Command-line argument parsing
+- `Colls` - Collection factories and pipelines (map/filter/fold, chunked/windowed, sumBy/maxBy)
+- `Iterables`, `Maps`, `Sets` - Iteration and map/set utility functions
+- `Text` - Console text layout (wrap, indent, aligned tables)
+- `OnionMath` - Hyperbolic trig, safe rounding/clamping, bounded random int
+- `Stats` - Numeric aggregation (sum, average, median, stddev)
+- `Format` - Locale-independent formatting (grouping, byte sizes, durations)
+- `Yaml`, `Csv` - YAML and RFC 4180 CSV parsing/serialization
+- `Config` - Dot-notation config access over parsed JSON
+- `Codec` - Base64/hex/URL encoding and decoding
+- `Hash` - Cryptographic and checksum digests (md5, sha256, ...)
+- `Outcome`, `Defect` - Reading external data: a value, or every reason it could not be read
+- `Origin` - Where a value came from, in the text it was read out of
+- `Shape`, `Shapes` - Bidirectional correspondence between external text and a typed value
+- `Scalars` - Strict scalar parsing for boundary derivations
 
 ## Testing
 

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -160,6 +160,22 @@ Onionコンパイラは、古典的なコンパイラアーキテクチャに従
 - `Concurrent` - スレッドプール、カウンタ、ロック、チャネル
 - `Net` - TCPソケット (connect, listen)
 - `Server` - 最小限のHTTPサーバー (ルーティング、リクエスト/レスポンス)
+- `Proc` - サブプロセス実行 (run, capture)
+- `Args` - コマンドライン引数のパース
+- `Colls` - コレクションのファクトリとパイプライン (map/filter/fold、chunked/windowed、sumBy/maxBy)
+- `Iterables`, `Maps`, `Sets` - イテレーションとマップ/セットのユーティリティ関数
+- `Text` - コンソール向けテキストレイアウト (wrap、indent、テーブル整形)
+- `OnionMath` - 双曲線三角関数、安全な丸め/クランプ、範囲付き乱数整数
+- `Stats` - 数値集計 (sum、average、median、stddev)
+- `Format` - ロケール非依存のフォーマット (桁区切り、バイトサイズ、時間長)
+- `Yaml`, `Csv` - YAMLおよびRFC 4180 CSVのパース/シリアライズ
+- `Config` - パース済みJSONに対するドット記法での設定アクセス
+- `Codec` - Base64/hex/URLエンコード・デコード
+- `Hash` - 暗号学的/チェックサムダイジェスト (md5, sha256, ...)
+- `Outcome`, `Defect` - 外部データの読み取り結果: 値、またはそれが読めなかったすべての理由
+- `Origin` - 値がどこから来たか（読み取り元のテキスト上の位置）
+- `Shape`, `Shapes` - 外部テキストと型付きの値との双方向対応
+- `Scalars` - 境界導出のための厳密なスカラー値パース
 
 ## テスト
 

--- a/src/test/scala/onion/compiler/tools/StdlibDocDriftSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocDriftSpec.scala
@@ -97,4 +97,43 @@ class StdlibDocDriftSpec extends AnyFunSpec {
     val unknown = named.filter(n => !notStdlibClasses.contains(n) && membersOf(n).isEmpty)
     assert(unknown.isEmpty, s"CLAUDE.md names stdlib modules that do not exist: ${unknown.mkString(", ")}")
   }
+
+  /** Module names (backtick-quoted, real `onion.*` classes) in the "Modules at a
+   * glance" table of `docs/reference/stdlib.md` — the authoritative list of what
+   * counts as a documented stdlib module. */
+  private def glanceModules(): Set[String] = {
+    val lines = read("docs/reference/stdlib.md").linesIterator.toSeq
+    val start = lines.indexWhere(_.contains("## Modules at a glance"))
+    assert(start >= 0, "docs/reference/stdlib.md has no Modules at a glance section — the scan has rotted")
+    val table = lines.drop(start + 1).takeWhile(!_.trim.startsWith("Most helpers"))
+    """`([A-Z][A-Za-z0-9]*)`""".r
+      .findAllMatchIn(table.mkString("\n"))
+      .map(_.group(1))
+      .filterNot(notStdlibClasses.contains)
+      .filter(membersOf(_).nonEmpty)
+      .toSet
+  }
+
+  /** Module names bulleted (`` - `Name` ... ``) under a "Standard Library" section header. */
+  private def namedInStandardLibrarySection(path: String, marker: String): Set[String] = {
+    val lines = read(path).linesIterator.toSeq
+    val start = lines.indexWhere(_.contains(marker))
+    assert(start >= 0, s"$path has no $marker section — the scan has rotted")
+    val section = lines.drop(start + 1).takeWhile(_.trim.startsWith("- `"))
+    """`([A-Z][A-Za-z0-9]*)`""".r.findAllMatchIn(section.mkString("\n")).map(_.group(1)).toSet
+  }
+
+  it("CLAUDE.md's Standard Library list covers every module in the stdlib reference") {
+    val missing = glanceModules() -- namedInStandardLibrarySection("CLAUDE.md", "**Standard Library**")
+    assert(missing.isEmpty,
+      s"CLAUDE.md's Standard Library list is missing modules documented in docs/reference/stdlib.md: " +
+      s"${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/CLAUDE_ja.md's 標準ライブラリ list covers every module in the stdlib reference") {
+    val missing = glanceModules() -- namedInStandardLibrarySection("docs/ja/CLAUDE_ja.md", "**標準ライブラリ**")
+    assert(missing.isEmpty,
+      s"docs/ja/CLAUDE_ja.md's 標準ライブラリ list is missing modules documented in docs/reference/stdlib.md: " +
+      s"${missing.toSeq.sorted.mkString(", ")}")
+  }
 }


### PR DESCRIPTION
## Summary

- `CLAUDE.md`'s and `docs/ja/CLAUDE_ja.md`'s "Standard Library" quick-reference bullet lists named only 16 of the ~38 `onion.*` stdlib modules documented in `docs/reference/stdlib.md`. `StdlibDocDriftSpec` already guarded that every *listed* name resolves to a real class, but nothing checked that the list was *complete*, so modules like `Colls`, `Yaml`, `Config`, `Shape`, and `Origin` were silently missing from both quick-reference lists.
- Added the missing 21 module bullets (with short descriptions, mirrored EN/JA) to both files.
- Extended `StdlibDocDriftSpec` with two new checks that derive the canonical module set from the "Modules at a glance" table in `docs/reference/stdlib.md` and assert both `CLAUDE.md` and `docs/ja/CLAUDE_ja.md` name every one of them — so this can't silently rot again.

## Test plan

- [x] New tests confirmed red before the fix (missing-module list matched exactly), green after.
- [x] Full suite, English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5032 succeeded, 0 failed, 1 canceled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCjJRzu6kYs8QSo9BMj4a

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQCjJRzu6kYs8QSo9BMj4a)_