### PR TITLE
docs(stdlib): document Strings::endsWith extension-call shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented `Strings::endsWith` extension-call shadowing by native
+  `java.lang.String`.** `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`
+  omitted `endsWith` from the exception list of `onion.Strings` methods
+  that behave differently via extension-call syntax, even though
+  `java.lang.String` already declares an instance `endsWith(String)`
+  method that always wins over the extension method of the same name --
+  the exact shadowing hazard already documented for its sibling
+  `startsWith` a few paragraphs below. `s.endsWith(x)` reaches the
+  *native* method and throws `NullPointerException` for a platform-typed
+  `null` receiver, unlike `onion.Strings::endsWith`'s null-safe
+  false-returning static-call form. Folded `endsWith` into the existing
+  `trim`/`startsWith`/`indexOf` shadowing paragraph and added a
+  regression case in a new
+  `StringsEndsWithExtensionCallShadowingSpec`.
+
 - **Fixed a false "identical behavior" claim for `Strings::trim`/`startsWith`/
   `indexOf` extension-call syntax.** `docs/reference/stdlib.md`/
   `docs/ja/reference/stdlib.md` listed `trim`, `startsWith` and `indexOf`

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1384,18 +1384,19 @@ JDK 側のメソッドから `NullPointerException` を投げますが、
 プラットフォーム `null` になり得る場合は `Strings::contains(...)` /
 `Strings::isEmpty(...)` の静的呼び出し形式を使ってください。
 
-**`trim`・`startsWith`・`indexOf` も同様に遮蔽されます**:
+**`trim`・`startsWith`・`endsWith`・`indexOf` も同様に遮蔽されます**:
 `java.lang.String` にはすでに `trim()`・`startsWith(String)`・
-`indexOf(String)` というインスタンスメソッドが定義されているため、
-`s.trim()`・`s.startsWith(x)`・`s.indexOf(x)` も `onion.Strings` 側
-ではなく **JDK 標準の同名メソッド** を暗黙のうちに呼び出します。
-上の `contains`/`isEmpty` と同様、`null` でない `String` では見分けが
-付かず、差が表面化するのはプラットフォーム型の `null` を受け手にした
-場合だけです: このとき JDK 側のメソッドは `NullPointerException` を
-投げますが、`onion.Strings` の版は null 安全です
+`endsWith(String)`・`indexOf(String)` というインスタンスメソッドが
+定義されているため、`s.trim()`・`s.startsWith(x)`・`s.endsWith(x)`・
+`s.indexOf(x)` も `onion.Strings` 側ではなく **JDK 標準の同名メソッド**
+を暗黙のうちに呼び出します。上の `contains`/`isEmpty` と同様、`null`
+でない `String` では見分けが付かず、差が表面化するのはプラットフォーム型の
+`null` を受け手にした場合だけです: このとき JDK 側のメソッドは
+`NullPointerException` を投げますが、`onion.Strings` の版は null 安全です
 （`Strings::trim(null) == ""`、`Strings::startsWith(null, x) == false`、
