### PR TITLE
docs(stdlib): document Sets::map extension-call shadowing by onion.Iterables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Sets`'s `map` extension-call shadowing by `onion.Iterables` documented.**
+  `onion.Iterables` also declares a `map(Set, Function1)` extension with the
+  same erased signature as `onion.Sets`'s, and `Iterables` is registered
+  ahead of `Sets` in the builtin extension container list, so `a.map(f)` on
+  a `Set` always reaches *`onion.Iterables`*'s `map` -- `onion.Sets`'s `map`
+  is never reachable by extension-call syntax at all. The two disagree on
+  order and on `null`: `Iterables::map` collects into a plain `HashSet`
+  (iteration order unspecified, contradicting the Sets Module's documented
+  insertion-order promise) and throws `NullPointerException` on a `null`
+  set, while `Sets::map` collects into a `LinkedHashSet` (insertion order
+  preserved) and returns an empty set for a `null` one. Added the caveat to
+  both docs' Sets Module section and a new
+  `SetsMapExtensionCallShadowingSpec` regression test that locks in the
+  shadowing and checks both docs for the warning.
+
 - **`Strings`'s `contains`/`isEmpty` extension-call shadowing by native
   `java.lang.String` documented.** `String` already defines `contains` and
   `isEmpty` instance methods, so `s.contains(x)`/`s.isEmpty()` silently

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1472,13 +1472,25 @@ Sets::containsAll(a, b)                       // a が b の要素をすべて�
 a.containsAll(b)
 Sets::isSubsetOf(a, b) / Sets::isSupersetOf(a, b) / Sets::isDisjoint(a, b)
 a.isSubsetOf(b) / a.isSupersetOf(b) / a.isDisjoint(b)
-Sets::map(a, f) / Sets::filter(a, p) / Sets::find(a, p)
-a.map(f) / a.filter(p) / a.find(p)
+Sets::map(a, f)                               // NOT a.map(f) で到達不可 -- 下記参照
+Sets::filter(a, p) / Sets::find(a, p)
+a.filter(p) / a.find(p)
 Sets::forEach(a, (x: Int) -> println(x))
 a.forEach((x: Int) -> println(x))
 Sets::count(a, p) / Sets::any(a, p) / Sets::all(a, p)
 a.count(p) / a.any(p) / a.all(p)
 ```
+
+**拡張呼び出しのシャドーイング:** `onion.Iterables` も同じ `(Set, Function1)` 消去
+シグネチャで `map` 拡張メソッドを宣言しており、組み込み拡張コンテナリストで
+`Iterables` が `Sets` より先に登録されているため、`a.map(f)` は常に
+*`onion.Iterables`* 側の `map` に到達し、`onion.Sets` 側の `map` には拡張呼び出し
+構文からは一切到達できません。両者は順序と `null` の扱いが異なります:
+`Iterables::map` は結果を通常の `HashSet` に集約する（反復順序は不定で、上記の
+「挿入順を保持する」という約束が破れる）うえ `null` の Set に対して
+`NullPointerException` を投げますが、`Sets::map` は `LinkedHashSet`（挿入順保持）
+に集約し、`null` の Set には空の Set を返します。挿入順が保たれた null 安全な
+結果が必要な場合は `a.map(...)` ではなく `Sets::map(...)` を直接呼んでください。
 
 ## Hash モジュール
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2479,10 +2479,11 @@ Sets::isDisjoint(a, b)                 // a.isDisjoint(b) -- share no elements
 
 ### Functional operations
 
-These are also builtin extension methods on `Set` (`a.map(...)`, `a.filter(...)`, ...):
+These are also builtin extension methods on `Set` (`a.filter(...)`, `a.forEach(...)`,
+...) -- **except `map`**, see the shadowing note below:
 
 ```onion
-Sets::map(a, (x: Int) -> x * 2)        // a.map((x: Int) -> x * 2)
+Sets::map(a, (x: Int) -> x * 2)        // NOT reachable as a.map(...) -- see below
 Sets::filter(a, (x: Int) -> x > 1)     // a.filter((x: Int) -> x > 1)
 Sets::forEach(a, (x: Int) -> println(x))  // a.forEach((x: Int) -> println(x))
 Sets::count(a, (x: Int) -> x > 1)      // a.count((x: Int) -> x > 1)
@@ -2490,6 +2491,19 @@ Sets::any(a, (x: Int) -> x > 2)        // a.any((x: Int) -> x > 2)
 Sets::all(a, (x: Int) -> x > 0)        // a.all((x: Int) -> x > 0)
 Sets::find(a, (x: Int) -> x > 2)       // a.find((x: Int) -> x > 2) -- matching element or null
 ```
