### PR TITLE
docs(stdlib): document Sets's union/intersection/difference extension-call shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Sets`'s `union`/`intersection`/`difference` extension-call shadowing by
+  `onion.Colls` documented.** `onion.Colls` also declares `union(Set, Set)`/
+  `intersection(Set, Set)`/`difference(Set, Set)` extension methods with the
+  same erased signatures as `onion.Sets`'s, and `Colls` is registered ahead
+  of `Sets` in the builtin extension container list, so `a.union(b)`,
+  `a.intersection(b)` and `a.difference(b)` always reach *`onion.Colls`*'s
+  versions -- `onion.Sets`'s versions of these three are never reachable by
+  extension-call syntax at all, even though `docs/reference/stdlib.md` (and
+  its Japanese translation) showed them as if they were plain `Sets` calls.
+  `Colls`'s results are unmodifiable; `Sets::union`/`intersection`/`difference`
+  called directly return a plain mutable `LinkedHashSet`. Added the caveat to
+  both files' Sets Module section and a new
+  `SetsUnionIntersectionDifferenceShadowingSpec` regression test that locks
+  in the shadowing and checks both docs for the warning.
+
 - **`Stats`'s `min`/`max` extension-call shadowing by `onion.Colls` documented.**
   `onion.Colls` also declares a `min(List)`/`max(List)` extension method with the
   same erased signature as `onion.Stats`'s, and `Colls` is registered ahead of

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1380,12 +1380,19 @@ Maps::update(m, "a", (v: Int) -> v + 1)       // 関数的更新
 
 Set ユーティリティ（`onion.Sets`）。結果 Set は挿入順を保持し、集合演算は null 安全。
 
-どのメソッドも `Set` の組み込み拡張メソッドとして呼び出せます（例: `Sets::union(a, b)` は `a.union(b)`）。
+どのメソッドも `Set` の組み込み拡張メソッドとして呼び出せます（例: `Sets::union(a, b)` は `a.union(b)`）
+-- **ただし `union`/`intersection`/`difference` は例外**: `onion.Colls` も同じ
+`(Set, Set)` 消去シグネチャでこの3つの名前の拡張メソッドを宣言しており、組み込み拡張コンテナ
+リストで `Colls` が `Sets` より先に登録されているため、`a.union(b)` / `a.intersection(b)` /
+`a.difference(b)` は常に *`onion.Colls`* 側の実装に到達し、`onion.Sets` 側のこの3つには拡張呼び出し
+構文からは一切到達できません。`Colls` の結果は **変更不可**（`Collections.unmodifiableSet`）、
+直接呼んだ `Sets::union`/`intersection`/`difference` は通常の **変更可能**な `LinkedHashSet` を
+返します。変更可能な結果が必要な場合は `Sets::` 形式を使ってください。
 
 ```onion
 Sets::of(1, 2, 3) / Sets::newSet[Int]() / Sets::fromList([1, 1, 2]) / Sets::toList(a)
-Sets::union(a, b) / Sets::intersection(a, b) / Sets::difference(a, b)
-a.union(b) / a.intersection(b) / a.difference(b)
+Sets::union(a, b) / Sets::intersection(a, b) / Sets::difference(a, b)  // 変更可能; a.union(b) 等では到達不可
+a.union(b) / a.intersection(b) / a.difference(b)  // onion.Colls 側の実装 -- 変更不可
 Sets::symmetricDifference(a, b)               // どちらか一方だけに含まれる
 a.symmetricDifference(b)
 Sets::containsAll(a, b)                       // a が b の要素をすべて含む

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2368,12 +2368,24 @@ Sets::toList(a)                        // back to a List
 ### Set algebra
 
 Every method below is also a builtin extension method on `Set`, callable as
-`a.union(b)` instead of `Sets::union(a, b)`.
+`a.union(b)` instead of `Sets::union(a, b)` -- **except `union`/`intersection`/
+`difference`**: `onion.Colls` also declares extension methods of those three
+names with the same erased `(Set, Set)` signature, and `Colls` is registered
+ahead of `Sets` in the builtin extension container list, so `a.union(b)`,
+`a.intersection(b)` and `a.difference(b)` always reach *`onion.Colls`*'s
+versions -- `onion.Sets`'s versions of these three are never reachable by
+extension-call syntax at all. `Colls`'s results are **unmodifiable**
+(`Collections.unmodifiableSet`); `Sets::union`/`intersection`/`difference`
+called directly return a plain **mutable** `LinkedHashSet`. Use the `Sets::`
+form when a mutable result is required.
 
 ```onion
-Sets::union(a, b)                      // a.union(b)
-Sets::intersection(a, b)               // a.intersection(b)
-Sets::difference(a, b)                 // a.difference(b)
+Sets::union(a, b)                      // mutable; NOT reachable as a.union(b)
+Sets::intersection(a, b)               // mutable; NOT reachable as a.intersection(b)
+Sets::difference(a, b)                 // mutable; NOT reachable as a.difference(b)
+a.union(b)                             // onion.Colls's version instead -- unmodifiable
+a.intersection(b)                      // onion.Colls's version instead -- unmodifiable
+a.difference(b)                        // onion.Colls's version instead -- unmodifiable
 Sets::symmetricDifference(a, b)        // a.symmetricDifference(b) -- in exactly one of the two
 Sets::containsAll(a, b)                // a.containsAll(b)
 Sets::isSubsetOf(a, b)                 // a.isSubsetOf(b) -- every element of a is in b

