### PR TITLE
docs(stdlib): document Strings::join extension-call shadowing by onion.Colls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Strings`'s `join` extension-call shadowing by `onion.Colls` documented.**
+  `onion.Colls` also declares a `join(List, String)` extension (an alias for
+  `mkString`) with the same erased signature as `onion.Strings`'s, and
+  `Colls` is registered ahead of `Strings` in the builtin extension
+  container list, so `parts.join(sep)` always reaches *`onion.Colls`*'s
+  version -- `onion.Strings`'s `join` is never reachable by extension-call
+  syntax at all. This is a different shadowing than the five JDK-native
+  methods (`split`/`substring`/`lines`/`chars`/`repeat`) already documented
+  in the same section: `String` has no native `join` method, `onion.Colls`
+  is the one claiming it. The two disagree on a `null` element:
+  `Colls::join`/`mkString` appends the literal `"null"`
+  (`StringBuilder.append(Object)`), while `Strings::join` throws
+  `NullPointerException` (`Object::toString` over a `null` element). Added
+  the caveat to both docs' Strings Module section and a new
+  `StringsJoinExtensionCallShadowingSpec` regression test that locks in the
+  shadowing and checks both docs for the warning.
+
 - **`Shapes::regex`/`Shapes::json` documented alongside `Shapes::config`/`Shapes::yaml`
   in the stdlib reference.** `docs/reference/stdlib.md`'s Shape section (and its
   Japanese translation) named `Shapes::config` and `Shapes::yaml` as the direct-API

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1354,6 +1354,20 @@ Strings::toIntOr("nope", 0)              // 0
 投げない挙動を得るには、`Strings::` の静的呼び出し形式（例:
 `Strings::split(...)`、`Strings::substring(...)`）を使ってください。
 
+**`join` も遮蔽されますが、JDK ではなく `onion.Colls` によるものです**:
+`String` に `join` というインスタンスメソッドはありませんが、
+`onion.Colls` も同じ消去シグネチャの `join(List, String)` 拡張メソッド
+（`mkString` の別名。後述の Colls モジュールを参照）を宣言しており、
+組み込み拡張コンテナのリストで `Colls` が `Strings` より先に登録されて
+いるため、`parts.join(sep)` は常に **`onion.Colls`** 側の実装に到達し、
+`onion.Strings` の `join` は拡張呼び出し構文からは一切到達できません。
+両者は `null` 要素の扱いが異なります: `Colls::join` は文字列
+`"null"` をそのまま連結しますが、`Strings::join` は
+`NullPointerException` を投げます。例外を投げる挙動が必要なら
+`Strings::join(...)` の静的呼び出し形式を使ってください（あるいは
+`null` 要素で例外を投げない `Colls` の `xs.join(sep)` /
+`xs.mkString(sep)` をそのまま使う手もあります）。
+
 ## Maps モジュール
 
 Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持（`LinkedHashMap`）。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1298,6 +1298,19 @@ returning `""`. Use the `Strings::` static-call form (e.g. `Strings::split(...)`
 `Strings::substring(...)`) for these five methods to get `onion.Strings`'s
 List-returning, exception-safe behavior.
 
+**`join` is shadowed too, but by `onion.Colls`, not the JDK**: `String` has
+no native `join` instance method, but `onion.Colls` also declares a
+`join(List, String)` extension (an alias for `mkString`, see the Colls
+Module section below) with the same erased signature, and `Colls` is
+registered ahead of `Strings` in the builtin extension container list, so
+`parts.join(sep)` always reaches *`onion.Colls`*'s version --
+`onion.Strings`'s `join` is never reachable by extension-call syntax at
+all. The two disagree on a `null` element: `Colls::join` appends the
+literal `"null"`, while `Strings::join` throws `NullPointerException`. Use
+the `Strings::join(...)` static-call form to get the throwing behavior (or
+just rely on `Colls`'s `xs.join(sep)` / `xs.mkString(sep)`, which never
+throws on a `null` element).
+
 ## Files Module
 
 File I/O (`onion.Files`):

--- a/src/test/scala/onion/compiler/tools/StringsJoinExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsJoinExtensionCallShadowingSpec.scala
@@ -1,0 +1,94 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Strings` declares `join(List, String)` and `onion.Colls` declares
+ * `join(List, String)` (an alias for `mkString`) with the same erased
+ * signature. Both are registered as builtin extension containers
+ * (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`), and `Colls`
+ * is listed ahead of `Strings`, so `parts.join(sep)` always reaches
+ * `onion.Colls`'s version -- `onion.Strings`'s `join` is never reachable by
+ * extension-call syntax at all. This is a different shadowing than the one
+ * `StringsExtensionCallShadowingSpec` covers (that one is native
+ * `java.lang.String` methods winning over `onion.Strings`; this one is
+ * `onion.Colls` winning over `onion.Strings` for a `List` receiver -- `join`
+ * is not one of the five JDK-shadowed names). The two disagree on a `null`
+ * element: `Colls::join`/`mkString` appends `"null"` (via
+ * `StringBuilder.append(Object)`), while `Strings::join` throws
+ * `NullPointerException` (via `Object::toString` over a `null` element).
+ * Locks in the shadowing so a future reordering of
+ * `BuiltinExtensionContainers` doesn't silently flip it, and checks that
+ * both docs carry the warning (docs/reference/stdlib.md and its Japanese
+ * translation, Strings Module section).
+ */
+class StringsJoinExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def runStr(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): String {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsJoinShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for join() on a List[String] shadows onion.Strings") {
+    it("parts.join(sep) with a null element appends the literal \"null\" (Colls's behavior), it does not throw") {
+      runStr(
+        "val parts: List[String] = [\"a\", null, \"c\"]\n    return parts.join(\",\")",
+        Shell.Success("a,null,c"))
+    }
+
+    it("Strings::join(parts, sep) with a null element throws NullPointerException instead") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): String {\n" +
+          "    val parts: List[String] = [\"a\", null, \"c\"]\n    return Strings::join(parts, \",\")\n  }\n}\n",
+          "StringsJoinShadowNpe.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+
+    it("without a null element, extension-call and static-call syntax agree") {
+      runStr(
+        "val parts: List[String] = [\"a\", \"b\", \"c\"]\n    return parts.join(\",\")",
+        Shell.Success("a,b,c"))
+      runStr(
+        "val parts: List[String] = [\"a\", \"b\", \"c\"]\n    return Strings::join(parts, \",\")",
+        Shell.Success("a,b,c"))
+    }
+  }
+
+  describe("docs carry the join shadowing warning in the Strings Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("join", "onion.Colls", "NullPointerException")
+
+    val jaMarkers =
+      Set("join", "onion.Colls", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Strings Module section warns about join() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Strings Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about join() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Strings section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Colls` declares `join(List, String)` (an alias for `mkString`) with the same erased signature as `onion.Strings`'s `join`, and `Colls` is registered ahead of `Strings` in the builtin extension container list, so `parts.join(sep)` always reaches `onion.Colls`'s version -- `onion.Strings`'s `join` is never reachable by extension-call syntax at all.
- This is a different shadowing than the five JDK-native methods already documented in the same doc section (`split`/`substring`/`lines`/`chars`/`repeat`): `String` has no native `join` method, it's `onion.Colls` claiming it.
- The two disagree on a `null` element: `Colls::join`/`mkString` appends the literal `"null"` (`StringBuilder.append(Object)`), while `Strings::join` throws `NullPointerException` (`Object::toString` over a `null` element) -- verified against the running compiler.
- Documented the caveat in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Strings Module section, added a `CHANGELOG.md` entry, and added a new `StringsJoinExtensionCallShadowingSpec` regression test that locks in the shadowing and checks both docs for the warning markers.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` -- 5107 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test unrelated to this change)
- [x] New spec confirmed red before the doc fix (missing warning markers) and green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8dGtNZuwKeYA9Vj9m5Ech

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8dGtNZuwKeYA9Vj9m5Ech)_