### PR TITLE
docs: document Sets extension-method call syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Sets`'s extension-method call syntax documented.** `docs/reference/stdlib.md`
+  and its Japanese translation only ever showed `onion.Sets`'s set-algebra and
+  functional operations (`union`, `intersection`, `difference`,
+  `symmetricDifference`, `containsAll`, `isSubsetOf`, `isSupersetOf`,
+  `isDisjoint`, `map`, `filter`, `forEach`, `count`, `any`, `all`, `find`) as
+  `Sets::name(a, ...)` static calls, but every one of them is also a builtin
+  extension method on `Set` (`a.union(b)`, `a.isDisjoint(c)`, ... -- several
+  already exercised as compiling/running extension calls by
+  `StdlibMethodChainSpec`), which was never shown in either doc. Added the
+  extension-call spellings to both files' Sets Module section and a new
+  `SetsExtensionCallDocSpec` regression test.
+
 - **`Hash`, `Codec`, `Text` and `Format`'s extension-method call syntax
   documented.** `docs/reference/stdlib.md` and its Japanese translation only ever
   showed these four modules as `Hash::name(...)` / `Codec::name(...)` /

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1364,15 +1364,24 @@ Maps::update(m, "a", (v: Int) -> v + 1)       // 関数的更新
 
 Set ユーティリティ（`onion.Sets`）。結果 Set は挿入順を保持し、集合演算は null 安全。
 
+どのメソッドも `Set` の組み込み拡張メソッドとして呼び出せます（例: `Sets::union(a, b)` は `a.union(b)`）。
+
 ```onion
 Sets::of(1, 2, 3) / Sets::newSet[Int]() / Sets::fromList([1, 1, 2]) / Sets::toList(a)
 Sets::union(a, b) / Sets::intersection(a, b) / Sets::difference(a, b)
+a.union(b) / a.intersection(b) / a.difference(b)
 Sets::symmetricDifference(a, b)               // どちらか一方だけに含まれる
+a.symmetricDifference(b)
 Sets::containsAll(a, b)                       // a が b の要素をすべて含む
+a.containsAll(b)
 Sets::isSubsetOf(a, b) / Sets::isSupersetOf(a, b) / Sets::isDisjoint(a, b)
+a.isSubsetOf(b) / a.isSupersetOf(b) / a.isDisjoint(b)
 Sets::map(a, f) / Sets::filter(a, p) / Sets::find(a, p)
+a.map(f) / a.filter(p) / a.find(p)
 Sets::forEach(a, (x: Int) -> println(x))
+a.forEach((x: Int) -> println(x))
 Sets::count(a, p) / Sets::any(a, p) / Sets::all(a, p)
+a.count(p) / a.any(p) / a.all(p)
 ```
 
 ## Hash モジュール

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2293,27 +2293,32 @@ Sets::toList(a)                        // back to a List
 
 ### Set algebra
 
+Every method below is also a builtin extension method on `Set`, callable as
+`a.union(b)` instead of `Sets::union(a, b)`.
+
 ```onion
-Sets::union(a, b)
-Sets::intersection(a, b)
-Sets::difference(a, b)
-Sets::symmetricDifference(a, b)        // in exactly one of the two
-Sets::containsAll(a, b)
-Sets::isSubsetOf(a, b)                 // every element of a is in b
-Sets::isSupersetOf(a, b)
-Sets::isDisjoint(a, b)                 // share no elements
+Sets::union(a, b)                      // a.union(b)
+Sets::intersection(a, b)               // a.intersection(b)
+Sets::difference(a, b)                 // a.difference(b)
+Sets::symmetricDifference(a, b)        // a.symmetricDifference(b) -- in exactly one of the two
+Sets::containsAll(a, b)                // a.containsAll(b)
+Sets::isSubsetOf(a, b)                 // a.isSubsetOf(b) -- every element of a is in b
+Sets::isSupersetOf(a, b)               // a.isSupersetOf(b)
+Sets::isDisjoint(a, b)                 // a.isDisjoint(b) -- share no elements
 ```
 
 ### Functional operations
 
+These are also builtin extension methods on `Set` (`a.map(...)`, `a.filter(...)`, ...):
+
 ```onion
