### PR TITLE
docs(stdlib): document Shapes::regex/json alongside config/yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Shapes::regex`/`Shapes::json` documented alongside `Shapes::config`/`Shapes::yaml`
+  in the stdlib reference.** `docs/reference/stdlib.md`'s Shape section (and its
+  Japanese translation) named `Shapes::config` and `Shapes::yaml` as the direct-API
+  equivalents of `shape name = config` / `shape name = yaml`, but never mentioned
+  `Shapes::regex` or `Shapes::json` -- the equivalents of the more common `shape name =
+  re"..."` / `shape name = json` forms -- even though all four are equally public
+  (`src/main/java/onion/Shapes.java`) and the sibling guide doc already covered all
+  four. Added the missing prose to both stdlib reference docs and extended
+  `StdlibDocShapeModuleParitySpec` to guard all four factory names.
+
 - **`Iterables`'s `map`/`filter` extension-call shadowing by `onion.Colls`
   documented.** `onion.Colls` also declares `map(List, Function1)`/
   `filter(List, Function1)` extensions with the same erased signatures as

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -492,8 +492,10 @@ val out = r.edit { v -> v.copy(port = 9090) }.render()
 // diff app.conf out  ->  1行だけ変わる
 ```
 
-`Shapes::config` と `Shapes::yaml` は、`shape name = config` / `shape name = yaml` の
-糖衣構文の裏にある lossless shape を、`Shape[T]` の値として直接組み立てます。
+`Shapes::regex` と `Shapes::json` は `shape name = re"..."` / `shape name = json` の
+裏にある shape を、`Shapes::config` と `Shapes::yaml` は `shape name = config` /
+`shape name = yaml` の糖衣構文の裏にある lossless shape を、それぞれ `Shape[T]` の値として
+直接組み立てます。
 
 ### コンビネータ
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -552,9 +552,10 @@ val out = r.edit { v -> v.copy(port = 9090) }.render()
 // diff app.conf out  ->  one changed line
 ```
 
-`Shapes::config` and `Shapes::yaml` build the lossless shapes behind `shape name =
-config` / `shape name = yaml` when you want the `Shape[T]` value directly instead of
-the sugar.
+`Shapes::regex` and `Shapes::json` build the shapes behind `shape name = re"..."` /
+`shape name = json`, and `Shapes::config` and `Shapes::yaml` build the lossless shapes
+behind `shape name = config` / `shape name = yaml` -- all four for when you want the
+`Shape[T]` value directly instead of the sugar.
 
 ### Combinators
 

--- a/src/test/scala/onion/compiler/tools/StdlibDocShapeModuleParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocShapeModuleParitySpec.scala
@@ -7,10 +7,12 @@ import org.scalatest.funspec.AnyFunSpec
  * translation) against `onion.Shape`'s public API. The section covered `parse`,
  * `print`, `canPrint`, and the L1/L2 laws, but never mentioned the lossless-shapes /
  * lens API (`isLossless`, `parseLossless`, `printLossless`, `Lossless`, `Residue`), the
- * combinators (`eachLine`, `lines`, `sepBy`, `xmap`, `orElse`), or the `Shapes::config`
- * / `Shapes::yaml` factories (see src/main/java/onion/Shape.java, Lossless.java,
- * Shapes.java) — making a real, actively-used feature undiscoverable from the API
- * reference doc a user would actually search.
+ * combinators (`eachLine`, `lines`, `sepBy`, `xmap`, `orElse`), or all four `Shapes`
+ * factories (see src/main/java/onion/Shape.java, Lossless.java, Shapes.java) — it named
+ * `Shapes::config` / `Shapes::yaml` but not `Shapes::regex` / `Shapes::json`, even though
+ * all four are equally public and `regex`/`json` back the more common `shape name =
+ * re"..."` / `shape name = json` forms — making a real, actively-used feature
+ * undiscoverable from the API reference doc a user would actually search.
  */
 class StdlibDocShapeModuleParitySpec extends AnyFunSpec {
 
@@ -28,7 +30,7 @@ class StdlibDocShapeModuleParitySpec extends AnyFunSpec {
     "isLossless", "parseLossless", "printLossless",
     "eachLine", "sepBy", "xmap", "orElse",
     "Lossless", "Residue",
-    "Shapes::config", "Shapes::yaml"
+    "Shapes::regex", "Shapes::json", "Shapes::config", "Shapes::yaml"
   )
 
   it("mentions every lossless-shape/lens/combinator member in the English stdlib reference's Shape section") {


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md`'s Shape section (and its Japanese translation) named `Shapes::config` and `Shapes::yaml` as the direct-API equivalents of `shape name = config` / `shape name = yaml`, but never mentioned `Shapes::regex` or `Shapes::json` — the equivalents of the more common `shape name = re"..."` / `shape name = json` forms — even though all four are equally public (`src/main/java/onion/Shapes.java`) and the sibling guide doc (`docs/guide/shapes.md`) already covers all four.
- Extended `StdlibDocShapeModuleParitySpec` to guard all four factory names (confirmed red before the doc fix, green after), and added the missing prose to both the English and Japanese stdlib reference docs.
- Noted the fix in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5102 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` `sbt dist` test, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5stLmGzAF9c5ni5LBvkbA

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5stLmGzAF9c5ni5LBvkbA)_