--- a/src/test/scala/onion/compiler/tools/SetsUnionIntersectionDifferenceShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsUnionIntersectionDifferenceShadowingSpec.scala
@@ -1,0 +1,135 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Sets::union`/`intersection`/`difference` all take `(Set, Set)`, the
+ * exact same erased signature as `onion.Colls`'s versions of the same names,
+ * and `Colls` is listed ahead of `Sets` in
+ * `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, so
+ * `a.union(b)`, `a.intersection(b)` and `a.difference(b)` always reach
+ * *`onion.Colls`*'s implementations -- `onion.Sets`'s versions of these three
+ * are never reachable by extension-call syntax at all, even though
+ * docs/reference/stdlib.md (and its Japanese translation) show them as if
+ * they were plain `Sets` chaining examples. The two implementations disagree
+ * on the result: `Colls::union`/`intersection`/`difference` wrap their result
+ * unmodifiable; `Sets::union`/`intersection`/`difference` return a plain
+ * mutable `LinkedHashSet` (confirmed by running both against `Shell`, below;
+ * a null-argument difference also exists source-side -- `Colls` calls
+ * `new LinkedHashSet<>(set1)`/`Collection.addAll(null)`, which reject null,
+ * while `Sets` treats a null set as empty -- but Onion's null-safety
+ * typechecking already rejects passing a nullable `Set?` to these methods'
+ * non-null `Set` parameter at compile time, in both the extension-call and
+ * `Sets::` spellings alike, so that difference is not independently
+ * observable through ordinary typed code and is not asserted here).
+ * `Sets::toList` also collides with both `Colls::toList(Set)` and
+ * `Iterables::toList(Iterable)`, but that is a compile-time ambiguity
+ * (E0005/E0006) rather than silent shadowing, and docs/reference/stdlib.md
+ * never shows `a.toList()` as an extension call in the first place, so it is
+ * out of scope here.
+ * This locks in the union/intersection/difference shadowing so a future
+ * reordering of `BuiltinExtensionContainers` doesn't silently flip it, and
+ * checks that both docs carry the warning (docs/reference/stdlib.md and its
+ * Japanese translation, Sets Module section).
+ */
+class SetsUnionIntersectionDifferenceShadowingSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "SetsShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for union()/intersection()/difference() on a Set[Int] shadows onion.Sets") {
+    it("a.union(b) is unmodifiable (Colls's behavior), unlike onion.Sets's mutable copy") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |val b = onion.Sets::of(3, 4, 5)
+          |try {
+          |  a.union(b).add(99)
+          |  return false
+          |} catch e: UnsupportedOperationException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Sets::union(a, b) stays mutable, unlike the shadowing extension call") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |val b = onion.Sets::of(3, 4, 5)
+          |onion.Sets::union(a, b).add(99)
+          |return true
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("a.intersection(b) is unmodifiable (Colls's behavior), unlike onion.Sets's mutable copy") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |val b = onion.Sets::of(3, 4, 5)
+          |try {
+          |  a.intersection(b).add(99)
+          |  return false
+          |} catch e: UnsupportedOperationException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("a.difference(b) is unmodifiable (Colls's behavior), unlike onion.Sets's mutable copy") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |val b = onion.Sets::of(3, 4, 5)
+          |try {
+          |  a.difference(b).add(99)
+          |  return false
+          |} catch e: UnsupportedOperationException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+  }
+
+  describe("docs carry the shadowing warning in the Sets Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("a.union(", "a.intersection(", "a.difference(", "onion.Colls", "unmodifiable")
+
+    val jaMarkers =
+      Set("a.union(", "a.intersection(", "a.difference(", "onion.Colls", "変更不可")
+
+    it("docs/reference/stdlib.md's Sets Module section warns about union()/intersection()/difference() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Sets Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Sets Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Sets section warns about union()/intersection()/difference() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Sets モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Sets モジュール section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Colls` also declares `union(Set, Set)`/`intersection(Set, Set)`/`difference(Set, Set)` extension methods with the same erased signatures as `onion.Sets`'s, and `Colls` is registered ahead of `Sets` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, so `a.union(b)`, `a.intersection(b)` and `a.difference(b)` always reach *`onion.Colls`*'s implementations — `onion.Sets`'s versions of these three names are never reachable by extension-call syntax at all.
- Confirmed by running both against `Shell`: `Colls`'s results are **unmodifiable** (`Collections.unmodifiableSet`), while `Sets::union`/`intersection`/`difference` called directly return a plain **mutable** `LinkedHashSet`.
- `docs/reference/stdlib.md` and its Japanese translation showed `a.union(b)` etc. as if they were plain `Sets` extension calls, without this caveat. Added the caveat to both files' Sets Module section, plus one line to `CHANGELOG.md`'s `[Unreleased]`.
- Added `SetsUnionIntersectionDifferenceShadowingSpec`, a regression test (written first, confirmed red against the un-patched docs) that locks in the shadowing behavior and checks both docs for the warning.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5088 succeeded, 0 failed, 1 canceled (an opt-in dist smoke test gated behind `-Donion.dist.path`, expected)
- [x] New spec run in isolation to confirm it failed red before the doc fix, green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Nuj61q45TYEVTsay7ZW13

---
_Generated by [Claude Code](https://claude.ai/code/session_016Nuj61q45TYEVTsay7ZW13)_