### PR TITLE
Extract ADT enum declaration lowering

### DIFF
--- a/docs/refactoring/current-architecture.md
+++ b/docs/refactoring/current-architecture.md
@@ -84,6 +84,13 @@ show that some transformations cross semantic boundaries. It should be split
 by explicit pass contracts only after characterization tests identify each
 pass's input/output invariants.
 
+`rewrite.AdtEnumLowering` is the first closed lowering boundary: an ADT enum
+becomes a sealed interface followed by its case records. It owns parameter
+validation and generated declaration construction, but no traversal or mutable
+compiler state. `Rewriting` still selects ADT versus homogeneous enums, rewrites
+the generated declarations at the original position, and enriches exceptions
+with the compilation unit's source file. The body-rewrite fast path is unchanged.
+
 ## Typing
 
 `Typing.scala` is now primarily a facade over four passes:

--- a/docs/refactoring/decision-log.md
+++ b/docs/refactoring/decision-log.md
@@ -142,3 +142,22 @@ after the removed `for ... in` cases and before declaration rules, and it stays
 ahead of the generic missing-block fallback. Message keys, arguments, regular
 expressions, localization, source locations, and no-match behavior do not
 change.
+
+## D012: extract ADT declaration construction, not another whole-tree pass
+
+Decision: `rewrite.AdtEnumLowering.lower` maps one ADT enum to its sealed
+interface and ordered case records. The caller keeps selection, traversal,
+and diagnostic source enrichment.
+
+Reason: this is a closed transformation with no reads of `Rewriting` state.
+Extracting it does not require callbacks, a service facade, a registry, or an
+additional tree walk. The surrounding dictionary scopes and body fast path
+remain untouched. Recent churn is low here; the benefit is an explicit tested
+declaration-construction boundary, not a claimed performance improvement.
+
+Invariant: modifiers, type-parameter order/bounds, applied parent type, field
+defaults, method filtering and order, singleton representation, and the
+shared-parameter rejection remain unchanged. Generated declaration locations
+remain the enum location, not the case location. Bodies still pass through
+the existing rewriters after expansion; homogeneous enums do not enter this
+lowering. No new singleton accessor or mixed-constant policy is introduced.

--- a/docs/refactoring/feature-recipes.md
+++ b/docs/refactoring/feature-recipes.md
@@ -86,6 +86,18 @@ foreign syntax usually needs no grammar change.
 5. Run `CodegenCorrectnessSpec`, relevant focused suites, samples, and both
    locale full suites.
 
+## Change ADT enum expansion
+
+1. Change `rewrite.AdtEnumLowering` for generated interface/case declarations.
+   Do not give it the `Rewriting` instance or its mutable scopes.
+2. Keep ADT selection and generated-body traversal in `Rewriting.rewrite`.
+   Homogeneous enums must continue down their separate path.
+3. Extend `AdtEnumRewritingSpec` with a complete expected AST, including
+   generic arguments, declaration order and source positions.
+4. Run the enum execution suites and `RewritingErrorLocationSpec`, then both
+   full locale suites. For a pure move, compare emitted `run/AdtExpr.on` classes
+   before and after without regenerating expected outputs from the new code.
+
 ## Before committing any compiler refactor
 
 - Focused RED was observed for the intended missing behavior or seam.

--- a/docs/refactoring/onion-maintainability-roadmap.md
+++ b/docs/refactoring/onion-maintainability-roadmap.md
@@ -185,6 +185,50 @@ Each item uses RED/GREEN/refactor and is a separate commit.
 Candidate files are determined after Phase 2; no speculative class names are
 committed before the call graph is read.
 
