### PR TITLE
docs(stdlib): document Strings::replace extension-call shadowing by native String.replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented that `Strings::replace`'s extension-call form is shadowed by
+  native `String.replace`, closing a gap in the "identical behavior" claim.**
+  The Strings Module section's opening paragraph claims most `Strings`
+  methods "also work as extension-call method chains ... with identical
+  behavior to the static form," but `java.lang.String` already declares an
+  instance method `replace(CharSequence, CharSequence)`, and an instance
+  method always wins over an extension method of the same name -- the same
+  hazard already documented for `trim`/`startsWith`/`endsWith`/`indexOf` in
+  the same section. `s.replace(a, b)` on a platform-typed `null` receiver
+  throws `NullPointerException` from the native method, while
+  `Strings::replace(null, a, b)` is null-safe and returns `""`. Added
+  `replace` to the `trim`/`startsWith`/`endsWith`/`indexOf` shadowing
+  paragraph in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`, and a new
+  `StringsReplaceExtensionCallShadowingSpec` regression test.
+
 - **Documented that `Colls::contains` is also native-shadowed, alongside
   `isEmpty`/`size`/`get`/`containsKey`.** The Colls Module section's
   shadowing-explanation paragraph said instance methods on `List`/`Set`/`Map`

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1384,20 +1384,23 @@ JDK 側のメソッドから `NullPointerException` を投げますが、
 プラットフォーム `null` になり得る場合は `Strings::contains(...)` /
 `Strings::isEmpty(...)` の静的呼び出し形式を使ってください。
 
-**`trim`・`startsWith`・`endsWith`・`indexOf` も同様に遮蔽されます**:
-`java.lang.String` にはすでに `trim()`・`startsWith(String)`・
-`endsWith(String)`・`indexOf(String)` というインスタンスメソッドが
-定義されているため、`s.trim()`・`s.startsWith(x)`・`s.endsWith(x)`・
-`s.indexOf(x)` も `onion.Strings` 側ではなく **JDK 標準の同名メソッド**
+**`trim`・`startsWith`・`endsWith`・`indexOf`・`replace` も同様に遮蔽され
+ます**: `java.lang.String` にはすでに `trim()`・`startsWith(String)`・
+`endsWith(String)`・`indexOf(String)`・`replace(CharSequence,
+CharSequence)` というインスタンスメソッドが定義されているため、
+`s.trim()`・`s.startsWith(x)`・`s.endsWith(x)`・`s.indexOf(x)`・
+`s.replace(a, b)` も `onion.Strings` 側ではなく **JDK 標準の同名メソッド**
 を暗黙のうちに呼び出します。上の `contains`/`isEmpty` と同様、`null`
 でない `String` では見分けが付かず、差が表面化するのはプラットフォーム型の
 `null` を受け手にした場合だけです: このとき JDK 側のメソッドは
 `NullPointerException` を投げますが、`onion.Strings` の版は null 安全です
 （`Strings::trim(null) == ""`、`Strings::startsWith(null, x) == false`、
 `Strings::endsWith(null, x) == false`、`Strings::indexOf(null, x) ==
