### PR TITLE
docs(stdlib): document Colls::forEach List shadowing and its lack of null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented that `Colls::forEach`'s extension-call form is shadowed by
+  native `List.forEach`, and that -- unlike `Maps::forEach`/`Sets::forEach`
+  -- this hides no null-safety gap.** `java.util.List` conforms to
+  `Iterable`, which already declares a default instance method
+  `forEach(Consumer)` (Java 8+), so `xs.forEach(action)` always reaches the
+  native method, never `onion.Colls::forEach` -- the same shadowing pattern
+  already documented for `Maps::forEach`/`Sets::forEach`. But
+  `onion.Colls::forEach` performs no null check at all (unlike its `Maps`/
+  `Sets` counterparts), so calling it directly on a null platform `List`
+  also throws `NullPointerException`, same as the native method it's
+  shadowed by -- there is no null-safe form to fall back on here. Added the
+  note to the Colls Module section of both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`, and a new `CollsForEachShadowingSpec`
+  regression test.
+
 - **Documented that `Maps::forEach`'s extension-call form is shadowed by
   native `Map.forEach`.** `java.util.Map` already declares a default
   instance method `forEach(BiConsumer)` (Java 8+), and instance-method

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -2062,6 +2062,16 @@ Colls::toList(args)               // Java配列（例: main の String[]）を L
 側のメソッドにしか届かない。ただしこれは観測できない差異である: `Colls` 側の
 実装はどれも同じネイティブメソッドへの1行委譲でしかないため。
 
+`forEach` も同じ理由でシャドーイングされる（上記の `Maps::forEach`・
+`Sets::forEach` と同様）: `List` は（`Iterable` 経由で）同じ形の1引数
+インスタンスメソッド `forEach(Consumer)`（Java 8 以降の default メソッド）を
+宣言しているため、`xs.forEach(action)` は常に**ネイティブの**メソッドに到達し、
+`onion.Colls::forEach` には到達しない。ただし `Maps`/`Sets` とは null 安全性の
+話が逆になる: `onion.Colls::forEach` はそもそも null チェックを行わないため、
+null なプラットフォーム型の `List` に対して直接呼び出しても同様に
+`NullPointerException` が発生する -- ここには頼れる null 安全な代替呼び出し方が
+無い。
+
 ### バッチ化・ウィンドウ化・セレクタ集計
 
 これらも `Colls::` の静的呼び出しとして、また `Colls` の他のメソッドと同様に

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1900,6 +1900,15 @@ so these five calls never actually reach `onion.Colls`'s versions, only the
 native ones. That is not observable here: `Colls`'s implementations are
 one-line pass-throughs to the same native method.
 
+`forEach` shadows the same way, for the same underlying reason as
+`Maps::forEach`/`Sets::forEach` documented above: `List` (via `Iterable`)
+already declares a matching one-arg instance `forEach(Consumer)` (a default
+method since Java 8), so `xs.forEach(action)` reaches the *native* method,
+never `onion.Colls::forEach`. Unlike `Maps`/`Sets`, though, that shadowing
+hides no null-safety gap: `onion.Colls::forEach` performs no null check at
+all, so calling it directly on a null platform `List` also throws
+`NullPointerException` -- there is no null-safe form to fall back on here.
+
 ### Batching, windowing, and selector aggregation
 
 Also available as `Colls::` static calls and, like the rest of `Colls`, as

--- a/src/test/scala/onion/compiler/tools/CollsForEachShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CollsForEachShadowingSpec.scala
@@ -1,0 +1,113 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `onion.Colls.forEach(List, Function1)` is registered as a builtin
+ * extension (`ExtensionMethodFallbackSupport.BuiltinExtensionContainers`),
+ * so `xs.forEach(action)` would ordinarily be reachable as extension-call
+ * syntax on any `List` receiver -- but `List` conforms to `java.lang.Iterable`,
+ * which already declares a default instance method `forEach(Consumer)`
+ * (since Java 8), and ordinary instance-method resolution runs before any
+ * extension fallback is even consulted. A one-arg Onion lambda SAM-converts
+ * to `Consumer` the same way it converts to `onion.Colls::forEach`'s
+ * `Function1`, so `xs.forEach(action)` always reaches the *native*
+ * `Iterable.forEach`, never `onion.Colls::forEach` -- the same shadowing
+ * pattern already documented for `Maps::forEach` and `Sets::forEach`
+ * (`MapsForEachShadowingSpec`, `SetsForEachShadowingSpec`).
+ *
+ * Unlike those two, though, the shadowing hides no null-safety gap:
+ * `onion.Colls::forEach` performs no null check at all (a plain
+ * `for (T element : list)` loop), so calling it *directly* on a null
+ * platform `List` also throws `NullPointerException`, the same as the
+ * native method it's shadowed by. There is no null-safe form to fall back
+ * on here.
+ *
+ * This locks in that shadowing so a future reordering of
+ * `BuiltinExtensionContainers` doesn't silently flip it, and checks that
+ * both docs carry the warning (docs/reference/stdlib.md and its Japanese
+ * translation, Colls Module section).
+ */
+class CollsForEachShadowingSpec extends AbstractShellSpec {
+
+  private def run(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Int {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "CollsForEachShadow.on", Array()))
+  }
+
+  describe("extension-call syntax for forEach() on a List shadows onion.Colls") {
+    it("xs.forEach(action) on a non-null List agrees with the static Colls:: form (native method, both agree)") {
+      run(
+        "val xs: List[Int] = [1, 2, 3]\n" +
+        "    var total = 0\n" +
+        "    xs.forEach((x: Int) -> { total = total + x })\n" +
+        "    return total",
+        Shell.Success(6))
+      run(
+        "val xs: List[Int] = [1, 2, 3]\n" +
+        "    var total = 0\n" +
+        "    Colls::forEach(xs, (x: Int) -> { total = total + x })\n" +
+        "    return total",
+        Shell.Success(6))
+    }
+
+    it("xs.forEach(action) on a null platform List reaches the native Iterable.forEach and throws NullPointerException") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val outer: HashMap[String, List[Int]] = new HashMap[String, List[Int]]\n" +
+          "    val xs: List[Int] = outer.get(\"missing\") as List[Int]\n" +
+          "    xs.forEach((x: Int) -> { })\n" +
+          "    return 0\n  }\n}\n",
+          "CollsForEachShadowNpe.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+
+    it("Colls::forEach(xs, action) called directly on that same null platform List is NOT null-safe either -- it also throws NullPointerException") {
+      val thrown = intercept[ScriptException] {
+        shell.run(
+          "class Test {\npublic:\n  static def main(args: String[]): Int {\n" +
+          "    val outer: HashMap[String, List[Int]] = new HashMap[String, List[Int]]\n" +
+          "    val xs: List[Int] = outer.get(\"missing\") as List[Int]\n" +
+          "    Colls::forEach(xs, (x: Int) -> { })\n" +
+          "    return 0\n  }\n}\n",
+          "CollsForEachDirectNpe.on", Array())
+      }
+      assert(thrown.getCause.isInstanceOf[NullPointerException])
+    }
+  }
+
+  describe("docs carry the shadowing warning in the Colls Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers = Set("xs.forEach(", "forEach", "native", "NullPointerException")
+    val jaMarkers = Set("xs.forEach(", "forEach", "ネイティブ", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Colls Module section warns about forEach() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Colls Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Colls Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+
+    it("docs/ja/reference/stdlib.md's Colls section warns about forEach() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Colls モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Colls section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `xs.forEach(action)` on a `List` always reaches native `Iterable.forEach` (the same instance-method shadowing already documented for `Maps::forEach`/`Sets::forEach`), since ordinary instance-method resolution runs before the extension fallback.
- Unlike `Maps::forEach`/`Sets::forEach`, `onion.Colls::forEach` performs no null check at all, so calling it *directly* on a null platform `List` also throws `NullPointerException` — there is no null-safe form to fall back on here.
- Documents this in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md` (Colls Module section), and adds a new `CollsForEachShadowingSpec` regression test that locks in the current behavior and checks both docs carry the warning.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5207 tests, 0 failed (1 pre-existing, unrelated environment-gated cancellation)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 5207 tests, 0 failed (same pre-existing cancellation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115pEcWsNYCU4iL9cJnyF5n

---
_Generated by [Claude Code](https://claude.ai/code/session_0115pEcWsNYCU4iL9cJnyF5n)_