### PR TITLE
docs(stdlib): document Maps::groupBy extension-call shadowing by onion.Colls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Maps`'s `groupBy` extension-call shadowing by `onion.Colls` documented.**
+  `onion.Colls` also declares a `groupBy(List, Function1)` extension with the
+  same erased signature as `onion.Maps`'s, and `Colls` is registered ahead of
+  `Maps` in the builtin extension container list, so `xs.groupBy(f)` always
+  reaches *onion.Colls*'s version -- `onion.Maps`'s `groupBy` is never
+  reachable by extension-call syntax at all. The two disagree on `null` and
+  on mutability: `Colls::groupBy` throws `NullPointerException` on a `null`
+  list and returns an unmodifiable `Map` of unmodifiable inner `List`s,
+  while `Maps::groupBy` returns an empty mutable `Map` for a `null` list and
+  mutable `ArrayList` buckets otherwise. Added the caveat to both docs'
+  Maps Module section and a new `MapsGroupByShadowingSpec` regression test
+  that locks in the shadowing and checks both docs for the warning.
+
 - **`Strings`'s `join` extension-call shadowing by `onion.Colls` documented.**
   `onion.Colls` also declares a `join(List, String)` extension (an alias for
   `mkString`) with the same erased signature as `onion.Strings`'s, and

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1422,6 +1422,17 @@ Maps::mergeWith(a, b, (x: Int, y: Int) -> x + y)  // 衝突を結合
 Maps::update(m, "a", (v: Int) -> v + 1)       // 関数的更新
 ```
 
+**拡張メソッドとしてのシャドーイング:** `onion.Colls` も `onion.Maps` と同じ消去
+シグネチャで `groupBy(List, Function1)` 拡張メソッドを宣言しており、組み込み拡張
+コンテナリストで `Colls` が `Maps` より先に登録されているため、`xs.groupBy(f)` は
+常に *onion.Colls 側の `groupBy`* に到達します -- `onion.Maps` 側は拡張メソッド
+構文からは到達できません。`null` と変更可能性の扱いが異なります:
+`Colls::groupBy` は `null` の List に対して `NullPointerException` を投げ、内側の
+List も含めて**変更不可**な `Map` を返しますが、`Maps::groupBy` は `null` の
+List に対して空の変更可能な `Map` を返し、それ以外は変更可能な `ArrayList` を
+バケツとして使います。`onion.Maps` 側の変更可能な結果が欲しい場合は
+`xs.groupBy(...)` ではなく `Maps::groupBy(...)` を直接呼び出してください。
+
 ## Sets モジュール
 
 Set ユーティリティ（`onion.Sets`）。結果 Set は挿入順を保持し、集合演算は null 安全。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2397,6 +2397,18 @@ Maps::groupBy(items, (x: Item) -> x.category())   // Map[K, List[Item]]
 Maps::countBy(items, (x: Item) -> x.category())   // Map[K, Integer] frequency
 ```
 
+**Extension-call shadowing:** `onion.Colls` also declares a `groupBy(List,
+Function1)` extension method with the same erased signature as
+`onion.Maps`'s, and `Colls` is registered ahead of `Maps` in the builtin
+extension container list, so `xs.groupBy(f)` always reaches onion.Colls's
+`groupBy` -- `onion.Maps`'s is never reachable by extension-call syntax at
+all. The two disagree on `null` and on mutability: `Colls::groupBy` throws
+`NullPointerException` on a `null` list and returns an **unmodifiable**
+`Map` of unmodifiable inner `List`s, while `Maps::groupBy` returns an empty
+mutable `Map` for a `null` list and mutable `ArrayList` buckets otherwise.
+Call `Maps::groupBy(...)` directly (not `xs.groupBy(...)`) to get
+`onion.Maps`'s mutable result.
+
 ### Combination
 
 ```onion

