### PR TITLE
docs(stdlib): document Sets::toList extension-call ambiguity vs onion.Colls/Iterables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Sets::toList` extension-call ambiguity documented -- not shadowing, a
+  compile error.** `onion.Colls` also declares a `toList(Set)` extension
+  with the same erased signature as `onion.Sets`'s, which would ordinarily
+  just shadow it (as `union`/`intersection`/`difference`/`map` already are
+  in this module). But `Set` also conforms to `Iterable`, and
+  `onion.Iterables` separately declares a `toList(Iterable)` extension with
+  a genuinely different erasure that is also applicable to a `Set`
+  argument, so `a.toList()` is ambiguous between the two and fails to
+  compile with E0006 instead of silently resolving to either -- unlike
+  every other method this module documents as "also a builtin extension
+  method." Added the caveat to both docs' Sets Module section (with the
+  static forms' disagreement on mutability and `null` handling) and a new
+  `SetsToListExtensionCallShadowingSpec` regression test that locks in the
+  E0006 compile failure and checks both docs for the warning.
+
 - **`Iterables`'s three-arg `reduce` extension-call shadowing by `onion.Colls`
   documented -- the first shadowing case with a compile-time, not just
   runtime, effect.** `onion.Colls` also declares a `reduce(List, Object,

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1478,6 +1478,28 @@ Set ユーティリティ（`onion.Sets`）。結果 Set は挿入順を保持�
 直接呼んだ `Sets::union`/`intersection`/`difference` は通常の **変更可能**な `LinkedHashSet` を
 返します。変更可能な結果が必要な場合は `Sets::` 形式を使ってください。
 
+**`toList` は `a.toList()` としては一切コンパイルできません -- シャドーイングでさえない**:
+`onion.Colls` も同じ `(Set)` 消去シグネチャで `toList` 拡張メソッドを宣言しており、本来なら
+下記の `union`/`intersection`/`difference`/`map` と同様に単純にシャドーイングされるだけの
+はずです。ところが `Set` は `Iterable` にも適合しており、`onion.Iterables` は別途
+`toList(Iterable)` 拡張メソッドを宣言しています -- これは消去シグネチャとして本当に異なる
+ものですが、`Set` 型の引数にも同じく適用可能です。そのため `a.toList()` は
+`onion.Colls` 側と `onion.Iterables` 側のどちらにも解釈できてしまい **曖昧**となり、
+どちらかへ黙って解決される代わりに `E0006`（"method call is applicable for both
+Colls.toList() and Iterables.toList()"）でコンパイルエラーになります -- このモジュールで
+「組み込み拡張メソッドとしても使える」と説明している他のすべてのメソッドとは異なります。
+さらに静的呼び出し形どうしも挙動が異なります: `Colls::toList` はコピーを
+`Collections.unmodifiableList` でラップし、`null` の Set には `NullPointerException` を
+投げますが、`Sets::toList` は通常の変更可能な `ArrayList` を返し、`null` は空として扱います。
+必ず `Sets::toList(a)`（変更不可・例外を投げる版が必要なら `Colls::toList(a)`）を明示的に
+呼び出してください -- `a.toList()` は `Set` レシーバに対しては絶対にコンパイルできません。
+
+```onion
+a.toList()                             // [E0006] 曖昧: Colls.toList() vs Iterables.toList()
+Sets::toList(a)                        // 変更可能; null 安全（null には空リスト）
+Colls::toList(a)                       // 変更不可; null には NullPointerException
+```
+
 ```onion
 Sets::of(1, 2, 3) / Sets::newSet[Int]() / Sets::fromList([1, 1, 2]) / Sets::toList(a)
 Sets::union(a, b) / Sets::intersection(a, b) / Sets::difference(a, b)  // 変更可能; a.union(b) 等では到達不可

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2483,6 +2483,30 @@ val c = Sets::fromList([1, 1, 2, 3])   // distinct, first-seen order
 Sets::toList(a)                        // back to a List
 ```
 
+**`toList` doesn't compile as `a.toList()` at all -- not even a shadowing
+case**: `onion.Colls` also declares a `toList(Set)` extension with the same
+erased signature as `onion.Sets`'s, which would ordinarily just shadow it
+the way `union`/`intersection`/`difference`/`map` are shadowed below. But
+`Set` also conforms to `Iterable`, and `onion.Iterables` separately declares
+a `toList(Iterable)` extension -- a genuinely different erased signature
+that is *also* applicable to a `Set` argument. That makes `a.toList()`
+**ambiguous** between `onion.Colls`'s and `onion.Iterables`'s versions, so
+it fails to compile with `E0006` ("method call is applicable for both
+Colls.toList() and Iterables.toList()") instead of silently picking one --
+unlike every other method this module documents as "also a builtin
+extension method." The static forms disagree with each other on top of
+that: `Colls::toList` wraps its copy in `Collections.unmodifiableList` and
+throws `NullPointerException` for a `null` set; `Sets::toList` returns a
+plain mutable `ArrayList` and treats `null` as empty. Always call
+`Sets::toList(a)` (or `Colls::toList(a)` for the unmodifiable, throwing
+variant) explicitly -- `a.toList()` never compiles for a `Set` receiver.
+
+```onion
+a.toList()                             // [E0006] ambiguous: Colls.toList() vs Iterables.toList()
+Sets::toList(a)                        // mutable; null-safe (empty list for null)
+Colls::toList(a)                       // unmodifiable; throws NullPointerException for null
+```
+
 ### Set algebra
 
 Every method below is also a builtin extension method on `Set`, callable as

--- a/src/test/scala/onion/compiler/tools/SetsToListExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsToListExtensionCallShadowingSpec.scala
@@ -1,0 +1,126 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Sets`'s `toList(Set)` has the same erased signature as
+ * `onion.Colls`'s `toList(Set)`, so per
+ * `ExtensionMethodFallbackSupport.BuiltinExtensionContainers` (`Colls` listed
+ * ahead of `Sets`) it is shadowed the same way `union`/`intersection`/
+ * `difference`/`map` already are elsewhere in this module -- except `toList`
+ * doesn't silently resolve to the earlier container's version at all: `Set`
+ * also conforms to `Iterable`, and `onion.Iterables` separately declares a
+ * `toList(Iterable)` extension. That's a genuinely different erasure from
+ * `Colls`/`Sets`'s `toList(Set)`, so instead of one shadowing the other,
+ * `a.toList()` on a `Set` is **ambiguous between `Colls.toList()` and
+ * `Iterables.toList()`** and fails to compile with E0006 -- unlike every
+ * other method the Sets Module documents as "also a builtin extension
+ * method." The three static forms disagree with each other too:
+ *   - `Colls::toList` wraps the copy in `Collections.unmodifiableList` and
+ *     throws `NullPointerException` on a `null` set (`new ArrayList<>(set)`)
+ *   - `Sets::toList` returns a plain mutable `ArrayList` and treats `null`
+ *     as empty
+ * This locks in that `a.toList()` does not compile for a `Set` receiver, and
+ * checks that both docs carry the warning (docs/reference/stdlib.md and its
+ * Japanese translation, Sets Module section).
+ */
+class SetsToListExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "SetsToListShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for toList() on a Set[Int] does not compile") {
+    it("a.toList() fails to compile -- ambiguous between Colls.toList() and Iterables.toList()") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |return a.toList().size == 3
+          |""".stripMargin,
+        Shell.Failure(-1))
+    }
+
+    it("onion.Colls::toList(a) returns an unmodifiable list") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |try {
+          |  onion.Colls::toList(a).add(4)
+          |  return false
+          |} catch e: UnsupportedOperationException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Sets::toList(a) returns a mutable list, unlike onion.Colls::toList") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |val xs = onion.Sets::toList(a)
+          |xs.add(4)
+          |return xs.size == 4
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Colls::toList(null) throws NullPointerException on a null Set") {
+      runBool(
+        """
+          |val n: Set[Int] = null
+          |try {
+          |  onion.Colls::toList(n)
+          |  return false
+          |} catch e: NullPointerException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Sets::toList(null) returns an empty list instead of throwing") {
+      runBool(
+        """
+          |return onion.Sets::toList(null).isEmpty()
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the toList() shadowing warning in the Sets Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("toList", "onion.Colls", "onion.Iterables", "E0006", "NullPointerException")
+
+    val jaMarkers =
+      Set("toList", "onion.Colls", "onion.Iterables", "E0006", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Sets Module section warns about toList() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Sets Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Sets Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Sets section warns about toList() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Sets モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Sets モジュール section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Colls` declares a `toList(Set)` extension with the same erased signature as `onion.Sets`'s, which would ordinarily just shadow it the way `union`/`intersection`/`difference`/`map` already are shadowed elsewhere in this module. But `Set` also conforms to `Iterable`, and `onion.Iterables` separately declares a `toList(Iterable)` extension — a genuinely different erasure that is also applicable to a `Set` argument.
- That makes `a.toList()` **ambiguous** between `Colls.toList()` and `Iterables.toList()`, so it fails to compile with `E0006` instead of silently resolving to either — unlike every other method this module documents as "also a builtin extension method."
- The static forms disagree with each other too: `Colls::toList` wraps its copy in `Collections.unmodifiableList` and throws `NullPointerException` for a `null` set; `Sets::toList` returns a plain mutable `ArrayList` and treats `null` as empty.
- Added the caveat to both docs' Sets Module section (English and Japanese) and a new `SetsToListExtensionCallShadowingSpec` regression test that locks in the E0006 compile failure (plus the static forms' mutability/null disagreement) and checks both docs for the warning.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.SetsToListExtensionCallShadowingSpec'` — all 7 tests pass
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — full suite green (5142 succeeded, 0 failed, 1 canceled — a pre-existing, unrelated distribution/packaging integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2T5pZfaHKYgex1cf4AhvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2T5pZfaHKYgex1cf4AhvP)_