### PR TITLE
docs: document Set.forEach() extension-call shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/ja/reference/stdlib.md`, and a new `MapsForEachShadowingSpec`
   regression test.
 
+- **Documented that `Sets::forEach`'s extension-call form is shadowed by
+  native `Iterable.forEach`.** `Set` conforms to `java.lang.Iterable`, which
+  already declares a default instance method `forEach(Consumer)` (Java 8+),
+  and instance-method resolution always wins over the extension fallback, so
+  `a.forEach(action)` silently reaches the native method instead of
+  `onion.Sets::forEach` -- the same shadowing pattern already documented for
+  `Maps::forEach` above. This is invisible on a non-null `Set`, but on a null
+  platform-typed `Set` the native method throws `NullPointerException` while
+  `Sets::forEach(...)` is a null-safe no-op. Added the note to the Sets
+  Module section of both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`, and a new `SetsForEachShadowingSpec`
+  regression test.
+
 ## [0.54.0] - 2026-09-05
 
 ### Documentation

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1553,8 +1553,7 @@ a.isSubsetOf(b) / a.isSupersetOf(b) / a.isDisjoint(b)
 Sets::map(a, f)                               // NOT a.map(f) で到達不可 -- 下記参照
 Sets::filter(a, p) / Sets::find(a, p)
 a.filter(p) / a.find(p)
-Sets::forEach(a, (x: Int) -> println(x))
-a.forEach((x: Int) -> println(x))
+Sets::forEach(a, (x: Int) -> println(x))      // NOT a.forEach(...) で到達不可 -- 下記参照
 Sets::count(a, p) / Sets::any(a, p) / Sets::all(a, p)
 a.count(p) / a.any(p) / a.all(p)
 ```
@@ -1569,6 +1568,26 @@ a.count(p) / a.any(p) / a.all(p)
 `NullPointerException` を投げますが、`Sets::map` は `LinkedHashSet`（挿入順保持）
 に集約し、`null` の Set には空の Set を返します。挿入順が保たれた null 安全な
 結果が必要な場合は `a.map(...)` ではなく `Sets::map(...)` を直接呼んでください。
+
+**`forEach` は他の onion モジュールではなく JDK にシャドーイングされます**:
+`Set` は `java.lang.Iterable` にも適合しており、`Iterable` はすでに default
+インスタンスメソッド `forEach(Consumer)` を宣言しています。拡張メソッドの
+フォールバック経路が参照される前にインスタンスメソッドが常に優先されるため
+（上記の `Maps::forEach` と同じシャドーイングのパターンです）、1引数の
+Onion ラムダは `onion.Sets::forEach` の `Function1` と同様に `Consumer` へ
+SAM 変換され、`a.forEach(action)` は常に **ネイティブの `Iterable.forEach`**
+に到達し、`onion.Sets::forEach` には到達しません。非 null のレシーバでは
+両者とも挿入順で全要素を訪問するため違いが見えませんが、コンパイル時には
+チェックされない「プラットフォーム型」が実行時に `null` だった場合に違いが
+現れます: `onion.Sets::forEach` は null 安全（`null` の Set は何もしない）
+ですが、同じ null な Set に対する `a.forEach(action)` はネイティブメソッドに
+到達して `NullPointerException` を投げます。null 安全な挙動を得るには
+`Sets::forEach(...)` を直接呼んでください。
+
+```onion
+a.forEach((x: Int) -> println(x))      // ネイティブの Iterable.forEach -- null の Set で NullPointerException
+Sets::forEach(a, (x: Int) -> println(x))  // onion.Sets の null 安全な結果
+```
 
 **`containsAll` のシャドーイング:** このリストの他のメソッドと異なり、
 `a.containsAll(b)` は `onion.Sets::containsAll` には一切到達しません --

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2631,13 +2631,14 @@ Sets::containsAll(null, b)             // false -- onion.Sets's null-safe result
 
 ### Functional operations
 
-These are also builtin extension methods on `Set` (`a.filter(...)`, `a.forEach(...)`,
-...) -- **except `map`**, see the shadowing note below:
+These are also builtin extension methods on `Set` (`a.filter(...)`,
+`a.count(...)`, ...) -- **except `map` and `forEach`**, see the shadowing
+notes below:
 
 ```onion
 Sets::map(a, (x: Int) -> x * 2)        // NOT reachable as a.map(...) -- see below
 Sets::filter(a, (x: Int) -> x > 1)     // a.filter((x: Int) -> x > 1)
