### PR TITLE
docs(stdlib): document Iterables's take/drop/reverse extension-call shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Module section and a new `StatsExtensionCallShadowingSpec` regression test
   that locks in the shadowing and checks both docs for the warning.
 
+- **`Iterables`'s `take`/`drop`/`reverse` extension-call shadowing by `onion.Colls`
+  documented.** `onion.Colls` also declares `take(List, int)`/`drop(List, int)`/
+  `reverse(List)` extensions with the same erased signatures as `onion.Iterables`'s,
+  and `Colls` is registered ahead of `Iterables`, so `xs.take(n)`, `xs.drop(n)` and
+  `xs.reverse()` always reach *`onion.Colls`*'s versions -- `onion.Iterables`'s are
+  never reachable by extension-call syntax at all, even though both docs showed
+  them as plain `Iterables` chaining examples. The two disagree on a negative `n`
+  (`Colls` clamps to an empty/unchanged result, `Iterables` throws), on `n` at or
+  past the list's size (`Colls` returns the same list reference, not a copy;
+  `Iterables` always copies), and on `reverse` (`Colls`'s result is unmodifiable,
+  `Iterables`'s is a mutable copy). Added the caveat to both files' Iterables
+  Module section and a new `IterablesTakeDropReverseShadowingSpec` regression
+  test that locks in the shadowing and checks both docs for the warning.
+
 ## [0.53.0] - 2026-09-03
 
 ### Documentation

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1625,6 +1625,31 @@ xs.take(2) / xs.drop(1)
 xs.sort() / xs.sort(comparator)
 ```
 
+**`take`/`drop`/`reverse` は例外です**: `onion.Colls` にも消去後シグネチャが
+同じ `take(List, int)`/`drop(List, int)`/`reverse(List)` 拡張メソッドがあり、
+`onion.Iterables` より先に登録されるため、`xs.take(n)`・`xs.drop(n)`・
+`xs.reverse()` は常に *`onion.Colls`* 側に到達し、`onion.Iterables` 側には
+到達しません。両者はエッジケースで挙動が異なります:
+
+- `n` が負の場合 -- `xs.take(-1)` / `xs.drop(-1)` は空/変更なしの結果を返す
+  が、`Iterables::take`/`Iterables::drop` は例外を投げる
+- `n` がリストのサイズ以上の場合 -- `xs.take(n)` / `xs.drop(n)` はコピーで
+  はなく**同じリスト参照そのもの**を返す。`Iterables::take`/`Iterables::drop`
+  は必ずコピーする
+- `xs.reverse()` は**変更不可 (unmodifiable)** なリストを返す。
+  `Iterables::reverse` は変更可能なコピーを返す
+
+コピーされ、サイズに関して安全な挙動が必要な場合は `Iterables::take`/
+`Iterables::drop`/`Iterables::reverse` の静的呼び出し形式を使ってください:
+
+```onion
+val xs: List[Int] = [1, 2, 3]
+xs.take(-1)                    // []      （onion.Colls::take。例外ではなく空リストにクランプ）
+xs.take(xs.size() + 1) === xs  // true    （onion.Colls::take。同じリスト参照）
+xs.reverse().add(4)            // UnsupportedOperationException を投げる（onion.Colls::reverse）
+Iterables::take(xs, -1)        // 例外を投げる（onion.Iterables::take。クランプしない）
+```
+
 ## Files モジュール
 
 ファイル I/O（`onion.Files`）:

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -867,6 +867,31 @@ xs.take(2) / xs.drop(1)
 xs.sort() / xs.sort(comparator)
 ```
 
+**`take`/`drop`/`reverse` are exceptions**: `onion.Colls` also declares
+`take(List, int)`/`drop(List, int)`/`reverse(List)` extensions with the same
+erased signatures, and it is registered ahead of `onion.Iterables`, so
+`xs.take(n)`, `xs.drop(n)` and `xs.reverse()` always reach *`onion.Colls`*'s
+versions, never `onion.Iterables`'s. The two disagree on edge cases:
+
+- a negative `n` -- `xs.take(-1)` / `xs.drop(-1)` return an empty/unchanged
+  result; `Iterables::take`/`Iterables::drop` throw instead
+- `n` at or past the list's size -- `xs.take(n)` / `xs.drop(n)` return the
+  **very same list reference**, not a copy; `Iterables::take`/`Iterables::drop`
+  always copy
+- `xs.reverse()` returns an **unmodifiable** list; `Iterables::reverse` returns
+  a plain mutable copy
+
+Use the `Iterables::take`/`Iterables::drop`/`Iterables::reverse` static-call
+form when you need copying, size-safe semantics instead:
+
+```onion
+val xs: List[Int] = [1, 2, 3]
+xs.take(-1)                    // []      (onion.Colls::take, clamps instead of throwing)
+xs.take(xs.size() + 1) === xs  // true    (onion.Colls::take, same list reference)
+xs.reverse().add(4)            // throws UnsupportedOperationException (onion.Colls::reverse)
+Iterables::take(xs, -1)        // throws  (onion.Iterables::take, no clamping)
+```
+
 ## Option Module
 
 Provided via `onion.Option`.

--- a/src/test/scala/onion/compiler/tools/IterablesTakeDropReverseShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IterablesTakeDropReverseShadowingSpec.scala
@@ -1,0 +1,156 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Iterables::take`/`drop`/`reverse` have the same erased signature as
+ * `onion.Colls`'s versions of the same names, and `Colls` is listed ahead of
+ * `Iterables` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`,
+ * so `xs.take(n)`, `xs.drop(n)` and `xs.reverse()` always reach *`onion.Colls`*'s
+ * implementations -- `onion.Iterables`'s versions of these three are never
+ * reachable by extension-call syntax at all, even though docs/reference/stdlib.md
+ * (and its Japanese translation) show them as if they were plain `Iterables`
+ * chaining examples. The two implementations disagree on edge cases:
+ *   - a negative `n`: `Colls::take`/`drop` clamp to an empty/unchanged result,
+ *     `Iterables::take`/`drop` throw (`subList` rejects the negative index)
+ *   - `n` at or past the list's size: `Colls::take`/`drop` return the very
+ *     same list reference, not a copy; `Iterables::take`/`drop` always copy
+ *   - `reverse`: `Colls::reverse` returns an unmodifiable list; `Iterables::reverse`
+ *     returns a plain mutable `ArrayList`
+ * This locks in that shadowing so a future reordering of
+ * `BuiltinExtensionContainers` doesn't silently flip it, and checks that both
+ * docs carry the warning (docs/reference/stdlib.md and its Japanese
+ * translation, Iterables Module section).
+ */
+class IterablesTakeDropReverseShadowingSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "IterablesShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for take()/drop()/reverse() on a List[Int] shadows onion.Iterables") {
+    it("xs.take(-1) returns an empty list (Colls's behavior), not a thrown exception") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |return xs.take(-1) == []
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("Iterables::take(xs, -1) throws instead, unlike the shadowing extension call") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |try {
+          |  Iterables::take(xs, -1)
+          |  return false
+          |} catch e: RuntimeException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("xs.drop(-1) returns the very same list reference (Colls's aliasing behavior)") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |return xs.drop(-1) === xs
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("Iterables::drop(xs, -1) throws instead, unlike the shadowing extension call") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |try {
+          |  Iterables::drop(xs, -1)
+          |  return false
+          |} catch e: RuntimeException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("xs.take(n) with n past the list's size returns the very same list reference, not a copy") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |return xs.take(xs.size() + 1) === xs
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("Iterables::take(xs, n) past the size copies instead of aliasing") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |return !(Iterables::take(xs, xs.size() + 1) === xs)
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("xs.reverse() is unmodifiable (Colls's behavior), unlike onion.Iterables's mutable copy") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |try {
+          |  xs.reverse().add(4)
+          |  return false
+          |} catch e: UnsupportedOperationException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("Iterables::reverse(xs) stays mutable, unlike the shadowing extension call") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |Iterables::reverse(xs).add(4)
+          |return true
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Iterables Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("xs.take(", "xs.drop(", "xs.reverse(", "onion.Colls", "same list reference", "unmodifiable")
+
+    val jaMarkers =
+      Set("xs.take(", "xs.drop(", "xs.reverse(", "onion.Colls", "同じリスト参照", "変更不可")
+
+    it("docs/reference/stdlib.md's Iterables Module section warns about take()/drop()/reverse() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Iterables Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Iterables Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Iterables section warns about take()/drop()/reverse() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Iterables モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Iterables モジュール section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Colls` also declares `take(List, int)`/`drop(List, int)`/`reverse(List)` extensions with the same erased signatures as `onion.Iterables`'s, and `Colls` is registered ahead of `Iterables` in the builtin extension container list, so `xs.take(n)`/`xs.drop(n)`/`xs.reverse()` always reach `onion.Colls`'s versions -- `onion.Iterables`'s are never reachable by extension-call syntax at all, even though both `docs/reference/stdlib.md` and its Japanese translation showed them as plain `Iterables` chaining examples.
- The two disagree on edge cases: a negative `n` (`Colls` clamps to an empty/unchanged result, `Iterables` throws), `n` at or past the list's size (`Colls` returns the very same list reference instead of copying), and `reverse` (`Colls`'s result is unmodifiable, `Iterables`'s is a mutable copy).
- Documented the caveat in both docs' Iterables Module section and added `IterablesTakeDropReverseShadowingSpec`, a regression test that locks in the shadowing/edge-case behavior and checks both docs for the warning.
- Noted the change in `CHANGELOG.md`'s `[Unreleased]` section.

This follows the same pattern as the recently merged `Stats::min`/`max` shadowing-by-`Colls` documentation fix (#1118).

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5082 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test), all green.
- [x] New spec `IterablesTakeDropReverseShadowingSpec` verified red (doc-check assertions) before the docs were updated, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFbwB91LSWveBXquSaAaTp

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFbwB91LSWveBXquSaAaTp)_