-`Strings::indexOf(null, x) == -1`）。受け手が未検査のプラットフォーム
-`null` になり得る場合は `Strings::trim(...)` / `Strings::startsWith(...)`
+`Strings::endsWith(null, x) == false`、`Strings::indexOf(null, x) ==
+-1`）。受け手が未検査のプラットフォーム `null` になり得る場合は
+`Strings::trim(...)` / `Strings::startsWith(...)` / `Strings::endsWith(...)`
 / `Strings::indexOf(...)` の静的呼び出し形式を使ってください。
 
 **`isBlank` も遮蔽されますが、`null` を渡さない通常の `String` でも

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1357,16 +1357,18 @@ the native method, while `onion.Strings`'s versions are null-safe
 false`). Use the `Strings::contains(...)` / `Strings::isEmpty(...)`
 static-call form when the receiver may be an unchecked platform `null`.
 
-**`trim`, `startsWith` and `indexOf` are shadowed the same way**:
-`java.lang.String` already defines `trim()`, `startsWith(String)` and
-`indexOf(String)` instance methods, so `s.trim()`, `s.startsWith(x)` and
-`s.indexOf(x)` also silently reach the *native JDK method* instead of
-`onion.Strings`'s. As with `contains`/`isEmpty` above, this is invisible for
-a non-null `String` and only becomes observable for a platform-typed `null`
-receiver, where the native methods throw `NullPointerException` while
-`onion.Strings`'s versions are null-safe (`Strings::trim(null) == ""`,
-`Strings::startsWith(null, x) == false`, `Strings::indexOf(null, x) ==
--1`). Use the `Strings::trim(...)` / `Strings::startsWith(...)` /
+**`trim`, `startsWith`, `endsWith` and `indexOf` are shadowed the same way**:
+`java.lang.String` already defines `trim()`, `startsWith(String)`,
+`endsWith(String)` and `indexOf(String)` instance methods, so `s.trim()`,
+`s.startsWith(x)`, `s.endsWith(x)` and `s.indexOf(x)` also silently reach
+the *native JDK method* instead of `onion.Strings`'s. As with
+`contains`/`isEmpty` above, this is invisible for a non-null `String` and
+only becomes observable for a platform-typed `null` receiver, where the
+native methods throw `NullPointerException` while `onion.Strings`'s
+versions are null-safe (`Strings::trim(null) == ""`,
+`Strings::startsWith(null, x) == false`, `Strings::endsWith(null, x) ==
+false`, `Strings::indexOf(null, x) == -1`). Use the `Strings::trim(...)` /
+`Strings::startsWith(...)` / `Strings::endsWith(...)` /
 `Strings::indexOf(...)` static-call form when the receiver may be an
 unchecked platform `null`.
 

--- a/src/test/scala/onion/compiler/tools/StringsEndsWithExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsEndsWithExtensionCallShadowingSpec.scala
@@ -1,0 +1,96 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `docs/reference/stdlib.md`'s Strings Module section lists `endsWith`
+ * alongside `startsWith`/`contains` in the static-call examples, but the
+ * "also work as extension-call method chains... with identical behavior to
+ * the static form" paragraph's exception list omitted it -- even though
+ * `java.lang.String` already defines an `endsWith(String)` instance method,
+ * the exact same shadowing hazard already documented for its sibling
+ * `startsWith` (and `trim`/`indexOf`) a few paragraphs below in the same
+ * section.
+ *
+ * For a non-null receiver the native method and `onion.Strings`'s agree, so
+ * the shadowing is invisible there. It becomes observable for a receiver
+ * that is `null` at runtime but was never checked at compile time: a value
+ * read back from unparameterized Java interop (a "platform type", per
+ * CLAUDE.md) carries no compile-time nullability tracking, so Onion's
+ * null-safety typechecking does not force a null check before
+ * `.endsWith(...)` on it. `onion.Strings::endsWith` is null-safe
+ * (`endsWith(null, x) == false`); the native method that extension-call
+ * syntax actually reaches throws `NullPointerException` instead. Locks in
+ * the shadowing and checks that both docs carry an accurate warning
+ * (docs/reference/stdlib.md and its Japanese translation, Strings Module
+ * section).
+ */
+class StringsEndsWithExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def nullPlatformString: String =
+    """
+      |val m: HashMap[String, String] = new HashMap[String, String]
+      |val s: String = m.get("missing") as String
+      |""".stripMargin
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsEndsWithShadowBool.on", Array()))
+  }
+
+  private def expectNpe(body: String, fileName: String): Unit = {
+    val thrown = intercept[ScriptException] {
+      shell.run(
+        "class Test {\npublic:\n  static def main(args: String[]): void {\n" + body + "\n  }\n}\n",
+        fileName, Array())
+    }
+    assert(thrown.getCause.isInstanceOf[NullPointerException])
+  }
+
+  describe("extension-call syntax for endsWith() on a null platform String shadows onion.Strings") {
+    it("s.endsWith(x) on a null platform String reaches the native String.endsWith and throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.endsWith(\"x\")\n", "StringsEndsWithShadowNpe.on")
+    }
+
+    it("Strings::endsWith(s, x) on the same null platform String is null-safe and returns false instead") {
+      runBool(nullPlatformString + "    return Strings::endsWith(s, \"x\")", Shell.Success(false))
+    }
+
+    it("for a non-null receiver, extension-call and static-call syntax agree") {
+      runBool("return \"hello\".endsWith(\"lo\")", Shell.Success(true))
+      runBool("return Strings::endsWith(\"hello\", \"lo\")", Shell.Success(true))
+    }
+  }
+
+  describe("docs carry an accurate endsWith() shadowing warning in the Strings Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    it("docs/reference/stdlib.md's Strings Module section warns about endsWith() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      assert(doc.contains("s.endsWith("),
+        "docs/reference/stdlib.md's Strings Module section is missing an endsWith() shadowing-warning marker")
+      assert(doc.contains("NullPointerException"),
+        "docs/reference/stdlib.md's Strings Module section is missing a NullPointerException marker")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about endsWith() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      assert(doc.contains("s.endsWith("),
+        "docs/ja/reference/stdlib.md's Strings section is missing an endsWith() shadowing-warning marker")
+      assert(doc.contains("NullPointerException"),
+        "docs/ja/reference/stdlib.md's Strings section is missing a NullPointerException marker")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md` / `docs/ja/reference/stdlib.md` omitted `endsWith` from the exception list of `onion.Strings` methods that behave differently via extension-call syntax, even though `java.lang.String` already declares an instance `endsWith(String)` method that always wins over the extension method of the same name — the exact shadowing hazard already documented for its sibling `startsWith` a few paragraphs below.
- `s.endsWith(x)` reaches the *native* method and throws `NullPointerException` for a platform-typed `null` receiver, unlike `onion.Strings::endsWith`'s null-safe false-returning static-call form.
- Folded `endsWith` into the existing `trim`/`startsWith`/`indexOf` shadowing paragraph in both docs and added a CHANGELOG entry.

## Test plan
- [x] Added `src/test/scala/onion/compiler/tools/StringsEndsWithExtensionCallShadowingSpec.scala`, locking in the `NullPointerException` via extension-call syntax vs. the null-safe static-call form, plus a doc-content check for both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5169 succeeded, 0 failed, 1 pre-existing environmental cancellation (network-dependent distribution e2e test, unrelated to this change).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4JhnWLMqvoJLwfe4AH5E1

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4JhnWLMqvoJLwfe4AH5E1)_