### PR TITLE
docs(stdlib): document Iterables::sort(comparator) extension-call shadowing by native List.sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented `Iterables::sort`'s two-arg form extension-call shadowing by
+  native `java.util.List`.** `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`
+  listed `xs.sort() / xs.sort(comparator)` together as plain `onion.Iterables`
+  chaining examples, but `java.util.List` already declares an instance method
+  `sort(Comparator)`, and an instance method always wins over an extension
+  method of the same name -- so `xs.sort(comparator)` never reaches
+  `Iterables::sort(List, Comparator)` at all. Unlike the runtime-only edge
+  cases documented for `map`/`filter`/`take`/`drop`/`reverse` nearby, this one
+  is a compile-time trap: native `List.sort` mutates its receiver in place and
+  returns `void`, while `Iterables::sort` returns a new sorted copy, so
+  `val ys = xs.sort(comparator)` fails to compile with E0000 ("type Object is
+  expected, but type void is used") instead of doing what the docs implied.
+  The no-arg form is unaffected (`List` declares no no-arg `sort()`). Added
+  the caveat to both docs' Iterables Module section and a new
+  `IterablesSortShadowingSpec` regression test.
+
 - **Documented `Strings::endsWith` extension-call shadowing by native
   `java.lang.String`.** `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`
   omitted `endsWith` from the exception list of `onion.Strings` methods

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1856,6 +1856,28 @@ Iterables::reduce(xs, 0, (acc, x) -> acc + x)         // [E0001] operator + is n
 イングされていても挙動に影響はなく、`xs.first()` は常に `Iterables::first(xs)`
 と等しく、`last` も同様です。
 
+**`sort` の2引数版もシャドーイングされますが、これまでのどれよりも深刻です**:
+`java.util.List` は既にインスタンスメソッド `sort(Comparator)`（Java 8 以降の
+デフォルトメソッド）を宣言しており、インスタンスメソッドは同名の拡張メソッド
+に常に優先するため、`xs.sort(comparator)` は `onion.Iterables::sort(List,
+Comparator)` に一切到達しません。これは実行時のエッジケースにとどまりません:
+ネイティブの `List.sort` はレシーバを**破壊的に（in place で）**ソートして
+`void` を返しますが、`Iterables::sort` はレシーバに触れず**新しい**ソート済み
+`List` を返します。そのため `xs.sort(comparator)` は使い捨ての文としては問題
+なくコンパイルできます（`xs` を破壊的にソートするだけです）が、その結果を値
+として使おうとした瞬間にコンパイルエラーになります:
+
+```onion
+val xs: List[Int] = [3, 1, 2]
+xs.sort((a, b) -> a - b)              // xs は [1, 2, 3] に -- ネイティブ List.sort、in place
+val ys = xs.sort((a, b) -> a - b)     // [E0000] type Object is expected, but type void is used
+Iterables::sort(xs, (a, b) -> a - b)  // ok -- 新しいソート済みコピー、xs は変化しない
+```
+
+引数無しの形は影響を受けません: `List` は引数無しの `sort()` を宣言していない
+ため、`xs.sort()` は常に `Iterables::sort(List)` に到達し、上記の通り新しい
+ソート済みコピーを返します。
+
 ## Files モジュール
 
 ファイル I/O（`onion.Files`）:

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -934,6 +934,28 @@ section, the two containers' implementations are **identical**
 index), so the shadowing has no observable effect: `xs.first()` always
 equals `Iterables::first(xs)`, and likewise for `last`.
 
+**`sort`'s two-arg form is shadowed too, harder than any of the above**:
+`java.util.List` already declares an instance method `sort(Comparator)` (a
+default method since Java 8), and an instance method always wins over an
+extension method of the same name -- so `xs.sort(comparator)` never reaches
+`onion.Iterables::sort(List, Comparator)` at all. This isn't just a runtime
+edge case: native `List.sort` mutates the receiver **in place** and returns
+`void`, while `Iterables::sort` leaves the receiver untouched and returns a
+**new** sorted `List`. So `xs.sort(comparator)` compiles fine as a bare,
+unused statement (it destructively sorts `xs`), but fails to compile the
+moment its result is used as a value:
+
+```onion
+val xs: List[Int] = [3, 1, 2]
+xs.sort((a, b) -> a - b)              // xs is now [1, 2, 3] -- native List.sort, in place
+val ys = xs.sort((a, b) -> a - b)     // [E0000] type Object is expected, but type void is used
+Iterables::sort(xs, (a, b) -> a - b)  // ok -- new sorted copy, xs untouched
+```
+
+The no-arg form is unaffected: `List` declares no no-arg `sort()`, so
+`xs.sort()` always reaches `Iterables::sort(List)` and returns a new sorted
+copy, exactly as shown above.
+
 ## Option Module
 
 Provided via `onion.Option`.

