### PR TITLE
Fix incorrect getOrDefault claim in Maps Module docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Fixed an incorrect `getOrDefault` claim in the Maps Module docs.**
+  `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md` claimed
+  `onion.Colls`, `onion.Maps`, and native `java.util.Map` all behave
+  identically for `m.getOrDefault(k, d)` extension-call syntax. That's
+  only true for a non-null receiver: `java.util.Map` already declares an
+  instance `getOrDefault`, so the extension call always reaches the
+  *native* method -- which throws `NullPointerException` for a
+  platform-typed `null` map, unlike `onion.Maps::getOrDefault`'s
+  null-safe default-returning behavior. Same shadowing hazard already
+  documented for `values()`/`contains()`/`isEmpty()` elsewhere in these
+  docs; added the caveat and a regression case to
+  `MapsExtensionCallShadowingSpec`.
+
 - **`Iterables::first`/`last` extension-call shadowing by `onion.Colls`
   documented.** `onion.Colls` also declares `first(List)`/`last(List)`
   extensions with the same erased signature as `onion.Iterables`'s, and

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1427,10 +1427,20 @@ map を裏で参照する *ライブビュー* を返すため、そのビュー
 `Colls` の変更不可スナップショットにも `Maps::values` の変更可能な
 `ArrayList` スナップショットにも存在しません。直接呼んだ
 `Maps::keys`/`values`/`mapValues` は通常の **変更可能**な
-`ArrayList`/`LinkedHashMap` を返します。`getOrDefault` はこれらの影響を
-受けません -- `java.util.Map` も同じ2引数の `getOrDefault` を宣言している
-ため、これもネイティブメソッドに解決されますが、拡張メソッドとして
-呼び出せる Map に対しては3つの実装とも結果は同じです。
+`ArrayList`/`LinkedHashMap` を返します。`getOrDefault` も `values()` と
+同様にシャドーイングされます -- `java.util.Map` も同じ2引数の
+`getOrDefault` を宣言しているため、`m.getOrDefault(k, d)` はどちらの
+拡張メソッドでもなくネイティブメソッドに解決されます。レシーバが
+非 null であればこれは見えません（ネイティブメソッドと両方の拡張実装が
+一致するため）。実行時には `null` だがコンパイル時にはチェックされて
+いなかったレシーバ（CLAUDE.md でいう「プラットフォーム型」-- 型引数の
+無い Java 相互運用から読み戻された値はコンパイル時の null 許容性
+追跡を持たない）に対しては、この違いが表面化します: `onion.Maps::getOrDefault`
+は null 安全（map が `null` ならデフォルト値を返す）ですが、同じ
+null な map に対する `m.getOrDefault(k, d)` はネイティブメソッドに
+到達し、代わりに `NullPointerException` を投げます -- null かもしれない
+値には `Maps::getOrDefault(...)` を直接呼んで null 安全な挙動を得て
+ください。
 
 ```onion
 val m: Map[String, Int] = Maps::newMap()

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2423,11 +2423,20 @@ that one call but for an unrelated reason -- the live-view aliasing has
 no equivalent in either `Colls`'s unmodifiable snapshot or
 `Maps::values`'s mutable `ArrayList` snapshot. `Maps::keys`/`values`/
 `mapValues` called directly return a plain mutable
-`ArrayList`/`LinkedHashMap`. `getOrDefault` is unaffected by any of this
--- `java.util.Map` also declares a matching two-arg `getOrDefault`, so it
-too resolves to the native method rather than an extension, but all three
-implementations behave identically for any map you can actually call an
-extension method on.
+`ArrayList`/`LinkedHashMap`. `getOrDefault` shadows the same way as
+`values()` -- `java.util.Map` also declares a matching two-arg
+`getOrDefault`, so `m.getOrDefault(k, d)` resolves to the native method
+rather than either extension too. For a non-null receiver that is
+invisible, since the native method and both extensions agree. It becomes
+observable for a receiver that is `null` at runtime but was never checked
+at compile time -- a "platform type" (per CLAUDE.md) read back from
+unparameterized Java interop carries no compile-time nullability
+tracking, so Onion's null-safety typechecking does not force a null check
+first. `onion.Maps::getOrDefault` is null-safe (a `null` map returns the
+default), but `m.getOrDefault(k, d)` on that same null map reaches the
+native method and throws `NullPointerException` instead -- call
+`Maps::getOrDefault(...)` directly to get the null-safe behavior on a
+value that might be null.
 
 ### Transformation
 

--- a/src/test/scala/onion/compiler/tools/MapsExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapsExtensionCallShadowingSpec.scala
@@ -21,11 +21,25 @@ import onion.tools.Shell
  * no-arg `values()` instance method, so `m.values()` reaches the *native*
  * `java.util.Map.values()` -- a live view over the map, not a snapshot from
  * either `Colls` or `Maps`. `Maps::keys`/`values`/`mapValues` called
- * directly return a plain mutable `ArrayList`/`LinkedHashMap`. This locks
- * in that shadowing so a future reordering of `BuiltinExtensionContainers`
- * doesn't silently flip it, and checks that both docs carry the warning
- * (docs/reference/stdlib.md and its Japanese translation, Maps Module
- * section).
+ * directly return a plain mutable `ArrayList`/`LinkedHashMap`.
+ *
+ * `getOrDefault(Map, K, V)` shadows the same way as `values()`: `Map`
+ * already declares a matching two-arg instance `getOrDefault`, so
+ * `m.getOrDefault(k, d)` reaches the *native* method rather than either
+ * extension container. For a non-null receiver that is invisible, since
+ * the native method and both extension versions agree. It becomes
+ * observable for a receiver that is `null` at runtime but was never
+ * checked at compile time (a "platform type", per CLAUDE.md, with no
+ * compile-time nullability tracking): `onion.Maps::getOrDefault` is
+ * null-safe (`map == null` returns the default), but the native method
+ * extension-call syntax actually reaches throws `NullPointerException`
+ * instead -- the same hazard `StringsContainsIsEmptyExtensionCallShadowingSpec`
+ * documents for `String#contains`/`isEmpty`.
+ *
+ * This locks in that shadowing so a future reordering of
+ * `BuiltinExtensionContainers` doesn't silently flip it, and checks that
+ * both docs carry the warning (docs/reference/stdlib.md and its Japanese
+ * translation, Maps Module section).
  */
 class MapsExtensionCallShadowingSpec extends AbstractShellSpec {
 
@@ -88,12 +102,32 @@ class MapsExtensionCallShadowingSpec extends AbstractShellSpec {
         Shell.Success("{a=2, b=4}"))
     }
 
