### PR TITLE
docs: document Iterables map/filter extension-call shadowing by Colls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Iterables`'s `map`/`filter` extension-call shadowing by `onion.Colls`
+  documented.** `onion.Colls` also declares `map(List, Function1)`/
+  `filter(List, Function1)` extensions with the same erased signatures as
+  `onion.Iterables`'s, and `Colls` is registered ahead of `Iterables` in
+  `ExtensionMethodFallbackSupport.BuiltinExtensionContainers` -- the same
+  ordering that already causes `take`/`drop`/`reverse` to shadow, and
+  previously documented as such, but `map`/`filter` were left out even
+  though they collide the same way. So `xs.map(f)` and `xs.filter(p)` always
+  reach *`onion.Colls`*'s versions -- `onion.Iterables`'s `map`/`filter` are
+  never reachable by extension-call syntax at all. The two disagree: `xs.map(f)`
+  returns an unmodifiable list (`Iterables::map` returns a mutable copy), and
+  `xs.filter(p)` throws `NullPointerException` when `p` returns `null`
+  (`Iterables::filter` treats a `null` result as "not kept" instead). Added
+  the caveat to both docs' Iterables Module section and a new
+  `IterablesMapFilterShadowingSpec` regression test that locks in the
+  shadowing and checks both docs for the warning.
+
 - **Fixed: `Maps`'s `m.values()` extension-call shadowing was documented incorrectly.**
   A previous entry in this file (and `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`'s
   Maps Module section) claimed `m.values()` reaches `onion.Colls`'s extension method, the same

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1662,12 +1662,18 @@ xs.take(2) / xs.drop(1)
 xs.sort() / xs.sort(comparator)
 ```
 
-**`take`/`drop`/`reverse` は例外です**: `onion.Colls` にも消去後シグネチャが
-同じ `take(List, int)`/`drop(List, int)`/`reverse(List)` 拡張メソッドがあり、
-`onion.Iterables` より先に登録されるため、`xs.take(n)`・`xs.drop(n)`・
-`xs.reverse()` は常に *`onion.Colls`* 側に到達し、`onion.Iterables` 側には
-到達しません。両者はエッジケースで挙動が異なります:
+**`map`/`filter`/`take`/`drop`/`reverse` は例外です**: `onion.Colls` にも消去後
+シグネチャが同じ `map(List, Function1)`/`filter(List, Function1)`/
+`take(List, int)`/`drop(List, int)`/`reverse(List)` 拡張メソッドがあり、
+`onion.Iterables` より先に登録されるため、`xs.map(f)`・`xs.filter(p)`・
+`xs.take(n)`・`xs.drop(n)`・`xs.reverse()` は常に *`onion.Colls`* 側に到達し、
+`onion.Iterables` 側には到達しません。両者はエッジケースで挙動が異なります:
 
+- `xs.map(f)` は**変更不可 (unmodifiable)** なリストを返す。`Iterables::map`
+  は変更可能なコピーを返す
+- `xs.filter(p)` は `p` を呼び出した後にその `Boolean` 結果をアンボックスする
+  ため、`p` が `null` を返すと **`NullPointerException`** を投げる。
+  `Iterables::filter` は `null` を「保持しない」として扱い、例外を投げない
 - `n` が負の場合 -- `xs.take(-1)` / `xs.drop(-1)` は空/変更なしの結果を返す
   が、`Iterables::take`/`Iterables::drop` は例外を投げる
 - `n` がリストのサイズ以上の場合 -- `xs.take(n)` / `xs.drop(n)` はコピーで
@@ -1676,11 +1682,16 @@ xs.sort() / xs.sort(comparator)
 - `xs.reverse()` は**変更不可 (unmodifiable)** なリストを返す。
   `Iterables::reverse` は変更可能なコピーを返す
 
