### PR TITLE
docs(stdlib): fix incorrect m.values() extension-call shadowing claim for Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Fixed: `Maps`'s `m.values()` extension-call shadowing was documented incorrectly.**
+  A previous entry in this file (and `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`'s
+  Maps Module section) claimed `m.values()` reaches `onion.Colls`'s extension method, the same
+  as `m.keys()` and `m.mapValues(...)`. Running it showed otherwise: `Map[K, V]` is backed by
+  `java.util.Map`, which already declares a no-arg `values()` instance method, and an applicable
+  instance method on the receiver's own type is always tried before any extension fallback --
+  `Colls` included. So `m.values()` never reaches an extension container at all; it reaches the
+  **native `java.util.Map.values()`**, which returns a *live view* backed by the map, not a
+  snapshot: removing through the view's iterator removes the entry from the map itself, and
+  mutating the map afterward is visible through a `values()` view obtained earlier. Neither
+  `Colls`'s unmodifiable snapshot nor `Maps::values`'s mutable `ArrayList` snapshot behaves that
+  way (`m.keys()`/`m.mapValues(...)` do still reach `Colls`, unaffected by this fix). Corrected
+  both docs and strengthened `MapsExtensionCallShadowingSpec` with a test that mutates the map
+  after calling `.values()` to prove the result is a live view, not a copy.
+
 - **`Maps`'s `keys`/`values`/`mapValues` extension-call shadowing by `onion.Colls`
   documented.** `onion.Colls` also declares `keys(Map)`/`values(Map)`/
   `mapValues(Map, Function1)` extension methods with the same erased signatures

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1358,13 +1358,31 @@ Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持�
 
 **拡張呼び出しのシャドーイング**: `onion.Colls` も `keys(Map)` / `values(Map)` /
 `mapValues(Map, Function1)` を同じ消去シグネチャで拡張メソッドとして宣言しており、
-組み込み拡張コンテナリストで `Colls` が `Maps` より先に登録されているため、
-`m.keys()` / `m.values()` / `m.mapValues(...)` は常に *`onion.Colls`* 側の実装に
-到達し、`onion.Maps` 側のこの3つには拡張呼び出し構文からは一切到達できません。
-`Colls` の結果は **変更不可**（`ks.add(...)` は `UnsupportedOperationException`
-を投げる）、直接呼んだ `Maps::keys`/`values`/`mapValues` は通常の **変更可能**な
-`ArrayList`/`LinkedHashMap` を返します。`getOrDefault` はこの影響を受けません --
-拡張メソッドとして呼び出せる Map に対しては、どちらの実装でも結果は同じです。
+組み込み拡張コンテナリストで `Colls` が `Maps` より先に登録されています -- ただし
+この登録順が効くのは `keys()` と `mapValues()` だけです。`m.keys()` /
+`m.mapValues(...)` は常に *`onion.Colls`* 側の実装に到達し、`onion.Maps` 側の
+この2つには拡張呼び出し構文からは一切到達できません。`Colls` の結果は
+**変更不可**（`ks.add(...)` は `UnsupportedOperationException` を投げる）です。
+
+`m.values()` は事情が異なり、どちらの拡張コンテナにも到達しません。
+`Map[K, V]` の実体は `java.util.Map` であり、これは引数なしのインスタンス
+メソッド `values()` を既に宣言しています。レシーバ自身の型に適用可能な
+インスタンスメソッドは、拡張メソッドへのフォールバック（`Colls` を含む）
+より常に先に試されるため、`m.values()` は **ネイティブの
+`java.util.Map.values()`** に到達します。これはスナップショットではなく
+map を裏で参照する *ライブビュー* を返すため、そのビューの iterator 経由で
+削除すると `m` 自体からエントリが削除され、あとから `m` を変更すると
+以前取得した `values()` ビューにもその変更が反映されます。このビューに
+対する `.add(...)` も `UnsupportedOperationException` を投げます（ビューは
+挿入をサポートしないため）が、これは `Colls` の変更不可な挙動とたまたま
+一致しているだけで理由は別物です -- このライブビューのエイリアシングは
+`Colls` の変更不可スナップショットにも `Maps::values` の変更可能な
+`ArrayList` スナップショットにも存在しません。直接呼んだ
+`Maps::keys`/`values`/`mapValues` は通常の **変更可能**な
+`ArrayList`/`LinkedHashMap` を返します。`getOrDefault` はこれらの影響を
+受けません -- `java.util.Map` も同じ2引数の `getOrDefault` を宣言している
+ため、これもネイティブメソッドに解決されますが、拡張メソッドとして
+呼び出せる Map に対しては3つの実装とも結果は同じです。
 
 ```onion
 val m: Map[String, Int] = Maps::newMap()
@@ -1372,7 +1390,8 @@ Maps::getOrDefault(m, "a", 0)                 // あればその値、無けれ�
 Maps::getOrElse(m, "x", () -> compute())      // 遅延デフォルト
 Maps::keys(m) / Maps::values(m)               // 変更可能なリスト; m.keys() / m.values() では到達不可
 m.getOrDefault("x", 0)                        // 拡張メソッドとしても呼べる（上と同じ）
-m.keys() / m.values() / m.mapValues(f)        // onion.Colls 側の実装 -- 変更不可
+m.keys() / m.mapValues(f)                     // onion.Colls 側の実装 -- 変更不可
+m.values()                                    // ネイティブ java.util.Map.values() -- ライブビュー
 Maps::mapValues(m, (v: Int) -> v * 2) / Maps::mapKeys(m, (k: String) -> k.toUpperCase())
 Maps::filterValues(m, (v: Int) -> v > 0) / Maps::filterKeys(m, (k: String) -> k.startsWith("a"))
 Maps::filter(m, (k: String, v: Int) -> v > 0) // キー+値の述語

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2310,20 +2310,39 @@ map itself, chaining into a pipeline like the rest of `Maps`:
 ```onion
 m.getOrDefault("x", 0)   // same as Maps::getOrDefault(m, "x", 0)
 m.keys()                 // NOT the same as Maps::keys(m) -- see caveat below
