### PR TITLE
docs: document Maps keys/values/mapValues extension-call shadowing by Colls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Maps`'s `keys`/`values`/`mapValues` extension-call shadowing by `onion.Colls`
+  documented.** `onion.Colls` also declares `keys(Map)`/`values(Map)`/
+  `mapValues(Map, Function1)` extension methods with the same erased signatures
+  as `onion.Maps`'s, and `Colls` is registered ahead of `Maps` in the builtin
+  extension container list, so `m.keys()`, `m.values()` and `m.mapValues(...)`
+  always reach *`onion.Colls`*'s versions -- `onion.Maps`'s versions of these
+  three are never reachable by extension-call syntax at all, even though
+  `docs/reference/stdlib.md` (and its Japanese translation) showed
+  `m.keys()`/`m.values()` as if they were "the same as" the `Maps::` static
+  calls. `Colls`'s results are unmodifiable (confirmed by running each against
+  `ScriptRunner`); `Maps::keys`/`values`/`mapValues` called directly return a
+  plain mutable `ArrayList`/`LinkedHashMap`. `getOrDefault` is unaffected --
+  both containers behave the same for any map an extension method can actually
+  be called on. Added the caveat to both files' Maps Module section and a new
+  `MapsExtensionCallShadowingSpec` regression test that locks in the shadowing
+  and checks both docs for the warning.
+
 - **`Sets`'s `union`/`intersection`/`difference` extension-call shadowing by
   `onion.Colls` documented.** `onion.Colls` also declares `union(Set, Set)`/
   `intersection(Set, Set)`/`difference(Set, Set)` extension methods with the

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1356,12 +1356,23 @@ Strings::toIntOr("nope", 0)              // 0
 
 Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持（`LinkedHashMap`）。
 
+**拡張呼び出しのシャドーイング**: `onion.Colls` も `keys(Map)` / `values(Map)` /
+`mapValues(Map, Function1)` を同じ消去シグネチャで拡張メソッドとして宣言しており、
+組み込み拡張コンテナリストで `Colls` が `Maps` より先に登録されているため、
+`m.keys()` / `m.values()` / `m.mapValues(...)` は常に *`onion.Colls`* 側の実装に
+到達し、`onion.Maps` 側のこの3つには拡張呼び出し構文からは一切到達できません。
+`Colls` の結果は **変更不可**（`ks.add(...)` は `UnsupportedOperationException`
+を投げる）、直接呼んだ `Maps::keys`/`values`/`mapValues` は通常の **変更可能**な
+`ArrayList`/`LinkedHashMap` を返します。`getOrDefault` はこの影響を受けません --
+拡張メソッドとして呼び出せる Map に対しては、どちらの実装でも結果は同じです。
+
 ```onion
 val m: Map[String, Int] = Maps::newMap()
 Maps::getOrDefault(m, "a", 0)                 // あればその値、無ければデフォルト
 Maps::getOrElse(m, "x", () -> compute())      // 遅延デフォルト
-Maps::keys(m) / Maps::values(m)               // 順序を保ったリスト
-m.getOrDefault("x", 0) / m.keys() / m.values() // 拡張メソッドとしても呼べる（上と同じ）
+Maps::keys(m) / Maps::values(m)               // 変更可能なリスト; m.keys() / m.values() では到達不可
+m.getOrDefault("x", 0)                        // 拡張メソッドとしても呼べる（上と同じ）
+m.keys() / m.values() / m.mapValues(f)        // onion.Colls 側の実装 -- 変更不可
 Maps::mapValues(m, (v: Int) -> v * 2) / Maps::mapKeys(m, (k: String) -> k.toUpperCase())
 Maps::filterValues(m, (v: Int) -> v > 0) / Maps::filterKeys(m, (k: String) -> k.startsWith("a"))
 Maps::filter(m, (k: String, v: Int) -> v > 0) // キー+値の述語

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2309,14 +2309,26 @@ map itself, chaining into a pipeline like the rest of `Maps`:
 
 ```onion
 m.getOrDefault("x", 0)   // same as Maps::getOrDefault(m, "x", 0)
-m.keys()                 // same as Maps::keys(m)
-m.values()               // same as Maps::values(m)
+m.keys()                 // NOT the same as Maps::keys(m) -- see caveat below
+m.values()               // NOT the same as Maps::values(m) -- see caveat below
 ```