-コピーされ、サイズに関して安全な挙動が必要な場合は `Iterables::take`/
-`Iterables::drop`/`Iterables::reverse` の静的呼び出し形式を使ってください:
+変更可能なコピーや、`null` を許容しサイズに関して安全な挙動が必要な場合は
+`Iterables::map`/`Iterables::filter`/`Iterables::take`/`Iterables::drop`/
+`Iterables::reverse` の静的呼び出し形式を使ってください:
 
 ```onion
 val xs: List[Int] = [1, 2, 3]
+xs.map { x -> x * 2 }.add(8)   // UnsupportedOperationException を投げる（onion.Colls::map）
+Iterables::map(xs, (x) -> x * 2).add(8)  // OK、変更可能なコピー（onion.Iterables::map）
+xs.filter { x -> null }        // NullPointerException を投げる（onion.Colls::filter）
+Iterables::filter(xs, (x) -> null)       // []（onion.Iterables::filter。null は「保持しない」扱い）
 xs.take(-1)                    // []      （onion.Colls::take。例外ではなく空リストにクランプ）
 xs.take(xs.size() + 1) === xs  // true    （onion.Colls::take。同じリスト参照）
 xs.reverse().add(4)            // UnsupportedOperationException を投げる（onion.Colls::reverse）

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -867,12 +867,18 @@ xs.take(2) / xs.drop(1)
 xs.sort() / xs.sort(comparator)
 ```
 
-**`take`/`drop`/`reverse` are exceptions**: `onion.Colls` also declares
-`take(List, int)`/`drop(List, int)`/`reverse(List)` extensions with the same
-erased signatures, and it is registered ahead of `onion.Iterables`, so
+**`map`/`filter`/`take`/`drop`/`reverse` are exceptions**: `onion.Colls` also
+declares `map(List, Function1)`/`filter(List, Function1)`/`take(List, int)`/
+`drop(List, int)`/`reverse(List)` extensions with the same erased signatures,
+and it is registered ahead of `onion.Iterables`, so `xs.map(f)`, `xs.filter(p)`,
 `xs.take(n)`, `xs.drop(n)` and `xs.reverse()` always reach *`onion.Colls`*'s
 versions, never `onion.Iterables`'s. The two disagree on edge cases:
 
+- `xs.map(f)` returns an **unmodifiable** list; `Iterables::map` returns a
+  plain mutable copy
+- `xs.filter(p)` calls `p` and auto-unboxes its `Boolean` result, throwing
+  **`NullPointerException`** if `p` returns `null`; `Iterables::filter` treats
+  a `null` result as "not kept" instead of throwing
 - a negative `n` -- `xs.take(-1)` / `xs.drop(-1)` return an empty/unchanged
   result; `Iterables::take`/`Iterables::drop` throw instead
 - `n` at or past the list's size -- `xs.take(n)` / `xs.drop(n)` return the
@@ -881,11 +887,16 @@ versions, never `onion.Iterables`'s. The two disagree on edge cases:
 - `xs.reverse()` returns an **unmodifiable** list; `Iterables::reverse` returns
   a plain mutable copy
 
