### PR TITLE
docs: document Map.forEach() extension-call shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Documented that `Maps::forEach`'s extension-call form is shadowed by
+  native `Map.forEach`.** `java.util.Map` already declares a default
+  instance method `forEach(BiConsumer)` (Java 8+), and instance-method
+  resolution always wins over the extension fallback, so `m.forEach(action)`
+  silently reaches the native method instead of `onion.Maps::forEach` -- the
+  same shadowing pattern already documented for `getOrDefault` in the same
+  section. This is invisible on a non-null `Map`, but on a null
+  platform-typed `Map` the native method throws `NullPointerException`
+  while `Maps::forEach(...)` is a null-safe no-op. Added the note to the
+  Maps Module section of both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`, and a new `MapsForEachShadowingSpec`
+  regression test.
+
 ## [0.54.0] - 2026-09-05
 
 ### Documentation

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1458,7 +1458,19 @@ map を裏で参照する *ライブビュー* を返すため、そのビュー
 null な map に対する `m.getOrDefault(k, d)` はネイティブメソッドに
 到達し、代わりに `NullPointerException` を投げます -- null かもしれない
 値には `Maps::getOrDefault(...)` を直接呼んで null 安全な挙動を得て
-ください。
+ください。`forEach` も同様にシャドーイングされます -- `java.util.Map` も
+同じ形の default メソッド `forEach(BiConsumer)`（Java 8 以降）を宣言して
+いるため、2引数の Onion ラムダは `onion.Maps::forEach` の `Function2` と
+同様に `BiConsumer` へ SAM 変換され、`m.forEach(action)` は
+`onion.Maps::forEach` ではなく **ネイティブの `java.util.Map.forEach`** に
+到達します。レシーバが非 null であればこれは見えません（どちらも
+反復順序ですべての (key, value) ペアを処理するため）。実行時には
+`null` だがコンパイル時にはチェックされていなかったレシーバ（上記と
+同じ「プラットフォーム型」の落とし穴）に対しては、この違いが表面化
+します: `onion.Maps::forEach` は null 安全（map が `null` なら何もしない）
+ですが、同じ null な map に対する `m.forEach(action)` はネイティブ
+メソッドに到達し、代わりに `NullPointerException` を投げます -- null 安全な
+挙動を得るには `Maps::forEach(...)` を直接呼んでください。
 
 ```onion
 val m: Map[String, Int] = Maps::newMap()

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2484,7 +2484,18 @@ first. `onion.Maps::getOrDefault` is null-safe (a `null` map returns the
 default), but `m.getOrDefault(k, d)` on that same null map reaches the
 native method and throws `NullPointerException` instead -- call
 `Maps::getOrDefault(...)` directly to get the null-safe behavior on a
-value that might be null.
+value that might be null. `forEach` shadows the same way too: `java.util.Map`
+also declares a matching default instance method `forEach(BiConsumer)`
+(since Java 8), and a two-arg Onion lambda SAM-converts to `BiConsumer` the
+same way it converts to `onion.Maps::forEach`'s `Function2`, so
+`m.forEach(action)` reaches the **native `java.util.Map.forEach`** rather
+than `onion.Maps::forEach`. For a non-null receiver that is invisible, since
+both visit every (key, value) pair in iteration order. It becomes observable
+for a receiver that is `null` at runtime but was never checked at compile
+time (the same "platform type" hazard as above): `onion.Maps::forEach` is
+null-safe (a `null` map is a no-op), but `m.forEach(action)` on that same
+null map reaches the native method and throws `NullPointerException`
+instead -- call `Maps::forEach(...)` directly to get the null-safe behavior.
 
 ### Transformation
 