-Sets::forEach(a, (x: Int) -> println(x))  // a.forEach((x: Int) -> println(x))
+Sets::forEach(a, (x: Int) -> println(x))  // NOT reachable as a.forEach(...) -- see below
 Sets::count(a, (x: Int) -> x > 1)      // a.count((x: Int) -> x > 1)
 Sets::any(a, (x: Int) -> x > 2)        // a.any((x: Int) -> x > 2)
 Sets::all(a, (x: Int) -> x > 0)        // a.all((x: Int) -> x > 0)
@@ -2656,6 +2657,28 @@ insertion-order promise above) and throws `NullPointerException` for a
 order preserved) and returns an empty set for a `null` one. Call
 `Sets::map(...)` directly (not `a.map(...)`) to get `onion.Sets`'s
 order-preserving, null-safe result.
+
+**`forEach` is shadowed too, but by the JDK, not another onion module**:
+`Set` conforms to `java.lang.Iterable`, which already declares a default
+instance method `forEach(Consumer)`, and an instance method always wins
+over an extension method before the extension fallback path is even
+consulted -- the same shadowing pattern already documented for
+`Maps::forEach` above. A one-arg Onion lambda SAM-converts to `Consumer`
+the same way it converts to `onion.Sets::forEach`'s `Function1`, so
+`a.forEach(action)` always reaches the **native `Iterable.forEach`**,
+never `onion.Sets::forEach`. For a non-null receiver that is invisible,
+since both visit every element in iteration order. It becomes observable
+for a receiver that is `null` at runtime but was never checked at compile
+time (a "platform type"): `onion.Sets::forEach` is null-safe (a `null` set
+is a no-op), but `a.forEach(action)` on that same null set reaches the
+native method and throws `NullPointerException` instead -- call
+`Sets::forEach(...)` directly to get the null-safe behavior on a value
+that might be null.
+
+```onion
+a.forEach((x: Int) -> println(x))      // native Iterable.forEach -- throws NullPointerException on a null Set
+Sets::forEach(a, (x: Int) -> println(x))  // onion.Sets's null-safe result
+```
 
 ---
 

--- a/src/test/scala/onion/compiler/tools/SetsForEachShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsForEachShadowingSpec.scala
@@ -1,0 +1,113 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Sets.forEach(Set, Function1)` is registered as a builtin extension
+ * (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`), so
+ * `a.forEach(action)` would ordinarily be reachable as extension-call syntax
+ * on any `Set` receiver -- but `Set` conforms to `java.lang.Iterable`, which
+ * already declares a default instance method `forEach(Consumer)` (since Java
+ * 8), and ordinary instance-method resolution runs before any extension
+ * fallback is even consulted. A one-arg Onion lambda SAM-converts to
+ * `Consumer` the same way it converts to `onion.Sets::forEach`'s
+ * `Function1`, so `a.forEach(action)` always reaches the *native*
+ * `Iterable.forEach`, never `onion.Sets::forEach` -- the same shadowing
+ * pattern already documented for `Maps::forEach` in this module
+ * (`MapsForEachShadowingSpec`).
+ *
+ * For a non-null receiver that is invisible: both the native method and
+ * `onion.Sets::forEach` visit every element in iteration order. It becomes
+ * observable for a receiver that is `null` at runtime but was never checked
+ * at compile time (a "platform type", per CLAUDE.md, with no compile-time
+ * nullability tracking): `onion.Sets::forEach` is null-safe (a `null` set is
+ * a no-op), but `a.forEach(action)` on that same null set reaches the native
+ * method and throws `NullPointerException` instead -- call
+ * `Sets::forEach(...)` directly to get the null-safe behavior on a value
+ * that might be null.
+ *
+ * This locks in that shadowing so a future reordering of
+ * `BuiltinExtensionContainers` doesn't silently flip it, and checks that
+ * both docs carry the warning (docs/reference/stdlib.md and its Japanese
+ * translation, Sets Module section).
+ */
+class SetsForEachShadowingSpec extends AbstractShellSpec {
+
+  private def run(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Int {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "SetsForEachShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for forEach() on a Set shadows onion.Sets") {
+    it("a.forEach(action) on a non-null Set agrees with the static Sets:: form (native method, both agree)") {
+      run(
+        "val a: Set[Int] = Sets::fromList([1, 2, 3])\n" +
+        "    var total = 0\n" +
+        "    a.forEach((x: Int) -> { total = total + x })\n" +
+        "    return total",
+        Shell.Success(6))
+      run(
+        "val a: Set[Int] = Sets::fromList([1, 2, 3])\n" +
+        "    var total = 0\n" +
+        "    Sets::forEach(a, (x: Int) -> { total = total + x })\n" +
+        "    return total",
+        Shell.Success(6))
+    }
+
+    it("a.forEach(action) on a null platform Set reaches the native Iterable.forEach and throws NullPointerException") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val outer: HashMap[String, Set[Int]] = new HashMap[String, Set[Int]]\n" +
+          "    val a: Set[Int] = outer.get(\"missing\") as Set[Int]\n" +
+          "    a.forEach((x: Int) -> { })\n" +
+          "    return 0\n  }\n}\n",
+          "SetsForEachShadowNpe.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+
+    it("Sets::forEach(a, action) on the same null platform Set is null-safe and is a no-op") {
+      run(
+        "val outer: HashMap[String, Set[Int]] = new HashMap[String, Set[Int]]\n" +
+        "    val a: Set[Int] = outer.get(\"missing\") as Set[Int]\n" +
+        "    var total = 0\n" +
+        "    Sets::forEach(a, (x: Int) -> { total = total + x })\n" +
+        "    return total",
+        Shell.Success(0))
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Sets Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers = Set("a.forEach(", "forEach", "native", "platform")
+    val jaMarkers = Set("a.forEach(", "forEach", "プラットフォーム")
+
+    it("docs/reference/stdlib.md's Sets Module section warns about forEach() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Sets Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Sets Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Sets section warns about forEach() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Sets モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Sets section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Sets.forEach(Set, Function1)` is registered as a builtin extension method, but `java.util.Set` conforms to `java.lang.Iterable`, which already declares a default instance method `forEach(Consumer)` (Java 8+). Instance-method resolution always wins over the extension fallback, so `a.forEach(action)` silently reaches the native `Iterable.forEach` instead of `onion.Sets::forEach` — the same shadowing pattern already documented for `Maps::forEach` in the same module.
- This is invisible for a non-null `Set` (both visit every element in iteration order), but observable for a `null` platform-typed `Set`: the native method throws `NullPointerException`, while `Sets::forEach(...)` is a null-safe no-op.
- Documented the shadowing in the Sets Module section of both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, added a `[Unreleased]` CHANGELOG entry, and added a new `SetsForEachShadowingSpec` regression test (verified empirically against the compiled `onion` script runner before writing the doc fix).

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5198 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test requiring `-Donion.dist.path`, unrelated to this change)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — same result (5198 succeeded, 1 canceled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BJWD7RnUtixZ5WVamJext

---
_Generated by [Claude Code](https://claude.ai/code/session_019BJWD7RnUtixZ5WVamJext)_