### PR TITLE
docs(stdlib): document Iterables::reduce extension-call shadowing by onion.Colls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Iterables`'s three-arg `reduce` extension-call shadowing by `onion.Colls`
+  documented -- the first shadowing case with a compile-time, not just
+  runtime, effect.** `onion.Colls` also declares a `reduce(List, Object,
+  Function2)` extension with the same erased signature as `onion.Iterables`'s,
+  and `Colls` is registered ahead of `Iterables` in the builtin extension
+  container list, so `xs.reduce(initial, f)` always reaches *`onion.Colls`*'s
+  implementation -- `onion.Iterables`'s three-arg `reduce` is never reachable
+  by extension-call syntax at all. Unlike the already-documented
+  `map`/`filter`/`take`/`drop`/`reverse` shadowing (runtime edge cases only),
+  this one changes what *type-checks*: `Colls::reduce`'s declared signature
+  types the accumulator as the actual generic `U`, while `Iterables::reduce`'s
+  erases it to `Object`, so `xs.reduce(0, (acc, x) -> acc + x)` compiles and
+  sums to an `Int` only because it silently reaches `Colls::reduce`; calling
+  `Iterables::reduce(xs, 0, (acc, x) -> acc + x)` explicitly fails to compile
+  with E0001 ("operator + is not applicable for type Object, Int"). Added the
+  caveat to both docs' Iterables Module section and a new
+  `IterablesReduceShadowingSpec` regression test that locks in the shadowing
+  (including the E0001 compile failure) and checks both docs for the warning.
+
 - **`Strings`'s `isBlank` extension-call shadowing by native `java.lang.String`
   documented.** `String` has defined an `isBlank()` instance method since
   Java 11, so `s.isBlank()` silently reaches the *native JDK method* instead

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1769,6 +1769,26 @@ xs.reverse().add(4)            // UnsupportedOperationException を投げる（o
 Iterables::take(xs, -1)        // 例外を投げる（onion.Iterables::take。クランプしない）
 ```
 