--1`）。受け手が未検査のプラットフォーム `null` になり得る場合は
-`Strings::trim(...)` / `Strings::startsWith(...)` / `Strings::endsWith(...)`
-/ `Strings::indexOf(...)` の静的呼び出し形式を使ってください。
+-1`、`Strings::replace(null, a, b) == ""`）。受け手が未検査の
+プラットフォーム `null` になり得る場合は `Strings::trim(...)` /
+`Strings::startsWith(...)` / `Strings::endsWith(...)` /
+`Strings::indexOf(...)` / `Strings::replace(...)` の静的呼び出し形式を
+使ってください。
 
 **`isBlank` も遮蔽されますが、`null` を渡さない通常の `String` でも
 挙動差が表面化します**: `java.lang.String` には Java 11 以降

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1379,20 +1379,21 @@ the native method, while `onion.Strings`'s versions are null-safe
 false`). Use the `Strings::contains(...)` / `Strings::isEmpty(...)`
 static-call form when the receiver may be an unchecked platform `null`.
 
-**`trim`, `startsWith`, `endsWith` and `indexOf` are shadowed the same way**:
-`java.lang.String` already defines `trim()`, `startsWith(String)`,
-`endsWith(String)` and `indexOf(String)` instance methods, so `s.trim()`,
-`s.startsWith(x)`, `s.endsWith(x)` and `s.indexOf(x)` also silently reach
-the *native JDK method* instead of `onion.Strings`'s. As with
-`contains`/`isEmpty` above, this is invisible for a non-null `String` and
-only becomes observable for a platform-typed `null` receiver, where the
-native methods throw `NullPointerException` while `onion.Strings`'s
-versions are null-safe (`Strings::trim(null) == ""`,
+**`trim`, `startsWith`, `endsWith`, `indexOf` and `replace` are shadowed the
+same way**: `java.lang.String` already defines `trim()`,
+`startsWith(String)`, `endsWith(String)`, `indexOf(String)` and
+`replace(CharSequence, CharSequence)` instance methods, so `s.trim()`,
+`s.startsWith(x)`, `s.endsWith(x)`, `s.indexOf(x)` and `s.replace(a, b)`
+also silently reach the *native JDK method* instead of `onion.Strings`'s.
+As with `contains`/`isEmpty` above, this is invisible for a non-null
+`String` and only becomes observable for a platform-typed `null` receiver,
+where the native methods throw `NullPointerException` while
+`onion.Strings`'s versions are null-safe (`Strings::trim(null) == ""`,
 `Strings::startsWith(null, x) == false`, `Strings::endsWith(null, x) ==
-false`, `Strings::indexOf(null, x) == -1`). Use the `Strings::trim(...)` /
-`Strings::startsWith(...)` / `Strings::endsWith(...)` /
-`Strings::indexOf(...)` static-call form when the receiver may be an
-unchecked platform `null`.
+false`, `Strings::indexOf(null, x) == -1`, `Strings::replace(null, a, b) ==
+""`). Use the `Strings::trim(...)` / `Strings::startsWith(...)` /
+`Strings::endsWith(...)` / `Strings::indexOf(...)` / `Strings::replace(...)`
+static-call form when the receiver may be an unchecked platform `null`.
 
 **`isBlank` is shadowed too, and observably so even on an ordinary non-null
 `String`**: `java.lang.String` has defined an `isBlank()` instance method

