### PR TITLE
docs(stdlib): document Strings::isBlank extension-call shadowing by native String

### DIFF
--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1384,6 +1384,22 @@ JDK 側のメソッドから `NullPointerException` を投げますが、
 プラットフォーム `null` になり得る場合は `Strings::contains(...)` /
 `Strings::isEmpty(...)` の静的呼び出し形式を使ってください。
 
+**`isBlank` も遮蔽されますが、`null` を渡さない通常の `String` でも
+挙動差が表面化します**: `java.lang.String` には Java 11 以降
+`isBlank()` というインスタンスメソッドが定義されているため、
+`s.isBlank()` も上記と同様に `onion.Strings` 側ではなく **JDK 標準の
+同名メソッド** を暗黙のうちに呼び出します。`contains`/`isEmpty` とは
+異なり、この差はプラットフォーム型の `null` がなくても現れます:
+`onion.Strings::isBlank` は `str.trim().isEmpty()` として実装されて
+おり、`String::trim` は `U+0020` 以下の文字しか取り除きません。一方
+ネイティブの `String::isBlank` は `Character.isWhitespace` を満たす
+すべての文字を空白とみなすため、EM SPACE（U+2003）のような `trim()`
+では取り除かれない Unicode の空白文字も対象になります。そのため
+EM SPACE だけからなる文字列は `s.isBlank()`（拡張呼び出し構文）では
+空白扱いになりますが、`Strings::isBlank(s)`（静的呼び出し構文）では
+空白扱いになりません。`trim()` ベースの ASCII 空白の意味論が必要な
+場合は `Strings::isBlank(...)` の静的呼び出し形式を使ってください。
+
 ## Maps モジュール
 
 Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持（`LinkedHashMap`）。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1327,6 +1327,20 @@ the native method, while `onion.Strings`'s versions are null-safe
 false`). Use the `Strings::contains(...)` / `Strings::isEmpty(...)`
 static-call form when the receiver may be an unchecked platform `null`.
 
+**`isBlank` is shadowed too, and observably so even on an ordinary non-null
+`String`**: `java.lang.String` has defined an `isBlank()` instance method
+since Java 11, so `s.isBlank()` also silently reaches the *native JDK
+method* instead of `onion.Strings`'s. Unlike `contains`/`isEmpty` above, the
+two disagree without needing a platform-typed `null`: `onion.Strings::isBlank`
+is implemented as `str.trim().isEmpty()`, and `String::trim` only strips
+characters `<= U+0020`, while native `String::isBlank` treats every
+character satisfying `Character.isWhitespace` as blank -- including Unicode
+space separators like EM SPACE (U+2003) that `trim()` does not strip. So a
+string consisting only of an EM SPACE is blank under `s.isBlank()`
+(extension-call syntax) but not blank under `Strings::isBlank(s)`
+(static-call syntax). Use the `Strings::isBlank(...)` static-call form for
+`trim()`-based, ASCII-whitespace semantics.
+
 ## Files Module
 
 File I/O (`onion.Files`):

--- a/src/test/scala/onion/compiler/tools/StringsIsBlankExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsIsBlankExtensionCallShadowingSpec.scala
@@ -1,0 +1,97 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Strings` declares `isBlank(String)`, but `java.lang.String` already
+ * defines an instance method with the same name (since Java 11), and an
+ * instance method always wins over an extension method of the same name --
+ * the same hazard `StringsExtensionCallShadowingSpec` documents for
+ * `split`/`substring`/`lines`/`chars`/`repeat` and
+ * `StringsContainsIsEmptyExtensionCallShadowingSpec` documents for
+ * `contains`/`isEmpty`.
+ *
+ * Unlike `contains`/`isEmpty`, this disagreement is observable on an
+ * ordinary non-null `String` -- no platform-typed `null` required.
+ * `onion.Strings::isBlank` is implemented as `str.trim().isEmpty()`, and
+ * `String::trim` only strips characters `<= U+0020`. Native
+ * `String::isBlank` instead treats every character satisfying
+ * `Character.isWhitespace` as blank, which includes Unicode space
+ * separators like EM SPACE (U+2003) that `trim()` does not strip. So a
+ * string made up only of an EM SPACE is blank under the native method that
+ * extension-call syntax reaches, but not blank under `onion.Strings`'s
+ * static form.
+ *
+ * Locks in the shadowing (a future reordering of `BuiltinExtensionContainers`
+ * or the resolution rule wouldn't be caught by unit tests exercising only
+ * ASCII-whitespace strings), and checks that both docs carry the warning
+ * (docs/reference/stdlib.md and its Japanese translation, Strings Module
+ * section).
+ */
+class StringsIsBlankExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  // U+2003 EM SPACE, embedded literally (not as a \u escape) to sidestep the
+  // Java/Scala-style unicode-escape pretokenizing that both the host Scala
+  // source and the generated Onion source would otherwise be subject to.
+  private val emSpace = " "
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsIsBlankShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for isBlank() on an EM-SPACE-only String shadows onion.Strings") {
+    it("s.isBlank() on a string containing only an EM SPACE (U+2003) reaches native String.isBlank and returns true") {
+      runBool(s"""val s: String = " $emSpace "\n    return s.isBlank()""", Shell.Success(true))
+    }
+
+    it("Strings::isBlank(s) on the same string is trim()-based and returns false instead") {
+      runBool(s"""val s: String = " $emSpace "\n    return Strings::isBlank(s)""", Shell.Success(false))
+    }
+
+    it("for an ASCII-whitespace-only string, extension-call and static-call syntax agree") {
+      runBool("return \"   \".isBlank()", Shell.Success(true))
+      runBool("return Strings::isBlank(\"   \")", Shell.Success(true))
+    }
+
+    it("for a non-blank string, extension-call and static-call syntax agree") {
+      runBool("return \"hi\".isBlank()", Shell.Success(false))
+      runBool("return Strings::isBlank(\"hi\")", Shell.Success(false))
+    }
+  }
+
+  describe("docs carry the isBlank() shadowing warning in the Strings Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("isBlank", "trim", "U+2003", "EM SPACE")
+
+    val jaMarkers =
+      Set("isBlank", "trim", "U+2003")
+
+    it("docs/reference/stdlib.md's Strings Module section warns about isBlank() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Strings Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about isBlank() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Strings section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `java.lang.String` has defined an `isBlank()` instance method since Java 11, so `s.isBlank()` (extension-call syntax) silently reaches the native JDK method instead of `onion.Strings`'s — the same "instance method always wins" hazard already documented for `split`/`substring`/`lines`/`chars`/`repeat`/`contains`/`isEmpty`.
- Unlike the already-documented `contains`/`isEmpty` case, this one is observable on an ordinary **non-null** `String`, no platform-typed `null` needed: `onion.Strings::isBlank` is `str.trim().isEmpty()`-based, and `String::trim` only strips characters `<= U+0020`, while native `String::isBlank` treats any `Character.isWhitespace` character as blank — including Unicode space separators like EM SPACE (U+2003) that `trim()` does not strip. So a string made only of an EM SPACE is blank under `s.isBlank()` but not under `Strings::isBlank(s)`.
- Documents the caveat in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Strings Module section.
- Adds `StringsIsBlankExtensionCallShadowingSpec`, which locks in the behavioral divergence (verified against actual JDK behavior) and checks both docs for the warning.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5131 succeeded, 0 failed (1 canceled, unrelated)
- [x] New spec run standalone, confirmed red before the doc changes and green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135JTRX3mKGwCZJcB9QRjx7

---
_Generated by [Claude Code](https://claude.ai/code/session_0135JTRX3mKGwCZJcB9QRjx7)_