### PR TITLE
docs(stdlib): fix false Strings trim/startsWith/indexOf extension-call claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Fixed a false "identical behavior" claim for `Strings::trim`/`startsWith`/
+  `indexOf` extension-call syntax.** `docs/reference/stdlib.md`/
+  `docs/ja/reference/stdlib.md` listed `trim`, `startsWith` and `indexOf`
+  as examples of `onion.Strings` methods that work identically via
+  extension-call syntax (`s.trim()`, `s.startsWith(...)`, `s.indexOf(...)`).
+  That's false in general: `java.lang.String` already declares instance
+  methods with these same names, and an instance method always wins over an
+  extension method of the same name, so these three always reach the
+  *native* method -- which throws `NullPointerException` for a
+  platform-typed `null` receiver, unlike `onion.Strings`'s null-safe
+  static-call form. Same shadowing hazard already documented for
+  `contains`/`isEmpty` a few paragraphs below; removed the three from the
+  "identical behavior" example list, added the caveat, and added a
+  regression case to a new `StringsTrimStartsWithIndexOfExtensionCallShadowingSpec`.
+
 - **Fixed an incorrect `getOrDefault` claim in the Maps Module docs.**
   `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md` claimed
   `onion.Colls`, `onion.Maps`, and native `java.util.Map` all behave

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1338,9 +1338,9 @@ Strings::toIntOrNull("42") / Strings::toLongOrNull("100") / Strings::toDoubleOrN
 Strings::toIntOr("nope", 0)              // 0
 ```
 
-`Strings` の大半のメソッド（`upper`、`trim`、`startsWith`、`indexOf`、
-`capitalize` など）は拡張メソッドのメソッドチェーン（`s.upper()`、
-`s.trim()` など）としても静的呼び出しと同じ挙動で使えます。**例外は
+`Strings` の大半のメソッド（`upper`、`lower`、`capitalize`、`reverse`
+など）は拡張メソッドのメソッドチェーン（`s.upper()`、`s.reverse()`
+など）としても静的呼び出しと同じ挙動で使えます。**例外は
 `split`・`substring`・`lines`・`chars`・`repeat` の5つ**です。
 `java.lang.String` にはすでに同名のメソッドが定義されており、同名の
 インスタンスメソッドは常に拡張メソッドより優先されるため、
@@ -1383,6 +1383,20 @@ JDK 側のメソッドから `NullPointerException` を投げますが、
 `Strings::contains(null, x) == false`）です。受け手が未検査の
 プラットフォーム `null` になり得る場合は `Strings::contains(...)` /
 `Strings::isEmpty(...)` の静的呼び出し形式を使ってください。
+
+**`trim`・`startsWith`・`indexOf` も同様に遮蔽されます**:
+`java.lang.String` にはすでに `trim()`・`startsWith(String)`・
+`indexOf(String)` というインスタンスメソッドが定義されているため、
+`s.trim()`・`s.startsWith(x)`・`s.indexOf(x)` も `onion.Strings` 側
+ではなく **JDK 標準の同名メソッド** を暗黙のうちに呼び出します。
+上の `contains`/`isEmpty` と同様、`null` でない `String` では見分けが
+付かず、差が表面化するのはプラットフォーム型の `null` を受け手にした
+場合だけです: このとき JDK 側のメソッドは `NullPointerException` を
+投げますが、`onion.Strings` の版は null 安全です
+（`Strings::trim(null) == ""`、`Strings::startsWith(null, x) == false`、
+`Strings::indexOf(null, x) == -1`）。受け手が未検査のプラットフォーム
+`null` になり得る場合は `Strings::trim(...)` / `Strings::startsWith(...)`
+/ `Strings::indexOf(...)` の静的呼び出し形式を使ってください。
 
 **`isBlank` も遮蔽されますが、`null` を渡さない通常の `String` でも
 挙動差が表面化します**: `java.lang.String` には Java 11 以降

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1313,9 +1313,9 @@ Strings::toLongOrNull("100") / Strings::toDoubleOrNull("3.14")
 Strings::toIntOr("nope", 0)              // 0
 ```
 
-Most `Strings` methods (`upper`, `trim`, `startsWith`, `indexOf`, `capitalize`,
-...) also work as extension-call method chains (`s.upper()`, `s.trim()`, ...)
-with identical behavior to the static form. **`split`, `substring`, `lines`,
+Most `Strings` methods (`upper`, `lower`, `capitalize`, `reverse`, ...) also
+work as extension-call method chains (`s.upper()`, `s.reverse()`, ...) with
+identical behavior to the static form. **`split`, `substring`, `lines`,
 `chars` and `repeat` are the exception**: `java.lang.String` already defines
 methods with these same names, and an instance method always wins over an
 extension method of the same name, so `s.split(",")`, `s.substring(1)`,
