### PR TITLE
docs(stdlib): document Iterables::first/last extension-call shadowing by onion.Colls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`Iterables::first`/`last` extension-call shadowing by `onion.Colls`
+  documented.** `onion.Colls` also declares `first(List)`/`last(List)`
+  extensions with the same erased signature as `onion.Iterables`'s, and
+  `Colls` is registered ahead of `Iterables` in the builtin extension
+  container list, so `xs.first()`/`xs.last()` always reach `onion.Colls`'s
+  versions -- `onion.Iterables`'s are never reachable by extension-call
+  syntax at all, same as the already-documented `map`/`filter`/`take`/
+  `drop`/`reverse`/`reduce` shadowing in that section. Unlike those, the two
+  implementations are identical, so the shadowing has no observable effect.
+  Added the caveat to both docs' Iterables Module section and a new
+  `IterablesFirstLastShadowingSpec` regression test that locks in the
+  agreement and checks both docs for the note.
+
 - **`Sets::containsAll` extension-call shadowing by native `java.util.Set`
   documented.** `java.util.Set` (via `java.util.Collection`) already declares
   an instance method `containsAll(Collection)`, and an instance method always

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1822,6 +1822,15 @@ xs.reduce(0, (acc, x) -> acc + x)                    // 6  （onion.Colls::reduc
 Iterables::reduce(xs, 0, (acc, x) -> acc + x)         // [E0001] operator + is not applicable for type Object, Int
 ```
 
+**`first`/`last` もシャドーイングされますが、無害です**: `onion.Colls` にも
+消去後シグネチャが同じ `first(List)`/`last(List)` 拡張メソッドがあり、
+`xs.first()`/`xs.last()` は常に *`onion.Colls`* 側に到達します --
+`onion.Iterables` 側の `first`/`last` は拡張呼び出し構文からは一切到達でき
+ません。このセクションの他の名前と違い、両者の実装は**同一**です
+（`list.isEmpty() ? null : list.get(0)`、末尾側も同様）。そのためシャドー
+イングされていても挙動に影響はなく、`xs.first()` は常に `Iterables::first(xs)`
+と等しく、`last` も同様です。
+
 ## Files モジュール
 
 ファイル I/O（`onion.Files`）:

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -924,6 +924,16 @@ xs.reduce(0, (acc, x) -> acc + x)                    // 6  (onion.Colls::reduce,
 Iterables::reduce(xs, 0, (acc, x) -> acc + x)         // [E0001] operator + is not applicable for type Object, Int
 ```
 
+**`first`/`last` are shadowed too, but harmlessly**: `onion.Colls` also
+declares `first(List)`/`last(List)` extensions with the same erased
+signature as `onion.Iterables`'s, so `xs.first()`/`xs.last()` always reach
+*`onion.Colls`*'s versions -- `onion.Iterables`'s `first`/`last` are never
+reachable by extension-call syntax at all. Unlike every other name in this
+section, the two containers' implementations are **identical**
+(`list.isEmpty() ? null : list.get(0)`, and the equivalent for the last
+index), so the shadowing has no observable effect: `xs.first()` always
+equals `Iterables::first(xs)`, and likewise for `last`.
+
 ## Option Module
 
 Provided via `onion.Option`.

--- a/src/test/scala/onion/compiler/tools/IterablesFirstLastShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IterablesFirstLastShadowingSpec.scala
@@ -1,0 +1,91 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * `onion.Colls::first(List)`/`last(List)` have the same erased signature as
+ * `onion.Iterables`'s `first(List)`/`last(List)`, and `Colls` is listed ahead
+ * of `Iterables` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`,
+ * so `xs.first()`/`xs.last()` always reach *`onion.Colls`*'s implementations --
+ * `onion.Iterables`'s versions of these two are never reachable by
+ * extension-call syntax at all, even though docs/reference/stdlib.md (and its
+ * Japanese translation) list them among the Iterables Module's plain chaining
+ * examples, right next to `take`/`drop`/`reverse`/`reduce` which the doc
+ * already flags as shadowed.
+ *
+ * Unlike those four, `Colls::first`/`last` and `Iterables::first`/`last` are
+ * implemented identically (`list.isEmpty() ? null : list.get(0)`, and the
+ * equivalent for the last index) -- so the shadowing has no observable
+ * runtime effect, and this spec locks in that harmlessness (both the
+ * extension call and the explicit `Iterables::` static call must always
+ * agree) rather than a behavioral disagreement, and checks that both docs
+ * carry a note saying so.
+ */
+class IterablesFirstLastShadowingSpec extends AbstractShellSpec {
+
+  private def run(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "IterablesFirstLastShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for first()/last() on a List[Int] shadows onion.Iterables harmlessly") {
+    it("xs.first() agrees with Iterables::first(xs) on a non-empty list") {
+      run(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |return xs.first() == Iterables::first(xs)
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("xs.last() agrees with Iterables::last(xs) on a non-empty list") {
+      run(
+        """
+          |val xs: List[Int] = [1, 2, 3]
+          |return xs.last() == Iterables::last(xs)
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+
+    it("xs.first() and xs.last() are both null on an empty list, same as Iterables::first/last") {
+      run(
+        """
+          |val xs: List[Int] = []
+          |return xs.first() == null && xs.last() == null && Iterables::first(xs) == null && Iterables::last(xs) == null
+          |""".stripMargin,
+        Shell.Success(true))
+    }
+  }
+
+  describe("docs carry the first()/last() shadowing note in the Iterables Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers = Set("xs.first(", "xs.last(", "onion.Colls", "identical")
+    val jaMarkers = Set("xs.first(", "xs.last(", "onion.Colls", "同一")
+
+    it("docs/reference/stdlib.md's Iterables Module section notes first()/last() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Iterables Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Iterables Module section is missing first()/last() shadowing markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Iterables section notes first()/last() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Iterables モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Iterables モジュール section is missing first()/last() shadowing markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Colls` also declares `first(List)`/`last(List)` extensions with the same erased signature as `onion.Iterables`'s, and `Colls` is registered ahead of `Iterables` in `ExtensionMethodFallbackSupport.BuiltinExtensionContainers`, so `xs.first()`/`xs.last()` always reach `onion.Colls`'s versions — `onion.Iterables`'s are never reachable by extension-call syntax at all. This is the same mechanism already documented for `map`/`filter`/`take`/`drop`/`reverse`/`reduce` in that section, but was missed for `first`/`last`.
- Unlike those other cases, `Colls::first`/`last` and `Iterables::first`/`last` are implemented identically (`list.isEmpty() ? null : list.get(0)`, equivalent for the last index), so the shadowing has no observable runtime effect — this PR documents that it happens, and that it's harmless.
- Added the caveat to both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Iterables Module section, a `CHANGELOG.md` entry, and a new `IterablesFirstLastShadowingSpec` regression test (locks in the agreement between the extension call and the explicit `Iterables::` static call, and checks both docs carry the note).

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5153 tests, 0 failed, 1 canceled (pre-existing, environment-dependent `dist` test unrelated to this change)
- [x] New spec verified red (missing doc markers / no shadowing note) before the doc changes, green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4UsNBRfbxjfcdTrXbqRwu

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4UsNBRfbxjfcdTrXbqRwu)_