### PR TITLE
test: add RandDocCoverageSpec regression guard for onion.Rand stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   members were already documented in both files; this guard now fails the
   build if a future addition to `onion.Strings` goes undocumented.
 
+- **Added a `RandDocCoverageSpec` regression guard checking that every public
+  `onion.Rand` member is documented in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`.** `onion.Rand` is a default-imported stdlib
+  module (`Rand::nextInt`, `Rand::shuffle`, `Rand::uuid`, ...) with 8 distinct
+  public static member names, but -- unlike `DateTime`/`Stats`/`OnionMath`,
+  the other default-imported date/random/numeric modules, each already
+  guarded by its own `*DocCoverageSpec` -- it never had one. All 8 members
+  were already documented in both files; this guard now fails the build if a
+  future addition to `onion.Rand` goes undocumented.
+
 ## [0.55.0] - 2026-09-05
 
 ### Documentation

--- a/src/test/scala/onion/compiler/tools/RandDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RandDocCoverageSpec.scala
@@ -1,0 +1,57 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Rand` module docs.
+ *
+ * `onion.Rand` is a default-imported stdlib module (`Rand::nextInt`, `Rand::shuffle`,
+ * `Rand::uuid`, ...) with its own section in docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md, but -- unlike `DateTime`/`Stats`/`OnionMath`, the other
+ * default-imported "date & random"/numeric modules, each already guarded by its own
+ * `*DocCoverageSpec` -- it never had one. All 8 members were already documented in
+ * both files; this guard now fails the build if a future addition to onion.Rand
+ * goes undocumented.
+ */
+class RandDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Rand::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Rand]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    methodNames.toSet
+  }
+
+  it("actual onion.Rand exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Rand found no static members — the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Rand member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Rand:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Rand member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Rand:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Rand in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Rand"),
+      "docs/reference/stdlib.md's overview table should mention Rand")
+    assert(read("docs/ja/reference/stdlib.md").contains("Rand"),
+      "docs/ja/reference/stdlib.md's overview table should mention Rand")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Rand` is a default-imported stdlib module (`Rand::nextInt`, `Rand::shuffle`, `Rand::uuid`, ...) with 8 distinct public static member names, but — unlike `DateTime`/`Stats`/`OnionMath`/`Maps`/`Sets`/`Csv`/`Strings`/`Iterables`, each already guarded by its own `*DocCoverageSpec` — it never had one.
- Added `RandDocCoverageSpec` (modeled on `StatsDocCoverageSpec`) which reflects on `onion.Rand`'s public static members and asserts every one is documented (as `Rand::name`) in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, plus a sanity check that the module is mentioned in each "Modules at a glance" overview.
- All 8 members were already documented in both files, so this is a pure regression guard: it fails the build if a future addition to `onion.Rand` goes undocumented.
- Noted the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5279 succeeded, 0 failed, 1 canceled (pre-existing, environment-conditional `ProjectDistributionSpec` smoke test)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — same result

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011e2T9DDDMooCnvwQLkYsar

---
_Generated by [Claude Code](https://claude.ai/code/session_011e2T9DDDMooCnvwQLkYsar)_