+### First slice: ADT enum lowering
+
+Base: `c9e77b96`. The 200-commit audit reports `Rewriting.scala` at 1,688
+lines / 392 branch proxies, with two recent edits (126 lines of churn).
+Those two edits touch only this file, so they provide no recent co-change
+evidence for separating stateful body rewriting. Parser hint development is
+still active (44 edits / 522 lines of churn); further hint grouping remains
+optional, not a prerequisite for this independent Phase 4 slice.
+
+The inspected call path is `rewrite -> desugarAdtEnum ->
+rewriteToplevelDeclaration -> rewriteInterfaceDeclaration / rewriteRecordDeclaration`.
+The lowering itself reads only its enum argument, constructs AST nodes, and
+can throw a `CompilationException`. It does not read dictionary scope,
+body-rewrite flags, counters, configuration, or compiler services.
+
+1. Characterize complete compilation-unit ASTs: product/singleton order,
+   generic application and bounds, metadata and positions, method filtering,
+   generated-body rewriting, homogeneous passthrough, and error provenance.
+2. Remove the sealed bit temporarily and confirm the characterization fails;
+   restore it before extraction.
+3. Move only the lowering into `rewrite.AdtEnumLowering`; retain dispatch,
+   subsequent rewriting, and source-file diagnostic enrichment in `Rewriting`.
+4. Run focused enum/rewriting tests and fresh English/Japanese `testFull`.
+5. Review the diff and update boundary documentation. This move adds no
+   traversal and does not modify the existing body-rewrite fast path.
+
+Rollback is a revert of this slice; no grammar, runtime, or public API changes.
+
+Verification (2026-09-05): the first slice is complete. The five full-AST
+characterizations passed before extraction; removing the sealed bit failed
+three, and all passed again after restoration and extraction. The focused
+suite passed 75 tests. Fresh English and Japanese JVMs each passed 5,230 tests
+in 714 suites (zero failures; one opt-in distribution smoke cancellation).
+`run/AdtExpr.on` emitted eight byte-identical class files totaling 10,545 bytes
+before/after, and the generated program returned `-15`. The audit test,
+`git diff --check`, strict MkDocs build, and independent review passed.
+
+`Rewriting.scala` moved from 1,688 lines / 392 branch proxies to 1,610 / 371;
+the new boundary is 87 / 21. These are responsibility-localization metrics,
+not evidence of less total complexity: package fan-out for the root compiler
+package rises from 11 to 12 because it now explicitly imports `rewrite`.
+No runtime speedup or measured performance improvement is claimed. Further
+extractions still require their own call-map and invariant evidence.
+
 ## Phase 5: typing dependency narrowing
 
 1. Inventory every helper that receives concrete `Typing`.

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -16,6 +16,7 @@ import _root_.onion.compiler.SemanticError._
 import _root_.onion.compiler.exceptions.CompilationException
 import _root_.onion.compiler.toolbox.{Boxing, Classes, Message, Paths, Systems}
 import onion.compiler.AST.{ClassDeclaration, InterfaceDeclaration, RecordDeclaration}
+import onion.compiler.rewrite.AdtEnumLowering
 
 import _root_.scala.jdk.CollectionConverters._
 import scala.collection.mutable.{Buffer, Map, Set => MutableSet}
@@ -185,9 +186,9 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
         newToplevels += rewriteGlobalVariableDeclaration(declaration)
       case declaration: AST.EnumDeclaration if declaration.constants.exists(_.isCase) =>
         // Scala-3-style ADT enum: replace it with the desugared sealed interface +
-        // one record per case (+ singleton statics). A homogeneous enum has no
+        // one record per case. A homogeneous enum has no
         // `case` constants and falls through to `otherwise`, untouched.
-        desugarAdtEnum(declaration).foreach { top => newToplevels += rewriteToplevelDeclaration(top) }
+        AdtEnumLowering.lower(declaration).foreach { top => newToplevels += rewriteToplevelDeclaration(top) }
       case declaration: AST.EnumDeclaration if declaration.typeParameters.nonEmpty =>
         // A homogeneous enum compiles to a java.lang.Enum, which the JVM does
         // not allow to be generic. The grammar accepts the type parameters so
@@ -227,85 +228,6 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
     case other                       => other
   }
 