@@ -1356,6 +1356,19 @@ the native method, while `onion.Strings`'s versions are null-safe
 (`Strings::isEmpty(null) == true`, `Strings::contains(null, x) ==
 false`). Use the `Strings::contains(...)` / `Strings::isEmpty(...)`
 static-call form when the receiver may be an unchecked platform `null`.
+
+**`trim`, `startsWith` and `indexOf` are shadowed the same way**:
+`java.lang.String` already defines `trim()`, `startsWith(String)` and
+`indexOf(String)` instance methods, so `s.trim()`, `s.startsWith(x)` and
+`s.indexOf(x)` also silently reach the *native JDK method* instead of
+`onion.Strings`'s. As with `contains`/`isEmpty` above, this is invisible for
+a non-null `String` and only becomes observable for a platform-typed `null`
+receiver, where the native methods throw `NullPointerException` while
+`onion.Strings`'s versions are null-safe (`Strings::trim(null) == ""`,
+`Strings::startsWith(null, x) == false`, `Strings::indexOf(null, x) ==
+-1`). Use the `Strings::trim(...)` / `Strings::startsWith(...)` /
+`Strings::indexOf(...)` static-call form when the receiver may be an
+unchecked platform `null`.
 
 **`isBlank` is shadowed too, and observably so even on an ordinary non-null
 `String`**: `java.lang.String` has defined an `isBlank()` instance method

