### PR TITLE
docs: document the Scalars module (EN/JA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Scalars` module documented.** `docs/reference/stdlib.md` and its Japanese
+  translation listed `Scalars` in the "Modules at a glance" table but had no section
+  documenting any of its members (`toBoolean`, `isBoolean`, `read`, `coerce`) -- the
+  strict scalar parser that `record ... from re"..."`/`shape` derivations use at
+  boundaries was effectively undocumented. Added a "Scalars Module" section to both
+  files and a new `ScalarsDocCoverageSpec` regression test.
+
 - **`Net::listen(port)` (single-argument overload) documented.** `docs/reference/stdlib.md`
   and its Japanese translation only ever named the three-argument
   `Net::listen(host, port, backlog)` form in the `### Net::listen` section, even though the

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -509,6 +509,66 @@ val out = r.edit { v -> v.copy(port = 9090) }.render()
 - `orElse(other)` — この shape、読めなければ `other`。どちらも読めない場合は両方の
   defect を報告します。印字はこの shape で行います。
 
+## Scalars モジュール
+
+境界（外部データを読み込む場所）向けの、厳格なスカラー変換です。`record ... from
+re"..."` や `shape` が生成するコードから使われるほか、直接呼び出すこともできます。
+JDK 自身のパーサが緩すぎてそのままでは使えない場面のためのものです。
+
+### なぜ `Boolean::parseBoolean` ではないのか
+
+`java.lang.X.parseX` はどれも不正な入力を例外で拒否します -- `Boolean::parseBoolean`
+だけが例外で、`"true"` 以外のすべてを `false` に変換してしまいます。これはパーサが
+絶対にやってはいけない失敗の仕方です。`"maybe"`・`"yes"`・`"1"` がすべて `false` に
+なり、データが不正だったことを示すものが何も残りません。
+
+```onion
+Scalars::toBoolean("TRUE")     // true
+Scalars::toBoolean("false")    // false
+Scalars::toBoolean("yes")      // IllegalArgumentException が発生
+Scalars::isBoolean("yes")      // false -- toBoolean を呼ぶ前に確認できる
+```
+
+`toBoolean` は `IllegalArgumentException` を投げます。これは数値パーサが投げる
+`NumberFormatException` の親クラスなので、派生コードは両方を同じ方法で捕捉できます。
+
+### Scalars::read
+
+`text` を `tag` で指定したスカラー種別（`String`・`Int`・`Long`・`Double`・`Float`・
+`Boolean`・`Short`・`Byte` のいずれか）として読み取り、例外ではなく位置情報付きの
+`Defect` として報告します。
+
+```onion
+import { onion.Scalars; onion.Outcome; }
+
+val port: Outcome[Object] = Scalars::read("Int", "8080", null, "port")
+println(port.get())                                    // 8080
+
+val bad: Outcome[Object] = Scalars::read("Int", "http", null, "port")
+println(bad.defects().get(0).describe())                // port: expected Int, found "http"
+```
+
+`origin`（`Origin` または `null`）は defect をソーステキスト上の位置に結び付け、
+`path` は構築中の値のどこに該当するフィールドかを示します。
+
+### Scalars::coerce
+
+`Json`/`Yaml` などで既にパース済みのドキュメント値を、`tag` で指定したスカラー種別に
+変換します。`read` と異なり値は既に型付きで渡ってくるため -- JSON の数値はすでに
+`Number` になっている -- これはパースではなく絞り込みです。形そのものが違う値
+（`Int` が必要な場所に文字列がある等）は、黙って `null` になるのではなく defect に
+なります。
+
+```onion
+Scalars::coerce("Int", 8080, null, "port")        // Outcome::ok(8080)
+Scalars::coerce("Int", "8080", null, "port")      // Outcome::ok(8080) -- 数値文字列も読める
+Scalars::coerce("Int", [1, 2], null, "port")      // defect: expected Int, found an array
+```
+
+`read` と `coerce` はどちらもコンパイラ自身のスカラー変換テーブルと同じタグの語彙を
+使うため、`shape`/`from re"..."` による導出と `Scalars` を直接使う手書きコードは、
+同じ方法で defect を報告します。
+
 ## 関数インターフェース
 
 ラムダとクロージャのための組み込み関数型。`f(args)`の代わりに`f(args)`として呼び出せます。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -569,6 +569,66 @@ the sugar.
 - `orElse(other)` — this shape, or `other` when it doesn't read; reports both shapes'
   defects when neither does. Prints with this shape.
 
+## Scalars Module
+
+Strict scalar parsing for boundary derivations, used by `record ... from re"..."`/`shape`
+generated code (and callable directly) wherever the JDK's own parser is too lenient to
+serve as one.
+
+### Why not `Boolean::parseBoolean`?
+
+Every `java.lang.X.parseX` rejects malformed input by throwing — except
+`Boolean::parseBoolean`, which maps everything that isn't `"true"` to `false`. That is
+the one failure mode a parser must never have: `"maybe"`, `"yes"` and `"1"` would all
+silently become `false` with nothing to indicate the data was wrong.
+
+```onion
+Scalars::toBoolean("TRUE")     // true
+Scalars::toBoolean("false")    // false
+Scalars::toBoolean("yes")      // throws IllegalArgumentException
+Scalars::isBoolean("yes")      // false -- check before you call toBoolean
+```
+
+`toBoolean` throws `IllegalArgumentException`, the supertype of the
+`NumberFormatException` the numeric parsers throw, so a derivation catches both the
+same way.
+
+### Scalars::read
+
+Reads `text` as the scalar kind named by `tag` (one of `String`, `Int`, `Long`,
+`Double`, `Float`, `Boolean`, `Short`, `Byte`), reporting a positioned `Defect` rather
+than throwing.
+
+```onion
+import { onion.Scalars; onion.Outcome; }
+
+val port: Outcome[Object] = Scalars::read("Int", "8080", null, "port")
+println(port.get())                                    // 8080
+
+val bad: Outcome[Object] = Scalars::read("Int", "http", null, "port")
+println(bad.defects().get(0).describe())                // port: expected Int, found "http"
+```
+
+`origin` (an `Origin` or `null`) positions the defect in the source text; `path` names
+where in the value being built this field belongs.
+
+### Scalars::coerce
+
+Coerces an already-parsed document value (from `Json`/`Yaml`/...) to the scalar kind
+named by `tag`. Unlike `read`, the value arrives typed — a JSON number is already a
+`Number`, so this narrows rather than parses; a value of the wrong shape entirely (a
+string where an `Int` was required) is a defect, not a silent `null`.
+
+```onion
+Scalars::coerce("Int", 8080, null, "port")        // Outcome::ok(8080)
+Scalars::coerce("Int", "8080", null, "port")      // Outcome::ok(8080) -- numeric string still parses
+Scalars::coerce("Int", [1, 2], null, "port")      // a defect: expected Int, found an array
+```
+
+Both `read` and `coerce` speak the same tag vocabulary as the compiler's own scalar
+conversion table, so a `shape`/`from re"..."` derivation and hand-written code using
+`Scalars` directly report defects the same way.
+
 ## Function Interfaces
 
 Built-in function types for lambdas and closures. You can call them with `f(args)` as a shorthand for `f(args)`.

--- a/src/test/scala/onion/compiler/tools/ScalarsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ScalarsDocCoverageSpec.scala
@@ -1,0 +1,50 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Scalars` module docs.
+ *
+ * `onion.Scalars` (`toBoolean`/`isBoolean`/`read`/`coerce`) was listed in the "Modules at
+ * a glance" table in both docs/reference/stdlib.md and docs/ja/reference/stdlib.md but had
+ * no dedicated section documenting any of its members in either file.
+ */
+class ScalarsDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => s"\\b${java.util.regex.Pattern.quote(n)}\\b".r.findFirstIn(doc).isDefined)
+
+  private def staticNames(c: Class[?]): Set[String] =
+    c.getDeclaredMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(m => java.lang.reflect.Modifier.isPublic(m.getModifiers))
+      .map(_.getName)
+      .toSet
+
+  private lazy val actualNames: Set[String] = staticNames(classOf[onion.Scalars])
+
+  it("actual onion.Scalars exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Scalars found no members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Scalars member") {
+    val missing = actualNames -- documentedNames(read("docs/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/reference/stdlib.md is missing Scalars members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Scalars member") {
+    val missing = actualNames -- documentedNames(read("docs/ja/reference/stdlib.md"), actualNames)
+    assert(missing.isEmpty, s"docs/ja/reference/stdlib.md is missing Scalars members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/reference/stdlib.md's Modules at a glance table names Scalars") {
+    assert(read("docs/reference/stdlib.md").contains("`Scalars`"))
+  }
+
+  it("docs/ja/reference/stdlib.md's Modules at a glance table names Scalars") {
+    assert(read("docs/ja/reference/stdlib.md").contains("`Scalars`"))
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Scalars` (`toBoolean`/`isBoolean`/`read`/`coerce`) was listed in the "Modules at a glance" table in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, but had no dedicated section documenting any of its members — the strict scalar parser that `record ... from re"..."`/`shape` boundary derivations rely on internally was effectively undocumented.
- Added a "Scalars Module" section (with examples) to both the English and Japanese stdlib references.
- Added `ScalarsDocCoverageSpec`, a reflection-based regression test (same pattern as `ProcDocCoverageSpec`/`StatsDocCoverageSpec`) that fails if a public `Scalars` member goes undocumented in either language, or if the module drops out of the "Modules at a glance" table.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5040 tests, 0 failed, 1 canceled (pre-existing, unrelated), all passed.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — same result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbmWp2CM3qckMZbQjuEswz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbmWp2CM3qckMZbQjuEswz)_