-    it("non-colliding Maps methods behave identically via extension-call and static-call syntax") {
+    it("m.getOrDefault(k, d) on a non-null Map agrees with the static Maps:: form (native method, both extensions concur)") {
       run(
         "val m: Map[String, Int] = [\"a\": 1]\n    return m.getOrDefault(\"x\", 0).toString()",
         Shell.Success("0"))
       run(
         "val m: Map[String, Int] = [\"a\": 1]\n    return Maps::getOrDefault(m, \"x\", 0).toString()",
+        Shell.Success("0"))
+    }
+
+    it("m.getOrDefault(k, d) on a null platform Map reaches the native Map.getOrDefault and throws NullPointerException") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val outer: HashMap[String, Map[String, Int]] = new HashMap[String, Map[String, Int]]\n" +
+          "    val m: Map[String, Int] = outer.get(\"missing\") as Map[String, Int]\n" +
+          "    return m.getOrDefault(\"x\", 0)\n  }\n}\n",
+          "MapsShadowGetOrDefaultNpe.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+
+    it("Maps::getOrDefault(m, k, d) on the same null platform Map is null-safe and returns the default instead") {
+      run(
+        "val outer: HashMap[String, Map[String, Int]] = new HashMap[String, Map[String, Int]]\n" +
+        "    val m: Map[String, Int] = outer.get(\"missing\") as Map[String, Int]\n" +
+        "    return Maps::getOrDefault(m, \"x\", 0).toString()",
         Shell.Success("0"))
     }
   }
@@ -112,19 +146,21 @@ class MapsExtensionCallShadowingSpec extends AbstractShellSpec {
     }
 
     val enMarkers =
-      Set("m.keys(", "m.values(", "m.mapValues(", "onion.Colls", "unmodifiable")
+      Set("m.keys(", "m.values(", "m.mapValues(", "onion.Colls", "unmodifiable",
+        "getOrDefault", "platform")
 
     val jaMarkers =
-      Set("m.keys(", "m.values(", "m.mapValues(", "onion.Colls")
+      Set("m.keys(", "m.values(", "m.mapValues(", "onion.Colls",
+        "getOrDefault", "プラットフォーム")
 
-    it("docs/reference/stdlib.md's Maps Module section warns about keys()/values()/mapValues() shadowing") {
+    it("docs/reference/stdlib.md's Maps Module section warns about keys()/values()/mapValues()/getOrDefault() shadowing") {
       val doc = section(read("docs/reference/stdlib.md"), "## Maps Module")
       val missing = enMarkers.filterNot(doc.contains)
       assert(missing.isEmpty,
         s"docs/reference/stdlib.md's Maps Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
     }
 
-    it("docs/ja/reference/stdlib.md's Maps section warns about keys()/values()/mapValues() shadowing") {
+    it("docs/ja/reference/stdlib.md's Maps section warns about keys()/values()/mapValues()/getOrDefault() shadowing") {
       val doc = section(read("docs/ja/reference/stdlib.md"), "## Maps モジュール")
       val missing = jaMarkers.filterNot(doc.contains)
       assert(missing.isEmpty,


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`'s Maps Module section claimed `onion.Colls`, `onion.Maps`, and native `java.util.Map` all behave identically for `m.getOrDefault(k, d)` called via extension-call syntax. That's only true for a non-null receiver: `java.util.Map` already declares an instance `getOrDefault`, so the extension call always reaches the *native* method, which throws `NullPointerException` for a platform-typed `null` map — unlike `onion.Maps::getOrDefault`'s null-safe default-returning behavior. Same hazard already documented elsewhere in these docs for `values()`/`contains()`/`isEmpty()`.
- Extended `MapsExtensionCallShadowingSpec` with the null-receiver regression (NPE via extension-call syntax vs. safe default via the static form) and doc-parity assertions, following the existing `*ExtensionCallShadowingSpec` pattern.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5155 succeeded, 0 failed, 1 canceled (pre-existing/unrelated), all green.
- [x] New spec cases verified red-before-fix (doc-marker assertions failed against the unpatched docs) and green-after-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwaWEW89Q7S58nhHENhJmc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwaWEW89Q7S58nhHENhJmc)_