-Sets::map(a, (x: Int) -> x * 2)
-Sets::filter(a, (x: Int) -> x > 1)
-Sets::forEach(a, (x: Int) -> println(x))
-Sets::count(a, (x: Int) -> x > 1)
-Sets::any(a, (x: Int) -> x > 2)
-Sets::all(a, (x: Int) -> x > 0)
-Sets::find(a, (x: Int) -> x > 2)       // matching element or null
+Sets::map(a, (x: Int) -> x * 2)        // a.map((x: Int) -> x * 2)
+Sets::filter(a, (x: Int) -> x > 1)     // a.filter((x: Int) -> x > 1)
+Sets::forEach(a, (x: Int) -> println(x))  // a.forEach((x: Int) -> println(x))
+Sets::count(a, (x: Int) -> x > 1)      // a.count((x: Int) -> x > 1)
+Sets::any(a, (x: Int) -> x > 2)        // a.any((x: Int) -> x > 2)
+Sets::all(a, (x: Int) -> x > 0)        // a.all((x: Int) -> x > 0)
+Sets::find(a, (x: Int) -> x > 2)       // a.find((x: Int) -> x > 2) -- matching element or null
 ```
 
 ---

--- a/src/test/scala/onion/compiler/tools/SetsExtensionCallDocSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsExtensionCallDocSpec.scala
@@ -1,0 +1,46 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * `onion.Sets`'s own javadoc and docs/reference/stdlib.md only ever spell its members as
+ * `Sets::name(a, ...)` static calls, but every one of its static methods is also a real
+ * extension method on `Set` (`a.union(b)`, `a.isDisjoint(c)`, ... -- `a.union(b)`,
+ * `a.intersection(b)`, `a.symmetricDifference(b)`, `a.isSubsetOf(b)` and `a.isDisjoint(b)`
+ * are already exercised as compiling/running extension calls by StdlibMethodChainSpec),
+ * left undocumented in both languages.
+ */
+class SetsExtensionCallDocSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def setsSection(doc: String, heading: String): String = {
+    val lines = doc.linesIterator.toIndexedSeq
+    val start = lines.indexWhere(_.contains(heading))
+    assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+    val rest = lines.drop(start + 1)
+    val end = rest.indexWhere(_.startsWith("## "))
+    (if (end < 0) rest else rest.take(end)).mkString("\n")
+  }
+
+  private val extensionCalls = Set(
+    "a.union(", "a.intersection(", "a.difference(", "a.symmetricDifference(",
+    "a.containsAll(", "a.isSubsetOf(", "a.isSupersetOf(", "a.isDisjoint(",
+    "a.map(", "a.filter(", "a.forEach(", "a.count(", "a.any(", "a.all(", "a.find("
+  )
+
+  it("docs/reference/stdlib.md's Sets Module section documents Set algebra and functional operations as extension calls") {
+    val doc = setsSection(read("docs/reference/stdlib.md"), "## Sets Module")
+    val missing = extensionCalls.filterNot(doc.contains)
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md's Sets Module section is missing extension-call spellings: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md's Sets section documents Set algebra and functional operations as extension calls") {
+    val doc = setsSection(read("docs/ja/reference/stdlib.md"), "## Sets モジュール")
+    val missing = extensionCalls.filterNot(doc.contains)
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md's Sets section is missing extension-call spellings: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Sets`'s set-algebra and functional operations (`union`, `intersection`, `difference`, `symmetricDifference`, `containsAll`, `isSubsetOf`, `isSupersetOf`, `isDisjoint`, `map`, `filter`, `forEach`, `count`, `any`, `all`, `find`) were only ever documented as `Sets::name(a, ...)` static calls in `docs/reference/stdlib.md` and its Japanese translation, even though every one of them is also a builtin extension method on `Set` (`a.union(b)`, `a.isDisjoint(c)`, ...). Several of these are already exercised as compiling/running extension calls by `StdlibMethodChainSpec`, confirming the behavior; it just wasn't documented.
- Added extension-call spellings to both files' Sets Module section and a new `SetsExtensionCallDocSpec` regression test, mirroring the existing `MapsExtensionCallDocSpec` / `HashCodecTextFormatExtensionCallDocSpec` pattern.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SetsExtensionCallDocSpec` fails without the doc fix (verified via `git stash` on the doc files) and passes with it.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5056 tests, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NLzGqyPtMfRPdbvaxw9Sm

---
_Generated by [Claude Code](https://claude.ai/code/session_012NLzGqyPtMfRPdbvaxw9Sm)_