--- a/src/test/scala/onion/compiler/tools/IterablesSortShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IterablesSortShadowingSpec.scala
@@ -1,0 +1,128 @@
+package onion.compiler.tools
+
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
+import onion.tools.Shell
+import java.io.StringReader
+
+/**
+ * `java.util.List` already declares an instance method `sort(Comparator)`
+ * (a default method since Java 8), and an instance method always wins over
+ * an extension method of the same name, so `xs.sort(comparator)` never
+ * reaches `onion.Iterables::sort(List, Comparator)` at all -- even though
+ * docs/reference/stdlib.md (and its Japanese translation) list
+ * `xs.sort() / xs.sort(comparator)` together as plain `Iterables` chaining
+ * examples without calling out the shadowing for the two-arg form.
+ *
+ * Unlike the runtime-only edge cases documented for `map`/`filter`/`take`/
+ * `drop`/`reverse` elsewhere in this section, this one is visible at
+ * *compile time*: native `List.sort` mutates its receiver in place and
+ * returns `void`, while `Iterables::sort` leaves the receiver untouched and
+ * returns a new sorted `List`. So `xs.sort(comparator)` compiles fine as an
+ * unused statement (destructively sorting `xs`), but fails to compile with
+ * E0000 the moment its result is used as a value. The no-arg form is
+ * unaffected: `List` declares no no-arg `sort()`, so `xs.sort()` still
+ * reaches `Iterables::sort(List)` and returns a new sorted copy.
+ */
+class IterablesSortShadowingSpec extends AbstractShellSpec {
+
+  private def errorCodes(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.flatMap(_.errorCode)
+      case _ => Seq.empty
+    }
+  }
+
+  describe("extension-call syntax for sort(comparator) on a List[Int] shadows onion.Iterables") {
+    it("xs.sort(comparator) as a bare statement mutates xs in place (native List.sort)") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs: List[Int] = [3, 1, 2]
+          |    xs.sort((a, b) -> a - b)
+          |    return xs[0] * 100 + xs[1] * 10 + xs[2]
+          |  }
+          |}
+          |""".stripMargin, "IterablesSortShadowStatement.on", Array())
+      assert(Shell.Success(123) == result)
+    }
+
+    it("val ys = xs.sort(comparator) fails to compile -- native List.sort returns void (E0000)") {
+      assert(errorCodes(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs: List[Int] = [3, 1, 2]
+          |    val ys = xs.sort((a, b) -> a - b)
+          |    return 0
+          |  }
+          |}
+          |""".stripMargin
+      ).contains("E0000"))
+    }
+
+    it("Iterables::sort(xs, comparator) returns a new sorted copy, leaving xs untouched") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs: List[Int] = [3, 1, 2]
+          |    val ys = Iterables::sort(xs, (a, b) -> a - b)
+          |    return xs[0] * 1000 + ys[0] * 100 + ys[1] * 10 + ys[2]
+          |  }
+          |}
+          |""".stripMargin, "IterablesSortStaticCall.on", Array())
+      assert(Shell.Success(3123) == result)
+    }
+
+    it("xs.sort() (no-arg) is unaffected by the shadowing and returns a new sorted copy") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val xs: List[Int] = [3, 1, 2]
+          |    val ys = xs.sort()
+          |    return xs[0] * 1000 + ys[0] * 100 + ys[1] * 10 + ys[2]
+          |  }
+          |}
+          |""".stripMargin, "IterablesSortNoArg.on", Array())
+      assert(Shell.Success(3123) == result)
+    }
+  }
+
+  describe("docs carry the sort(comparator) shadowing warning in the Iterables Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers = Set("sort", "List.sort", "E0000")
+    val jaMarkers = Set("sort", "List.sort", "E0000")
+
+    it("docs/reference/stdlib.md's Iterables Module section warns about sort(comparator) shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Iterables Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Iterables Module section is missing sort()-shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Iterables section warns about sort(comparator) shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Iterables モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Iterables モジュール section is missing sort()-shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `java.util.List` already declares an instance method `sort(Comparator)` (a default method since Java 8), and an instance method always wins over an extension method of the same name — so `xs.sort(comparator)` never reaches `Iterables::sort(List, Comparator)` at all.
- Unlike the runtime-only edge cases already documented nearby for `map`/`filter`/`take`/`drop`/`reverse`, this is a compile-time trap: native `List.sort` mutates its receiver **in place** and returns `void`, while `Iterables::sort` returns a **new** sorted copy. So `val ys = xs.sort(comparator)` fails to compile with `E0000` ("type Object is expected, but type void is used") instead of doing what the docs implied.
- The no-arg form (`xs.sort()`) is unaffected — `List` declares no no-arg `sort()`.
- Added the caveat to both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`'s Iterables Module sections, a `CHANGELOG.md` entry, and a new `IterablesSortShadowingSpec` regression test (verifies the runtime behavior, the E0000 compile failure, and that both docs carry the warning).

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5179 tests, 0 failed, 1 canceled (pre-existing, opt-in dist smoke test requiring `-Donion.dist.path`)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 5179 tests, 0 failed, 1 canceled (same)
- [x] New `IterablesSortShadowingSpec` (6 assertions) run in isolation and as part of the full suite above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHXcdqVAwPLb5kgQe43fe8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHXcdqVAwPLb5kgQe43fe8)_