--- a/src/test/scala/onion/compiler/tools/MapsGroupByShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapsGroupByShadowingSpec.scala
@@ -1,0 +1,90 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Maps` and `onion.Colls` both declare a `groupBy(List, Function1)`
+ * static method with the same erased receiver+name+signature (`Maps.groupBy`
+ * groups a `List` by a key function, same as `Colls.groupBy`). Both are
+ * registered as builtin extension containers
+ * (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`), and `Colls`
+ * is listed ahead of `Maps` -- so `xs.groupBy(f)` always reaches
+ * `onion.Colls`'s version, `onion.Maps`'s is never reachable by
+ * extension-call syntax at all, and the two disagree on `null` handling and
+ * mutability: `Colls.groupBy` throws `NullPointerException` on a `null` list
+ * and returns an unmodifiable `Map` of unmodifiable inner `List`s, while
+ * `Maps.groupBy` returns an empty (mutable) `Map` for a `null` list and
+ * mutable `ArrayList` buckets otherwise. This locks in that shadowing so a
+ * future reordering of `BuiltinExtensionContainers` doesn't silently flip
+ * it, and checks that both docs carry the warning (docs/reference/stdlib.md
+ * and its Japanese translation, Maps Module section).
+ */
+class MapsGroupByShadowingSpec extends AbstractShellSpec {
+
+  private def run(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): String {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "MapsGroupByShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for groupBy() on a List shadows onion.Maps") {
+    it("xs.groupBy(f) returns an unmodifiable Map of unmodifiable Lists (onion.Colls's behavior), not onion.Maps's mutable one") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val xs: List[Int] = [1, 2, 3]\n    val g = xs.groupBy { x -> x % 2 }\n    g.put(9, [1])\n    return 0\n  }\n}\n",
+          "MapsGroupByShadowMutateOuter.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[UnsupportedOperationException])
+    }
+
+    it("xs.groupBy(f)'s inner Lists are unmodifiable too (onion.Colls's behavior)") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val xs: List[Int] = [1, 2, 3]\n    val g = xs.groupBy { x -> x % 2 }\n    g[1].add(9)\n    return 0\n  }\n}\n",
+          "MapsGroupByShadowMutateInner.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[UnsupportedOperationException])
+    }
+
+    it("the static Maps:: form keeps onion.Maps's mutable Map/List result, never reachable via extension-call syntax") {
+      run(
+        "val xs: List[Int] = [1, 2, 3]\n" +
+        "    val g = Maps::groupBy(xs, (x: Int) -> x % 2)\n    g[1].add(9)\n    return g.toString()",
+        Shell.Success("{1=[1, 3, 9], 0=[2]}"))
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Maps Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString(" ")
+    }
+
+    val enMarkers = Set("xs.groupBy(", "onion.Colls's `groupBy`", "unmodifiable")
+    val jaMarkers = Set("xs.groupBy(", "onion.Colls")
+
+    it("docs/reference/stdlib.md's Maps Module section warns about groupBy() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Maps Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Maps Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Maps section warns about groupBy() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Maps モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Maps section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Colls` also declares a `groupBy(List, Function1)` extension method with the same erased signature as `onion.Maps`'s, and `Colls` is registered ahead of `Maps` in the builtin extension container list, so `xs.groupBy(f)` always reaches *onion.Colls*'s version — `onion.Maps`'s `groupBy` is never reachable by extension-call syntax at all.
- The two disagree on `null` handling and mutability: `Colls::groupBy` throws `NullPointerException` on a `null` list and returns an unmodifiable `Map` of unmodifiable inner `List`s, while `Maps::groupBy` returns an empty mutable `Map` for a `null` list and mutable `ArrayList` buckets otherwise.
- Adds the caveat to both docs' Maps Module section (`docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`) and a new `MapsGroupByShadowingSpec` regression test that locks in the shadowing behavior and checks both docs for the warning, following the same pattern as the existing `keys()`/`values()`/`mapValues()` and `union()`/`intersection()`/`difference()` shadowing specs.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5112 tests, 0 failed, 1 expected cancel (opt-in dist-smoke test gated on `-Donion.dist.path`, unrelated to this change)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198pXMVFhsYnfUWFQzVcRLQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0198pXMVFhsYnfUWFQzVcRLQ)_