### PR TITLE
docs: document List any/all/none/find/forEach/count/reverse/contains and Colls::toList(array)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **List `any`/`all`/`none`/`find`/`forEach`/`count`/`reverse`/`contains` and
+  `Colls::toList(array)` documented.** `docs/reference/stdlib.md` and its Japanese
+  translation never showed these as List extension methods in the Colls Module section
+  (`CollsDocCoverageSpec`'s whole-file check missed the gap by coincidence: `forEach`/
+  `count`/`contains` are documented for `Option`/`Result`/`Maps`/`Sets` elsewhere in the
+  file, and `any`/`all`/`none`/`find`/`reverse` are common English words that appear in
+  unrelated prose), and `Colls::toList(array)` -- the array-to-`List` crossing point
+  CLAUDE.md itself calls out -- was never shown in either doc at all. Added examples for
+  all nine to both files and extended `CollsDocCoverageSpec` with section-scoped checks
+  for actual call syntax, not just word presence.
+
 - **`Scalars` module documented.** `docs/reference/stdlib.md` and its Japanese
   translation listed `Scalars` in the "Modules at a glance" table but had no section
   documenting any of its members (`toBoolean`, `isBoolean`, `read`, `coerce`) -- the

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1658,6 +1658,15 @@ xs.groupBy { x -> x % 2 }         // キーごとの要素の List を値に持�
 xs.mkString(", ")                 // "1, 2, 3" - 要素を文字列として連結（join は別名）
 Colls::isNotEmpty(xs)             // true - isEmpty の否定
 m.filterMap { k, v -> k == "name" }   // 条件に合うエントリだけの Map
+xs.any { x -> x > 1 }             // いずれかの要素が条件を満たせば true
+xs.all { x -> x > 0 }             // すべての要素が条件を満たせば true
+xs.none { x -> x > 5 }            // どの要素も条件を満たさなければ true
+xs.find { x -> x > 1 }            // 最初に条件を満たす要素、なければ null
+xs.forEach { x -> println(x) }    // 各要素に対して処理を実行、戻り値なし
+xs.count { x -> x > 1 }           // 条件を満たす要素の数
+xs.reverse()                      // 要素を逆順にした新しい List
+xs.contains(2)                    // いずれかの要素が2と等しければ true
+Colls::toList(args)               // Java配列（例: main の String[]）を List に変換
 ```
 
 ### バッチ化・ウィンドウ化・セレクタ集計

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1646,6 +1646,15 @@ xs.groupBy { x -> x % 2 }         // Map from key to the List of elements with t
 xs.mkString(", ")                 // "1, 2, 3" - joins elements into a String (join is an alias)
 Colls::isNotEmpty(xs)             // true - the negation of isEmpty
 m.filterMap { k, v -> k == "name" }   // Map with only the matching entries
+xs.any { x -> x > 1 }             // true if some element matches
+xs.all { x -> x > 0 }             // true if every element matches
+xs.none { x -> x > 5 }            // true if no element matches
+xs.find { x -> x > 1 }            // first matching element, or null
+xs.forEach { x -> println(x) }    // runs an action per element, returns nothing
+xs.count { x -> x > 1 }           // how many elements match
+xs.reverse()                      // new List, elements in reverse order
+xs.contains(2)                    // true if some element equals 2
+Colls::toList(args)               // a Java array (e.g. main's String[]) as a List
 ```
 
 ### Batching, windowing, and selector aggregation

--- a/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
@@ -95,4 +95,47 @@ class CollsDocCoverageSpec extends AnyFunSpec {
     assert(missing.isEmpty,
       s"docs/ja/reference/stdlib.md's Colls section is missing: ${missing.toSeq.sorted.mkString(", ")}")
   }
+
+  /**
+   * `any`/`all`/`none`/`find`/`forEach`/`count`/`reverse`/`contains` are real List
+   * extension methods backed by `onion.Colls` (same fallback mechanism as
+   * `flatMap`/`bind`/`zip`/`groupBy` above), but the whole-file checks miss their absence
+   * by accident too: `forEach`/`count`/`contains` are documented for `Option`/`Result`/
+   * `Maps`/`Sets` elsewhere in the file, and `any`/`all`/`none`/`find`/`reverse` are common
+   * enough English words to appear in unrelated prose. Pin their presence in the Colls
+   * section itself, spelled as an actual List call, so neither coincidence hides a real gap.
+   */
+  private val listPredicateAndQueryNames = Set("any", "all", "none", "find", "forEach", "count", "reverse", "contains")
+
+  private def documentedCalls(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => doc.contains(s"xs.$n(") || doc.contains(s".$n {"))
+
+  it("docs/reference/stdlib.md's Colls Module section documents List any/all/none/find/forEach/count/reverse/contains") {
+    val doc = collsSection(read("docs/reference/stdlib.md"), "## Colls Module")
+    val missing = listPredicateAndQueryNames -- documentedCalls(doc, listPredicateAndQueryNames)
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md's Colls Module section is missing: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md's Colls section documents List any/all/none/find/forEach/count/reverse/contains") {
+    val doc = collsSection(read("docs/ja/reference/stdlib.md"), "## Colls モジュール")
+    val missing = listPredicateAndQueryNames -- documentedCalls(doc, listPredicateAndQueryNames)
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md's Colls section is missing: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  /**
+   * `Colls::toList(array)` -- converting a Java array (e.g. `main(args: String[])`) into a
+   * `List` -- is the one crossing point CLAUDE.md itself calls out ("Use Colls::toList(args)
+   * to cross over"), but neither doc file ever showed the call.
+   */
+  it("docs/reference/stdlib.md documents Colls::toList(array)") {
+    assert(read("docs/reference/stdlib.md").contains("Colls::toList("),
+      "docs/reference/stdlib.md never shows Colls::toList(...)")
+  }
+
+  it("docs/ja/reference/stdlib.md documents Colls::toList(array)") {
+    assert(read("docs/ja/reference/stdlib.md").contains("Colls::toList("),
+      "docs/ja/reference/stdlib.md never shows Colls::toList(...)")
+  }
 }


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md` and its Japanese translation never showed `any`/`all`/`none`/`find`/`forEach`/`count`/`reverse`/`contains` as `List` extension methods in the Colls Module section, even though all eight are real `onion.Colls`-backed extension methods (`xs.any { ... }`, `xs.reverse()`, etc.).
- `CollsDocCoverageSpec`'s existing whole-file check missed this by coincidence: `forEach`/`count`/`contains` are already documented for `Option`/`Result`/`Maps`/`Sets` elsewhere in the file, and `any`/`all`/`none`/`find`/`reverse` are common enough English words to appear in unrelated prose — so the word-presence check was satisfied without the List usage ever being shown.
- `Colls::toList(array)` — the array-to-`List` crossing point that CLAUDE.md itself calls out ("Use `Colls::toList(args)` to cross over") — was never documented in either stdlib doc at all.

## Changes

- Added examples for all nine members to the Colls Module section of `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- Extended `CollsDocCoverageSpec` with two new section-scoped regression tests (mirroring the existing `flatMap`/`bind`/`zip`/`groupBy` guard) that check for the actual call syntax within the Colls section itself, not just word presence anywhere in the file. Verified red before the doc fix, green after.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5044 succeeded, 0 failed, 1 pre-existing conditional skip (distribution-packaging test, unrelated to this change).
- [x] `sbt -Duser.language=en "testOnly *CollsDocCoverageSpec"` — confirmed red before the doc fix, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh4nbrE9fFJfbxTR8WprpP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh4nbrE9fFJfbxTR8WprpP)_