### PR TITLE
feat(parser): trailing lambda on a static call without parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A trailing lambda now attaches to a static call without an empty argument
+  list: `Future::async { -> compute() }`, `Helper::twice { x -> x + 1 }`.**
+  Instance calls already accepted `list.map { x -> x * 2 }`, but the
+  `Type::method` forms only took a trailing lambda after `(...)`, so the
+  zero-argument case had to be written `Future::async() { -> ... }` or
+  `Future::async(() -> { return compute(); })`. Both the JavaCC grammar and
+  the handwritten fast-path parser gained the alternative; `Type::name`
+  without a following `{ ... -> }` is still a static member selection, so
+  no accepted program changes meaning (`StaticTrailingLambdaSpec`).
+
 ### Documentation
+
+- **The README, `docs/index.md`, the async/functional examples, the stdlib
+  and specification references and `CLAUDE.md` (EN/JA) now write zero-argument
+  callbacks as trailing lambdas (`Future::async { -> ... }`,
+  `Timing::measure { -> ... }`) instead of `(() -> { return ...; })`.**
 
 - **Added a `CsvDocCoverageSpec` regression guard checking that every public
   `onion.Csv` member is documented in both `docs/reference/stdlib.md` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,7 @@ def main(name: String, count: Int = 3, loud: Boolean = false): void { ... }
 
 **Asynchronous Programming:**
 ```onion
-val future: Future[String] = Future::async(() -> { longOperation() })
+val future: Future[String] = Future::async { -> longOperation() }
 future.map((s) -> s.toUpperCase())
 future.onSuccess((s) -> IO::println(s))
 future.onFailure((e) -> IO::println("Error: " + e.message()))
@@ -530,6 +530,7 @@ These are frequently confused with other languages. **Always check these:**
 | `Int -> Int` | ✓ correct - single param function type |
 | `(Int, Int) -> Int` | ✓ correct - multi-param function type |
 | `list.map { x => x * 2 }` | `list.map { x -> x * 2 }` - the trailing-lambda arrow is `->` too; `=>` is not part of the language (one arrow everywhere: function types, `(x) -> e`, `{ x -> e }`) |
+| `Future::async(() -> { return compute(); })` | `Future::async { -> compute() }` - a trailing lambda attaches to a static call too, with no empty `()` in between; `{ -> body }` is the zero-parameter form, and the block's last expression is its value |
 | `stream().map().collect()` | `list.map { ... }.filter { ... }` - List/Iterable/arrays have builtin extension pipelines |
 
 ### Method Calls

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Onion supports Haskell-style do notation for composing monadic operations (Optio
 ```onion
 // Async computation with do notation
 val result: Future[Int] = do[Future] {
-  x <- Future::async(() -> { return fetchUser(); })
-  y <- Future::async(() -> { return fetchData(x); })
+  x <- Future::async { -> fetchUser() }
+  y <- Future::async { -> fetchData(x) }
   ret x + y
 }
 
@@ -205,7 +205,7 @@ Methods accepting a function as the last parameter can use trailing lambda synta
 
 ```onion
 // Traditional call
-list.map((x: Int) -> { return x * 2; })
+list.map((x: Int) -> x * 2)
 
 // With trailing lambda
 list.map { x -> x * 2 }
@@ -214,6 +214,9 @@ list.map { x -> x * 2 }
 list.fold(0) { acc, x ->
   acc + x
 }
+
+// Zero parameters: `{ -> body }`; works on static calls too
+val answer: Future[Int] = Future::async { -> compute() }
 ```
 
 ### Asynchronous Programming with Future
