### PR TITLE
docs(stdlib): document Sets::containsAll extension-call shadowing by native Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Sets::containsAll` extension-call shadowing by native `java.util.Set`
+  documented.** `java.util.Set` (via `java.util.Collection`) already declares
+  an instance method `containsAll(Collection)`, and an instance method always
+  wins over an extension method of the same name -- so `a.containsAll(b)`
+  never reaches `onion.Sets::containsAll` at all. The two disagree on `null`:
+  `onion.Sets::containsAll` is null-safe (a `null` subset means "contains
+  all," a `null` container means "contains none"), while native
+  `Set.containsAll` throws `NullPointerException` for a `null` argument.
+  Added the caveat to both docs' Sets Module section and a new
+  `SetsContainsAllExtensionCallShadowingSpec` regression test that locks in
+  the shadowing and checks both docs for the warning.
+
 - **`Sets::toList` extension-call ambiguity documented -- not shadowing, a
   compile error.** `onion.Colls` also declares a `toList(Set)` extension
   with the same erased signature as `onion.Sets`'s, which would ordinarily

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1506,8 +1506,8 @@ Sets::union(a, b) / Sets::intersection(a, b) / Sets::difference(a, b)  // 変更
 a.union(b) / a.intersection(b) / a.difference(b)  // onion.Colls 側の実装 -- 変更不可
 Sets::symmetricDifference(a, b)               // どちらか一方だけに含まれる
 a.symmetricDifference(b)
-Sets::containsAll(a, b)                       // a が b の要素をすべて含む
-a.containsAll(b)
+Sets::containsAll(a, b)                       // a が b の要素をすべて含む -- a.containsAll(b) では到達不可、下記参照
+a.containsAll(b)                              // java.util.Set のネイティブメソッド -- null で NullPointerException
 Sets::isSubsetOf(a, b) / Sets::isSupersetOf(a, b) / Sets::isDisjoint(a, b)
 a.isSubsetOf(b) / a.isSupersetOf(b) / a.isDisjoint(b)
 Sets::map(a, f)                               // NOT a.map(f) で到達不可 -- 下記参照
@@ -1529,6 +1529,17 @@ a.count(p) / a.any(p) / a.all(p)
 `NullPointerException` を投げますが、`Sets::map` は `LinkedHashSet`（挿入順保持）
 に集約し、`null` の Set には空の Set を返します。挿入順が保たれた null 安全な
 結果が必要な場合は `a.map(...)` ではなく `Sets::map(...)` を直接呼んでください。
+
+**`containsAll` のシャドーイング:** このリストの他のメソッドと異なり、
+`a.containsAll(b)` は `onion.Sets::containsAll` には一切到達しません --
+`java.util.Set`（`java.util.Collection` 由来）がすでにインスタンスメソッド
+`containsAll(Collection)` を宣言しており、拡張メソッドのフォールバック経路が
+参照される前に、インスタンスメソッドが常に優先されるためです。両者は `null`
+の扱いが異なります: `onion.Sets::containsAll` は null 安全（`null` の subset は
+「すべて含む」、`null` の container は「何も含まない」として扱う）ですが、
+ネイティブの `Set.containsAll` は `null` を渡すと `NullPointerException` を
+投げます。null 安全な結果が必要な場合は `a.containsAll(...)` ではなく
+`Sets::containsAll(...)` を直接呼んでください。
 
 ## Hash モジュール
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2529,10 +2529,26 @@ a.union(b)                             // onion.Colls's version instead -- unmod
 a.intersection(b)                      // onion.Colls's version instead -- unmodifiable
 a.difference(b)                        // onion.Colls's version instead -- unmodifiable
 Sets::symmetricDifference(a, b)        // a.symmetricDifference(b) -- in exactly one of the two
-Sets::containsAll(a, b)                // a.containsAll(b)
+Sets::containsAll(a, b)                // NOT a.containsAll(b) -- see the shadowing note below
 Sets::isSubsetOf(a, b)                 // a.isSubsetOf(b) -- every element of a is in b
 Sets::isSupersetOf(a, b)               // a.isSupersetOf(b)
 Sets::isDisjoint(a, b)                 // a.isDisjoint(b) -- share no elements
+```
+
+**Extension-call shadowing:** unlike every other method in this list, `a.containsAll(b)`
+does not reach `onion.Sets::containsAll` at all -- `java.util.Set` (via
+`java.util.Collection`) already declares an instance method `containsAll(Collection)`,
+and an instance method always wins over an extension method before the extension
+fallback path is even consulted. The two disagree on `null`: `onion.Sets::containsAll`
+is null-safe (a `null` subset means "contains all," a `null` container means "contains
+none"), while native `Set.containsAll` throws `NullPointerException` for a `null`
+argument. Call `Sets::containsAll(...)` directly (not `a.containsAll(...)`) to get
+`onion.Sets`'s null-safe result.
+
+```onion
+a.containsAll(b)                       // java.util.Set's native method -- throws NullPointerException on null
+Sets::containsAll(a, null)             // true -- onion.Sets's null-safe result
+Sets::containsAll(null, b)             // false -- onion.Sets's null-safe result
 ```
 
 ### Functional operations

--- a/src/test/scala/onion/compiler/tools/SetsContainsAllExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsContainsAllExtensionCallShadowingSpec.scala
@@ -1,0 +1,101 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Sets` declares `containsAll(Set, Set)` as a builtin extension method
+ * on `Set`, but an instance method always wins over an extension method of
+ * the same name -- and `java.util.Set` (via `java.util.Collection`) already
+ * defines `containsAll(Collection)`. So `a.containsAll(b)` silently reaches
+ * the *native JDK method* instead of `onion.Sets`'s, with different `null`
+ * semantics: `onion.Sets::containsAll` is null-safe (a `null` subset means
+ * "contains all," a `null` container means "contains none"), while native
+ * `Set.containsAll` throws `NullPointerException` for a `null` argument.
+ * This locks in that shadowing so a future change to extension-method
+ * resolution order doesn't silently flip it, and checks that both docs carry
+ * the warning (docs/reference/stdlib.md and its Japanese translation, Sets
+ * Module section).
+ */
+class SetsContainsAllExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "SetsContainsAllShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for containsAll() on a Set[Int] shadows onion.Sets") {
+    it("a.containsAll(null) throws NullPointerException (native Set.containsAll's behavior)") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |val n: Set[Int] = null
+          |try {
+          |  a.containsAll(n)
+          |  return false
+          |} catch e: NullPointerException {
+          |  return true
+          |}
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Sets::containsAll(a, null) returns true instead of throwing (null subset means \"contains all\")") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |return onion.Sets::containsAll(a, null)
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("onion.Sets::containsAll(null, b) returns false instead of throwing (null container means \"contains none\")") {
+      runBool(
+        """
+          |return onion.Sets::containsAll(null, onion.Sets::of(1))
+          |""".stripMargin,
+        Shell.Success(false))
+    }
+
+    it("non-null arguments agree between extension-call and static-call syntax") {
+      runBool(
+        """
+          |val a = onion.Sets::of(1, 2, 3)
+          |val b = onion.Sets::of(1, 2)
+          |return a.containsAll(b) && onion.Sets::containsAll(a, b)
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the containsAll() shadowing warning in the Sets Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers = Set("a.containsAll(", "java.util.Set", "NullPointerException")
+    val jaMarkers = Set("a.containsAll(", "java.util.Set", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Sets Module section warns about containsAll shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Sets Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Sets Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Sets section warns about containsAll shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Sets モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Sets section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `java.util.Set` (via `java.util.Collection`) already declares an instance method `containsAll(Collection)`, and an instance method always wins over an extension method of the same name — so `a.containsAll(b)` never reaches `onion.Sets::containsAll` at all, unlike every other method documented in the Sets Module's "Set algebra" section.
- The two disagree on `null`: `onion.Sets::containsAll` is null-safe (a `null` subset means "contains all," a `null` container means "contains none"), while native `Set.containsAll` throws `NullPointerException` for a `null` argument.
- Documents the caveat in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md` (Sets Module section), adds a `[Unreleased]` CHANGELOG entry, and adds a new `SetsContainsAllExtensionCallShadowingSpec` regression test that locks in the shadowing/null-handling divergence and checks both docs for the warning.

## Test plan
- [x] New spec `SetsContainsAllExtensionCallShadowingSpec` passes (verified red before the doc fix, green after)
- [x] Full suite green: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5148 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test unrelated to this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9xzFWLJmrUFro19uTtzze

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9xzFWLJmrUFro19uTtzze)_