+**`reduce` もシャドーイングされますが、実行時ではなくコンパイル時に現れます**:
+`onion.Colls` にも消去後シグネチャが同じ3引数の `reduce(List, Object, Function2)`
+拡張メソッドがあり、`xs.reduce(initial, f)` は常に *`onion.Colls`* 側の実装に
+到達します -- `onion.Iterables` の3引数 `reduce` は拡張呼び出し構文からは
+一切到達できません。上記の `map`/`filter`/`take`/`drop`/`reverse` と違い、
+両者は実行時のエッジケースだけでなく型で異なります: `Colls::reduce` の宣言
+シグネチャは `initial` と戻り値を実際のジェネリック型 `U` として型付けする
+ため、アキュムレータには具体的な型（例えば `Int`）が推論されますが、
+`Iterables::reduce` の宣言シグネチャは両方とも単なる `Object` に消去します。
+そのため上のコード例の `xs.reduce(0, (acc, x) -> acc + x)` がコンパイルでき
+`Int` を合計しているのは、このリストでの見た目とは異なり `onion.Iterables::reduce`
+ではなく `onion.Colls::reduce` に静かに到達しているからです -- `Iterables::reduce`
+を明示的に呼び出すとコンパイルが失敗します:
+
+```onion
+val xs: List[Int] = [1, 2, 3]
+xs.reduce(0, (acc, x) -> acc + x)                    // 6  （onion.Colls::reduce。acc は Int）
+Iterables::reduce(xs, 0, (acc, x) -> acc + x)         // [E0001] operator + is not applicable for type Object, Int
+```
+
 ## Files モジュール
 
 ファイル I/O（`onion.Files`）:

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -904,6 +904,26 @@ xs.reverse().add(4)            // throws UnsupportedOperationException (onion.Co
 Iterables::take(xs, -1)        // throws  (onion.Iterables::take, no clamping)
 ```
 
+**`reduce` is shadowed too, but at compile time, not just runtime**: `onion.Colls`
+also declares a three-arg `reduce(List, Object, Function2)` extension with the
+same erased signature as `onion.Iterables`'s, so `xs.reduce(initial, f)` always
+reaches *`onion.Colls`*'s implementation -- `onion.Iterables`'s three-arg
+`reduce` is never reachable by extension-call syntax at all. Unlike
+`map`/`filter`/`take`/`drop`/`reverse` above, the two don't just disagree on
+runtime edge cases: `Colls::reduce`'s declared signature types `initial` and
+the return value as the actual generic `U`, so the accumulator gets a concrete
+inferred type (e.g. `Int`); `Iterables::reduce`'s declared signature erases
+both to plain `Object`. So `xs.reduce(0, (acc, x) -> acc + x)` above compiles
+and sums to an `Int` because it silently reaches `onion.Colls::reduce`, not
+`onion.Iterables::reduce` as its placement in this list suggests -- calling
+`Iterables::reduce` explicitly fails to compile instead:
+
+```onion
+val xs: List[Int] = [1, 2, 3]
+xs.reduce(0, (acc, x) -> acc + x)                    // 6  (onion.Colls::reduce, acc: Int)
+Iterables::reduce(xs, 0, (acc, x) -> acc + x)         // [E0001] operator + is not applicable for type Object, Int
+```
+
 ## Option Module
 
 Provided via `onion.Option`.

--- a/src/test/scala/onion/compiler/tools/IterablesReduceShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IterablesReduceShadowingSpec.scala
@@ -1,0 +1,100 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import onion.tools.Shell
+import java.io.StringReader
+
+/**
+ * `onion.Colls` also declares a three-arg `reduce(List<T> list, U initial,
+ * Function2<U, T, U> f)` with the same erased signature as `onion.Iterables`'s
+ * `reduce(List<T> list, Object initial, Function2<Object, T, Object> reducer)`,
+ * and `Colls` is registered ahead of `Iterables` in
+ * `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, so `xs.reduce(initial, f)`
+ * always reaches *`onion.Colls`*'s implementation -- `onion.Iterables`'s three-arg
+ * `reduce` is never reachable by extension-call syntax at all, even though
+ * docs/reference/stdlib.md (and its Japanese translation) list
+ * `xs.reduce(0, (acc, x) -> acc + x)` as a plain `Iterables` chaining example
+ * alongside `map`/`filter`/`take`/`drop`/`reverse` (already documented as shadowed)
+ * without calling out the same shadowing for `reduce`.
+ *
+ * Unlike those runtime-only edge cases, this one is visible at *compile time*:
+ * `Colls::reduce`'s declared signature types `initial`/the return value as the
+ * actual generic `U`, so the compiler infers a concrete type (e.g. `Int`) for the
+ * accumulator; `Iterables::reduce`'s declared signature erases both to plain
+ * `Object`. So `xs.reduce(0, (acc, x) -> acc + x)` compiles and sums to an `Int`
+ * (Colls's generics, via the shadowing), while calling
+ * `Iterables::reduce(xs, 0, (acc, x) -> acc + x)` explicitly fails to compile
+ * with E0001 ("operator + is not applicable for type Object, Int") because its
+ * `acc` is typed `Object`.
+ */
+class IterablesReduceShadowingSpec extends AbstractShellSpec {
+
+  private def errorCodes(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.flatMap(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("extension-call syntax for reduce() on a List[Int] shadows onion.Iterables") {
+    it("xs.reduce(0, f) type-checks acc as Int and sums correctly (Colls's generic behavior)") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs: List[Int] = [1, 2, 3]
+          |    return xs.reduce(0, (acc, x) -> acc + x)
+          |  }
+          |}
+          |""".stripMargin, "IterablesReduceShadow.on", Array())
+      assert(Shell.Success(6) == result)
+    }
+
+    it("Iterables::reduce(xs, 0, f) fails to compile -- its acc is Object, not Int (E0001)") {
+      assert(errorCodes(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs: List[Int] = [1, 2, 3]
+          |    return Iterables::reduce(xs, 0, (acc, x) -> acc + x)
+          |  }
+          |}
+          |""".stripMargin
+      ).contains("E0001"))
+    }
+  }
+
+  describe("docs carry the reduce() shadowing warning in the Iterables Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers = Set("reduce", "onion.Colls", "E0001")
+    val jaMarkers = Set("reduce", "onion.Colls", "E0001")
+
+    it("docs/reference/stdlib.md's Iterables Module section warns about reduce() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Iterables Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Iterables Module section is missing reduce()-shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Iterables section warns about reduce() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Iterables モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Iterables モジュール section is missing reduce()-shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Colls` declares a three-arg `reduce(List, Object, Function2)` extension with the same erased signature as `onion.Iterables`'s, and `Colls` is registered ahead of `Iterables` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, so `xs.reduce(initial, f)` always reaches *`onion.Colls`*'s implementation — `onion.Iterables`'s three-arg `reduce` is never reachable by extension-call syntax at all, even though the docs listed `xs.reduce(0, (acc, x) -> acc + x)` as a plain `Iterables` chaining example.
- Unlike the already-documented `map`/`filter`/`take`/`drop`/`reverse` shadowing (runtime edge cases only), this one changes what *type-checks*: `Colls::reduce`'s declared signature types the accumulator as the actual generic `U`, while `Iterables::reduce`'s erases it to `Object`. Verified with `ScriptRunner`: `xs.reduce(0, (acc, x) -> acc + x)` compiles and sums to an `Int`, but calling `Iterables::reduce(xs, 0, (acc, x) -> acc + x)` explicitly fails to compile with `E0001` ("operator + is not applicable for type Object, Int") because its `acc` is typed `Object`.
- Corrected `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Iterables Module sections, and added a `[Unreleased]` CHANGELOG entry.

## Test plan

- [x] Added `IterablesReduceShadowingSpec` (new, TDD red→green): locks in the shadowing behavior (`xs.reduce` sums as `Int`) and the `Iterables::reduce` compile failure (`E0001`), and checks both docs carry the warning.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5135 succeeded, 0 failed, 1 canceled, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SsWJZa33UYSvBSQM8Thq1

---
_Generated by [Claude Code](https://claude.ai/code/session_016SsWJZa33UYSvBSQM8Thq1)_