### PR TITLE
docs(stdlib): warn that Strings::split/substring/lines/chars/repeat are shadowed by java.lang.String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Strings`'s extension-call shadowing by `java.lang.String` documented.**
+  `onion.Strings` is registered as a builtin extension container, so most of
+  its methods work as method chains (`s.upper()`, `s.trim()`, ...) -- but an
+  instance method always wins over an extension method of the same name, and
+  `java.lang.String` already defines `split`, `substring`, `lines`, `chars`
+  and `repeat`. So `s.split(",")`, `s.substring(10)`, `s.lines()`,
+  `s.chars()` and `s.repeat(-1)` silently reach the *native JDK method*
+  instead of `onion.Strings`'s (an array instead of a `List`, a thrown
+  exception instead of a safe fallback -- confirmed by running each against
+  `ScriptRunner`), which neither `docs/reference/stdlib.md` nor its Japanese
+  translation warned about. Added the caveat to both files' Strings Module
+  section and a new `StringsExtensionCallShadowingSpec` regression test that
+  locks in the shadowing behavior and checks both docs for the warning.
+
 - **`Sets`'s extension-method call syntax documented.** `docs/reference/stdlib.md`
   and its Japanese translation only ever showed `onion.Sets`'s set-algebra and
   functional operations (`union`, `intersection`, `difference`,

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1336,6 +1336,22 @@ Strings::toIntOrNull("42") / Strings::toLongOrNull("100") / Strings::toDoubleOrN
 Strings::toIntOr("nope", 0)              // 0
 ```
 