-  /**
-   * Desugars a Scala-3-style ADT (`case`) enum into already-working constructs —
-   * NO new codegen. Given
-   *
-   *   enum Shape {
-   *     case Circle(radius: Double)
-   *     case Square(side: Double)
-   *     case Origin
-   *   public:
-   *     def area(): Double = select this { ... }
-   *   }
-   *
-   * we generate:
-   *   - `sealed interface Shape { <the enum body-section methods, verbatim, as
-   *     default methods> }`
-   *   - `record Circle(radius: Double) conforms Shape`  (one per product case)
-   *   - `record Square(side: Double) conforms Shape`
-   *   - `record Origin() conforms Shape`               (zero-field record per singleton)
-   *
-   * A `sealed interface` + `record X conforms Shape` + a `select` over `case x is X:`
-   * gives exhaustiveness (E0042) for free. A singleton case is constructed as
-   * `new Origin()` (first-cut form; see the singleton note below).
-   */
-  private def desugarAdtEnum(enumDecl: AST.EnumDeclaration): List[AST.Toplevel] = {
-    val loc = enumDecl.location
-    val enumName = enumDecl.name
-    // Scope guard (first version): ADT enums have PER-CASE fields only; enum-level
-    // shared params mixed with `case` cases is a separate feature.
-    if (enumDecl.params.nonEmpty) {
-      throw new CompilationException(Seq(CompileError("", loc,
-        s"enum $enumName mixes shared parameters with `case` cases; ADT enums carry per-case fields only")))
-    }
-
-    // A generic ADT enum (`enum Opt[T] { case Some(value: T); case Nothing }`)
-    // carries its parameters onto every generated declaration: the sealed
-    // interface becomes `Opt[T]`, each case record becomes `Some[T]`, and each
-    // case's implemented supertype becomes `Opt[T]` rather than a raw `Opt`
-    // (#311). Without the applied supertype the record would implement the raw
-    // type, which E0066 forbids.
-    val typeParams = enumDecl.typeParameters
-    val enumTypeNode =
-      if (typeParams.isEmpty) AST.TypeNode(loc, AST.ReferenceType(enumName, false), false)
-      else
-        AST.TypeNode(
-          loc,
-          AST.ParameterizedType(
-            AST.ReferenceType(enumName, false),
-            typeParams.map(tp => AST.ReferenceType(tp.name, false))
-          ),
-          false
-        )
-
-    // Interface methods: the enum body sections' methods become interface members
-    // verbatim (bodies preserved -> default methods; bodiless -> abstract).
-    val bodyMethods: List[AST.MethodDeclaration] = enumDecl.sections.flatMap(_.members).collect {
-      case m: AST.MethodDeclaration => m
-    }
-
-    // Singleton cases (`case Origin`) desugar to a ZERO-FIELD record `record Origin()`,
-    // constructed as `new Origin()` and matched via `case o is Origin:`. A dedicated
-    // `Name::Origin` static VALUE accessor is intentionally not synthesized: the
-    // singleton record type and any same-named accessor would collide under `::`
-    // resolution (the name `Origin` already denotes the record type), so `new Origin()`
-    // is the first-cut construction form (see the class notes / final report).
-    val interfaceDecl = AST.InterfaceDeclaration(
-      loc, enumDecl.modifiers | AST.M_SEALED, enumName, Nil, bodyMethods, typeParams
-    )
-
-    // One record per case; singleton -> zero-field record. All implement the enum.
-    val recordDecls: List[AST.RecordDeclaration] = enumDecl.constants.filter(_.isCase).map { c =>
-      val fields = c.caseFields.getOrElse(Nil)
-      AST.recordDeclaration(
-        loc, AST.M_PUBLIC, c.name, typeParams, fields, List(enumTypeNode),
-        null, Nil, Nil, Nil, Nil, Nil
-      )
-    }
-
-    interfaceDecl :: recordDecls
-  }
 
   /**
    * Auto-CLI: a top-level `def main(p1: T1, p2: T2 = default, ...)` whose

--- a/src/main/scala/onion/compiler/rewrite/AdtEnumLowering.scala
+++ b/src/main/scala/onion/compiler/rewrite/AdtEnumLowering.scala
@@ -1,0 +1,87 @@
+package onion.compiler.rewrite
+
+import onion.compiler.{AST, CompileError}
+import onion.compiler.exceptions.CompilationException
+
+/** Declaration construction only; the caller owns selection and body rewriting. */
+private[compiler] object AdtEnumLowering {
+  /**
+   * Desugars a Scala-3-style ADT (`case`) enum into already-working constructs —
+   * NO new codegen. Given
+   *
+   *   enum Shape {
+   *     case Circle(radius: Double)
+   *     case Square(side: Double)
+   *     case Origin
+   *   public:
+   *     def area(): Double = select this { ... }
+   *   }
+   *
+   * we generate:
+   *   - `sealed interface Shape { <the enum body-section methods, verbatim, as
+   *     default methods> }`
+   *   - `record Circle(radius: Double) conforms Shape`  (one per product case)
+   *   - `record Square(side: Double) conforms Shape`
+   *   - `record Origin() conforms Shape`               (zero-field record per singleton)
+   *
+   * A `sealed interface` + `record X conforms Shape` + a `select` over `case x is X:`
+   * gives exhaustiveness (E0042) for free. A singleton case is constructed as
+   * `new Origin()` (first-cut form; see the singleton note below).
+   */
+  def lower(enumDecl: AST.EnumDeclaration): List[AST.Toplevel] = {
+    val loc = enumDecl.location
+    val enumName = enumDecl.name
+    // Scope guard (first version): ADT enums have PER-CASE fields only; enum-level
+    // shared params mixed with `case` cases is a separate feature.
+    if (enumDecl.params.nonEmpty) {
+      throw new CompilationException(Seq(CompileError("", loc,
+        s"enum $enumName mixes shared parameters with `case` cases; ADT enums carry per-case fields only")))
+    }
+
+    // A generic ADT enum (`enum Opt[T] { case Some(value: T); case Nothing }`)
+    // carries its parameters onto every generated declaration: the sealed
+    // interface becomes `Opt[T]`, each case record becomes `Some[T]`, and each
+    // case's implemented supertype becomes `Opt[T]` rather than a raw `Opt`
+    // (#311). Without the applied supertype the record would implement the raw
+    // type, which E0066 forbids.
+    val typeParams = enumDecl.typeParameters
+    val enumTypeNode =
+      if (typeParams.isEmpty) AST.TypeNode(loc, AST.ReferenceType(enumName, false), false)
+      else
+        AST.TypeNode(
+          loc,
+          AST.ParameterizedType(
+            AST.ReferenceType(enumName, false),
+            typeParams.map(tp => AST.ReferenceType(tp.name, false))
+          ),
+          false
+        )
+
+    // Interface methods: the enum body sections' methods become interface members
+    // verbatim (bodies preserved -> default methods; bodiless -> abstract).
+    val bodyMethods: List[AST.MethodDeclaration] = enumDecl.sections.flatMap(_.members).collect {
+      case m: AST.MethodDeclaration => m
+    }
+
+    // Singleton cases (`case Origin`) desugar to a ZERO-FIELD record `record Origin()`,
+    // constructed as `new Origin()` and matched via `case o is Origin:`. A dedicated
+    // `Name::Origin` static VALUE accessor is intentionally not synthesized: the
+    // singleton record type and any same-named accessor would collide under `::`
+    // resolution (the name `Origin` already denotes the record type), so `new Origin()`
+    // is the first-cut construction form (see the class notes / final report).
+    val interfaceDecl = AST.InterfaceDeclaration(
+      loc, enumDecl.modifiers | AST.M_SEALED, enumName, Nil, bodyMethods, typeParams
+    )
+
+    // One record per case; singleton -> zero-field record. All implement the enum.
+    val recordDecls: List[AST.RecordDeclaration] = enumDecl.constants.filter(_.isCase).map { c =>
+      val fields = c.caseFields.getOrElse(Nil)
+      AST.recordDeclaration(
+        loc, AST.M_PUBLIC, c.name, typeParams, fields, List(enumTypeNode),
+        null, Nil, Nil, Nil, Nil, Nil
+      )
+    }
+
+    interfaceDecl :: recordDecls
+  }
+}