--- a/src/test/scala/onion/compiler/tools/StringsReplaceExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsReplaceExtensionCallShadowingSpec.scala
@@ -1,0 +1,99 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `docs/reference/stdlib.md`'s Strings Module section opens by claiming
+ * "most `Strings` methods ... also work as extension-call method chains
+ * ... with identical behavior to the static form," and never lists
+ * `replace` among the documented exceptions (`split`/`substring`/`lines`/
+ * `chars`/`repeat`, `join`, `contains`/`isEmpty`, `trim`/`startsWith`/
+ * `endsWith`/`indexOf`, `isBlank`). That is false: `java.lang.String`
+ * already defines an instance method `replace(CharSequence, CharSequence)`,
+ * and an instance method always wins over an extension method of the same
+ * name -- the same hazard already documented for `trim`/`startsWith`/
+ * `endsWith`/`indexOf` a few paragraphs below in the same section.
+ *
+ * For a non-null receiver the native method and `onion.Strings`'s agree, so
+ * the shadowing is invisible there. It becomes observable for a receiver
+ * that is `null` at runtime but was never checked at compile time: a value
+ * read back from unparameterized Java interop (a "platform type", per
+ * CLAUDE.md) carries no compile-time nullability tracking, so Onion's
+ * null-safety typechecking does not force a null check before
+ * `.replace(...)` on it. `onion.Strings::replace(null, ...)` is null-safe
+ * (returns `""`); the native method that extension-call syntax actually
+ * reaches throws `NullPointerException` instead (dispatching any instance
+ * method on a null receiver throws, regardless of which method). Locks in
+ * the shadowing and checks that both docs carry an accurate warning
+ * (docs/reference/stdlib.md and its Japanese translation, Strings Module
+ * section).
+ */
+class StringsReplaceExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def nullPlatformString: String =
+    """
+      |val m: HashMap[String, String] = new HashMap[String, String]
+      |val s: String = m.get("missing") as String
+      |""".stripMargin
+
+  private def runStr(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): String {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsReplaceShadowStr.on", Array()))
+  }
+
+  private def expectNpe(body: String, fileName: String): Unit = {
+    val thrown = intercept[ScriptException] {
+      shell.run(
+        "class Test {\npublic:\n  static def main(args: String[]): void {\n" + body + "\n  }\n}\n",
+        fileName, Array())
+    }
+    assert(thrown.getCause.isInstanceOf[NullPointerException])
+  }
+
+  describe("extension-call syntax for replace() on a null platform String shadows onion.Strings") {
+    it("s.replace(a, b) on a null platform String reaches the native String.replace and throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.replace(\"a\", \"b\")\n", "StringsReplaceShadowNpe.on")
+    }
+
+    it("Strings::replace(s, a, b) on the same null platform String is null-safe and returns \"\" instead") {
+      runStr(nullPlatformString + "    return Strings::replace(s, \"a\", \"b\")", Shell.Success(""))
+    }
+
+    it("for a non-null receiver, extension-call and static-call syntax agree") {
+      runStr("return \"banana\".replace(\"a\", \"o\")", Shell.Success("bonono"))
+      runStr("return Strings::replace(\"banana\", \"a\", \"o\")", Shell.Success("bonono"))
+    }
+  }
+
+  describe("docs carry an accurate replace() shadowing warning in the Strings Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    it("docs/reference/stdlib.md's Strings Module section warns about replace() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      assert(doc.contains("`replace`"),
+        "docs/reference/stdlib.md's Strings Module section does not mention replace() shadowing at all")
+      assert(doc.contains("s.replace("),
+        "docs/reference/stdlib.md's Strings Module section is missing an s.replace(...) shadowing example")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about replace() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      assert(doc.contains("`replace`"),
+        "docs/ja/reference/stdlib.md's Strings section does not mention replace() shadowing at all")
+      assert(doc.contains("s.replace("),
+        "docs/ja/reference/stdlib.md's Strings section is missing an s.replace(...) shadowing example")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md`'s Strings Module section opens by claiming most `Strings` methods "also work as extension-call method chains ... with identical behavior to the static form," and lists several documented exceptions (`split`/`substring`/`lines`/`chars`/`repeat`, `join`, `contains`/`isEmpty`, `trim`/`startsWith`/`endsWith`/`indexOf`, `isBlank`) — but never `replace`.
- `java.lang.String` already declares an instance method `replace(CharSequence, CharSequence)`, and an instance method always wins over an `onion.Strings` extension method of the same name — the same hazard already documented for `trim`/`startsWith`/`endsWith`/`indexOf` a few lines below in the same section.
- For a non-null receiver both agree. It becomes observable for a platform-typed `null` receiver (a value read back from unparameterized Java interop, with no compile-time nullability tracking): `s.replace(a, b)` reaches the native method and throws `NullPointerException`, while `Strings::replace(null, a, b)` is null-safe and returns `""`.
- Added `replace` to the existing `trim`/`startsWith`/`endsWith`/`indexOf` shadowing paragraph in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, plus a new `StringsReplaceExtensionCallShadowingSpec` regression test (modeled on the existing `StringsTrimStartsWithIndexOfExtensionCallShadowingSpec`) that pins both the runtime behavior and the doc text.

## Test plan

- [x] `StringsReplaceExtensionCallShadowingSpec` written first and confirmed red (doc-coverage assertions failed while behavior assertions already passed, proving the gap)
- [x] Docs updated, spec confirmed green (5/5)
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5188 tests, 0 failed, 1 canceled, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXUne2dUtWRB8BeUtGRUbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXUne2dUtWRB8BeUtGRUbD)_