--- a/src/test/scala/onion/compiler/tools/StringsTrimStartsWithIndexOfExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsTrimStartsWithIndexOfExtensionCallShadowingSpec.scala
@@ -1,0 +1,136 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `docs/reference/stdlib.md`'s Strings Module section claims `trim`,
+ * `startsWith` and `indexOf` are among the `onion.Strings` methods that
+ * "also work as extension-call method chains... with identical behavior to
+ * the static form." That is false: `java.lang.String` already defines
+ * instance methods with these same names (`trim()`, `startsWith(String)`,
+ * `indexOf(String)`), and an instance method always wins over an extension
+ * method of the same name -- the same hazard already documented for
+ * `contains`/`isEmpty` a few paragraphs below in the same section.
+ *
+ * For a non-null receiver the native method and `onion.Strings`'s agree, so
+ * the shadowing is invisible there. It becomes observable for a receiver
+ * that is `null` at runtime but was never checked at compile time: a value
+ * read back from unparameterized Java interop (a "platform type", per
+ * CLAUDE.md) carries no compile-time nullability tracking, so Onion's
+ * null-safety typechecking does not force a null check before
+ * `.trim()`/`.startsWith(...)`/`.indexOf(...)` on it. `onion.Strings`'s
+ * versions are null-safe (`trim(null) == ""`, `startsWith(null, x) ==
+ * false`, `indexOf(null, x) == -1`); the native methods that extension-call
+ * syntax actually reaches throw `NullPointerException` instead (dispatching
+ * any instance method on a null receiver throws, regardless of which
+ * method). Locks in the shadowing and checks that both docs carry an
+ * accurate warning instead of the false "identical behavior" claim
+ * (docs/reference/stdlib.md and its Japanese translation, Strings Module
+ * section).
+ */
+class StringsTrimStartsWithIndexOfExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def nullPlatformString: String =
+    """
+      |val m: HashMap[String, String] = new HashMap[String, String]
+      |val s: String = m.get("missing") as String
+      |""".stripMargin
+
+  private def runStr(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): String {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsTrimShadowStr.on", Array()))
+  }
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsTrimShadowBool.on", Array()))
+  }
+
+  private def runInt(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Int {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsTrimShadowInt.on", Array()))
+  }
+
+  private def expectNpe(body: String, fileName: String): Unit = {
+    val thrown = intercept[ScriptException] {
+      shell.run(
+        "class Test {\npublic:\n  static def main(args: String[]): void {\n" + body + "\n  }\n}\n",
+        fileName, Array())
+    }
+    assert(thrown.getCause.isInstanceOf[NullPointerException])
+  }
+
+  describe("extension-call syntax for trim()/startsWith()/indexOf() on a null platform String shadows onion.Strings") {
+    it("s.trim() on a null platform String reaches the native String.trim and throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.trim()\n", "StringsTrimShadowNpe.on")
+    }
+
+    it("Strings::trim(s) on the same null platform String is null-safe and returns \"\" instead") {
+      runStr(nullPlatformString + "    return Strings::trim(s)", Shell.Success(""))
+    }
+
+    it("s.startsWith(x) on a null platform String reaches the native String.startsWith and throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.startsWith(\"x\")\n", "StringsStartsWithShadowNpe.on")
+    }
+
+    it("Strings::startsWith(s, x) on the same null platform String is null-safe and returns false instead") {
+      runBool(nullPlatformString + "    return Strings::startsWith(s, \"x\")", Shell.Success(false))
+    }
+
+    it("s.indexOf(x) on a null platform String reaches the native String.indexOf and throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.indexOf(\"x\")\n", "StringsIndexOfShadowNpe.on")
+    }
+
+    it("Strings::indexOf(s, x) on the same null platform String is null-safe and returns -1 instead") {
+      runInt(nullPlatformString + "    return Strings::indexOf(s, \"x\")", Shell.Success(-1))
+    }
+
+    it("for a non-null receiver, extension-call and static-call syntax agree") {
+      runStr("return \"  hi  \".trim()", Shell.Success("hi"))
+      runBool("return \"hello\".startsWith(\"he\")", Shell.Success(true))
+      runInt("return \"hello\".indexOf(\"l\")", Shell.Success(2))
+    }
+  }
+
+  describe("docs carry an accurate trim()/startsWith()/indexOf() shadowing warning in the Strings Module section, not the false \"identical behavior\" claim") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("s.trim()", "s.startsWith(", "s.indexOf(", "NullPointerException")
+
+    val jaMarkers =
+      Set("s.trim()", "s.startsWith(", "s.indexOf(", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Strings Module section warns about trim()/startsWith()/indexOf() shadowing, and no longer claims identical behavior for them") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Strings Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+      assert(!doc.contains("`trim`, `startsWith`, `indexOf`"),
+        "docs/reference/stdlib.md still lists trim/startsWith/indexOf as having \"identical behavior\" via extension-call syntax")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about trim()/startsWith()/indexOf() shadowing, and no longer claims identical behavior for them") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Strings section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+      assert(!doc.contains("`trim`、`startsWith`、`indexOf`"),
+        "docs/ja/reference/stdlib.md still lists trim/startsWith/indexOf as having identical behavior via extension-call syntax")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md` claimed `trim`, `startsWith` and `indexOf` are among the `onion.Strings` methods that work "with identical behavior" via extension-call syntax (`s.trim()`, `s.startsWith(...)`, `s.indexOf(...)`). That's false: `java.lang.String` already declares instance methods with these same names, and an instance method always wins over an extension method of the same name, so all three calls always reach the *native* method — which throws `NullPointerException` for a platform-typed `null` receiver, unlike `onion.Strings`'s null-safe static-call form (`trim(null) == ""`, `startsWith(null, x) == false`, `indexOf(null, x) == -1`). This is the same shadowing hazard already documented for `contains`/`isEmpty` a few paragraphs below in the same section.
- Removed `trim`/`startsWith`/`indexOf` from the "identical behavior" example list (replaced with non-colliding examples: `lower`, `capitalize`, `reverse`) and added an accurate caveat paragraph to both docs, mirroring the existing `contains`/`isEmpty` note.
- Added `StringsTrimStartsWithIndexOfExtensionCallShadowingSpec` covering the null-platform-receiver divergence and locking in that both docs carry the caveat instead of the false claim.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] New spec passes: `sbt -Duser.language=en 'testOnly onion.compiler.tools.StringsTrimStartsWithIndexOfExtensionCallShadowingSpec'`
- [x] Related Strings shadowing/doc-parity specs still pass (`StringsExtensionCallShadowingSpec`, `StringsContainsIsEmptyExtensionCallShadowingSpec`, `StringsIsBlankExtensionCallShadowingSpec`, `StdlibDocStringsModuleParitySpec`, `StdlibDocStringsAccessorParitySpec`)
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5164 succeeded, 0 failed (1 canceled: `ProjectDistributionSpec`'s opt-in dist smoke test, requires `-Donion.dist.path=...`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019daXV175A7ufsjMQD5Xo9E

---
_Generated by [Claude Code](https://claude.ai/code/session_019daXV175A7ufsjMQD5Xo9E)_