### PR TITLE
docs(stdlib): document Colls::contains native-shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented that `Colls::contains` is also native-shadowed, alongside
+  `isEmpty`/`size`/`get`/`containsKey`.** The Colls Module section's
+  shadowing-explanation paragraph said instance methods on `List`/`Set`/`Map`
+  always win over an extension method of the same name for "`isEmpty`,
+  `size`, `get` and `containsKey`" ("these four calls"), but `contains` is
+  shadowed by `Collection.contains(Object)` the exact same way and was left
+  out of that list in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`, even though the code example right above it
+  already showed `xs.contains(2)`. Added `contains` to both paragraphs and a
+  `CollsDocCoverageSpec` regression pinning that the explanation names it.
+
 - **Documented `Colls`'s `isEmpty`/`size`/`get`/`containsKey` extension-call
   spellings, and closed a false-coverage gap in `CollsDocCoverageSpec`.**
   `onion.Colls` declares `isEmpty(Collection)`, `size(Collection)`,

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -2022,9 +2022,9 @@ m.containsKey("key")              // "key" というエントリがあれば tru
 Colls::toList(args)               // Java配列（例: main の String[]）を List に変換
 ```
 
-`isEmpty`・`size`・`get`・`containsKey` は `List`/`Set`/`Map` 自体のインスタンス
+`contains`・`isEmpty`・`size`・`get`・`containsKey` は `List`/`Set`/`Map` 自体のインスタンス
 メソッドでもあり、インスタンスメソッドは常に同名の拡張メソッドより優先される
-ため、この4つの呼び出しは実際には `onion.Colls` 側には決して届かず、ネイティブ
+ため、この5つの呼び出しは実際には `onion.Colls` 側には決して届かず、ネイティブ
 側のメソッドにしか届かない。ただしこれは観測できない差異である: `Colls` 側の
 実装はどれも同じネイティブメソッドへの1行委譲でしかないため。
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1893,9 +1893,9 @@ m.containsKey("key")              // true if the map has a "key" entry
 Colls::toList(args)               // a Java array (e.g. main's String[]) as a List
 ```
 
-`isEmpty`, `size`, `get` and `containsKey` are also plain instance methods on
+`contains`, `isEmpty`, `size`, `get` and `containsKey` are also plain instance methods on
 `List`/`Set`/`Map`, which always win over an extension method of the same name --
-so these four calls never actually reach `onion.Colls`'s versions, only the
+so these five calls never actually reach `onion.Colls`'s versions, only the
 native ones. That is not observable here: `Colls`'s implementations are
 one-line pass-throughs to the same native method.
 

--- a/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CollsDocCoverageSpec.scala
@@ -155,6 +155,30 @@ class CollsDocCoverageSpec extends AnyFunSpec {
   }
 
   /**
+   * `contains(Collection<T>, T)` is, like `isEmpty`/`size`/`get`/`containsKey` above, a
+   * one-line pass-through to the identically-named native instance method
+   * (`Collection.contains(Object)`), which always wins over the `onion.Colls` extension --
+   * but the shadowing-explanation paragraph right after the code block names only
+   * "isEmpty, size, get and containsKey" ("these four calls"), omitting `contains` even
+   * though it is shadowed the exact same way. Pin that `contains` is named in the
+   * explanation itself (not merely shown as a call, which the whole-file check and the
+   * `listPredicateAndQueryNames` guard above already pin) so this omission cannot recur.
+   */
+  it("docs/reference/stdlib.md's Colls Module section names contains in the native-shadowing explanation") {
+    val doc = collsSection(read("docs/reference/stdlib.md"), "## Colls Module")
+    assert(doc.contains("`contains`"),
+      "docs/reference/stdlib.md's Colls Module section's shadowing explanation should name `contains` " +
+        "alongside isEmpty/size/get/containsKey -- it is shadowed by Collection.contains(Object) the same way")
+  }
+
+  it("docs/ja/reference/stdlib.md's Colls section names contains in the native-shadowing explanation") {
+    val doc = collsSection(read("docs/ja/reference/stdlib.md"), "## Colls モジュール")
+    assert(doc.contains("`contains`"),
+      "docs/ja/reference/stdlib.md's Colls section's shadowing explanation should name `contains` " +
+        "alongside isEmpty/size/get/containsKey -- it is shadowed by Collection.contains(Object) the same way")
+  }
+
+  /**
    * `Colls::toList(array)` -- converting a Java array (e.g. `main(args: String[])`) into a
    * `List` -- is the one crossing point CLAUDE.md itself calls out ("Use Colls::toList(args)
    * to cross over"), but neither doc file ever showed the call.


### PR DESCRIPTION
## Summary

- The Colls Module section's shadowing-explanation paragraph said instance methods on `List`/`Set`/`Map` always win over an extension method of the same name for "`isEmpty`, `size`, `get` and `containsKey`" ("these four calls"), but `Colls::contains(Collection<T>, T)` is a one-line pass-through to `Collection.contains(Object)`, shadowed the exact same way — and was left out of that sentence in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, even though the code example directly above it already showed `xs.contains(2)`.
- Added `contains` to both paragraphs ("these five calls") and a `CollsDocCoverageSpec` regression pinning that the explanation names it, so this specific omission cannot recur.
- Added a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.CollsDocCoverageSpec'` — confirmed red before the doc fix (2 new assertions failed), green after.
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — full suite: 5183 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011GkpQftv4Yn3ayPaaRgsnr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GkpQftv4Yn3ayPaaRgsnr

---
_Generated by [Claude Code](https://claude.ai/code/session_011GkpQftv4Yn3ayPaaRgsnr)_