### PR TITLE
docs(stdlib): document Regex extension-call shadowing, incl. replace's regex-vs-literal trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented that `Regex::matches`/`replace`/`replaceFirst`/`split`'s
+  extension-call forms are shadowed by native `String` methods of the same
+  name, and that `replace` in particular silently switches from regex to
+  literal semantics.** `java.lang.String` already declares `matches`,
+  `replace`, `replaceFirst` and `split` instance methods with the same
+  arity as their `onion.Regex` counterparts, and an instance method always
+  wins over an extension method of the same name -- the same shadowing
+  pattern already documented for `Strings`/`Colls`/`Iterables`/`Maps`/`Sets`.
+  Unlike those, `replace` is not just a null-safety gap: `String.replace`
+  does a **literal** substring replacement while `onion.Regex::replace`
+  treats its pattern as a **regex**, so `s.replace(pattern, replacement)`
+  silently gives the wrong result even on a non-null receiver (e.g.
+  `"a1b22c333".replace("\d+", "-")` is unchanged, while
+  `Regex::replace("a1b22c333", "\d+", "-")` is `"a-b-c-"`). `matches`/
+  `replaceFirst`/`split` agree on a non-null receiver (the native methods
+  are already regex-based there) but throw `NullPointerException` on a
+  `null` platform receiver instead of `onion.Regex`'s null-safe result;
+  `split` also returns a raw `String[]` array rather than `List[String]`.
+  Added a new "Extension-call shadowing" subsection to the Regex module
+  section of both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`, and a new
+  `RegexExtensionCallShadowingSpec` regression test.
+
 - **Documented that `Colls::forEach`'s extension-call form is shadowed by
   native `List.forEach`, and that -- unlike `Maps::forEach`/`Sets::forEach`
   -- this hides no null-safety gap.** `java.util.List` conforms to

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -2519,6 +2519,40 @@ Regex::quote(literal): String    // 特殊文字をエスケープ
 Regex::isValid(pattern): Boolean
 ```
 
+### 拡張呼び出しでのシャドーイング
+
+`matches`、`replace`、`replaceFirst`、`split` は拡張呼び出しのメソッドチェーン
+（`s.matches(p)`、`s.replace(p, r)` など）としても書けるが、`java.lang.String`
+にはこれと同名・同じ引数の数のインスタンスメソッドが既にあり、インスタンス
+メソッドは常に同名の拡張メソッドより優先される -- `Strings`/`Colls`/`Iterables`/
+`Maps`/`Sets` で既に説明している問題と同じ現象。`find`、`findAll`、`findFirst`、
+`groups`、`groupsAll`、`quote`、`isValid`、`matchGroups` はこの衝突が無く、
+シャドーイングされない。
+
+この1つのシャドーイング機構の裏に、性質の異なる2つの罠がある:
+
+- **`replace` は null 安全性だけでなく意味そのものが変わってしまう。**
+  `String.replace(CharSequence, CharSequence)` は**リテラル**な部分文字列
+  置換であるのに対し、`onion.Regex::replace` は第2引数を**正規表現**として
+  扱う。そのため `s.replace(pattern, replacement)` はリテラル版のネイティブ
+  メソッドに到達し、`s` が非 null の通常の値であっても誤った結果になる:
+  ```
+  "a1b22c333".replace("\\d+", "-")          // "a1b22c333" -- リテラル "\d+" は含まれないので変化なし
+  Regex::replace("a1b22c333", "\\d+", "-")  // "a-b-c-"    -- \d+ が正規表現としてマッチ
+  ```
+  パターンが正規表現である場合は `s.replace(...)` ではなく必ず
+  `Regex::replace(...)` を明示的に使うこと。
+
+- **`matches`/`replaceFirst`/`split` が到達するネイティブメソッドは既に正規表現
+  として動作するため、非 null な受信者では結果が一致する -- 違いが表面化する
+  のは `null` なプラットフォーム型の受信者のときだけ**（CLAUDE.md の通り、
+  型パラメータ無しの Java 相互運用から得た値）。その場合、拡張呼び出しが到達
+  するネイティブメソッドは `NullPointerException` を投げるが、`onion.Regex`
+  なら null 安全な結果（`matches` は `false`、`replaceFirst` は `""`、`split`
+  は `[]`）を返す。`split` には非 null な受信者でも起きるもう1つの問題があり、
+  `s.split(pattern)` は他のコレクションを返す標準ライブラリメソッドが約束する
+  `List[String]` ではなく、生の `String[]` 配列を返してしまう。
+
 ### アンカー付きマッチ
 
 ```

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2363,6 +2363,40 @@ Regex::quote(literal): String    // Escape special characters
 Regex::isValid(pattern): Boolean
 ```
 
