### PR TITLE
docs: document Map's keys()/values()/getOrDefault() extension-call syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Map`'s `keys()`/`values()`/`getOrDefault()` extension-method call syntax
+  documented.** `docs/reference/stdlib.md` and its Japanese translation only ever
+  showed these as `Maps::name(m, ...)` static calls, but `m.keys()`, `m.values()`
+  and `m.getOrDefault("x", 0)` are also real extension methods on `Map` (verified
+  by running them against a `Map` literal) that were never shown in either doc.
+  Added the extension-call spellings to both files' Maps Module section and a new
+  `MapsExtensionCallDocSpec` regression test.
+
 - **List `any`/`all`/`none`/`find`/`forEach`/`count`/`reverse`/`contains` and
   `Colls::toList(array)` documented.** `docs/reference/stdlib.md` and its Japanese
   translation never showed these as List extension methods in the Colls Module section

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1345,6 +1345,7 @@ val m: Map[String, Int] = Maps::newMap()
 Maps::getOrDefault(m, "a", 0)                 // あればその値、無ければデフォルト
 Maps::getOrElse(m, "x", () -> compute())      // 遅延デフォルト
 Maps::keys(m) / Maps::values(m)               // 順序を保ったリスト
+m.getOrDefault("x", 0) / m.keys() / m.values() // 拡張メソッドとしても呼べる（上と同じ）
 Maps::mapValues(m, (v: Int) -> v * 2) / Maps::mapKeys(m, (k: String) -> k.toUpperCase())
 Maps::filterValues(m, (v: Int) -> v > 0) / Maps::filterKeys(m, (k: String) -> k.startsWith("a"))
 Maps::filter(m, (k: String, v: Int) -> v > 0) // キー+値の述語

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2194,6 +2194,15 @@ Maps::keys(m)                              // List of keys, in order
 Maps::values(m)                            // List of values, in order
 ```
 
+`getOrDefault`, `keys` and `values` are also usable as extension methods on the
+map itself, chaining into a pipeline like the rest of `Maps`:
+
+```onion
+m.getOrDefault("x", 0)   // same as Maps::getOrDefault(m, "x", 0)
+m.keys()                 // same as Maps::keys(m)
+m.values()               // same as Maps::values(m)
+```
+
 ### Transformation
 
 ```onion

--- a/src/test/scala/onion/compiler/tools/MapsExtensionCallDocSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapsExtensionCallDocSpec.scala
@@ -1,0 +1,40 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * `onion.Maps`'s own javadoc and docs/reference/stdlib.md only ever spell its members as
+ * `Maps::name(m, ...)` static calls, but `keys`, `values` and `getOrDefault` are also real
+ * extension methods on `Map` (`m.keys()`, `m.values()`, `m.getOrDefault("x", 0)` all compile
+ * and run -- verified against a `Map` literal), left undocumented in both languages.
+ */
+class MapsExtensionCallDocSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def mapsSection(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toIndexedSeq
+    val start = lines.indexWhere(_.contains(heading))
+    assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+    val rest = lines.drop(start + 1)
+    val end = rest.indexWhere(_.startsWith("## "))
+    (if (end < 0) rest else rest.take(end)).mkString("\n")
+  }
+
+  private val extensionCalls = Set("m.keys(", "m.values(", "m.getOrDefault(")
+
+  it("docs/reference/stdlib.md's Maps Module section documents m.keys()/m.values()/m.getOrDefault() as extension calls") {
+    val doc = mapsSection(read("docs/reference/stdlib.md"), "## Maps Module")
+    val missing = extensionCalls.filterNot(doc.contains)
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md's Maps Module section is missing extension-call spellings: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md's Maps section documents m.keys()/m.values()/m.getOrDefault() as extension calls") {
+    val doc = mapsSection(read("docs/ja/reference/stdlib.md"), "## Maps モジュール")
+    val missing = extensionCalls.filterNot(doc.contains)
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md's Maps section is missing extension-call spellings: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md` and its Japanese translation only ever spelled `Maps` members as `Maps::name(m, ...)` static calls. `m.keys()`, `m.values()` and `m.getOrDefault("x", 0)` are also real extension methods on `Map` (verified by running them against a `Map` literal via `sbt runScript`), but that call syntax was never shown in either doc.
- Added the extension-call spellings to both files' Maps Module section, plus a `CHANGELOG.md` entry.

## Test plan

- [x] Added `MapsExtensionCallDocSpec` (TDD: confirmed red before the doc changes, green after).
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5046 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-journey test), 0 ignored.
- [x] Same suite with `-Duser.language=ja` — identical result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhgeABsUEpurqNzqAiV1Jw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhgeABsUEpurqNzqAiV1Jw)_