-Use the `Iterables::take`/`Iterables::drop`/`Iterables::reverse` static-call
-form when you need copying, size-safe semantics instead:
+Use the `Iterables::map`/`Iterables::filter`/`Iterables::take`/
+`Iterables::drop`/`Iterables::reverse` static-call form when you need
+mutable-copy or null-tolerant, size-safe semantics instead:
 
 ```onion
 val xs: List[Int] = [1, 2, 3]
+xs.map { x -> x * 2 }.add(8)   // throws UnsupportedOperationException (onion.Colls::map)
+Iterables::map(xs, (x) -> x * 2).add(8)  // ok, mutable copy (onion.Iterables::map)
+xs.filter { x -> null }        // throws NullPointerException (onion.Colls::filter)
+Iterables::filter(xs, (x) -> null)       // []  (onion.Iterables::filter, null is not-kept)
 xs.take(-1)                    // []      (onion.Colls::take, clamps instead of throwing)
 xs.take(xs.size() + 1) === xs  // true    (onion.Colls::take, same list reference)
 xs.reverse().add(4)            // throws UnsupportedOperationException (onion.Colls::reverse)

--- a/src/test/scala/onion/compiler/tools/IterablesMapFilterShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IterablesMapFilterShadowingSpec.scala
@@ -1,0 +1,115 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Iterables::map(List, Function1)`/`filter(List, Function1)` have the same
+ * erased signature as `onion.Colls`'s versions of the same names, and `Colls` is
+ * listed ahead of `Iterables` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`,
+ * so `xs.map(f)` and `xs.filter(predicate)` always reach *`onion.Colls`*'s
+ * implementations -- `onion.Iterables`'s versions of these two are never reachable
+ * by extension-call syntax at all, even though docs/reference/stdlib.md (and its
+ * Japanese translation) show them as plain `Iterables` chaining examples alongside
+ * `take`/`drop`/`reverse` (already documented as shadowed) without calling out the
+ * same shadowing for `map`/`filter`. The two implementations disagree on edge cases:
+ *   - `map`: `Colls::map` returns an unmodifiable list; `Iterables::map` returns a
+ *     plain mutable `ArrayList`
+ *   - `filter`: `Colls::filter` calls the predicate and auto-unboxes its `Boolean`
+ *     result, throwing `NullPointerException` if the predicate returns `null`;
+ *     `Iterables::filter` treats a `null` predicate result as "not kept" instead
+ * This locks in that shadowing so a future reordering of
+ * `BuiltinExtensionContainers` doesn't silently flip it, and checks that both
+ * docs carry the warning (docs/reference/stdlib.md and its Japanese translation,
+ * Iterables Module section).
+ */
+class IterablesMapFilterShadowingSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "IterablesMapFilterShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for map()/filter() on a List[Int] shadows onion.Iterables") {
+    it("xs.map(f) is unmodifiable (Colls's behavior), unlike onion.Iterables's mutable copy") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |try {
+          |  xs.map((x: Int) -> x * 2).add(8)
+          |  return false
+          |} catch e: UnsupportedOperationException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("Iterables::map(xs, f) stays mutable, unlike the shadowing extension call") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |Iterables::map(xs, (x: Int) -> x * 2).add(8)
+          |return true
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("xs.filter(predicate) throws NullPointerException when the predicate returns null (Colls's behavior)") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |try {
+          |  xs.filter { x -> null }
+          |  return false
+          |} catch e: NullPointerException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("Iterables::filter(xs, predicate) treats a null predicate result as not-kept instead") {
+      runBool(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |return Iterables::filter(xs, (x) -> null) == []
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the map()/filter() shadowing warning in the Iterables Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("xs.map {", "xs.filter {", "NullPointerException", "unmodifiable")
+
+    val jaMarkers =
+      Set("xs.map {", "xs.filter {", "NullPointerException", "変更不可")
+
+    it("docs/reference/stdlib.md's Iterables Module section warns about map()/filter() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Iterables Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Iterables Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Iterables section warns about map()/filter() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Iterables モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Iterables モジュール section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Colls` also declares `map(List, Function1)`/`filter(List, Function1)` extensions with the same erased signatures as `onion.Iterables`'s, and `Colls` is registered ahead of `Iterables` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers` — the same ordering already documented as causing `take`/`drop`/`reverse` to shadow, but `map`/`filter` were left out even though they collide the same way.
- Verified empirically: `xs.map(f)` reaches `Colls::map` (returns an **unmodifiable** list; `Iterables::map` returns a mutable copy), and `xs.filter(p)` reaches `Colls::filter` (throws `NullPointerException` when `p` returns `null`; `Iterables::filter` treats `null` as "not kept" instead).
- Updated `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Iterables Module sections to warn about the shadowing, following the same pattern already used for `take`/`drop`/`reverse`.
- Added `IterablesMapFilterShadowingSpec` to lock in the shadowing behavior and assert both docs carry the warning.

## Test plan
- [x] `IterablesMapFilterShadowingSpec` written first and confirmed red (missing doc markers) before the doc fix
- [x] `IterablesMapFilterShadowingSpec`, `IterablesTakeDropReverseShadowingSpec`, `IterablesExtensionCallDocSpec` green after the fix
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5102 succeeded, 0 failed, 1 canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVsG6MMD3eTaZwkVc23hGT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVsG6MMD3eTaZwkVc23hGT)_