### PR TITLE
docs(stdlib): document onion.Stats's min/max extension-call shadowing

### DIFF
--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1462,6 +1462,21 @@ xs.sum()             // 100.0  （Double: 汎用集計）
 Stats::sumInt(xs)    // 100    （Int）
 ```
 
+**`min`/`max` は例外です**: `onion.Colls` にも消去後シグネチャが同じ
+`min(List)`/`max(List)` 拡張メソッドがあり、`onion.Stats` より先に登録される
+ため、`xs.min()` と `xs.max()` は常に *`onion.Colls`* 側に到達し、
+`onion.Stats` 側には到達しません。つまり `xs.min()` はリストの要素型そのまま
+（`List[Int]` なら精度の落ちない `Int`）を返し、**空リストでは `0.0` を返す
+代わりに `NoSuchElementException` を投げます**。`Double` の結果と空リストに
+安全な `0.0` フォールバックが必要な場合は `Stats::min`/`Stats::max` の静的
+呼び出し形式を使ってください:
+
+```onion
+val xs: List[Int] = [10, 20, 30, 40]
+xs.min()             // 10   （Int: onion.Colls::min であって onion.Stats::min ではない）
+Stats::min(xs)       // 10.0 （Double。空リストでも例外ではなく 0.0）
+```
+
 `Int` を返す `sum()` のオーバーロードが無いのは型消去のためです。実行時には要素型が
 消えるので、`sum(List[Int])` と `sum(List[Double])` は同じ JVM シグネチャになります。
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1583,6 +1583,21 @@ xs.sum()             // 100.0  (Double — the generic aggregate)
 Stats::sumInt(xs)    // 100    (Int)
 ```
 
+**`min`/`max` are the exception**: `onion.Colls` also declares a
+`min(List)`/`max(List)` extension with the same erased signature, and it is
+registered ahead of `onion.Stats`, so `xs.min()` and `xs.max()` always reach
+*`onion.Colls`'s* versions, never `onion.Stats`'s. That means `xs.min()`
+returns the list's exact element type (an `Int` for `List[Int]`, not a lossy
+`Double`) and **throws `NoSuchElementException` on an empty list** instead of
+returning `0.0`. Use the `Stats::min`/`Stats::max` static-call form when you
+need the `Double` result and the empty-list-safe `0.0` fallback:
+
+```onion
+val xs: List[Int] = [10, 20, 30, 40]
+xs.min()             // 10   (Int — onion.Colls::min, not onion.Stats::min)
+Stats::min(xs)       // 10.0 (Double, and 0.0 rather than a throw for [])
+```
+
 Type erasure is the reason there is no `Int`-returning `sum()` overload: the
 element type is gone at runtime, so `sum(List[Int])` and `sum(List[Double])`
 would be the same JVM signature.

--- a/src/test/scala/onion/compiler/tools/StatsExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StatsExtensionCallShadowingSpec.scala
@@ -1,0 +1,96 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Stats` and `onion.Colls` are both registered as builtin extension
+ * containers (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`),
+ * and both declare a `min(List)`/`max(List)` static method with the same
+ * erased signature. Extension registration keeps the first container that
+ * claims a given receiver+name+erased-signature, and `Colls` is listed
+ * ahead of `Stats`, so `xs.min()`/`xs.max()` always reach `onion.Colls`'s
+ * versions -- `onion.Stats`'s `min`/`max` are never reachable by
+ * extension-call syntax at all. This locks in that shadowing so a future
+ * reordering of `BuiltinExtensionContainers` doesn't silently flip it, and
+ * checks that both docs carry the warning (docs/reference/stdlib.md and
+ * its Japanese translation, Stats Module section).
+ */
+class StatsExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def runInt(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Int {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StatsShadowInt.on", Array()))
+  }
+
+  private def runDouble(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Double {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StatsShadowDouble.on", Array()))
+  }
+
+  describe("extension-call syntax for min()/max() on a List[Int] shadows onion.Stats") {
+    it("xs.min() returns the exact Int element (Colls's behavior), not a Double") {
+      // If this reached onion.Stats::min (which returns Double), a method
+      // declared to return Int could not hand its result back without a
+      // narrowing conversion, and this would fail to compile.
+      runInt("val xs: List[Int] = [10, 20, 30, 40]\n    return xs.min()", Shell.Success(10))
+      runInt("val xs: List[Int] = [10, 20, 30, 40]\n    return xs.max()", Shell.Success(40))
+    }
+
+    it("xs.min() throws on an empty list instead of returning 0.0") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val xs: List[Int] = []\n    return xs.min()\n  }\n}\n",
+          "StatsShadowEmptyMin.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[java.util.NoSuchElementException])
+    }
+
+    it("the static Stats:: form keeps onion.Stats's safe empty-list behavior (0.0), never reachable via extension-call syntax") {
+      runDouble("val xs: List[Int] = []\n    return Stats::min(xs)", Shell.Success(0.0))
+      runDouble("val xs: List[Int] = [10, 20, 30, 40]\n    return Stats::min(xs)", Shell.Success(10.0))
+    }
+
+    it("non-colliding Stats methods behave identically via extension-call and static-call syntax") {
+      runDouble("val xs: List[Int] = [10, 20, 30, 40]\n    return xs.average()", Shell.Success(25.0))
+      runDouble("val xs: List[Int] = [10, 20, 30, 40]\n    return Stats::average(xs)", Shell.Success(25.0))
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Stats Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("xs.min(", "xs.max(", "onion.Colls", "NoSuchElementException")
+
+    val jaMarkers =
+      Set("xs.min(", "xs.max(", "onion.Colls", "NoSuchElementException")
+
+    it("docs/reference/stdlib.md's Stats Module section warns about min()/max() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Stats Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Stats Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Stats section warns about min()/max() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Stats モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Stats section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Colls` also declares `min(List)`/`max(List)` with the same erased signature as `onion.Stats`'s, and `Colls` is listed ahead of `Stats` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, so `xs.min()`/`xs.max()` always reach *`onion.Colls`*'s versions — `onion.Stats`'s `min`/`max` are never reachable by extension-call syntax at all.
- Concretely: `xs.min()` on a `List[Int]` returns the exact `Int` element (not a lossy `Double`), and **throws `NoSuchElementException` on an empty list** instead of returning `0.0` as `Stats::min` does — neither stdlib doc mentioned this.
- Documents the caveat in the Stats Module section of both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, following the same pattern as the existing `Strings`/`Iterables` extension-call-shadowing doc fixes.
- Adds `StatsExtensionCallShadowingSpec` (TDD: written first, confirmed red on the doc-coverage checks, green after the doc update) that locks in the shadowing behavior and checks both docs for the warning.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5072 succeeded, 0 failed, 1 canceled, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116C58euKdoaNNZGcxzh84a

---
_Generated by [Claude Code](https://claude.ai/code/session_0116C58euKdoaNNZGcxzh84a)_