--- a/src/test/scala/onion/compiler/AdtEnumRewritingSpec.scala
+++ b/src/test/scala/onion/compiler/AdtEnumRewritingSpec.scala
@@ -1,0 +1,99 @@
+package onion.compiler
+
+import onion.compiler.AST.*
+import onion.compiler.exceptions.CompilationException
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Full-AST characterization of the ADT expansion and its position in Rewriting. */
+class AdtEnumRewritingSpec extends AnyFunSuite {
+  private val loc = Location(3, 5, 12, 6)
+  private val fieldLoc = Location(4, 17)
+  private val intType = TypeNode(fieldLoc, PrimitiveType(KInt), false)
+  private val field = Argument(fieldLoc, "value", intType, IntegerLiteral(fieldLoc, 7))
+  private val declaration = EnumDeclaration(loc, M_PUBLIC, "Choice", Nil, List(
+    EnumConstant(Location(4, 7), "Value", Nil, Some(List(field))),
+    EnumConstant(Location(5, 7), "Empty", Nil, Some(Nil))
+  ))
+
+  private def unit(tops: List[Toplevel], rewriteBodies: Boolean = true): CompilationUnit =
+    CompilationUnit(Location(1, 1), "choices.on", ModuleDeclaration(Location(1, 1), "demo"),
+      ImportClause(Location(2, 1), List("List" -> "java.util.List")), tops,
+      needsBodyRewrite = rewriteBodies, topLevelAssignedNames = Set("existing"))
+
+  test("expand products and singleton cases in place, retaining fields, spans and unit metadata") {
+    val before = IntegerLiteral(Location(2, 8), 1)
+    val after = StringLiteral(Location(14, 1), "after")
+    val input = unit(List(before, declaration, after), rewriteBodies = false)
+    val parent = TypeNode(loc, ReferenceType("Choice", false), false)
+    val expected = input.copy(toplevels = List(
+      before,
+      InterfaceDeclaration(loc, M_PUBLIC | M_SEALED, "Choice", Nil, Nil),
+      RecordDeclaration(loc, M_PUBLIC, "Value", Nil, List(field), List(parent)),
+      RecordDeclaration(loc, M_PUBLIC, "Empty", Nil, Nil, List(parent)),
+      after
+    ))
+    assert(TestSupport.rewrite(input) == expected)
+  }
+
+  test("propagate ordered type parameters and bounds to every case and apply the parent type") {
+    val params = List(
+      TypeParameter(Location(3, 17), "T", Some(TypeNode(loc, ReferenceType("Object", false), false))),
+      TypeParameter(Location(3, 20), "U")
+    )
+    val genericField = field.copy(typeRef = TypeNode(fieldLoc, ReferenceType("T", false), false))
+    val generic = declaration.copy(typeParameters = params, constants = List(
+      EnumConstant(fieldLoc, "Value", Nil, Some(List(genericField))),
+      EnumConstant(Location(5, 7), "Empty", Nil, Some(Nil))))
+    val input = unit(List(generic))
+    val parent = TypeNode(loc, ParameterizedType(ReferenceType("Choice", false),
+      List(ReferenceType("T", false), ReferenceType("U", false))), false)
+    assert(TestSupport.rewrite(input) == input.copy(toplevels = List(
+      InterfaceDeclaration(loc, M_PUBLIC | M_SEALED, "Choice", Nil, Nil, params),
+      RecordDeclaration(loc, M_PUBLIC, "Value", params, List(genericField), List(parent)),
+      RecordDeclaration(loc, M_PUBLIC, "Empty", params, Nil, List(parent))
+    )))
+  }
+
+  test("preserve section method order and rewrite generated interface method bodies") {
+    val bodyLoc = Location(8, 9)
+    val monad = TypeNode(bodyLoc, ReferenceType("Future", false), false)
+    val body = BlockExpression(bodyLoc, List(DoExpression(bodyLoc, monad,
+      List(IntegerLiteral(bodyLoc, 42)))))
+    val method = MethodDeclaration(bodyLoc, M_PUBLIC, "answer", Nil, monad, body)
+    val abstractMethod = method.copy(name = "other", block = null)
+    val input = unit(List(declaration.copy(sections = List(
+      AccessSection(loc, M_PUBLIC, List(method,
+        FieldDeclaration(fieldLoc, M_PUBLIC, "ignored", intType, null))),
+      AccessSection(bodyLoc, M_PUBLIC, List(abstractMethod))
+    ))))
+    val loweredMethod = method.copy(block = BlockExpression(bodyLoc,
+      List(StaticMethodCall(bodyLoc, monad, "successful", List(IntegerLiteral(bodyLoc, 42))))))
+    val parent = TypeNode(loc, ReferenceType("Choice", false), false)
+    assert(TestSupport.rewrite(input) == input.copy(toplevels = List(
+      InterfaceDeclaration(loc, M_PUBLIC | M_SEALED, "Choice", Nil, List(loweredMethod, abstractMethod)),
+      RecordDeclaration(loc, M_PUBLIC, "Value", Nil, List(field), List(parent)),
+      RecordDeclaration(loc, M_PUBLIC, "Empty", Nil, Nil, List(parent))
+    )))
+  }
+
+  test("leave homogeneous enums untouched and only lower case constants in mixed AST input") {
+    val plain = EnumConstant(loc, "PLAIN", Nil)
+    val homogeneous = declaration.copy(constants = List(plain))
+    val input = unit(List(homogeneous))
+    assert(TestSupport.rewrite(input) == input)
+    val mixed = declaration.copy(constants = plain :: declaration.constants)
+    assert(TestSupport.rewrite(unit(List(mixed))) == TestSupport.rewrite(unit(List(declaration))))
+  }
+
+  test("reject shared parameters with the original diagnostic and attach the unit source file") {
+    val input = unit(List(declaration.copy(params = List(field))))
+    val rewriter = TestSupport.createRewriting
+    val expected = CompileError("", loc,
+      "enum Choice mixes shared parameters with `case` cases; ADT enums carry per-case fields only")
+    val direct = intercept[CompilationException](rewriter.rewrite(input))
+    assert(direct.problems.toList == List(expected))
+    val processed = intercept[CompilationException](
+      rewriter.processBody(Seq(input), rewriter.newEnvironment(Seq(input))))
+    assert(processed.problems.toList == List(expected.copy(sourceFile = "choices.on")))
+  }
+}