+
+**Extension-call shadowing:** `onion.Iterables` also declares a `map(Set,
+Function1)` extension method with the same erased signature as
+`onion.Sets`'s, and `Iterables` is registered ahead of `Sets` in the builtin
+extension container list, so `a.map(f)` always reaches *`onion.Iterables`*'s
+`map` -- `onion.Sets`'s `map` is never reachable by extension-call syntax at
+all. The two disagree on order and on `null`: `Iterables::map` collects into
+a plain `HashSet` (iteration order unspecified, breaking this module's
+insertion-order promise above) and throws `NullPointerException` for a
+`null` set, while `Sets::map` collects into a `LinkedHashSet` (insertion
+order preserved) and returns an empty set for a `null` one. Call
+`Sets::map(...)` directly (not `a.map(...)`) to get `onion.Sets`'s
+order-preserving, null-safe result.
 
 ---
 

--- a/src/test/scala/onion/compiler/tools/SetsMapExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsMapExtensionCallShadowingSpec.scala
@@ -1,0 +1,110 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Iterables::map(Set, Function1)` has the same erased signature as
+ * `onion.Sets`'s `map(Set, Function1)`, and `Iterables` is listed ahead of
+ * `Sets` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, so
+ * `a.map(f)` on a `Set` always reaches *`onion.Iterables`*'s implementation
+ * -- `onion.Sets`'s `map` is never reachable by extension-call syntax at
+ * all, even though docs/reference/stdlib.md (and its Japanese translation)
+ * list `map` among the Sets Module's "Functional operations" as if
+ * `a.map(...)` reached `onion.Sets::map`. The two implementations disagree:
+ *   - order: `Sets::map` collects into a `LinkedHashSet` (insertion-order
+ *     preserved, matching the Sets Module's documented promise that "result
+ *     sets preserve insertion order"); `Iterables::map` collects into a
+ *     plain `HashSet`, so the result's iteration order is unspecified
+ *   - null: `Sets::map` treats a `null` set as empty; `Iterables::map`
+ *     iterates its argument directly and throws `NullPointerException`
+ * This locks in that shadowing (via the resulting `Set` implementation's
+ * class name, rather than a specific hash-bucket order, so the assertion
+ * doesn't depend on `HashSet`'s internal layout for particular elements) so
+ * a future reordering of `BuiltinExtensionContainers` doesn't silently flip
+ * it, and checks that both docs carry the warning (docs/reference/stdlib.md
+ * and its Japanese translation, Sets Module section).
+ */
+class SetsMapExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "SetsMapShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for map() on a Set[Int] shadows onion.Sets") {
+    it("a.map(f) collects into a plain HashSet (Iterables's behavior), not a LinkedHashSet") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |return a.map((x: Int) -> x * 2).getClass().getName() == "java.util.HashSet"
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Sets::map(a, f) collects into a LinkedHashSet, unlike the shadowing extension call") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |return onion.Sets::map(a, (x: Int) -> x * 2).getClass().getName() == "java.util.LinkedHashSet"
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("a.map(f) throws NullPointerException on a null Set (Iterables's behavior)") {
+      runBool(
+        """
+          |val n: Set[Int] = null
+          |try {
+          |  n.map((x: Int) -> x * 2)
+          |  return false
+          |} catch e: NullPointerException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Sets::map(null, f) returns an empty set instead of throwing") {
+      runBool(
+        """
+          |return onion.Sets::map(null, (x: Int) -> x * 2) == onion.Sets::of()
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the map() shadowing warning in the Sets Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("a.map(", "onion.Iterables", "HashSet", "NullPointerException")
+
+    val jaMarkers =
+      Set("a.map(", "onion.Iterables", "HashSet", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Sets Module section warns about map() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Sets Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Sets Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Sets section warns about map() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Sets モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Sets モジュール section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Iterables` declares a `map(Set, Function1)` extension with the same erased signature as `onion.Sets`'s, and `Iterables` is registered ahead of `Sets` in the builtin extension container list, so `a.map(f)` on a `Set` always reaches *`onion.Iterables`*'s `map` — `onion.Sets`'s `map` is never reachable by extension-call syntax at all.
- The two implementations disagree: `Iterables::map` collects into a plain `HashSet` (iteration order unspecified, contradicting the Sets Module's documented insertion-order promise) and throws `NullPointerException` on a `null` set, while `Sets::map` collects into a `LinkedHashSet` (order preserved) and returns an empty set for a `null` one.
- Documents the caveat in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Sets Module sections, following the same pattern used for the previously-documented `Colls`/`Sets` `union`/`intersection`/`difference` shadowing.
- Adds `SetsMapExtensionCallShadowingSpec`, a regression test that locks in the shadowing (asserted via the result's runtime class name, not hash-bucket order, so it doesn't depend on `HashSet`'s internal layout) and checks both docs carry the warning.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5125 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated distribution test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQVU67rPxwbSvN91Vg6m8

---
_Generated by [Claude Code](https://claude.ai/code/session_011pQVU67rPxwbSvN91Vg6m8)_