--- a/src/test/scala/onion/compiler/tools/MapsForEachShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/MapsForEachShadowingSpec.scala
@@ -1,0 +1,112 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Maps.forEach(Map, Function2)` is registered as a builtin extension
+ * (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`), so
+ * `m.forEach(action)` is reachable as extension-call syntax on any `Map`
+ * receiver -- but `java.util.Map` already declares a matching default
+ * instance method `forEach(BiConsumer)` (since Java 8), and ordinary
+ * instance-method resolution runs before any extension fallback is even
+ * consulted. A two-arg Onion lambda SAM-converts to `BiConsumer` the same
+ * way it converts to `onion.Maps::forEach`'s `Function2`, so `m.forEach(action)`
+ * always reaches the *native* `java.util.Map.forEach`, never
+ * `onion.Maps::forEach` -- the same shadowing pattern already documented for
+ * `getOrDefault` in this module (`MapsExtensionCallShadowingSpec`).
+ *
+ * For a non-null receiver that is invisible: both the native method and
+ * `onion.Maps::forEach` visit every (key, value) pair in iteration order.
+ * It becomes observable for a receiver that is `null` at runtime but was
+ * never checked at compile time (a "platform type", per CLAUDE.md, with no
+ * compile-time nullability tracking): `onion.Maps::forEach` is null-safe (a
+ * `null` map is a no-op), but `m.forEach(action)` on that same null map
+ * reaches the native method and throws `NullPointerException` instead --
+ * call `Maps::forEach(...)` directly to get the null-safe behavior on a
+ * value that might be null.
+ *
+ * This locks in that shadowing so a future reordering of
+ * `BuiltinExtensionContainers` doesn't silently flip it, and checks that
+ * both docs carry the warning (docs/reference/stdlib.md and its Japanese
+ * translation, Maps Module section).
+ */
+class MapsForEachShadowingSpec extends AbstractShellSpec {
+
+  private def run(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Int {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "MapsForEachShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for forEach() on a Map shadows onion.Maps") {
+    it("m.forEach(action) on a non-null Map agrees with the static Maps:: form (native method, both agree)") {
+      run(
+        "val m: Map[String, Int] = [\"a\": 1, \"b\": 2, \"c\": 3]\n" +
+        "    var total = 0\n" +
+        "    m.forEach((k: String, v: Int) -> { total = total + v })\n" +
+        "    return total",
+        Shell.Success(6))
+      run(
+        "val m: Map[String, Int] = [\"a\": 1, \"b\": 2, \"c\": 3]\n" +
+        "    var total = 0\n" +
+        "    Maps::forEach(m, (k: String, v: Int) -> { total = total + v })\n" +
+        "    return total",
+        Shell.Success(6))
+    }
+
+    it("m.forEach(action) on a null platform Map reaches the native Map.forEach and throws NullPointerException") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val outer: HashMap[String, Map[String, Int]] = new HashMap[String, Map[String, Int]]\n" +
+          "    val m: Map[String, Int] = outer.get(\"missing\") as Map[String, Int]\n" +
+          "    m.forEach((k: String, v: Int) -> { })\n" +
+          "    return 0\n  }\n}\n",
+          "MapsForEachShadowNpe.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+
+    it("Maps::forEach(m, action) on the same null platform Map is null-safe and is a no-op") {
+      run(
+        "val outer: HashMap[String, Map[String, Int]] = new HashMap[String, Map[String, Int]]\n" +
+        "    val m: Map[String, Int] = outer.get(\"missing\") as Map[String, Int]\n" +
+        "    var total = 0\n" +
+        "    Maps::forEach(m, (k: String, v: Int) -> { total = total + v })\n" +
+        "    return total",
+        Shell.Success(0))
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Maps Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers = Set("m.forEach(", "forEach", "native", "platform")
+    val jaMarkers = Set("m.forEach(", "forEach", "プラットフォーム")
+
+    it("docs/reference/stdlib.md's Maps Module section warns about forEach() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Maps Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Maps Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Maps section warns about forEach() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Maps モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Maps section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Maps.forEach(Map, Function2)` is registered as a builtin extension method, but `java.util.Map` already declares a matching default instance method `forEach(BiConsumer)` (since Java 8), and instance-method resolution always runs before the extension fallback — so `m.forEach(action)` silently reaches the **native** `Map.forEach` instead of `onion.Maps::forEach`. This is invisible on a non-null `Map`, but on a `null` platform-typed `Map` (read back from unparameterized Java interop, with no compile-time nullability tracking) the native method throws `NullPointerException`, while `onion.Maps::forEach` is a null-safe no-op — the same shadowing pattern already documented for `getOrDefault` in the same section.
- Added the equivalent shadowing note to the Maps Module section of both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- Added `MapsForEachShadowingSpec` to pin the behavior (extension-call reaches the native method and NPEs on null; the static `Maps::forEach(...)` form stays null-safe) and to regression-check that both docs carry the warning.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.MapsForEachShadowingSpec'` — new spec green (was red on the doc-coverage assertions before the doc edit, confirming TDD)
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.MapsExtensionCallShadowingSpec onion.compiler.tools.MapsGroupByShadowingSpec onion.compiler.tools.MapsExtensionCallDocSpec onion.compiler.tools.StdlibDocMapsSetsModuleParitySpec onion.compiler.tools.MapsEnrichedSpec onion.compiler.tools.MapsSpec'` — no regressions in sibling Maps specs
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5193 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test requiring `-Donion.dist.path`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KhV2GKTLpUvxrZhsHGuBy

---
_Generated by [Claude Code](https://claude.ai/code/session_018KhV2GKTLpUvxrZhsHGuBy)_