### PR TITLE
docs(stdlib): document Strings::contains/isEmpty extension-call shadowing by native String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Strings`'s `contains`/`isEmpty` extension-call shadowing by native
+  `java.lang.String` documented.** `String` already defines `contains` and
+  `isEmpty` instance methods, so `s.contains(x)`/`s.isEmpty()` silently
+  reach the *native JDK method* instead of `onion.Strings`'s, same as the
+  already-documented `split`/`substring`/`lines`/`chars`/`repeat`. The
+  difference is invisible for an ordinary non-null `String` (both paths run
+  the same JDK logic) but becomes observable for a platform-typed value
+  read back from unparameterized Java interop that is `null` at runtime:
+  the native method throws `NullPointerException`, while
+  `onion.Strings::contains`/`isEmpty` are null-safe. Added the caveat to
+  both docs' Strings Module section and a new
+  `StringsContainsIsEmptyExtensionCallShadowingSpec` regression test that
+  locks in the shadowing (via a `HashMap.get` platform-typed null) and
+  checks both docs for the warning.
+
 - **`Maps`'s `groupBy` extension-call shadowing by `onion.Colls` documented.**
   `onion.Colls` also declares a `groupBy(List, Function1)` extension with the
   same erased signature as `onion.Maps`'s, and `Colls` is registered ahead of

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1368,6 +1368,22 @@ Strings::toIntOr("nope", 0)              // 0
 `null` 要素で例外を投げない `Colls` の `xs.join(sep)` /
 `xs.mkString(sep)` をそのまま使う手もあります）。
 
+**`contains` と `isEmpty` も遮蔽されますが、プラットフォーム型の
+`null` を渡したときだけ挙動差が見えます**: `java.lang.String` には
+すでに `contains`・`isEmpty` というインスタンスメソッドが定義されて
+いるため、`s.contains(x)` と `s.isEmpty()` も上の5つと同様に
+`onion.Strings` 側ではなく **JDK 標準の同名メソッド** を暗黙のうちに
+呼び出します。`null` でない `String` に対しては両者は同じ JDK ロジック
+に行き着くため通常のコードでは見分けが付きません。差が表面化するのは、
+型引数を持たない Java 相互運用から読み戻した値 -- コンパイル時の
+null 安全性チェックが及ばない「プラットフォーム」型の値 -- が実行時に
+`null` だった場合です: このとき `s.isEmpty()` / `s.contains(x)` は
+JDK 側のメソッドから `NullPointerException` を投げますが、
+`onion.Strings` の版は null 安全（`Strings::isEmpty(null) == true`、
+`Strings::contains(null, x) == false`）です。受け手が未検査の
+プラットフォーム `null` になり得る場合は `Strings::contains(...)` /
+`Strings::isEmpty(...)` の静的呼び出し形式を使ってください。
+
 ## Maps モジュール
 
 Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持（`LinkedHashMap`）。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1311,6 +1311,22 @@ the `Strings::join(...)` static-call form to get the throwing behavior (or
 just rely on `Colls`'s `xs.join(sep)` / `xs.mkString(sep)`, which never
 throws on a `null` element).
 
+**`contains` and `isEmpty` are shadowed too, but only observably for a
+platform-typed `null`**: `java.lang.String` already defines `contains`
+and `isEmpty` instance methods, so `s.contains(x)` and `s.isEmpty()` also
+silently reach the *native JDK method* instead of `onion.Strings`'s, same
+as the five methods above. For a non-null `String` the two agree (both
+end up running the same JDK logic), so this is invisible in ordinary
+code. It becomes observable for a value read back from unparameterized
+Java interop -- a platform type carries no compile-time nullability
+tracking, so Onion's null-safety checking does not force a null check
+before the call -- and that value happens to be `null` at runtime:
+`s.isEmpty()` / `s.contains(x)` then throw `NullPointerException` from
+the native method, while `onion.Strings`'s versions are null-safe
+(`Strings::isEmpty(null) == true`, `Strings::contains(null, x) ==
+false`). Use the `Strings::contains(...)` / `Strings::isEmpty(...)`
+static-call form when the receiver may be an unchecked platform `null`.
+
 ## Files Module
 
 File I/O (`onion.Files`):

--- a/src/test/scala/onion/compiler/tools/StringsContainsIsEmptyExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsContainsIsEmptyExtensionCallShadowingSpec.scala
@@ -1,0 +1,112 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Strings` declares `contains(String, String)` and `isEmpty(String)`,
+ * but `java.lang.String` already defines instance methods with these same
+ * names (`contains(CharSequence)`, `isEmpty()`), and an instance method
+ * always wins over an extension method of the same name -- the same hazard
+ * `StringsExtensionCallShadowingSpec` documents for `split`/`substring`/
+ * `lines`/`chars`/`repeat`, but that spec's list stops at those five and
+ * does not cover these two.
+ *
+ * For a non-null receiver the native method and `onion.Strings`'s agree
+ * (both ultimately call the same JDK logic), so the shadowing is invisible
+ * there. It becomes observable for a receiver that is `null` at runtime but
+ * was never checked at compile time: a value read back from unparameterized
+ * Java interop (a "platform type", per CLAUDE.md) carries no compile-time
+ * nullability tracking, so Onion's null-safety typechecking does not force
+ * a null check before `.contains(...)`/`.isEmpty()` on it. `onion.Strings`'s
+ * versions are null-safe (`isEmpty(null) == true`, `contains(null, x) ==
+ * false`); the native methods that extension-call syntax actually reaches
+ * throw `NullPointerException` instead. Locks in the shadowing (a future
+ * reordering of `BuiltinExtensionContainers` or the resolution rule
+ * wouldn't be caught by unit tests exercising only non-null receivers), and
+ * checks that both docs carry the warning (docs/reference/stdlib.md and its
+ * Japanese translation, Strings Module section).
+ */
+class StringsContainsIsEmptyExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def nullPlatformString: String =
+    """
+      |val m: HashMap[String, String] = new HashMap[String, String]
+      |val s: String = m.get("missing") as String
+      |""".stripMargin
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsContainsIsEmptyShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for contains()/isEmpty() on a null platform String shadows onion.Strings") {
+    it("s.isEmpty() on a null platform String reaches the native String.isEmpty and throws NullPointerException") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" +
+          nullPlatformString + "    return s.isEmpty()\n  }\n}\n",
+          "StringsContainsIsEmptyShadowNpe.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+
+    it("Strings::isEmpty(s) on the same null platform String is null-safe and returns true instead") {
+      runBool(nullPlatformString + "    return Strings::isEmpty(s)", Shell.Success(true))
+    }
+
+    it("s.contains(x) on a null platform String reaches the native String.contains and throws NullPointerException") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" +
+          nullPlatformString + "    return s.contains(\"x\")\n  }\n}\n",
+          "StringsContainsIsEmptyShadowNpe2.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+
+    it("Strings::contains(s, x) on the same null platform String is null-safe and returns false instead") {
+      runBool(nullPlatformString + "    return Strings::contains(s, \"x\")", Shell.Success(false))
+    }
+
+    it("for a non-null receiver, extension-call and static-call syntax agree") {
+      runBool("return \"hello\".isEmpty()", Shell.Success(false))
+      runBool("return \"hello\".contains(\"ell\")", Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the contains()/isEmpty() shadowing warning in the Strings Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("s.contains(", "s.isEmpty()", "platform", "NullPointerException")
+
+    val jaMarkers =
+      Set("s.contains(", "s.isEmpty()", "プラットフォーム", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Strings Module section warns about contains()/isEmpty() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Strings Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about contains()/isEmpty() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Strings section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `java.lang.String` already defines `contains`/`isEmpty` instance methods, so `s.contains(x)`/`s.isEmpty()` silently reach the native JDK method instead of `onion.Strings`'s — the same hazard already documented for `split`/`substring`/`lines`/`chars`/`repeat`, but not previously called out for these two.
- For an ordinary non-null `String` the two agree, so this is invisible in normal code. It becomes observable for a platform-typed value read back from unparameterized Java interop (no compile-time nullability tracking) that is `null` at runtime: the native method throws `NullPointerException`, while `onion.Strings::contains`/`isEmpty` are null-safe.
- Added the caveat to both docs' Strings Module section (EN/JA) and a new `StringsContainsIsEmptyExtensionCallShadowingSpec` regression test that locks in the shadowing (via a `HashMap.get` platform-typed null) and checks both docs carry the warning.
- Added a `CHANGELOG.md` Unreleased entry.

## Test plan
- [x] New spec `StringsContainsIsEmptyExtensionCallShadowingSpec` passes (verified red before the doc changes, green after).
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5119 tests, 0 failed, 1 canceled (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wnJiGSBHgxHbotCZPLAhT

---
_Generated by [Claude Code](https://claude.ai/code/session_013wnJiGSBHgxHbotCZPLAhT)_