+
+**Extension-call shadowing:** `onion.Colls` also declares `keys(Map)`/
+`values(Map)`/`mapValues(Map, Function1)` extension methods with the same
+erased signatures as `onion.Maps`'s, and `Colls` is registered ahead of
+`Maps` in the builtin extension container list, so `m.keys()`, `m.values()`
+and `m.mapValues(...)` always reach *`onion.Colls`*'s versions --
+`onion.Maps`'s versions of these three are never reachable by extension-call
+syntax at all. `Colls`'s results are **unmodifiable** (`ks.add(...)` throws
+`UnsupportedOperationException`); `Maps::keys`/`values`/`mapValues` called
+directly return a plain mutable `ArrayList`/`LinkedHashMap`. `getOrDefault`
+is unaffected -- both containers' implementations behave the same for any
+map you can actually call an extension method on.
 
 ### Transformation
 
 ```onion
-Maps::mapValues(m, (v: Int) -> v * 2)
+Maps::mapValues(m, (v: Int) -> v * 2)   // extension call m.mapValues(...) reaches onion.Colls's -- see caveat above
 Maps::mapKeys(m, (k: String) -> k.toUpperCase())
 Maps::filterValues(m, (v: Int) -> v > 0)
 Maps::filterKeys(m, (k: String) -> k.startsWith("a"))

--- a/src/test/scala/onion/compiler/tools/MapsExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapsExtensionCallShadowingSpec.scala
@@ -1,0 +1,115 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Maps` and `onion.Colls` are both registered as builtin extension
+ * containers (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`),
+ * and both declare `keys(Map)`/`values(Map)`/`getOrDefault(Map, K, V)`/
+ * `mapValues(Map, Function1)` static methods with the same erased
+ * receiver+name+signature. Extension registration keeps the first container
+ * that claims a given receiver+name+erased-signature, and `Colls` is listed
+ * ahead of `Maps`, so `m.keys()`/`m.values()`/`m.mapValues(...)` always reach
+ * `onion.Colls`'s versions -- `onion.Maps`'s are never reachable by
+ * extension-call syntax at all. `Colls`'s results are unmodifiable;
+ * `Maps::keys`/`values`/`mapValues` called directly return a plain mutable
+ * `ArrayList`/`LinkedHashMap`. This locks in that shadowing so a future
+ * reordering of `BuiltinExtensionContainers` doesn't silently flip it, and
+ * checks that both docs carry the warning (docs/reference/stdlib.md and
+ * its Japanese translation, Maps Module section).
+ */
+class MapsExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def run(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): String {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "MapsShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for keys()/values()/mapValues() on a Map shadows onion.Maps") {
+    it("m.keys() returns an unmodifiable List (onion.Colls's behavior), not onion.Maps's mutable one") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val m: Map[String, Int] = [\"a\": 1]\n    m.keys().add(\"z\")\n    return 0\n  }\n}\n",
+          "MapsShadowKeysMutate.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[UnsupportedOperationException])
+    }
+
+    it("m.values() returns an unmodifiable List (onion.Colls's behavior), not onion.Maps's mutable one") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val m: Map[String, Int] = [\"a\": 1]\n    m.values().add(9)\n    return 0\n  }\n}\n",
+          "MapsShadowValuesMutate.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[UnsupportedOperationException])
+    }
+
+    it("m.mapValues(f) returns an unmodifiable Map (onion.Colls's behavior), not onion.Maps's mutable one") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val m: Map[String, Int] = [\"a\": 1]\n    m.mapValues((v: Int) -> v * 2).put(\"b\", 2)\n    return 0\n  }\n}\n",
+          "MapsShadowMapValuesMutate.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[UnsupportedOperationException])
+    }
+
+    it("the static Maps:: form keeps onion.Maps's mutable List/Map results, never reachable via extension-call syntax") {
+      run(
+        "val m: Map[String, Int] = [\"a\": 1]\n" +
+        "    val ks = Maps::keys(m)\n    ks.add(\"z\")\n    return ks.toString()",
+        Shell.Success("[a, z]"))
+      run(
+        "val m: Map[String, Int] = [\"a\": 1]\n" +
+        "    val mv = Maps::mapValues(m, (v: Int) -> v * 2)\n    mv.put(\"b\", 4)\n    return mv.toString()",
+        Shell.Success("{a=2, b=4}"))
+    }
+
+    it("non-colliding Maps methods behave identically via extension-call and static-call syntax") {
+      run(
+        "val m: Map[String, Int] = [\"a\": 1]\n    return m.getOrDefault(\"x\", 0).toString()",
+        Shell.Success("0"))
+      run(
+        "val m: Map[String, Int] = [\"a\": 1]\n    return Maps::getOrDefault(m, \"x\", 0).toString()",
+        Shell.Success("0"))
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Maps Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("m.keys(", "m.values(", "m.mapValues(", "onion.Colls", "unmodifiable")
+
+    val jaMarkers =
+      Set("m.keys(", "m.values(", "m.mapValues(", "onion.Colls")
+
+    it("docs/reference/stdlib.md's Maps Module section warns about keys()/values()/mapValues() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Maps Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Maps Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Maps section warns about keys()/values()/mapValues() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Maps モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Maps section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Colls` and `onion.Maps` both register `keys(Map)`/`values(Map)`/`mapValues(Map, Function1)` as builtin extension methods with identical erased signatures. Because `Colls` is listed ahead of `Maps` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, `m.keys()` / `m.values()` / `m.mapValues(...)` always dispatch to `onion.Colls`'s implementations — `onion.Maps`'s are unreachable via extension-call syntax.
- The two disagree on mutability: `Colls`'s results are unmodifiable (mutating throws `UnsupportedOperationException`), while `Maps::keys`/`values`/`mapValues` called directly return a plain mutable `ArrayList`/`LinkedHashMap`. Confirmed by running both paths against `ScriptRunner`.
- `docs/reference/stdlib.md` and its Japanese translation previously stated `m.keys()`/`m.values()` were "the same as" the `Maps::` static calls, which is not true for mutability. Added the shadowing caveat to both files' Maps Module section, following the same pattern already used for the `Sets`/`Stats`/`Iterables` shadowing entries.
- `getOrDefault` is unaffected — both implementations behave identically for any map an extension method can actually be called on.
- Added `MapsExtensionCallShadowingSpec` (TDD: written and confirmed red on the doc-check assertions before the doc edits) to lock in the shadowing behavior and verify both docs carry the warning.
- Added a `[Unreleased]` `CHANGELOG.md` entry.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.MapsExtensionCallShadowingSpec onion.compiler.tools.MapsExtensionCallDocSpec onion.compiler.tools.StdlibDocMapsSetsModuleParitySpec onion.compiler.tools.MapsSpec onion.compiler.tools.MapsEnrichedSpec'` — all pass
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5095 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UkDShXtt9PsbbYdWsZbdu

---
_Generated by [Claude Code](https://claude.ai/code/session_016UkDShXtt9PsbbYdWsZbdu)_