### PR TITLE
test: add SetsDocCoverageSpec regression guard for onion.Sets stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   members were already documented in both files; this guard now fails the
   build if a future addition to `onion.Csv` goes undocumented.
 
+- **Added a `SetsDocCoverageSpec` regression guard checking that every public
+  `onion.Sets` member is documented in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`.** `onion.Sets` is a genuine, default-imported
+  stdlib module (`Sets::newSet`, `Sets::union`, `Sets::isDisjoint`, ...) with
+  19 distinct public static member names, but -- unlike `Maps`, already
+  guarded by `MapsDocCoverageSpec` -- it never had one. All 19 members were
+  already documented in both files; this guard now fails the build if a
+  future addition to `onion.Sets` goes undocumented.
+
 ## [0.55.0] - 2026-09-05
 
 ### Documentation

--- a/src/test/scala/onion/compiler/tools/SetsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SetsDocCoverageSpec.scala
@@ -1,0 +1,59 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Sets` module docs.
+ *
+ * `onion.Sets` is a genuine, default-imported stdlib module (`Sets::newSet`,
+ * `Sets::union`, `Sets::isDisjoint`, ...) with several members already guarded
+ * individually by `SetsForEachShadowingSpec`/`SetsMapExtensionCallShadowingSpec`/
+ * `SetsToListExtensionCallShadowingSpec`/`SetsUnionIntersectionDifferenceShadowingSpec`/
+ * `SetsContainsAllExtensionCallShadowingSpec`/`SetsExtensionCallDocSpec`, but -- unlike
+ * `Maps`, guarded by `MapsDocCoverageSpec` -- it has never had a regression test checking
+ * that every member stays documented in both docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md. Every public member is checked here so a future addition to
+ * onion.Sets fails the build instead of silently staying undocumented.
+ */
+class SetsDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Sets::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Sets]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    methodNames.toSet
+  }
+
+  it("actual onion.Sets exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Sets found no static members — the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Sets member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Sets:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Sets member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Sets:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Sets in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Sets"),
+      "docs/reference/stdlib.md's overview table should mention Sets")
+    assert(read("docs/ja/reference/stdlib.md").contains("Sets"),
+      "docs/ja/reference/stdlib.md's overview table should mention Sets")
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Sets` is a genuine, default-imported stdlib module (`Sets::newSet`, `Sets::union`, `Sets::isDisjoint`, ...) with 19 distinct public static member names, but unlike `Maps` (guarded by `MapsDocCoverageSpec`), it never had a reflection-based regression test checking that every member stays documented in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- Added `SetsDocCoverageSpec`, modeled directly on `MapsDocCoverageSpec`: it reflects over `onion.Sets`'s public static methods and asserts each name appears (as `Sets::name`) in both docs files, plus a sanity check and an overview-table mention check.
- All 19 members were already documented in both files, so this is a pure regression guard — it fails the build only if a future addition to `onion.Sets` goes undocumented.
- Recorded the addition in `CHANGELOG.md`'s `[Unreleased]` section, following the same pattern as the recent `CsvDocCoverageSpec`/`FilesDocCoverageSpec` entries.

## Test plan

- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.SetsDocCoverageSpec"` — 4/4 passed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` (full suite, English locale, cold sbt) — 5229 succeeded, 0 failed, 1 canceled (pre-existing `ProjectDistributionSpec` smoke test that self-cancels without `-Donion.dist.path`, unrelated to this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BbnTNy3Er8Dq5SNsyuszxg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbnTNy3Er8Dq5SNsyuszxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbnTNy3Er8Dq5SNsyuszxg)_