### PR TITLE
docs(stdlib): document Colls isEmpty/size/get/containsKey extension calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented `Colls`'s `isEmpty`/`size`/`get`/`containsKey` extension-call
+  spellings, and closed a false-coverage gap in `CollsDocCoverageSpec`.**
+  `onion.Colls` declares `isEmpty(Collection)`, `size(Collection)`,
+  `get(Map, K)` and `containsKey(Map, K)`, registered as builtin extensions
+  the same as the rest of the module, but none of the four was ever shown
+  as `Colls`-backed usage in either `docs/reference/stdlib.md`'s or
+  `docs/ja/reference/stdlib.md`'s Colls Module section. `CollsDocCoverageSpec`
+  claims to check "every onion.Colls member" but only ever looks for a name
+  anywhere in the whole file, so this gap passed silently: `isEmpty`, `get`
+  and `size` are common enough words to appear elsewhere in the docs for
+  unrelated reasons, and `containsKey` already appears once, in the
+  unrelated `java.util.HashMap` interop example. Added the four calls to
+  both docs' Colls Module section (noting that, like several methods
+  already documented elsewhere, an instance method on `List`/`Set`/`Map`
+  always wins over an extension method of the same name, so these four
+  never actually reach `onion.Colls`'s versions -- unobservable here since
+  `Colls`'s implementations are one-line pass-throughs to the same native
+  method) and added a section-scoped regression check to
+  `CollsDocCoverageSpec` that pins their presence, so the whole-file check's
+  false coverage cannot hide this again.
+
 - **Documented `Iterables::sort`'s two-arg form extension-call shadowing by
   native `java.util.List`.** `docs/reference/stdlib.md`/`docs/ja/reference/stdlib.md`
   listed `xs.sort() / xs.sort(comparator)` together as plain `onion.Iterables`

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -2015,8 +2015,18 @@ xs.forEach { x -> println(x) }    // 各要素に対して処理を実行、戻�
 xs.count { x -> x > 1 }           // 条件を満たす要素の数
 xs.reverse()                      // 要素を逆順にした新しい List
 xs.contains(2)                    // いずれかの要素が2と等しければ true
+xs.isEmpty()                      // 要素が1つもなければ true
+xs.size()                         // 要素数
+m.get("key")                      // "key" に対応する値、なければ null
+m.containsKey("key")              // "key" というエントリがあれば true
 Colls::toList(args)               // Java配列（例: main の String[]）を List に変換
 ```
+
+`isEmpty`・`size`・`get`・`containsKey` は `List`/`Set`/`Map` 自体のインスタンス
+メソッドでもあり、インスタンスメソッドは常に同名の拡張メソッドより優先される
+ため、この4つの呼び出しは実際には `onion.Colls` 側には決して届かず、ネイティブ
+側のメソッドにしか届かない。ただしこれは観測できない差異である: `Colls` 側の
+実装はどれも同じネイティブメソッドへの1行委譲でしかないため。
 
 ### バッチ化・ウィンドウ化・セレクタ集計
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1886,8 +1886,18 @@ xs.forEach { x -> println(x) }    // runs an action per element, returns nothing
 xs.count { x -> x > 1 }           // how many elements match
 xs.reverse()                      // new List, elements in reverse order
 xs.contains(2)                    // true if some element equals 2
+xs.isEmpty()                      // true if xs has no elements
+xs.size()                         // element count
+m.get("key")                      // value for "key", or null if absent
+m.containsKey("key")              // true if the map has a "key" entry
 Colls::toList(args)               // a Java array (e.g. main's String[]) as a List
 ```
+
+`isEmpty`, `size`, `get` and `containsKey` are also plain instance methods on
+`List`/`Set`/`Map`, which always win over an extension method of the same name --
+so these four calls never actually reach `onion.Colls`'s versions, only the
+native ones. That is not observable here: `Colls`'s implementations are
+one-line pass-throughs to the same native method.
 
 ### Batching, windowing, and selector aggregation
 

--- a/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
@@ -125,6 +125,36 @@ class CollsDocCoverageSpec extends AnyFunSpec {
   }
 
   /**
+   * `isEmpty(Collection)`, `size(Collection)`, `get(Map, K)` and `containsKey(Map, K)` are
+   * real `onion.Colls` members, registered as builtin extensions the same as everything
+   * else in this file -- but the whole-file checks above miss their absence entirely by
+   * coincidence: `isEmpty`, `get` and `size` are common enough words to appear all over the
+   * doc for unrelated reasons, and `containsKey` is shown once already, in the unrelated
+   * `java.util.HashMap` interop example earlier in the file. None of the four is ever shown
+   * as Colls-backed usage in the Colls Module section itself. Pin their presence there, so
+   * this guard's "documents every onion.Colls member" claim is no longer only accidentally
+   * true for these.
+   */
+  private val collectionAndMapUtilityNames = Set("isEmpty", "size", "get", "containsKey")
+
+  private def documentedCollectionAndMapCalls(doc: String, names: Set[String]): Set[String] =
+    names.filter(n => doc.contains(s"xs.$n(") || doc.contains(s"m.$n("))
+
+  it("docs/reference/stdlib.md's Colls Module section documents isEmpty/size/get/containsKey") {
+    val doc = collsSection(read("docs/reference/stdlib.md"), "## Colls Module")
+    val missing = collectionAndMapUtilityNames -- documentedCollectionAndMapCalls(doc, collectionAndMapUtilityNames)
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md's Colls Module section is missing: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md's Colls section documents isEmpty/size/get/containsKey") {
+    val doc = collsSection(read("docs/ja/reference/stdlib.md"), "## Colls モジュール")
+    val missing = collectionAndMapUtilityNames -- documentedCollectionAndMapCalls(doc, collectionAndMapUtilityNames)
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md's Colls section is missing: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  /**
    * `Colls::toList(array)` -- converting a Java array (e.g. `main(args: String[])`) into a
    * `List` -- is the one crossing point CLAUDE.md itself calls out ("Use Colls::toList(args)
    * to cross over"), but neither doc file ever showed the call.


### PR DESCRIPTION
## Summary

- `onion.Colls` declares `isEmpty(Collection)`, `size(Collection)`, `get(Map, K)` and `containsKey(Map, K)` as builtin extensions, but none of the four was ever shown as `Colls`-backed usage in either `docs/reference/stdlib.md`'s or `docs/ja/reference/stdlib.md`'s Colls Module section.
- `CollsDocCoverageSpec` claims to check "every onion.Colls member" but only searches for a name anywhere in the whole file, so this gap passed silently: `isEmpty`, `get` and `size` are common enough words to appear elsewhere in the docs for unrelated reasons, and `containsKey` already appears once, in the unrelated `java.util.HashMap` interop example.
- Added the four calls to both docs' Colls Module section, noting (like several methods already documented elsewhere in this file) that an instance method on `List`/`Set`/`Map` always wins over an extension method of the same name, so these four never actually reach `onion.Colls`'s versions — unobservable here since `Colls`'s implementations are one-line pass-throughs to the same native method.
- Added a section-scoped regression check to `CollsDocCoverageSpec` (mirroring its existing `listPredicateAndQueryNames` pattern) that pins the four names' presence within the Colls Module section itself, so the whole-file check's false coverage can't hide this gap again.

## Test plan

- [x] Added the new section-scoped test first and confirmed it failed red before the doc changes.
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.CollsDocCoverageSpec'` — green after the doc fix.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5181 succeeded, 0 failed, 1 canceled (pre-existing environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtaVnsPm5P9QqbxAyxxQYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtaVnsPm5P9QqbxAyxxQYE)_