-m.values()               // NOT the same as Maps::values(m) -- see caveat below
+m.values()               // NOT onion.Maps's or onion.Colls's values() -- see caveat below
 ```
 
 **Extension-call shadowing:** `onion.Colls` also declares `keys(Map)`/
 `values(Map)`/`mapValues(Map, Function1)` extension methods with the same
 erased signatures as `onion.Maps`'s, and `Colls` is registered ahead of
-`Maps` in the builtin extension container list, so `m.keys()`, `m.values()`
-and `m.mapValues(...)` always reach *`onion.Colls`*'s versions --
-`onion.Maps`'s versions of these three are never reachable by extension-call
-syntax at all. `Colls`'s results are **unmodifiable** (`ks.add(...)` throws
-`UnsupportedOperationException`); `Maps::keys`/`values`/`mapValues` called
-directly return a plain mutable `ArrayList`/`LinkedHashMap`. `getOrDefault`
-is unaffected -- both containers' implementations behave the same for any
-map you can actually call an extension method on.
+`Maps` in the builtin extension container list -- but that registration
+order only decides `keys()` and `mapValues()`. `m.keys()` and
+`m.mapValues(...)` reach *`onion.Colls`*'s versions (`onion.Maps`'s
+versions of these two are never reachable by extension-call syntax at
+all); `Colls`'s results are **unmodifiable** (`ks.add(...)` throws
+`UnsupportedOperationException`).
+
+`m.values()` is different: it never reaches either extension container.
+`Map[K, V]` is backed by `java.util.Map`, which already declares an
+instance `values()` method taking no arguments, and an applicable
+instance method on the receiver's own type is always tried before any
+extension fallback -- `Colls` included. So `m.values()` reaches the
+**native `java.util.Map.values()`**, which returns a *live view* backed
+by the map, not a snapshot: removing through the view's iterator removes
+the entry from `m` itself, and mutating `m` afterward is visible through
+a `values()` view obtained earlier. Calling `.add(...)` on that view
+throws `UnsupportedOperationException` too (views don't support
+insertion), which happens to match `Colls`'s unmodifiable behavior on
+that one call but for an unrelated reason -- the live-view aliasing has
+no equivalent in either `Colls`'s unmodifiable snapshot or
+`Maps::values`'s mutable `ArrayList` snapshot. `Maps::keys`/`values`/
+`mapValues` called directly return a plain mutable
+`ArrayList`/`LinkedHashMap`. `getOrDefault` is unaffected by any of this
+-- `java.util.Map` also declares a matching two-arg `getOrDefault`, so it
+too resolves to the native method rather than an extension, but all three
+implementations behave identically for any map you can actually call an
+extension method on.
 
 ### Transformation
 

--- a/src/test/scala/onion/compiler/tools/MapsExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapsExtensionCallShadowingSpec.scala
@@ -10,14 +10,22 @@ import onion.tools.Shell
  * `mapValues(Map, Function1)` static methods with the same erased
  * receiver+name+signature. Extension registration keeps the first container
  * that claims a given receiver+name+erased-signature, and `Colls` is listed
- * ahead of `Maps`, so `m.keys()`/`m.values()`/`m.mapValues(...)` always reach
- * `onion.Colls`'s versions -- `onion.Maps`'s are never reachable by
- * extension-call syntax at all. `Colls`'s results are unmodifiable;
- * `Maps::keys`/`values`/`mapValues` called directly return a plain mutable
- * `ArrayList`/`LinkedHashMap`. This locks in that shadowing so a future
- * reordering of `BuiltinExtensionContainers` doesn't silently flip it, and
- * checks that both docs carry the warning (docs/reference/stdlib.md and
- * its Japanese translation, Maps Module section).
+ * ahead of `Maps` -- but that ordering only decides `keys()`/`mapValues()`:
+ * `m.keys()`/`m.mapValues(...)` always reach `onion.Colls`'s versions,
+ * `onion.Maps`'s are never reachable by extension-call syntax at all, and
+ * `Colls`'s results are unmodifiable.
+ *
+ * `m.values()` never reaches either extension container at all: ordinary
+ * instance-method resolution runs before any extension fallback, and
+ * `java.util.Map` (the runtime type backing `Map[K, V]`) already declares a
+ * no-arg `values()` instance method, so `m.values()` reaches the *native*
+ * `java.util.Map.values()` -- a live view over the map, not a snapshot from
+ * either `Colls` or `Maps`. `Maps::keys`/`values`/`mapValues` called
+ * directly return a plain mutable `ArrayList`/`LinkedHashMap`. This locks
+ * in that shadowing so a future reordering of `BuiltinExtensionContainers`
+ * doesn't silently flip it, and checks that both docs carry the warning
+ * (docs/reference/stdlib.md and its Japanese translation, Maps Module
+ * section).
  */
 class MapsExtensionCallShadowingSpec extends AbstractShellSpec {
 
@@ -38,7 +46,18 @@ class MapsExtensionCallShadowingSpec extends AbstractShellSpec {
       assert(thrown.getCause.isInstanceOf[UnsupportedOperationException])
     }
 
-    it("m.values() returns an unmodifiable List (onion.Colls's behavior), not onion.Maps's mutable one") {
+    it("m.values() reaches the native java.util.Map.values() -- a live view, not a snapshot from onion.Colls or onion.Maps") {
+      // If this reached a snapshot (either Colls's unmodifiable copy or Maps's
+      // mutable ArrayList copy), a mutation made to the map *after* calling
+      // .values() would not show up in the already-obtained result. It does,
+      // because the native view stays backed by the map.
+      run(
+        "val m: Map[String, Int] = [\"a\": 1, \"b\": 2]\n" +
+        "    val vs = m.values()\n    m[\"c\"] = 3\n    return vs.toString()",
+        Shell.Success("[1, 2, 3]"))
+    }
+
+    it("m.values().add(9) still throws, but as an unsupported view mutation, not onion.Colls's unmodifiable-snapshot behavior") {
       val thrown = intercept[ScriptException] {
         shell.run(
           "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +


### PR DESCRIPTION
## Summary

- The just-merged Maps Module caveat (from PR #1121) claimed `m.values()` reaches `onion.Colls`'s extension method, the same as `m.keys()`/`m.mapValues(...)`. Running it against `ScriptRunner` shows this is wrong: `java.util.Map` (the runtime type backing `Map[K, V]`) already declares a no-arg `values()` instance method, and an applicable instance method on the receiver's own type is always tried before any extension fallback — `Colls` included. So `m.values()` reaches the **native `java.util.Map.values()`**, a *live view* backed by the map, not a snapshot from either `Colls` or `Maps`.
- Verified directly: removing an element through the view's iterator removes it from the underlying map, and mutating the map afterward is visible through a `values()` view obtained earlier — neither `Colls`'s unmodifiable snapshot nor `Maps::values`'s mutable `ArrayList` snapshot behaves that way. `m.keys()`/`m.mapValues(...)` are unaffected and still correctly reach `Colls`.
- Corrected `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Maps Module sections.
- Replaced the `MapsExtensionCallShadowingSpec` assertion that only checked `.add()` throwing `UnsupportedOperationException` (true for the native view too, but for an unrelated reason, so it didn't actually distinguish the two) with a test that mutates the map after calling `.values()` and shows the result reflects it — proof of the live-view aliasing that a snapshot could never produce.
- Added a `CHANGELOG.md` entry under `[Unreleased]` noting the correction.

## Test plan

- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.MapsExtensionCallShadowingSpec"` — all 8 tests pass, including the new live-view proof.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5096 tests, 0 failed (1 pre-existing, unrelated `canceled` test in `ProjectDistributionSpec`, an environment-dependent distribution round-trip test unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHS6myaph6RkjsEUUiXK36


---
_Generated by [Claude Code](https://claude.ai/code/session_01KHS6myaph6RkjsEUUiXK36)_