+`Strings` の大半のメソッド（`upper`、`trim`、`startsWith`、`indexOf`、
+`capitalize` など）は拡張メソッドのメソッドチェーン（`s.upper()`、
+`s.trim()` など）としても静的呼び出しと同じ挙動で使えます。**例外は
+`split`・`substring`・`lines`・`chars`・`repeat` の5つ**です。
+`java.lang.String` にはすでに同名のメソッドが定義されており、同名の
+インスタンスメソッドは常に拡張メソッドより優先されるため、
+`s.split(",")`、`s.substring(1)`、`s.lines()`、`s.chars()`、`s.repeat(3)`
+は `onion.Strings` 側ではなく **JDK 標準の同名メソッド** を暗黙のうちに
+呼び出します。そのため `s.split(",")` は `List` ではなく `String[]` を
+返し、`s.substring(10)` は範囲外の開始位置で `""` を返す代わりに例外を
+投げ、`s.lines()` / `s.chars()` は `List` ではなく JDK の `Stream` /
+`IntStream` を返し、`s.repeat(-1)` は `""` を返す代わりに例外を投げます。
+これら5つのメソッドについて `onion.Strings` の List を返す・例外を
+投げない挙動を得るには、`Strings::` の静的呼び出し形式（例:
+`Strings::split(...)`、`Strings::substring(...)`）を使ってください。
+
 ## Maps モジュール
 
 Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持（`LinkedHashMap`）。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1227,6 +1227,21 @@ Strings::toLongOrNull("100") / Strings::toDoubleOrNull("3.14")
 Strings::toIntOr("nope", 0)              // 0
 ```
 
+Most `Strings` methods (`upper`, `trim`, `startsWith`, `indexOf`, `capitalize`,
+...) also work as extension-call method chains (`s.upper()`, `s.trim()`, ...)
+with identical behavior to the static form. **`split`, `substring`, `lines`,
+`chars` and `repeat` are the exception**: `java.lang.String` already defines
+methods with these same names, and an instance method always wins over an
+extension method of the same name, so `s.split(",")`, `s.substring(1)`,
+`s.lines()`, `s.chars()` and `s.repeat(3)` silently call the *native JDK
+method* instead of `onion.Strings`'s. That means `s.split(",")` returns a
+`String[]` (not a `List`), `s.substring(10)` throws on an out-of-range start
+instead of returning `""`, `s.lines()` / `s.chars()` return a JDK
+`Stream`/`IntStream` (not a `List`), and `s.repeat(-1)` throws instead of
+returning `""`. Use the `Strings::` static-call form (e.g. `Strings::split(...)`,
+`Strings::substring(...)`) for these five methods to get `onion.Strings`'s
+List-returning, exception-safe behavior.
+
 ## Files Module
 
 File I/O (`onion.Files`):

--- a/src/test/scala/onion/compiler/tools/StringsExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsExtensionCallShadowingSpec.scala
@@ -1,0 +1,105 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Strings` is registered as a builtin extension container
+ * (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`), but an instance
+ * method always wins over an extension method of the same name -- and
+ * `java.lang.String` already defines `split`, `substring`, `lines`, `chars` and
+ * `repeat`. So calling those five by extension-call syntax silently reaches the
+ * *native JDK method* instead of `onion.Strings`'s, with different semantics
+ * (array instead of List, a thrown exception instead of a safe fallback). This
+ * locks in that shadowing so a future change to extension-method resolution
+ * order doesn't silently flip it, and checks that both docs carry the warning
+ * (docs/reference/stdlib.md and its Japanese translation, Strings Module
+ * section).
+ */
+class StringsExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsShadowBool.on", Array()))
+  }
+
+  private def runStr(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): String {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsShadowStr.on", Array()))
+  }
+
+  describe("extension-call syntax on String shadows onion.Strings for five methods") {
+    it("split() reaches the native String.split, not Strings::split -- it returns an array, not a List") {
+      // A List has no .length property; only an array does. If the extension
+      // call reached onion.Strings::split (which returns a List), this would
+      // fail to compile instead of running.
+      runBool("return \"a,b,c\".split(\",\").length == 3", Shell.Success(true))
+    }
+
+    it("substring() reaches the native String.substring -- it throws on an out-of-range start instead of returning \"\"") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): String {\n" +
+          "    return \"abc\".substring(10)\n  }\n}\n",
+          "StringsShadowSubstring.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[StringIndexOutOfBoundsException])
+    }
+
+    it("repeat() reaches the native String.repeat -- it throws on a negative count instead of returning \"\"") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): String {\n" +
+          "    return \"abc\".repeat(-1)\n  }\n}\n",
+          "StringsShadowRepeat.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[IllegalArgumentException])
+    }
+
+    it("the static Strings:: form keeps onion.Strings's safe behavior for the same inputs") {
+      runStr("return Strings::substring(\"abc\", 10)", Shell.Success(""))
+      runStr("return Strings::repeat(\"abc\", -1)", Shell.Success(""))
+    }
+
+    it("non-colliding Strings methods behave identically via extension-call and static-call syntax") {
+      runStr("return \"Hello\".upper()", Shell.Success("HELLO"))
+      runBool("return \"Hello\".startsWith(\"He\")", Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Strings Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("s.split(", "s.substring(", "s.lines()", "s.chars()", "s.repeat(", "java.lang.String")
+
+    val jaMarkers =
+      Set("s.split(", "s.substring(", "s.lines()", "s.chars()", "s.repeat(", "java.lang.String")
+
+    it("docs/reference/stdlib.md's Strings Module section warns about the five shadowed methods") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Strings Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about the five shadowed methods") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Strings section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Strings` is registered as a builtin extension container, so most of its methods work as extension-call method chains (`s.upper()`, `s.trim()`, ...) with the same behavior as the static form.
- But an instance method always wins over an extension method of the same name, and `java.lang.String` already defines `split`, `substring`, `lines`, `chars` and `repeat` -- so those five extension calls silently reach the *native JDK method* instead of `onion.Strings`'s, with different semantics: an array instead of a `List` (`split`), a thrown exception instead of a safe fallback (`substring`, `repeat`), and a JDK `Stream`/`IntStream` instead of a `List` (`lines`, `chars`). Confirmed by running each against `ScriptRunner`.
- Neither `docs/reference/stdlib.md` nor its Japanese translation warned about this, unlike the recent PRs documenting the *positive* case (Sets/Hash/Codec/Text/Format/Maps/Colls extension-call syntax) -- this is the corresponding negative case for `Strings`.
- Added the caveat to both files' Strings Module section and a new `StringsExtensionCallShadowingSpec` regression test that locks in the shadowing behavior at runtime (via `Shell.run`) and checks both docs for the warning, plus a `CHANGELOG.md` entry.

## Test plan

- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.StringsExtensionCallShadowingSpec onion.compiler.tools.StdlibDocDriftSpec"` — green
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5063 succeeded, 0 failed (1 pre-existing, unrelated cancellation: the distribution-journey test, cancelled in this sandbox before this change too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AJKMvWRhUuCkmXMGDFZQT

---
_Generated by [Claude Code](https://claude.ai/code/session_017AJKMvWRhUuCkmXMGDFZQT)_