### PR DESCRIPTION
## Summary

Begin the roadmap's rewriting decomposition with one closed transformation:
move ADT enum declaration construction into `rewrite.AdtEnumLowering`.
The method body is unchanged. `Rewriting` retains enum selection, subsequent
body rewriting, mutable scopes, the body fast path, and diagnostic source enrichment.

Full-AST characterizations cover ordered product/singleton expansion, generic
bounds and parent application, locations and unit metadata, method filtering
and body rewriting, homogeneous passthrough, and original diagnostic provenance.
Architecture, decision log, roadmap, and contributor recipe document the boundary.

## Verification

- Baseline focused tests: 70 passed; five new characterizations also passed before extraction.
- Mutation: removing the sealed bit failed three characterizations; restored before extraction.
- Final focused tests: 75 passed.
- Fresh English and Japanese `testFull`: **5,230 passed each**, 714 suites, zero failures.
  Each retains the existing one opt-in distribution-smoke cancellation.
- `run/AdtExpr.on`: all eight emitted class files / 10,545 bytes are byte-identical
  before and after; direct execution prints `((2 + 3) * -(4 - 1)) = -15`.
- Maintainability audit test, `git diff --check`, and `mkdocs build --strict` passed.
- Independent read-only review: no findings.

Rewriting: 1,688 → 1,610 lines; no extra traversal or performance-improvement claim.
Existing JavaCC/JDK/build warnings are unchanged. Revert this commit to roll back;
no grammar, runtime, resources, generated sources, or public API changes.