+### Extension-call shadowing
+
+`matches`, `replace`, `replaceFirst` and `split` also work as extension-call
+method chains (`s.matches(p)`, `s.replace(p, r)`, ...), but `java.lang.String`
+already declares instance methods with these exact names and arities, and an
+instance method always wins over an extension method of the same name -- the
+same hazard already documented for `Strings`/`Colls`/`Iterables`/`Maps`/`Sets`.
+`find`, `findAll`, `findFirst`, `groups`, `groupsAll`, `quote`, `isValid` and
+`matchGroups` have no such collision and are not shadowed.
+
+Two different traps hide behind that one shadowing mechanism:
+
+- **`replace` silently changes meaning, not just null-safety.**
+  `String.replace(CharSequence, CharSequence)` is a **literal** substring
+  replacement, while `onion.Regex::replace` treats its second argument as a
+  **regex**. So `s.replace(pattern, replacement)` reaches the literal native
+  method and gives the wrong answer even for an ordinary non-null `s`:
+  ```
+  "a1b22c333".replace("\\d+", "-")     // "a1b22c333" -- no literal "\d+" substring, unchanged
+  Regex::replace("a1b22c333", "\\d+", "-")  // "a-b-c-"   -- \d+ matched as a regex
+  ```
+  Use `Regex::replace(...)` explicitly whenever the pattern is a regex, not
+  `s.replace(...)`.
+
+- **`matches`/`replaceFirst`/`split` reach a native method that already uses
+  regex semantics, so results agree on a non-null receiver -- the divergence
+  only shows up on a `null` platform-typed receiver** (a value from
+  unparameterized Java interop, per CLAUDE.md), where the native method
+  extension-call syntax reaches throws `NullPointerException` instead of the
+  null-safe result `onion.Regex` would give (`false` for `matches`, `""` for
+  `replaceFirst`, `[]` for `split`). `split` has a second gap even for a
+  non-null receiver: `s.split(pattern)` returns a raw `String[]` array, not
+  the `List[String]` every other stdlib collection-returning method promises.
+
 ### Anchored match
 
 ```

--- a/src/test/scala/onion/compiler/tools/RegexExtensionCallShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RegexExtensionCallShadowingSpec.scala
@@ -1,0 +1,143 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `docs/reference/stdlib.md`'s Regex module section documents every
+ * `Regex::...` static method but never mentions extension-call syntax at
+ * all -- unlike the Strings/Colls/Iterables/Maps/Sets/Stats sections, which
+ * all carry an explicit shadowing warning by now. `java.lang.String`
+ * already declares instance methods named `matches`, `replace`,
+ * `replaceFirst` and `split` with the same arity as their `onion.Regex`
+ * counterparts, and an instance method always wins over an extension
+ * method of the same name -- the same hazard documented elsewhere.
+ *
+ * Two distinct traps hide behind that single shadowing mechanism here:
+ *
+ *   - `matches`/`replaceFirst`/`split` reach a native method that already
+ *     uses regex semantics, so for a non-null receiver the *result* agrees
+ *     with `onion.Regex`. The divergence only shows up on a `null` platform
+ *     receiver: `onion.Regex::...` is null-safe, but dispatching any
+ *     instance method (including the native one extension-call syntax
+ *     reaches) on a `null` receiver throws `NullPointerException`
+ *     regardless of which method it is. `split` has a second-order gap
+ *     even for a non-null receiver: the native method returns a raw
+ *     `String[]` array, not the `List[String]` every other stdlib
+ *     collection-returning method promises (per CLAUDE.md's "the standard
+ *     library ... never [returns] arrays" rule).
+ *
+ *   - `replace` is worse: `java.lang.String.replace(CharSequence,
+ *     CharSequence)` performs a **literal** substring replacement, while
+ *     `onion.Regex::replace` treats its second argument as a **regex**.
+ *     `s.replace(pattern, replacement)` therefore silently reaches the
+ *     literal native method, not the regex-based `onion.Regex::replace` --
+ *     wrong *results* on an ordinary non-null receiver, not just a crash on
+ *     a null one.
+ *
+ * Locks in both behaviors and checks that both docs (English and Japanese)
+ * carry an accurate warning in the Regex module section.
+ */
+class RegexExtensionCallShadowingSpec extends AbstractShellSpec {
+
+  private def nullPlatformString: String =
+    """
+      |val m: HashMap[String, String] = new HashMap[String, String]
+      |val s: String = m.get("missing") as String
+      |""".stripMargin
+
+  private def runStr(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): String {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "RegexShadowStr.on", Array()))
+  }
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "RegexShadowBool.on", Array()))
+  }
+
+  private def expectNpe(body: String, fileName: String): Unit = {
+    val thrown = intercept[ScriptException] {
+      shell.run(
+        "class Test {\npublic:\n  static def main(args: String[]): void {\n" + body + "\n  }\n}\n",
+        fileName, Array())
+    }
+    assert(thrown.getCause.isInstanceOf[NullPointerException])
+  }
+
+  describe("extension-call syntax for replace() silently switches from regex to literal semantics") {
+    it("s.replace(pattern, replacement) treats pattern as a literal substring, not a regex") {
+      runStr("return \"a1b22c333\".replace(\"\\\\d+\", \"-\")", Shell.Success("a1b22c333"))
+    }
+
+    it("Regex::replace(s, pattern, replacement) treats the same pattern as a regex") {
+      runStr("return Regex::replace(\"a1b22c333\", \"\\\\d+\", \"-\")", Shell.Success("a-b-c-"))
+    }
+  }
+
+  describe("extension-call syntax for matches()/replaceFirst()/split() agrees on non-null input") {
+    it("s.matches(pattern) and Regex::matches(s, pattern) agree for a non-null receiver") {
+      runBool("return \"abc123\".matches(\"[a-z]+\\\\d+\")", Shell.Success(true))
+      runBool("return Regex::matches(\"abc123\", \"[a-z]+\\\\d+\")", Shell.Success(true))
+    }
+
+    it("s.replaceFirst(pattern, replacement) and Regex::replaceFirst agree for a non-null receiver") {
+      runStr("return \"a1b22c333\".replaceFirst(\"\\\\d+\", \"-\")", Shell.Success("a-b22c333"))
+      runStr("return Regex::replaceFirst(\"a1b22c333\", \"\\\\d+\", \"-\")", Shell.Success("a-b22c333"))
+    }
+  }
+
+  describe("extension-call syntax and onion.Regex diverge on a null platform receiver") {
+    it("s.matches(pattern) on a null platform String throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.matches(\"x\")\n", "RegexShadowMatchesNpe.on")
+    }
+
+    it("Regex::matches(s, pattern) on the same null platform String is null-safe and returns false") {
+      runBool(nullPlatformString + "    return Regex::matches(s, \"x\")", Shell.Success(false))
+    }
+
+    it("s.replace(pattern, replacement) on a null platform String throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.replace(\"x\", \"y\")\n", "RegexShadowReplaceNpe.on")
+    }
+
+    it("Regex::replace(s, pattern, replacement) on the same null platform String is null-safe and returns \"\"") {
+      runStr(nullPlatformString + "    return Regex::replace(s, \"x\", \"y\")", Shell.Success(""))
+    }
+  }
+
+  describe("docs carry an accurate extension-call shadowing warning in the Regex module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    it("docs/reference/stdlib.md's Regex module section warns about extension-call shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Regex")
+      assert(doc.contains("shadow"),
+        "docs/reference/stdlib.md's Regex section does not mention extension-call shadowing at all")
+      assert(doc.contains("`replace`") && doc.contains("`matches`"),
+        "docs/reference/stdlib.md's Regex section does not name the shadowed methods")
+      assert(doc.contains("s.replace("),
+        "docs/reference/stdlib.md's Regex section is missing an s.replace(...) shadowing example")
+    }
+
+    it("docs/ja/reference/stdlib.md's Regex section warns about extension-call shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Regex")
+      assert(doc.contains("シャドー") || doc.contains("shadow"),
+        "docs/ja/reference/stdlib.md's Regex section does not mention extension-call shadowing at all")
+      assert(doc.contains("`replace`") && doc.contains("`matches`"),
+        "docs/ja/reference/stdlib.md's Regex section does not name the shadowed methods")
+      assert(doc.contains("s.replace("),
+        "docs/ja/reference/stdlib.md's Regex section is missing an s.replace(...) shadowing example")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Regex::matches`/`replace`/`replaceFirst`/`split` can all be called via extension-call syntax (`s.matches(p)`, `s.replace(p, r)`, ...), but `java.lang.String` already declares instance methods of the same name and arity, and an instance method always wins over an extension method of the same name — the same shadowing pattern already documented for `Strings`/`Colls`/`Iterables`/`Maps`/`Sets`, but never mentioned anywhere in the Regex module docs until now.
- `replace` is worse than a null-safety gap: `String.replace(CharSequence, CharSequence)` does a **literal** substring replacement, while `onion.Regex::replace` treats its pattern as a **regex**. So `s.replace(pattern, replacement)` silently gives the wrong result even on a non-null receiver, e.g. `"a1b22c333".replace("\d+", "-")` is unchanged, while `Regex::replace("a1b22c333", "\d+", "-")` is `"a-b-c-"`.
- `matches`/`replaceFirst`/`split` agree with `onion.Regex` on a non-null receiver (the native methods are already regex-based there), but throw `NullPointerException` on a `null` platform-typed receiver instead of `onion.Regex`'s null-safe result; `split` also returns a raw `String[]` array rather than the `List[String]` every other stdlib collection-returning method promises.
- Added an "Extension-call shadowing" subsection to the Regex module section of both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, and a new `RegexExtensionCallShadowingSpec` regression test that locks in the runtime behavior and checks both docs carry the warning.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `RegexExtensionCallShadowingSpec` written first (red on the doc-content assertions), docs updated to make it green (10/10 passing)
- [x] Full suite in English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5217 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Tdka7H9CKrR5SobCAzT74

---
_Generated by [Claude Code](https://claude.ai/code/session_017Tdka7H9CKrR5SobCAzT74)_