### PR TITLE
test: add StringsDocCoverageSpec regression guard for onion.Strings stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already documented in both files; this guard now fails the build if a
   future addition to `onion.Sets` goes undocumented.
 
+- **Added a `StringsDocCoverageSpec` regression guard checking that every
+  public `onion.Strings` member is documented in both
+  `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.**
+  `onion.Strings` is a large, default-imported stdlib module (`Strings::trim`,
+  `Strings::padLeft`, `Strings::capitalizeWords`, ...) with almost 40 distinct
+  public static member names, several already individually guarded against
+  native-method shadowing by its `*ExtensionCallShadowingSpec` files, but --
+  unlike `Maps`/`Sets`/`Csv` -- it never had a regression test checking that
+  every member stays documented using the `Strings::name` spelling. All ~40
+  members were already documented in both files; this guard now fails the
+  build if a future addition to `onion.Strings` goes undocumented.
+
 ## [0.55.0] - 2026-09-05
 
 ### Documentation

--- a/src/test/scala/onion/compiler/tools/StringsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsDocCoverageSpec.scala
@@ -1,0 +1,61 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Strings` module docs.
+ *
+ * `onion.Strings` is a large, default-imported stdlib module (`Strings::trim`,
+ * `Strings::padLeft`, `Strings::capitalizeWords`, ...) with almost 40 distinct public static
+ * member names, several already guarded individually against native-method shadowing by
+ * `StringsExtensionCallShadowingSpec`/`StringsIsBlankExtensionCallShadowingSpec`/
+ * `StringsJoinExtensionCallShadowingSpec`/`StringsReplaceExtensionCallShadowingSpec`/
+ * `StringsEndsWithExtensionCallShadowingSpec`/`StringsContainsIsEmptyExtensionCallShadowingSpec`/
+ * `StringsTrimStartsWithIndexOfExtensionCallShadowingSpec` -- but, unlike `Maps`/`Sets`/`Csv`,
+ * it has never had a regression test checking that every member stays documented in both
+ * docs/reference/stdlib.md and docs/ja/reference/stdlib.md using the `Strings::name` spelling.
+ * Every public member is checked here so a future addition to onion.Strings fails the build
+ * instead of silently staying undocumented.
+ */
+class StringsDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Strings::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Strings]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    methodNames.toSet
+  }
+
+  it("actual onion.Strings exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Strings found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Strings member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Strings:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Strings member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Strings:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Strings in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Strings"),
+      "docs/reference/stdlib.md's overview table should mention Strings")
+    assert(read("docs/ja/reference/stdlib.md").contains("Strings"),
+      "docs/ja/reference/stdlib.md's overview table should mention Strings")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Strings` is a large, default-imported stdlib module (`Strings::trim`, `Strings::padLeft`, `Strings::capitalizeWords`, ...) with almost 40 distinct public static member names, several already individually guarded against native-method shadowing by its `*ExtensionCallShadowingSpec` files, but — unlike `Maps`/`Sets`/`Csv` — it never had a regression test checking that every member stays documented in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- Adds `StringsDocCoverageSpec`, following the same pattern as `MapsDocCoverageSpec`/`SetsDocCoverageSpec`/`CsvDocCoverageSpec`: reflects over `onion.Strings`'s static methods and asserts every name appears as `Strings::name` in both doc files.
- All ~40 members were already documented in both files, so this is a pure regression guard (currently green) that will fail the build if a future addition to `onion.Strings` goes undocumented.
- Records the addition in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `sbt -Duser.language=en testOnly onion.compiler.tools.StringsDocCoverageSpec` — 4/4 passed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5233 tests, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test requiring `-Donion.dist.path`), 0 ignored — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH3AT2sWzb6F6wPidj2tEj

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH3AT2sWzb6F6wPidj2tEj)_