### PR TITLE
test: add IterablesDocCoverageSpec regression guard for onion.Iterables stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Added an `IterablesDocCoverageSpec` regression guard checking that every
+  public `onion.Iterables` member is documented in both
+  `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.**
+  `onion.Iterables` is a default-imported stdlib module (`Iterables::map`,
+  `Iterables::filter`, `Iterables::foldl`, ...) with 16 distinct public static
+  member names, but -- unlike `Strings`/`Regex`/`Csv`, the other
+  default-imported modules, each already guarded by its own
+  `*DocCoverageSpec` -- it never had one. All 16 members were already
+  documented in both files; this guard now fails the build if a future
+  addition to `onion.Iterables` goes undocumented.
+
 - **Added a `CsvDocCoverageSpec` regression guard checking that every public
   `onion.Csv` member is documented in both `docs/reference/stdlib.md` and
   `docs/ja/reference/stdlib.md`.** `onion.Csv` is a genuine, default-imported

--- a/src/test/scala/onion/compiler/tools/IterablesDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/IterablesDocCoverageSpec.scala
@@ -1,0 +1,56 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Iterables` module docs.
+ *
+ * `onion.Iterables` is a default-imported stdlib module (`Iterables::map`,
+ * `Iterables::filter`, `Iterables::foldl`, ...) with 16 distinct public static
+ * member names, but -- unlike `Strings`/`Regex`/`Csv`, the other default-imported
+ * modules, each already guarded by its own `*DocCoverageSpec` -- it never had one.
+ * All 16 members were already documented in both files; this guard now fails the
+ * build if a future addition to `onion.Iterables` goes undocumented.
+ */
+class IterablesDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Iterables::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Iterables]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    methodNames.toSet
+  }
+
+  it("actual onion.Iterables exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Iterables found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Iterables member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Iterables:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Iterables member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Iterables:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Iterables in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Iterables"),
+      "docs/reference/stdlib.md's overview table should mention Iterables")
+    assert(read("docs/ja/reference/stdlib.md").contains("Iterables"),
+      "docs/ja/reference/stdlib.md's overview table should mention Iterables")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Iterables` is default-imported (alongside `Strings`/`Regex`/`Csv`, each already guarded by its own `*DocCoverageSpec`), but never had a regression test checking its public members stay documented.
- Adds `IterablesDocCoverageSpec`, following the exact pattern of `StringsDocCoverageSpec`/`CsvDocCoverageSpec`/`SetsDocCoverageSpec`: reflects on `onion.Iterables`'s 16 public static members and asserts each is mentioned (as `Iterables::name`) in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- All 16 members were already documented in both files, so this only adds a build-time guard against future undocumented additions.
- Adds the corresponding `[Unreleased]` entry to `CHANGELOG.md`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5272 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TsaewxujGVfQaBV8moWxR

---
_Generated by [Claude Code](https://claude.ai/code/session_019TsaewxujGVfQaBV8moWxR)_