@@ -221,13 +224,13 @@ list.fold(0) { acc, x ->
 Built-in `Future[T]` type for async operations:
 
 ```onion
-val future: Future[String] = Future::async(() -> {
-  return Http::get("https://api.example.com/data");
-})
+val future: Future[String] = Future::async { ->
+  Http::get("https://api.example.com/data")
+}
 
-future.map((data: String) -> { return parseJson(data); })
-      .onSuccess((result: Object) -> { println(result); })
-      .onFailure((error: Throwable) -> { println("Error: " + error); })
+future.map { data -> parseJson(data) }
+      .onSuccess { result -> println(result) }
+      .onFailure { error -> println("Error: " + error) }
 ```
 
 ### Shape-First Scripting

--- a/docs/examples/async.md
+++ b/docs/examples/async.md
@@ -8,10 +8,10 @@ Run work in the background with `Future::async`.
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async(() -> {
+  return Future::async { ->
     Thread::sleep(delayMs)
-    return "body of " + url
-  })
+    "body of " + url
+  }
 }
 
 val f = fetchPage("https://example.com", 100L)
@@ -74,10 +74,10 @@ println("value=" + recovered.getOrElse(-1))
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async(() -> {
+  return Future::async { ->
     Thread::sleep(delayMs)
-    return "body of " + url
-  })
+    "body of " + url
+  }
 }
 
 val urls = [

--- a/docs/examples/functional.md
+++ b/docs/examples/functional.md
@@ -443,18 +443,18 @@ val nested: Option[Int] = do[Option] {
 val immediate: Future[Int] = Future::successful(42)
 
 // Async computation
-val async: Future[String] = Future::async(() -> {
-  Thread::sleep(1000L);
-  return "Hello after 1 second";
-})
+val async: Future[String] = Future::async { ->
+  Thread::sleep(1000L)
+  "Hello after 1 second"
+}
 
 // From throwing operation
-val risky: Future[Int] = Future::asyncThrowing(() -> {
+val risky: Future[Int] = Future::asyncThrowing { ->
   if Math::random() < 0.5 {
-    throw new RuntimeException("Bad luck!");
+    throw new RuntimeException("Bad luck!")
   }
-  return 100;
-})
+  100
+}
 ```
 
 ### Transforming Futures
@@ -467,9 +467,9 @@ val doubled: Future[Int] = numbers.map((x: Int) -> { return x * 2; })
 
 // FlatMap: chain async operations
 val chained: Future[String] = numbers.flatMap((x: Int) -> {
-  return Future::async(() -> {
-    return "Number is: " + x;
-  });
+  return Future::async { ->
+    "Number is: " + x
+  };
 })
 
 // Filter: fail if predicate not met
@@ -496,8 +496,8 @@ val retried: Future[Int] = failing.recoverWith((error: Throwable) -> {
 ### Combining Futures
 
 ```onion
-val f1: Future[Int] = Future::async(() -> { Thread::sleep(100L); return 1; })
-val f2: Future[Int] = Future::async(() -> { Thread::sleep(200L); return 2; })
+val f1: Future[Int] = Future::async { -> Thread::sleep(100L); 1 }
+val f2: Future[Int] = Future::async { -> Thread::sleep(200L); 2 }
 
 // Wait for all
 val all: Future[Object[]] = Future::all(f1, f2)
@@ -518,9 +518,9 @@ val zipped: Future[Object[]] = f1.zip(f2)
 ### Callbacks
 
 ```onion
-val future: Future[String] = Future::async(() -> {
-  return "Async result";
-})
+val future: Future[String] = Future::async { ->
+  "Async result"
+}
 
 future
   .onSuccess((value: String) -> { println("Success: " + value); })
@@ -530,7 +530,7 @@ future
 ### Blocking (Use Sparingly)
 
 ```onion
-val future: Future[Int] = Future::async(() -> { return 42; })
+val future: Future[Int] = Future::async { -> 42 }
 
 // Block until complete
 val result: Int = future.await()
@@ -546,11 +546,11 @@ val safe: Int = future.getOrElse(0)
 
 ```onion
 def fetchUser(id: Int): Future[String] {
-  return Future::async(() -> { return "User" + id; });
+  return Future::async { -> "User" + id };
 }
 
 def fetchProfile(name: String): Future[String] {
-  return Future::async(() -> { return name + "'s profile"; });
+  return Future::async { -> name + "'s profile" };
 }
 
 val profile: Future[String] = do[Future] {
@@ -567,11 +567,11 @@ profile.onSuccess((p: String) -> { println(p); })
 
 ```onion
 def fetchFromApi(url: String): Future[String] {
-  return Future::async(() -> {
+  return Future::async { ->
     // Simulate network request
-    Thread::sleep((Math::random() * 1000L) as Long);
-    return "Data from " + url;
-  });
+    Thread::sleep((Math::random() * 1000L) as Long)
+    "Data from " + url
+  };
 }
 
 // Fire off multiple requests in parallel

--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -111,7 +111,8 @@ primary               ::= id
 
 /* One arrow, everywhere a function is written: function types, parenthesized
    lambdas, and trailing lambdas all use '->'. A trailing lambda follows a call
-   (with or without parentheses) as its last argument; its parameters are not
+   -- unqualified, instance (`obj.m`) or static (`Type::m`), with or without
+   parentheses -- as its last argument; its parameters are not
    parenthesized, and a parameter's type may not itself be a bare function type
    (write such a lambda in the parenthesized form). */
 lambda                ::= '(' [lambda_param (',' lambda_param)*] ')' '->' (block | term)

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ val result: Option[Int] = do[Option] {
 }
 
 // Async programming with Future
-val future: Future[String] = Future::async(() -> { return fetchData(); })
+val future: Future[String] = Future::async { -> fetchData() }
 future.map { data -> processData(data) }
       .onSuccess { result -> println(result) }
 

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -331,7 +331,7 @@ do[Option] { a <- getA(); b <- getB(); ret a + b }
 
 **非同期プログラミング:**
 ```onion
-val future: Future[String] = Future::async(() -> { longOperation() })
+val future: Future[String] = Future::async { -> longOperation() }
 future.map((s) -> s.toUpperCase())
 future.onSuccess((s) -> IO::println(s))
 future.onFailure((e) -> IO::println("Error: " + e.message()))
@@ -471,6 +471,7 @@ try {
 | `Int -> Int` | ✓ 正しい - 単一引数の関数型 |
 | `(Int, Int) -> Int` | ✓ 正しい - 複数引数の関数型 |
 | `list.map { x => x * 2 }` | `list.map { x -> x * 2 }` - トレイリングラムダの矢印も`->`。`=>`は言語には存在しない（関数型、`(x) -> e`、`{ x -> e }`のすべてで矢印は`->`の一種類だけ） |
+| `Future::async(() -> { return compute(); })` | `Future::async { -> compute() }` - トレイリングラムダは static 呼び出しにも直接付けられる（間に空の`()`は不要）。引数なしは`{ -> 本体 }`と書き、ブロック最後の式が値になる |
 | `stream().map().collect()` | `list.map { ... }.filter { ... }` - List/Iterable/配列に組み込みのextensionパイプラインがある |
 
 ### メソッド呼び出し

--- a/docs/ja/examples/async.md
+++ b/docs/ja/examples/async.md
@@ -8,10 +8,10 @@ Onionは `Future` 型と `do[Future]` 構文を提供し、非同期プログラ
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async(() -> {
+  return Future::async { ->
     Thread::sleep(delayMs)
-    return "body of " + url
-  })
+    "body of " + url
+  }
 }
 
 val f = fetchPage("https://example.com", 100L)
@@ -74,10 +74,10 @@ println("value=" + recovered.getOrElse(-1))
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async(() -> {
+  return Future::async { ->
     Thread::sleep(delayMs)
-    return "body of " + url
-  })
+    "body of " + url
+  }
 }
 
 val urls = [

--- a/docs/ja/examples/functional.md
+++ b/docs/ja/examples/functional.md
@@ -444,18 +444,18 @@ val nested: Option[Int] = do[Option] {
 val immediate: Future[Int] = Future::successful(42)
 
 // 非同期計算
-val async: Future[String] = Future::async(() -> {
-  Thread::sleep(1000L);
-  return "Hello after 1 second";
-})
+val async: Future[String] = Future::async { ->
+  Thread::sleep(1000L)
+  "Hello after 1 second"
+}
 
 // 例外を投げうる操作から
-val risky: Future[Int] = Future::asyncThrowing(() -> {
+val risky: Future[Int] = Future::asyncThrowing { ->
   if Math::random() < 0.5 {
-    throw new RuntimeException("Bad luck!");
+    throw new RuntimeException("Bad luck!")
   }
-  return 100;
-})
+  100
+}
 ```
 
 ### Future の変換
@@ -468,9 +468,9 @@ val doubled: Future[Int] = numbers.map((x: Int) -> { return x * 2; })
 
 // flatMap: 非同期操作を連鎖
 val chained: Future[String] = numbers.flatMap((x: Int) -> {
-  return Future::async(() -> {
-    return "Number is: " + x;
-  });
+  return Future::async { ->
+    "Number is: " + x
+  };
 })
 
 // filter: 述語を満たさない場合は失敗
@@ -497,8 +497,8 @@ val retried: Future[Int] = failing.recoverWith((error: Throwable) -> {
 ### Future の合成
 
 ```onion
-val f1: Future[Int] = Future::async(() -> { Thread::sleep(100L); return 1; })
-val f2: Future[Int] = Future::async(() -> { Thread::sleep(200L); return 2; })
+val f1: Future[Int] = Future::async { -> Thread::sleep(100L); 1 }
+val f2: Future[Int] = Future::async { -> Thread::sleep(200L); 2 }
 
 // すべて待つ
 val all: Future[Object[]] = Future::all(f1, f2)
@@ -519,9 +519,9 @@ val zipped: Future[Object[]] = f1.zip(f2)
 ### コールバック
 
 ```onion
-val future: Future[String] = Future::async(() -> {
-  return "Async result";
-})
+val future: Future[String] = Future::async { ->
+  "Async result"
+}
 
 future
   .onSuccess((value: String) -> { println("Success: " + value); })
@@ -531,7 +531,7 @@ future
 ### ブロッキング（控えめに使う）
 
 ```onion
-val future: Future[Int] = Future::async(() -> { return 42; })
+val future: Future[Int] = Future::async { -> 42 }
 
 // 完了までブロック
 val result: Int = future.await()
@@ -547,11 +547,11 @@ val safe: Int = future.getOrElse(0)
 
 ```onion
 def fetchUser(id: Int): Future[String] {
-  return Future::async(() -> { return "User" + id; });
+  return Future::async { -> "User" + id };
 }
 
 def fetchProfile(name: String): Future[String] {
-  return Future::async(() -> { return name + "'s profile"; });
+  return Future::async { -> name + "'s profile" };
 }
 
 val profile: Future[String] = do[Future] {
@@ -568,11 +568,11 @@ profile.onSuccess((p: String) -> { println(p); })
 
 ```onion
 def fetchFromApi(url: String): Future[String] {
-  return Future::async(() -> {
+  return Future::async { ->
     // ネットワークリクエストをシミュレート
-    Thread::sleep((Math::random() * 1000L) as Long);
-    return "Data from " + url;
-  });
+    Thread::sleep((Math::random() * 1000L) as Long)
+    "Data from " + url
+  };
 }
 
 // 複数のリクエストを並列で発行

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -68,7 +68,7 @@ val result: Option[Int] = do[Option] {
 }
 
 // Futureによる非同期プログラミング
-val future: Future[String] = Future::async(() -> { return fetchData(); })
+val future: Future[String] = Future::async { -> fetchData() }
 future.map { data -> processData(data) }
       .onSuccess { result -> println(result) }
 

--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -524,7 +524,7 @@ throw new IllegalStateException("message")
 val f: Int -> Int = x -> x * 2          // 裸パラメータ、式本体
 val g = (a: Int, b: Int) -> a + b
 list.map { x -> x * 2 }                 // 末尾ラムダ
-Future::async(() -> { return compute() })
+Future::async { -> compute() }
 val r: Runnable = () -> println("hi")   // SAM 変換
 ```
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -921,19 +921,19 @@ Timing::sleepNanos(500000L) // 500,000ナノ秒スリープ
 
 ```onion
 // 実行時間を計測して表示し、結果を返す
-val result: Int = Timing::measure(() -> { return expensiveOperation(); })
+val result: Int = Timing::measure { -> expensiveOperation() }
 // 出力: "Elapsed: 123.45ms"
-val result2: Int = Timing::measure("task", () -> { return expensiveOperation(); })
+val result2: Int = Timing::measure("task") { -> expensiveOperation() }
 // 出力: "task: 123.45ms"
 
 // 戻り値のない関数版
-Timing::measureVoid(() -> { expensiveOperation(); })
+Timing::measureVoid { -> expensiveOperation() }
 // 出力: "Elapsed: 123.45ms"
-Timing::measureVoid("task", () -> { expensiveOperation(); })
+Timing::measureVoid("task") { -> expensiveOperation() }
 // 出力: "task: 123.45ms"
 
 // 表示なしで実行時間（ナノ秒）を取得
-val timeNanos: Long = Timing::time(() -> { return expensiveOperation(); })
+val timeNanos: Long = Timing::time { -> expensiveOperation() }
 ```
 
 ## Option モジュール
@@ -979,12 +979,12 @@ val done: Future[Int] = Future::successful(42)
 val fail: Future[Int] = Future::failed(new RuntimeException("error"))
 
 // バックグラウンドスレッドで非同期実行
-val async: Future[String] = Future::async(() -> { return compute(); })
+val async: Future[String] = Future::async { -> compute() }
 
 // 例外処理付きの非同期実行
-val safe: Future[Int] = Future::asyncThrowing(() -> {
-  return riskyOperation();
-})
+val safe: Future[Int] = Future::asyncThrowing { ->
+  riskyOperation()
+}
 
 // 遅延
 val delayed: Future[Void] = Future::delay(1000L)  // 1秒
@@ -1026,7 +1026,7 @@ f.mapError((e: Throwable) -> { return new CustomException(e); })
 ### コールバック
 
 ```onion
-val f: Future[String] = Future::async(() -> { return "result"; })
+val f: Future[String] = Future::async { -> "result" }
 
 f.onSuccess((value: String) -> { IO::println(value); })
 f.onFailure((error: Throwable) -> { IO::println(error); })
@@ -1098,8 +1098,8 @@ Futureは順次非同期合成のためのdo記法で動作：
 
 ```onion
 val result: Future[Int] = do[Future] {
-  x <- Future::async(() -> { return fetchA(); })
-  y <- Future::async(() -> { return fetchB(x); })
+  x <- Future::async { -> fetchA() }
+  y <- Future::async { -> fetchB(x) }
   ret x + y
 }
 ```
@@ -2403,7 +2403,7 @@ val hits = Concurrent::counter()
 hits.increment()
 
 val lock = Concurrent::lock()
-lock.withLock(() -> { /* … */ })     // 本体が例外を投げても解放される
+lock.withLock { -> /* … */ }         // 本体が例外を投げても解放される
 
 val chan = Concurrent::channel(16)   // 意図的に上限つき
 chan.send("work")

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -551,7 +551,7 @@ Resources close automatically in reverse declaration order.
 val f: Int -> Int = x -> x * 2          // bare param, expression body
 val g = (a: Int, b: Int) -> a + b
 list.map { x -> x * 2 }                 // trailing lambda
-Future::async(() -> { return compute() })
+Future::async { -> compute() }
 val r: Runnable = () -> println("hi")   // SAM conversion
 ```
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -999,12 +999,12 @@ val done: Future[Int] = Future::successful(42)
 val fail: Future[Int] = Future::failed(new RuntimeException("error"))
 
 // Run async on background thread
-val async: Future[String] = Future::async(() -> { return compute(); })
+val async: Future[String] = Future::async { -> compute() }
 
 // Async with exception handling
-val safe: Future[Int] = Future::asyncThrowing(() -> {
-  return riskyOperation();
-})
+val safe: Future[Int] = Future::asyncThrowing { ->
+  riskyOperation()
+}
 
 // Delay
 val delayed: Future[Void] = Future::delay(1000L)  // 1 second
@@ -1046,7 +1046,7 @@ f.mapError((e: Throwable) -> { return new CustomException(e); })
 ### Callbacks
 
 ```onion
-val f: Future[String] = Future::async(() -> { return "result"; })
+val f: Future[String] = Future::async { -> "result" }
 
 f.onSuccess((value: String) -> { IO::println(value); })
 f.onFailure((error: Throwable) -> { IO::println(error); })
@@ -1118,8 +1118,8 @@ Future works with do notation for sequential async composition:
 
 ```onion
 val result: Future[Int] = do[Future] {
-  x <- Future::async(() -> { return fetchA(); })
-  y <- Future::async(() -> { return fetchB(x); })
+  x <- Future::async { -> fetchA() }
+  y <- Future::async { -> fetchB(x) }
   ret x + y
 }
 ```
@@ -1271,19 +1271,19 @@ Timing::sleepNanos(500000L) // Sleep for 500,000 nanoseconds
 
 ```onion
 // Measure and print execution time, return result
-val result: Int = Timing::measure(() -> { return expensiveOperation(); })
+val result: Int = Timing::measure { -> expensiveOperation() }
 // Prints: "Elapsed: 123.45ms"
-val result2: Int = Timing::measure("task", () -> { return expensiveOperation(); })
+val result2: Int = Timing::measure("task") { -> expensiveOperation() }
 // Prints: "task: 123.45ms"
 
 // Same, but for a function that returns nothing
-Timing::measureVoid(() -> { expensiveOperation(); })
+Timing::measureVoid { -> expensiveOperation() }
 // Prints: "Elapsed: 123.45ms"
-Timing::measureVoid("task", () -> { expensiveOperation(); })
+Timing::measureVoid("task") { -> expensiveOperation() }
 // Prints: "task: 123.45ms"
 
 // Get execution time in nanoseconds without printing
-val timeNanos: Long = Timing::time(() -> { return expensiveOperation(); })
+val timeNanos: Long = Timing::time { -> expensiveOperation() }
 ```
 
 ## Strings Module
@@ -2245,7 +2245,7 @@ val hits = Concurrent::counter()
 hits.increment()
 
 val lock = Concurrent::lock()
-lock.withLock(() -> { /* … */ })     // releases even if the body throws
+lock.withLock { -> /* … */ }         // releases even if the body throws
 
 val chan = Concurrent::channel(16)   // bounded on purpose
 chan.send("work")

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -352,6 +352,14 @@ public class JJOnionParser implements Parser {
    * right-hand side: f -> f(e); f(a) -> f(e, a); obj.m -> obj.m(e);
    * obj.m(a) -> obj.m(e, a); C::m(a) -> C::m(e, a).
    */
+  /** `Type::name` is a member selection, unless a trailing lambda follows: then it is a call with that one argument. */
+  private AST.Expression staticMemberOrCall(Token colon2, Token name, AST.TypeNode ty, AST.ClosureExpression tl) {
+    if (tl == null) return new AST.StaticMemberSelection(p(colon2), ty, c(name));
+    List<AST.Expression> es = (List<AST.Expression>)AST.NIL();
+    es = AST.appendToList(es, tl);
+    return new AST.StaticMethodCall(through(name), ty, c(name), es);
+  }
+
   private AST.Expression pipeInto(Location loc, AST.Expression value, AST.Expression rhs) throws ParseException {
     if (rhs instanceof AST.UnqualifiedMethodCall) {
       AST.UnqualifiedMethodCall c = (AST.UnqualifiedMethodCall) rhs;
@@ -2839,7 +2847,8 @@ AST.Expression static_access_primary() : {
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es); }
 | LOOKAHEAD( boxed_class_type() "::" ) ty=boxed_class_type() t="::" n=id()
-    { return new AST.StaticMemberSelection(p(t), ty, c(n)); }
+    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    { return staticMemberOrCall(t, n, ty, tl); }
 | LOOKAHEAD( dotted_class_type() "::" id() type_arguments() "(" ) ty=dotted_class_type() t="::" n=id() tas=type_arguments() "(" es=terms() ")"
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es, tas); }
@@ -2847,14 +2856,17 @@ AST.Expression static_access_primary() : {
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es); }
 | LOOKAHEAD( dotted_class_type() "::" ) ty=dotted_class_type() t="::" n=id()
-    { return new AST.StaticMemberSelection(p(t), ty, c(n)); }
+    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    { return staticMemberOrCall(t, n, ty, tl); }
 | LOOKAHEAD( class_type() "::" id() type_arguments() "(" ) ty=class_type() t="::" n=id() tas=type_arguments() "(" es=terms()  ")"
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es, tas); }
 | LOOKAHEAD(4) ty=class_type() t="::" n=id() "(" es=terms()  ")"
     [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es); }
-| LOOKAHEAD(2) ty=class_type() t="::" n=id()                        {return new AST.StaticMemberSelection(p(t), ty, c(n));}
+| LOOKAHEAD(2) ty=class_type() t="::" n=id()
+    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    { return staticMemberOrCall(t, n, ty, tl); }
 | LOOKAHEAD({ true }) e=primary_rest() {return e;}
 }
 

--- a/src/main/scala/onion/compiler/parser/OnionParser.scala
+++ b/src/main/scala/onion/compiler/parser/OnionParser.scala
@@ -1998,7 +1998,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
       }
       if (looksLike { boxedClassType(); expect(K.COLON2) }) {
         val ty = boxedClassType(); val t = expect(K.COLON2); val n = id()
-        return AST.StaticMemberSelection(p(t), ty, c(n))
+        return staticMemberOrCall(t, n, ty, trailingLambdaOpt())
       }
     }
     if (isId(kind(1)) && kind(2) == K.DOT) {
@@ -2016,7 +2016,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
       }
       if (looksLike { dottedClassType(); expect(K.COLON2) }) {
         val ty = dottedClassType(); val t = expect(K.COLON2); val n = id()
-        return AST.StaticMemberSelection(p(t), ty, c(n))
+        return staticMemberOrCall(t, n, ty, trailingLambdaOpt())
       }
     }
     if (looksLike { classType(); expect(K.COLON2); id(); typeArguments(); expect(K.LPAREN) }) {
@@ -2033,10 +2033,15 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     }
     if ((isId(kind(1)) || kind(1) == K.FQCN) && kind(2) == K.COLON2) {
       val ty = classType(); val t = expect(K.COLON2); val n = id()
-      return AST.StaticMemberSelection(p(t), ty, c(n))
+      return staticMemberOrCall(t, n, ty, trailingLambdaOpt())
     }
     primaryRest()
   }
+
+  /** `Type::name` is a member selection, unless a trailing lambda follows: then it is a call with that one argument. */
+  private def staticMemberOrCall(colon2: Token, name: Token, ty: AST.TypeNode, tl: AST.ClosureExpression): AST.Expression =
+    if (tl == null) AST.StaticMemberSelection(p(colon2), ty, c(name))
+    else new AST.StaticMethodCall(through(name), ty, c(name), List[AST.Expression](tl))
 
   private def lambdaOrParen(): AST.Expression = {
     if (looksLike(lambdaHead())) arrowAnonymousFunction()

--- a/src/test/scala/onion/compiler/tools/StaticTrailingLambdaSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StaticTrailingLambdaSpec.scala
@@ -1,0 +1,73 @@
+package onion.compiler.tools
+
+import onion.tools.Shell
+
+/**
+ * A trailing lambda attaches to a static call without an empty argument list, the way it
+ * already does to an instance call: `Future::async { -> compute() }` mirrors
+ * `list.map { x -> x * 2 }`. Before this, only `Future::async() { -> ... }` parsed.
+ */
+class StaticTrailingLambdaSpec extends AbstractShellSpec {
+
+  describe("a trailing lambda on a static call without parentheses") {
+    it("is the only argument of a simple `Type::method` call") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val f: Future[Int] = Future::async { -> 21 * 2 }
+          |    return f.await()
+          |  }
+          |}
+          |""".stripMargin,
+        "StaticTrailingLambda.on",
+        Array()
+      )
+      assert(Shell.Success(42) == result)
+    }
+
+    it("binds lambda parameters and reaches a user-defined static method") {
+      val result = shell.run(
+        """
+          |class Helper {
+          |public:
+          |  static def twice(f: Function1[Int, Int]): Int = f.call(f.call(1))
+          |}
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return Helper::twice { x -> x + 1 }
+          |  }
+          |}
+          |""".stripMargin,
+        "StaticTrailingLambdaParams.on",
+        Array()
+      )
+      assert(Shell.Success(3) == result)
+    }
+
+    it("works on a package-qualified type and inside do notation") {
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val r: Future[Int] = do[Future] {
+          |      x <- onion.Future::async { -> 1 }
+          |      y <- Future::async { ->
+          |        x + 1
+          |      }
+          |      ret x + y
+          |    }
+          |    return r.await()
+          |  }
+          |}
+          |""".stripMargin,
+        "StaticTrailingLambdaDo.on",
+        Array()
+      )
+      assert(Shell.Success(3) == result)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `Future::async { -> compute() }` and `Helper::twice { x -> x + 1 }` now parse. Instance calls already took a trailing lambda with no argument list (`list.map { x -> x * 2 }`), but the `Type::method` forms only accepted one after `(...)`, so the zero-argument case had to be written `Future::async() { -> ... }` or `Future::async(() -> { return compute(); })`.
- Both the JavaCC grammar and the handwritten fast-path parser gain the alternative on the three `Type::name` member-selection forms. Without a following `{ ... -> }` they still yield a `StaticMemberSelection`, so no accepted program changes meaning.
- Docs: README, `docs/index.md`, the async/functional examples, the stdlib and specification references, `docs/grammar.txt` and `CLAUDE.md` (EN/JA) write zero-argument callbacks as `{ -> ... }` trailing lambdas instead of `(() -> { return ...; })`.

Note: the arrow is still required in the zero-parameter form (`{ -> body }`). An arrow-less `Type::m { body }` cannot be told apart from the block of an `if`/`while` whose condition ends in a paren-less call (`if xs.isEmpty { ... }`), so that stays a syntax error.

## Test plan

- [x] New `StaticTrailingLambdaSpec` (simple, user-defined static with params, package-qualified + do notation, multi-line body) — RED before the parser change, GREEN after
- [x] `FastPathParserParitySpec`, `FutureErgonomicsSpec`, `TrailingLambdaParenHintSpec`, `DocExamplesCompileSpec`, `RunSamplesSpec` green
- [x] `sbt -Duser.language=en testFull`: 5228 passed, 0 failed
- [x] `sbt -Duser.language=ja testFull`: 5228 passed, 0 failed
- [x] README snippets run end to end on the assembled jar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc

