### PR TITLE
feat(parser): arrow-less trailing lambda outside condition positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **A trailing lambda now attaches to a static call without an empty argument
-  list: `Future::async { -> compute() }`, `Helper::twice { x -> x + 1 }`.**
+- **A trailing lambda with no parameters needs no arrow, and attaches to a
+  static or bare call without an empty argument list:
+  `Future::async { return fetchUser() }`, `Helper::twice { x -> x + 1 }`,
+  `once { 3 }`.** `{ body }` is the zero-parameter closure `{ -> body }`
+  (the arrow form still works); the block's last expression is its value.
   Instance calls already accepted `list.map { x -> x * 2 }`, but the
-  `Type::method` forms only took a trailing lambda after `(...)`, so the
-  zero-argument case had to be written `Future::async() { -> ... }` or
-  `Future::async(() -> { return compute(); })`. Both the JavaCC grammar and
-  the handwritten fast-path parser gained the alternative; `Type::name`
-  without a following `{ ... -> }` is still a static member selection, so
-  no accepted program changes meaning (`StaticTrailingLambdaSpec`).
+  `Type::method` forms only took a trailing lambda after `(...)` and a bare
+  name took none, so the zero-argument case had to be written
+  `Future::async() { -> ... }` or `Future::async(() -> { return compute(); })`.
+  The `{` is read as a lambda only where a block could not follow the call
+  anyway: in a condition position -- the condition of `if`/`while`/`do ...
+  while`, the collection of `foreach ... in`, the scrutinee of `select`, the
+  `for` header -- a bare `{` is still the statement block, so `if flag { ... }`
+  and `foreach x in xs { ... }` keep their meaning, the arrow form is a lambda
+  there as before, and parentheses, argument lists, index brackets and blocks
+  restore the arrow-less form (`if (once { 1 }) == 1 { ... }`). Both the
+  JavaCC grammar and the handwritten fast-path parser track the condition
+  context; the `{ (k, v) -> ... }` and `{ x => ... }` hints are still reported
+  at the `{` (`BareTrailingLambdaSpec`, `StaticTrailingLambdaSpec`).
 
 ### Documentation
 
 - **The README, `docs/index.md`, the async/functional examples, the stdlib
   and specification references and `CLAUDE.md` (EN/JA) now write zero-argument
-  callbacks as trailing lambdas (`Future::async { -> ... }`,
-  `Timing::measure { -> ... }`) instead of `(() -> { return ...; })`.**
+  callbacks as trailing lambdas (`Future::async { ... }`,
+  `Timing::measure { ... }`) instead of `(() -> { return ...; })`; the lambda
+  guide (EN/JA) gained a "Trailing Lambdas" section with the condition rule.**
 
 - **Added an `IterablesDocCoverageSpec` regression guard checking that every
   public `onion.Iterables` member is documented in both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,7 @@ def main(name: String, count: Int = 3, loud: Boolean = false): void { ... }
 
 **Asynchronous Programming:**
 ```onion
-val future: Future[String] = Future::async { -> longOperation() }
+val future: Future[String] = Future::async { longOperation() }
 future.map((s) -> s.toUpperCase())
 future.onSuccess((s) -> IO::println(s))
 future.onFailure((e) -> IO::println("Error: " + e.message()))
@@ -530,7 +530,7 @@ These are frequently confused with other languages. **Always check these:**
 | `Int -> Int` | ✓ correct - single param function type |
 | `(Int, Int) -> Int` | ✓ correct - multi-param function type |
 | `list.map { x => x * 2 }` | `list.map { x -> x * 2 }` - the trailing-lambda arrow is `->` too; `=>` is not part of the language (one arrow everywhere: function types, `(x) -> e`, `{ x -> e }`) |
-| `Future::async(() -> { return compute(); })` | `Future::async { -> compute() }` - a trailing lambda attaches to a static call too, with no empty `()` in between; `{ -> body }` is the zero-parameter form, and the block's last expression is its value |
+| `Future::async(() -> { return compute(); })` | `Future::async { compute() }` - a trailing lambda attaches to a static call too, with no empty `()` in between; with no parameters it needs no arrow (`{ -> body }` also works), and the block's last expression is its value. In a condition position (`if c {`, `while c {`, `foreach x in xs {`, `select v {`, the `for` header) a bare `{` is still the statement block; parenthesize the call (`if (f { 1 }) == 1 {`) to pass a lambda there |
 | `stream().map().collect()` | `list.map { ... }.filter { ... }` - List/Iterable/arrays have builtin extension pipelines |
 
 ### Method Calls

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Onion supports Haskell-style do notation for composing monadic operations (Optio
 ```onion
 // Async computation with do notation
 val result: Future[Int] = do[Future] {
-  x <- Future::async { -> fetchUser() }
-  y <- Future::async { -> fetchData(x) }
+  x <- Future::async { fetchUser() }
+  y <- Future::async { fetchData(x) }
   ret x + y
 }
 
@@ -215,8 +215,8 @@ list.fold(0) { acc, x ->
   acc + x
 }
 
-// Zero parameters: `{ -> body }`; works on static calls too
-val answer: Future[Int] = Future::async { -> compute() }
+// No parameters: just the body; works on static calls too
+val answer: Future[Int] = Future::async { compute() }
 ```
 
 ### Asynchronous Programming with Future
@@ -224,7 +224,7 @@ val answer: Future[Int] = Future::async { -> compute() }
 Built-in `Future[T]` type for async operations:
 
 ```onion
-val future: Future[String] = Future::async { ->
+val future: Future[String] = Future::async {
   Http::get("https://api.example.com/data")
 }
 

--- a/docs/examples/async.md
+++ b/docs/examples/async.md
@@ -8,7 +8,7 @@ Run work in the background with `Future::async`.
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async { ->
+  return Future::async {
     Thread::sleep(delayMs)
     "body of " + url
   }
@@ -74,7 +74,7 @@ println("value=" + recovered.getOrElse(-1))
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async { ->
+  return Future::async {
     Thread::sleep(delayMs)
     "body of " + url
   }

--- a/docs/examples/functional.md
+++ b/docs/examples/functional.md
@@ -443,13 +443,13 @@ val nested: Option[Int] = do[Option] {
 val immediate: Future[Int] = Future::successful(42)
 
 // Async computation
-val async: Future[String] = Future::async { ->
+val async: Future[String] = Future::async {
   Thread::sleep(1000L)
   "Hello after 1 second"
 }
 
 // From throwing operation
-val risky: Future[Int] = Future::asyncThrowing { ->
+val risky: Future[Int] = Future::asyncThrowing {
   if Math::random() < 0.5 {
     throw new RuntimeException("Bad luck!")
   }
@@ -467,7 +467,7 @@ val doubled: Future[Int] = numbers.map((x: Int) -> { return x * 2; })
 
 // FlatMap: chain async operations
 val chained: Future[String] = numbers.flatMap((x: Int) -> {
-  return Future::async { ->
+  return Future::async {
     "Number is: " + x
   };
 })
@@ -496,8 +496,8 @@ val retried: Future[Int] = failing.recoverWith((error: Throwable) -> {
 ### Combining Futures
 
 ```onion
-val f1: Future[Int] = Future::async { -> Thread::sleep(100L); 1 }
-val f2: Future[Int] = Future::async { -> Thread::sleep(200L); 2 }
+val f1: Future[Int] = Future::async { Thread::sleep(100L); 1 }
+val f2: Future[Int] = Future::async { Thread::sleep(200L); 2 }
 
 // Wait for all
 val all: Future[Object[]] = Future::all(f1, f2)
@@ -518,7 +518,7 @@ val zipped: Future[Object[]] = f1.zip(f2)
 ### Callbacks
 
 ```onion
-val future: Future[String] = Future::async { ->
+val future: Future[String] = Future::async {
   "Async result"
 }
 
@@ -530,7 +530,7 @@ future
 ### Blocking (Use Sparingly)
 
 ```onion
-val future: Future[Int] = Future::async { -> 42 }
+val future: Future[Int] = Future::async { 42 }
 
 // Block until complete
 val result: Int = future.await()
@@ -546,11 +546,11 @@ val safe: Int = future.getOrElse(0)
 
 ```onion
 def fetchUser(id: Int): Future[String] {
-  return Future::async { -> "User" + id };
+  return Future::async { "User" + id };
 }
 
 def fetchProfile(name: String): Future[String] {
-  return Future::async { -> name + "'s profile" };
+  return Future::async { name + "'s profile" };
 }
 
 val profile: Future[String] = do[Future] {
@@ -567,7 +567,7 @@ profile.onSuccess((p: String) -> { println(p); })
 
 ```onion
 def fetchFromApi(url: String): Future[String] {
-  return Future::async { ->
+  return Future::async {
     // Simulate network request
     Thread::sleep((Math::random() * 1000L) as Long)
     "Data from " + url

--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -114,11 +114,16 @@ primary               ::= id
    -- unqualified, instance (`obj.m`) or static (`Type::m`), with or without
    parentheses -- as its last argument; its parameters are not
    parenthesized, and a parameter's type may not itself be a bare function type
-   (write such a lambda in the parenthesized form). */
+   (write such a lambda in the parenthesized form). With no parameters the
+   arrow may be omitted (`f { body }`), except in a condition position -- the
+   condition of if/while/do-while, the collection of foreach, the scrutinee of
+   select, the for header -- where a bare '{' is the statement block; there
+   only the arrow form is a lambda (`if xs.any { x -> x > 0 } { ... }`), and a
+   parenthesized call restores the arrow-less form. */
 lambda                ::= '(' [lambda_param (',' lambda_param)*] ')' '->' (block | term)
                        | id '->' (block | term)
 lambda_param          ::= id [':' type]
-trailing_lambda       ::= '{' [trailing_param (',' trailing_param)*] '->' block_elements? '}'
+trailing_lambda       ::= '{' [[trailing_param (',' trailing_param)*] '->'] block_elements? '}'
 trailing_param        ::= id [':' type_no_arrow]
 
 list_literal          ::= '[' terms? ']'

--- a/docs/guide/lambda-expressions.md
+++ b/docs/guide/lambda-expressions.md
@@ -21,6 +21,35 @@ val add = (a: Int, b: Int) -> a + b
 val greet: () -> String = () -> { println("Hello!"); return "done"; }
 ```
 
+### Trailing Lambdas
+
+When a lambda is the last argument of a call, it can follow the call as a
+brace block. Parameters go before `->` inside the braces, and a lambda with no
+parameters needs no arrow at all: the block's last expression is its value.
+This works on instance, static and unqualified calls, with or without an
+argument list in between:
+
+```onion
+list.map { x -> x * 2 }
+list.fold(0) { acc, x -> acc + x }
+val f: Future[Int] = Future::async { compute() }
+val g: Future[Int] = Future::async { -> compute() }   // same, with an explicit arrow
+Timing::measure("step") { expensiveOperation() }
+```
+
+In a condition position -- the condition of `if`, `while` and `do ... while`,
+the collection of `foreach ... in`, the scrutinee of `select`, the `for`
+header -- a bare `{` is the statement block, so `if flag { ... }` and
+`foreach x in xs { ... }` mean what they always did. Only the arrow form is a
+lambda there; to pass an arrow-less lambda inside a condition, parenthesize
+the call:
+
+```onion
+if xs.any { x -> x > 0 } { println("positive") }   // arrow form: a lambda
+if (once { 1 }) == 1 { println("one") }             // parenthesized: a lambda
+if ready { println("go") }                          // block of the if
+```
+
 ## Type Inference
 
 When the target function type is known, parameter types can be omitted:

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ val result: Option[Int] = do[Option] {
 }
 
 // Async programming with Future
-val future: Future[String] = Future::async { -> fetchData() }
+val future: Future[String] = Future::async { fetchData() }
 future.map { data -> processData(data) }
       .onSuccess { result -> println(result) }
 

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -331,7 +331,7 @@ do[Option] { a <- getA(); b <- getB(); ret a + b }
 
 **非同期プログラミング:**
 ```onion
-val future: Future[String] = Future::async { -> longOperation() }
+val future: Future[String] = Future::async { longOperation() }
 future.map((s) -> s.toUpperCase())
 future.onSuccess((s) -> IO::println(s))
 future.onFailure((e) -> IO::println("Error: " + e.message()))
@@ -471,7 +471,7 @@ try {
 | `Int -> Int` | ✓ 正しい - 単一引数の関数型 |
 | `(Int, Int) -> Int` | ✓ 正しい - 複数引数の関数型 |
 | `list.map { x => x * 2 }` | `list.map { x -> x * 2 }` - トレイリングラムダの矢印も`->`。`=>`は言語には存在しない（関数型、`(x) -> e`、`{ x -> e }`のすべてで矢印は`->`の一種類だけ） |
-| `Future::async(() -> { return compute(); })` | `Future::async { -> compute() }` - トレイリングラムダは static 呼び出しにも直接付けられる（間に空の`()`は不要）。引数なしは`{ -> 本体 }`と書き、ブロック最後の式が値になる |
+| `Future::async(() -> { return compute(); })` | `Future::async { compute() }` - トレイリングラムダは static 呼び出しにも直接付けられる（間に空の`()`は不要）。引数なしなら矢印も不要（`{ -> 本体 }`も可）で、ブロック最後の式が値になる。条件位置（`if c {`・`while c {`・`foreach x in xs {`・`select v {`・`for`ヘッダ）では裸の`{`は従来どおり文ブロックなので、そこでラムダを渡すなら呼び出しを括弧で囲む（`if (f { 1 }) == 1 {`） |
 | `stream().map().collect()` | `list.map { ... }.filter { ... }` - List/Iterable/配列に組み込みのextensionパイプラインがある |
 
 ### メソッド呼び出し

--- a/docs/ja/examples/async.md
+++ b/docs/ja/examples/async.md
@@ -8,7 +8,7 @@ Onionは `Future` 型と `do[Future]` 構文を提供し、非同期プログラ
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async { ->
+  return Future::async {
     Thread::sleep(delayMs)
     "body of " + url
   }
@@ -74,7 +74,7 @@ println("value=" + recovered.getOrElse(-1))
 
 ```onion
 def fetchPage(url: String, delayMs: Long): Future[String] {
-  return Future::async { ->
+  return Future::async {
     Thread::sleep(delayMs)
     "body of " + url
   }

--- a/docs/ja/examples/functional.md
+++ b/docs/ja/examples/functional.md
@@ -444,13 +444,13 @@ val nested: Option[Int] = do[Option] {
 val immediate: Future[Int] = Future::successful(42)
 
 // 非同期計算
-val async: Future[String] = Future::async { ->
+val async: Future[String] = Future::async {
   Thread::sleep(1000L)
   "Hello after 1 second"
 }
 
 // 例外を投げうる操作から
-val risky: Future[Int] = Future::asyncThrowing { ->
+val risky: Future[Int] = Future::asyncThrowing {
   if Math::random() < 0.5 {
     throw new RuntimeException("Bad luck!")
   }
@@ -468,7 +468,7 @@ val doubled: Future[Int] = numbers.map((x: Int) -> { return x * 2; })
 
 // flatMap: 非同期操作を連鎖
 val chained: Future[String] = numbers.flatMap((x: Int) -> {
-  return Future::async { ->
+  return Future::async {
     "Number is: " + x
   };
 })
@@ -497,8 +497,8 @@ val retried: Future[Int] = failing.recoverWith((error: Throwable) -> {
 ### Future の合成
 
 ```onion
-val f1: Future[Int] = Future::async { -> Thread::sleep(100L); 1 }
-val f2: Future[Int] = Future::async { -> Thread::sleep(200L); 2 }
+val f1: Future[Int] = Future::async { Thread::sleep(100L); 1 }
+val f2: Future[Int] = Future::async { Thread::sleep(200L); 2 }
 
 // すべて待つ
 val all: Future[Object[]] = Future::all(f1, f2)
@@ -519,7 +519,7 @@ val zipped: Future[Object[]] = f1.zip(f2)
 ### コールバック
 
 ```onion
-val future: Future[String] = Future::async { ->
+val future: Future[String] = Future::async {
   "Async result"
 }
 
@@ -531,7 +531,7 @@ future
 ### ブロッキング（控えめに使う）
 
 ```onion
-val future: Future[Int] = Future::async { -> 42 }
+val future: Future[Int] = Future::async { 42 }
 
 // 完了までブロック
 val result: Int = future.await()
@@ -547,11 +547,11 @@ val safe: Int = future.getOrElse(0)
 
 ```onion
 def fetchUser(id: Int): Future[String] {
-  return Future::async { -> "User" + id };
+  return Future::async { "User" + id };
 }
 
 def fetchProfile(name: String): Future[String] {
-  return Future::async { -> name + "'s profile" };
+  return Future::async { name + "'s profile" };
 }
 
 val profile: Future[String] = do[Future] {
@@ -568,7 +568,7 @@ profile.onSuccess((p: String) -> { println(p); })
 
 ```onion
 def fetchFromApi(url: String): Future[String] {
-  return Future::async { ->
+  return Future::async {
     // ネットワークリクエストをシミュレート
     Thread::sleep((Math::random() * 1000L) as Long)
     "Data from " + url

--- a/docs/ja/guide/lambda-expressions.md
+++ b/docs/ja/guide/lambda-expressions.md
@@ -20,6 +20,33 @@ val add = (a: Int, b: Int) -> a + b
 val greet: () -> String = () -> { println("Hello!"); return "done"; }
 ```
 
+### トレイリングラムダ
+
+ラムダが呼び出しの最後の引数なら、呼び出しの後ろに波括弧ブロックとして書けます。
+パラメータは波括弧の中の `->` の前に置き、パラメータがなければ矢印も不要です。
+ブロック最後の式がラムダの値になります。インスタンス呼び出し・static 呼び出し・
+非修飾呼び出しのいずれにも、間に引数リストがあってもなくても付けられます：
+
+```onion
+list.map { x -> x * 2 }
+list.fold(0) { acc, x -> acc + x }
+val f: Future[Int] = Future::async { compute() }
+val g: Future[Int] = Future::async { -> compute() }   // 同じ意味（矢印を明示）
+Timing::measure("step") { expensiveOperation() }
+```
+
+条件位置 ── `if`・`while`・`do ... while` の条件、`foreach ... in` の反復対象、
+`select` の被検査式、`for` ヘッダ ── では裸の `{` は従来どおり文ブロックです。
+`if flag { ... }` や `foreach x in xs { ... }` の意味は変わりません。そこでラムダに
+なるのは矢印付きの形だけで、矢印なしのラムダを条件の中で渡したいときは呼び出しを
+括弧で囲みます：
+
+```onion
+if xs.any { x -> x > 0 } { println("positive") }   // 矢印付き：ラムダ
+if (once { 1 }) == 1 { println("one") }             // 括弧付き：ラムダ
+if ready { println("go") }                          // if のブロック
+```
+
 ## 型推論
 
 ターゲットの関数型が分かっている場合、パラメータの型を省略できます：

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -68,7 +68,7 @@ val result: Option[Int] = do[Option] {
 }
 
 // Futureによる非同期プログラミング
-val future: Future[String] = Future::async { -> fetchData() }
+val future: Future[String] = Future::async { fetchData() }
 future.map { data -> processData(data) }
       .onSuccess { result -> println(result) }
 

--- a/docs/ja/reference/specification.md
+++ b/docs/ja/reference/specification.md
@@ -524,7 +524,7 @@ throw new IllegalStateException("message")
 val f: Int -> Int = x -> x * 2          // 裸パラメータ、式本体
 val g = (a: Int, b: Int) -> a + b
 list.map { x -> x * 2 }                 // 末尾ラムダ
-Future::async { -> compute() }
+Future::async { compute() }             // 引数なしなら矢印も不要
 val r: Runnable = () -> println("hi")   // SAM 変換
 ```
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -921,19 +921,19 @@ Timing::sleepNanos(500000L) // 500,000ナノ秒スリープ
 
 ```onion
 // 実行時間を計測して表示し、結果を返す
-val result: Int = Timing::measure { -> expensiveOperation() }
+val result: Int = Timing::measure { expensiveOperation() }
 // 出力: "Elapsed: 123.45ms"
-val result2: Int = Timing::measure("task") { -> expensiveOperation() }
+val result2: Int = Timing::measure("task") { expensiveOperation() }
 // 出力: "task: 123.45ms"
 
 // 戻り値のない関数版
-Timing::measureVoid { -> expensiveOperation() }
+Timing::measureVoid { expensiveOperation() }
 // 出力: "Elapsed: 123.45ms"
-Timing::measureVoid("task") { -> expensiveOperation() }
+Timing::measureVoid("task") { expensiveOperation() }
 // 出力: "task: 123.45ms"
 
 // 表示なしで実行時間（ナノ秒）を取得
-val timeNanos: Long = Timing::time { -> expensiveOperation() }
+val timeNanos: Long = Timing::time { expensiveOperation() }
 ```
 
 ## Option モジュール
@@ -979,10 +979,10 @@ val done: Future[Int] = Future::successful(42)
 val fail: Future[Int] = Future::failed(new RuntimeException("error"))
 
 // バックグラウンドスレッドで非同期実行
-val async: Future[String] = Future::async { -> compute() }
+val async: Future[String] = Future::async { compute() }
 
 // 例外処理付きの非同期実行
-val safe: Future[Int] = Future::asyncThrowing { ->
+val safe: Future[Int] = Future::asyncThrowing {
   riskyOperation()
 }
 
@@ -1026,7 +1026,7 @@ f.mapError((e: Throwable) -> { return new CustomException(e); })
 ### コールバック
 
 ```onion
-val f: Future[String] = Future::async { -> "result" }
+val f: Future[String] = Future::async { "result" }
 
 f.onSuccess((value: String) -> { IO::println(value); })
 f.onFailure((error: Throwable) -> { IO::println(error); })
@@ -1098,8 +1098,8 @@ Futureは順次非同期合成のためのdo記法で動作：
 
 ```onion
 val result: Future[Int] = do[Future] {
-  x <- Future::async { -> fetchA() }
-  y <- Future::async { -> fetchB(x) }
+  x <- Future::async { fetchA() }
+  y <- Future::async { fetchB(x) }
   ret x + y
 }
 ```
@@ -2403,7 +2403,7 @@ val hits = Concurrent::counter()
 hits.increment()
 
 val lock = Concurrent::lock()
-lock.withLock { -> /* … */ }         // 本体が例外を投げても解放される
+lock.withLock { /* … */ }         // 本体が例外を投げても解放される
 
 val chan = Concurrent::channel(16)   // 意図的に上限つき
 chan.send("work")

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -551,7 +551,7 @@ Resources close automatically in reverse declaration order.
 val f: Int -> Int = x -> x * 2          // bare param, expression body
 val g = (a: Int, b: Int) -> a + b
 list.map { x -> x * 2 }                 // trailing lambda
-Future::async { -> compute() }
+Future::async { compute() }             // no parameters: no arrow needed
 val r: Runnable = () -> println("hi")   // SAM conversion
 ```
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -999,10 +999,10 @@ val done: Future[Int] = Future::successful(42)
 val fail: Future[Int] = Future::failed(new RuntimeException("error"))
 
 // Run async on background thread
-val async: Future[String] = Future::async { -> compute() }
+val async: Future[String] = Future::async { compute() }
 
 // Async with exception handling
-val safe: Future[Int] = Future::asyncThrowing { ->
+val safe: Future[Int] = Future::asyncThrowing {
   riskyOperation()
 }
 
@@ -1046,7 +1046,7 @@ f.mapError((e: Throwable) -> { return new CustomException(e); })
 ### Callbacks
 
 ```onion
-val f: Future[String] = Future::async { -> "result" }
+val f: Future[String] = Future::async { "result" }
 
 f.onSuccess((value: String) -> { IO::println(value); })
 f.onFailure((error: Throwable) -> { IO::println(error); })
@@ -1118,8 +1118,8 @@ Future works with do notation for sequential async composition:
 
 ```onion
 val result: Future[Int] = do[Future] {
-  x <- Future::async { -> fetchA() }
-  y <- Future::async { -> fetchB(x) }
+  x <- Future::async { fetchA() }
+  y <- Future::async { fetchB(x) }
   ret x + y
 }
 ```
@@ -1271,19 +1271,19 @@ Timing::sleepNanos(500000L) // Sleep for 500,000 nanoseconds
 
 ```onion
 // Measure and print execution time, return result
-val result: Int = Timing::measure { -> expensiveOperation() }
+val result: Int = Timing::measure { expensiveOperation() }
 // Prints: "Elapsed: 123.45ms"
-val result2: Int = Timing::measure("task") { -> expensiveOperation() }
+val result2: Int = Timing::measure("task") { expensiveOperation() }
 // Prints: "task: 123.45ms"
 
 // Same, but for a function that returns nothing
-Timing::measureVoid { -> expensiveOperation() }
+Timing::measureVoid { expensiveOperation() }
 // Prints: "Elapsed: 123.45ms"
-Timing::measureVoid("task") { -> expensiveOperation() }
+Timing::measureVoid("task") { expensiveOperation() }
 // Prints: "task: 123.45ms"
 
 // Get execution time in nanoseconds without printing
-val timeNanos: Long = Timing::time { -> expensiveOperation() }
+val timeNanos: Long = Timing::time { expensiveOperation() }
 ```
 
 ## Strings Module
@@ -2245,7 +2245,7 @@ val hits = Concurrent::counter()
 hits.increment()
 
 val lock = Concurrent::lock()
-lock.withLock { -> /* … */ }         // releases even if the body throws
+lock.withLock { /* … */ }         // releases even if the body throws
 
 val chan = Concurrent::channel(16)   // bounded on purpose
 chan.send("work")

--- a/grammar/JJOnionParser.jj
+++ b/grammar/JJOnionParser.jj
@@ -862,6 +862,44 @@ public class JJOnionParser implements Parser {
     leaveState();
   }
 
+  // ---- Condition positions: where a bare `{` after a call is the statement block, not a lambda.
+  // A trailing lambda without an arrow (`f { body }`) is only read as such where no block could
+  // follow the call anyway. In the condition of if/while/do-while, the collection of foreach, the
+  // scrutinee of select and the for header, `if flag { ... }` keeps its block; the arrow form
+  // `{ x -> ... }` is recognised there as before. Parentheses, argument lists, index brackets and
+  // blocks (including lambda bodies) start a fresh operand context, so `if (f { 1 }) == 1 { ... }`
+  // and `if xs.any { x -> g { x } } { ... }` see the lambda again.
+  private final java.util.ArrayDeque<Boolean> conditionContexts = new java.util.ArrayDeque<Boolean>();
+  private void enterCondition() { conditionContexts.push(Boolean.TRUE); }
+  private void enterOperand() { conditionContexts.push(Boolean.FALSE); }
+  private void leaveCondition() { if (!conditionContexts.isEmpty()) conditionContexts.pop(); }
+  private boolean inCondition() { return !conditionContexts.isEmpty() && conditionContexts.peek().booleanValue(); }
+  private boolean bareTrailingBlockAhead() { return getToken(1).kind == LBRACE && !inCondition(); }
+
+  /** After the `{` of an arrow-less trailing lambda: `(a, b) ->` -- the parenthesized-parameter slip the hint names. */
+  private boolean parenthesizedLambdaHeadAhead() {
+    if (getToken(1).kind != LPAREN) return false;
+    int i = 2;
+    while (i < 64) {
+      int k = getToken(i).kind;
+      if (k == RPAREN) return getToken(i + 1).kind == ARROW;
+      if (!(k == ID || k == COMMA || k == COLON || k == LBRACKET || k == RBRACKET || k == QUESTION || k == FQCN || k == DOT)) return false;
+      i++;
+    }
+    return false;
+  }
+
+  /** After the `{` of an arrow-less trailing lambda: `a, b =>` -- the old arrow, lexed as `=` `>`. */
+  private boolean oldArrowLambdaHeadAhead() {
+    int i = 1;
+    int k = getToken(i).kind;
+    if (k == LPAREN) { i++; k = getToken(i).kind; }
+    while (i < 64 && (k == ID || k == COMMA || k == COLON || k == LBRACKET || k == RBRACKET || k == QUESTION || k == FQCN || k == DOT || k == RPAREN)) { i++; k = getToken(i).kind; }
+    if (k != ASSIGN) return false;
+    Token eq = getToken(i), gt = getToken(i + 1);
+    return gt.kind == GT && gt.beginLine == eq.endLine && gt.beginColumn == eq.endColumn + 1;
+  }
+
   private void enterSection() {
     enterState(IN_STATEMENT);
   }
@@ -1616,7 +1654,7 @@ AST.TypeDeclaration type_decl(int modifiers) :{AST.TypeDeclaration ty = null;}{
 }
 
 AST.BlockExpression block():{Token t; List<AST.BlockElement> elements = (List<AST.BlockElement>)AST.NIL(); AST.BlockExpression s;}{
-  t="{" {enterAssignScope();} eols() [ LOOKAHEAD({ getToken(1).kind != RBRACE }) elements=block_elements() ] eols() "}" {return new AST.BlockExpression(p(t), elements, leaveAssignScope());}
+  t="{" {enterAssignScope(); enterOperand();} eols() [ LOOKAHEAD({ getToken(1).kind != RBRACE }) elements=block_elements() ] eols() "}" {leaveCondition(); return new AST.BlockExpression(p(t), elements, leaveAssignScope());}
 }
 
 List<AST.BlockElement> block_elements():{ AST.BlockElement element; ArrayBuffer<AST.BlockElement> elements = new ArrayBuffer<AST.BlockElement>(); }{
@@ -2438,7 +2476,7 @@ AST.Expression expression_element() :{AST.Expression e;}{
 }
 
 AST.IfExpression if_expression() :{Token t; AST.Expression e; AST.BlockExpression b1, b2 = null; AST.IfExpression elif = null; ArrayBuffer<AST.BlockElement> elifElems = new ArrayBuffer<AST.BlockElement>();}{
-  t="if" e=term() b1=block()
+  t="if" {enterCondition();} e=term() {leaveCondition();} b1=block()
   [ LOOKAHEAD({elseFollows()}) eols() "else"
     ( b2=block()
     | {enterAssignScope();} elif=if_expression() {
@@ -2509,7 +2547,7 @@ AST.SelectExpression select_expression() :{
   ArrayBuffer<Tuple2<List<AST.Pattern>, AST.BlockExpression>> branches = new ArrayBuffer<Tuple2<List<AST.Pattern>, AST.BlockExpression>>();
   AST.BlockExpression elseBlock = null ;
 }{
-  t1="select" e1=term() eols() "{" eols()
+  t1="select" {enterCondition();} e1=term() {leaveCondition();} eols() "{" eols()
     (
       LOOKAHEAD({la("case")})
       t2="case" p=case_pattern() {append(patterns, p);} ("," p=case_pattern() {append(patterns, p);})* ":" eols() {enterAssignScope();} ss=block_elements() {
@@ -2544,11 +2582,11 @@ AST.SynchronizedExpression synchronized_expression() :{Token t; AST.Expression e
 }
 
 AST.WhileExpression while_expression() :{Token t; AST.Expression e; AST.BlockExpression b;}{
-  t="while" e=term() b=block() {return new AST.WhileExpression(p(t), e, b);}
+  t="while" {enterCondition();} e=term() {leaveCondition();} b=block() {return new AST.WhileExpression(p(t), e, b);}
 }
 
 AST.DoWhileExpression do_while_expression() :{Token t; AST.Expression e; AST.BlockExpression b;}{
-  t="do" b=block() "while" {enterSection();} e=term() eos_or_block_end() {
+  t="do" b=block() "while" {enterSection(); enterCondition();} e=term() {leaveCondition();} eos_or_block_end() {
     return new AST.DoWhileExpression(p(t), b, e);
   }
 }
@@ -2556,10 +2594,10 @@ AST.DoWhileExpression do_while_expression() :{Token t; AST.Expression e; AST.Blo
 AST.ForeachExpression foreach_expression() :{Token t, k = null, v = null; AST.Argument a; AST.Expression e; AST.BlockExpression b;}{
   t="foreach"
   ( LOOKAHEAD("(")
-    "(" k=id() "," v=id() ")" (LOOKAHEAD({la("in")}) id()) e=term() b=block() {
+    "(" k=id() "," v=id() ")" (LOOKAHEAD({la("in")}) id()) {enterCondition();} e=term() {leaveCondition();} b=block() {
       return desugarMapForeach(p(t), c(k), c(v), e, b);
     }
-  | a=argument() (LOOKAHEAD({la("in")}) id()) e=term() b=block() {
+  | a=argument() (LOOKAHEAD({la("in")}) id()) {enterCondition();} e=term() {leaveCondition();} b=block() {
       return new AST.ForeachExpression(p(t), a, e, b);
     }
   )
@@ -2577,8 +2615,8 @@ AST.ForInitializer for_initializer() :{AST.BlockElement d; AST.Expression e; Tok
 }
 
 AST.ForExpression for_expression() :{Token t; AST.ForInitializer init; AST.Expression e1 = null, e2 = null; AST.BlockExpression b;}{
-  t="for" init=for_initializer()
-  [e1=term()] ";" [LOOKAHEAD({!la("{")}) e2=term()] b=block() {
+  t="for" {enterCondition();} init=for_initializer()
+  [e1=term()] ";" [LOOKAHEAD({!la("{")}) e2=term()] {leaveCondition();} b=block() {
   	return new AST.ForExpression(p(t), init, e1, e2, b);
   }
 }
@@ -2766,7 +2804,7 @@ AST.Expression primary_suffix() : {
   // suffixes leave the optional eols() unmatched.
 ( LOOKAHEAD({ suffixContinues() })
   eols()
-  ( t="[" eols() a=term() eols() "]"                                                              {e = new AST.Indexing(p(t), e, a);}
+  ( t="[" {enterOperand();} eols() a=term() eols() "]"                                            {leaveCondition(); e = new AST.Indexing(p(t), e, a);}
   | t=<SAFE_INDEX> eols() a=term() eols() "]"                                                     {e = new AST.SafeIndexing(p(t), e, a);}
   | e=dot_suffix(e)
   | e=safe_access_suffix(e)
@@ -2785,12 +2823,12 @@ AST.Expression dot_suffix(AST.Expression e) : {
   t="." eols() n=id() (
       LOOKAHEAD( type_arguments() eols() "(" )
         tas=type_arguments() eols() "(" eols() args=terms() ")"
-        [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+        tl=trailing_lambda_opt()
           { args = AST.appendToList(args, tl); tl = null; e = new AST.MethodCall(through(n), e, c(n), args, tas); }
     | LOOKAHEAD(1) "(" eols() args=terms() ")"
-        [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+        tl=trailing_lambda_opt()
           { args = AST.appendToList(args, tl); tl = null; e = new AST.MethodCall(through(n), e, c(n), args); }
-    | [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()] {
+    | tl=trailing_lambda_opt() {
         if (tl != null) {
           args = (List<AST.Expression>)AST.NIL();
           args = AST.appendToList(args, tl);
@@ -2810,12 +2848,12 @@ AST.Expression safe_access_suffix(AST.Expression e) : {
   t=<SAFE_ACCESS> eols() n=id() (
       LOOKAHEAD( type_arguments() eols() "(" )
         tas=type_arguments() eols() "(" eols() args=terms() ")"
-        [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+        tl=trailing_lambda_opt()
           { args = AST.appendToList(args, tl); tl = null; e = new AST.SafeMethodCall(p(t), e, c(n), args, tas); }
     | LOOKAHEAD(1) "(" eols() args=terms() ")"
-        [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+        tl=trailing_lambda_opt()
           { args = AST.appendToList(args, tl); tl = null; e = new AST.SafeMethodCall(p(t), e, c(n), args); }
-    | [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()] {
+    | tl=trailing_lambda_opt() {
         if (tl != null) {
           args = (List<AST.Expression>)AST.NIL();
           args = AST.appendToList(args, tl);
@@ -2838,34 +2876,34 @@ AST.Expression static_access_primary() : {
   AST.ClosureExpression tl = null;
 }{
   LOOKAHEAD( class_type() type_arguments() "::" ) ty=class_type() tas=type_arguments() t="::" n=id() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); needsBodyRewrite = true; return new AST.TraitMethodCall(through(n), ty, tas, c(n), es); }
 | LOOKAHEAD( boxed_class_type() "::" id() type_arguments() "(" ) ty=boxed_class_type() t="::" n=id() tas=type_arguments() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es, tas); }
 | LOOKAHEAD( boxed_class_type() "::" id() "(" ) ty=boxed_class_type() t="::" n=id() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es); }
 | LOOKAHEAD( boxed_class_type() "::" ) ty=boxed_class_type() t="::" n=id()
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { return staticMemberOrCall(t, n, ty, tl); }
 | LOOKAHEAD( dotted_class_type() "::" id() type_arguments() "(" ) ty=dotted_class_type() t="::" n=id() tas=type_arguments() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es, tas); }
 | LOOKAHEAD( dotted_class_type() "::" id() "(" ) ty=dotted_class_type() t="::" n=id() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es); }
 | LOOKAHEAD( dotted_class_type() "::" ) ty=dotted_class_type() t="::" n=id()
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { return staticMemberOrCall(t, n, ty, tl); }
 | LOOKAHEAD( class_type() "::" id() type_arguments() "(" ) ty=class_type() t="::" n=id() tas=type_arguments() "(" es=terms()  ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es, tas); }
 | LOOKAHEAD(4) ty=class_type() t="::" n=id() "(" es=terms()  ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.StaticMethodCall(through(n), ty, c(n), es); }
 | LOOKAHEAD(2) ty=class_type() t="::" n=id()
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { return staticMemberOrCall(t, n, ty, tl); }
 | LOOKAHEAD({ true }) e=primary_rest() {return e;}
 }
@@ -2873,7 +2911,7 @@ AST.Expression static_access_primary() : {
 /** A `(`: a lambda when lambda_head() parses, else a parenthesised term. */
 AST.Expression lambda_or_paren() : { AST.Expression e; }{
   LOOKAHEAD( lambda_head() ) e=arrow_anonymous_function() {return e;}
-| "(" eols() e=term() eols() ")" {return e;}
+| "(" {enterOperand();} eols() e=term() eols() ")" {leaveCondition(); return e;}
 }
 
 AST.Expression primary() : {
@@ -2886,10 +2924,10 @@ AST.Expression primary() : {
 }{
   LOOKAHEAD( "super" eols() "." eols() id() type_arguments() "(" )
     t="super" eols() "." eols() n=id() tas=type_arguments() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.SuperMethodCall(p(t), c(n), es, tas); }
 | t="super" eols() "." eols() n=id() [LOOKAHEAD(2) "(" es=terms() ")"]
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.SuperMethodCall(through(n), c(n), es); }
 // Every alternative below needs a `::` after a type. Peeking for that first spares the
 // full syntactic type scans -- eleven of them, per primary -- on the common case.
@@ -2910,14 +2948,18 @@ AST.Expression primary_rest() : {
   AST.ClosureExpression tl = null;
 }{
   LOOKAHEAD( id() type_arguments() "(" ) t=id() tas=type_arguments() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.UnqualifiedMethodCall(through(t), c(t), es, tas); }
 | LOOKAHEAD(2) t=id() "(" es=terms() ")"
-    [LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda()]
+    tl=trailing_lambda_opt()
     { es = AST.appendToList(es, tl); return new AST.UnqualifiedMethodCall(through(t), c(t), es); }
 | LOOKAHEAD(2, id() <ARROW>) e=arrow_anonymous_function()                 {return e;}
-| LOOKAHEAD(1) t=id()                                               {return new AST.Id(p(t), c(t));}
-| {enterDefault();} t="[" eols() e=bracket_literal_rest(t) {leaveDefault();} {return e;}
+| LOOKAHEAD(1) t=id() tl=trailing_lambda_opt() {
+    if (tl == null) return new AST.Id(p(t), c(t));
+    es = AST.appendToList(es, tl);
+    return new AST.UnqualifiedMethodCall(through(t), c(t), es);
+  }
+| {enterDefault();} t="[" {enterOperand();} eols() e=bracket_literal_rest(t) {leaveCondition(); leaveDefault();} {return e;}
 // A parenthesised lambda is `( ... ) ->`; matching the parenthesis by depth is a token peek,
 // where lambda_head() re-parsed the whole parenthesised expression on every `(`.
 | LOOKAHEAD({ jj_lookingAhead || arrowAfterParenAhead() }) e=lambda_or_paren() {return e;}
@@ -2964,7 +3006,7 @@ AST.Expression primary_rest() : {
 | e=scheme_literal()                                                      {return e;}
 | e=boolean_literal()                                                     {return e;}
 | e=null_literal()                                                        {return e;}
-| "(" eols() e=term() eols() ")"                                          {return e;}
+| "(" {enterOperand();} eols() e=term() eols() ")"                        {leaveCondition(); return e;}
 }
 
 AST.Expression argument_expr() :{Token n; AST.Expression e;}{
@@ -2978,7 +3020,9 @@ List<AST.Expression> terms() :{AST.Expression arg; ArrayBuffer<AST.Expression> a
   // multiple lines: f(\n a,\n b\n)
   // Leading newlines are consumed before the choice: with them inside the optional, JavaCC
   // had to run a syntactic scan (through the nullable eols()) to decide it at every call.
+  {enterOperand();}
   eols() [ LOOKAHEAD({ getToken(1).kind != RPAREN }) arg=argument_expr() {append(args, arg);} ("," eols() arg=argument_expr() {append(args, arg);})* eols()] {
+    leaveCondition();
     return toList(args);
   }
 }
@@ -3085,19 +3129,39 @@ Object do_clause() :{
 // nowhere else, which made `[1, 2, 3].filter { x -> x % 2 == 0 }` a syntax error for no
 // reason a reader could see.
 AST.ClosureExpression trailing_lambda() :{
-  Token t;
+  Token t, prev;
   List<AST.Argument> args = (List<AST.Argument>)AST.NIL();
   List<AST.BlockElement> stmts = (List<AST.BlockElement>)AST.NIL();
   AST.BlockExpression body;
   AST.TypeNode ty = null;
 }{
-  {enterDefault();}
-  t="{" eols() args=lambda_args(false) eols() <ARROW> eols() {enterAssignScope();} [ LOOKAHEAD({ getToken(1).kind != RBRACE }) stmts=block_elements() ] eols() "}" {
+  {enterDefault(); prev = token;}
+  t="{" eols()
+  ( LOOKAHEAD( [trailing_lambda_arg_head() ("," eols() trailing_lambda_arg_head())*] eols() <ARROW> )
+      args=lambda_args(false) eols() <ARROW> eols()
+  | {
+      // No arrow: a zero-parameter lambda, `{ body }`. Three slips still get their hints, reported
+      // at the `{` as before: `{ (k, v) -> ... }`, the old arrow `{ x => ... }`, and a `case`
+      // right after the brace (`switch (x) { case ... }` -- no lambda body starts with `case`).
+      if (getToken(1).kind == K_CASE || parenthesizedLambdaHeadAhead() || oldArrowLambdaHeadAhead()) {
+        throw new ParseException(prev, new int[][] { { ARROW } }, tokenImage);
+      }
+    }
+  )
+  {enterOperand(); enterAssignScope();} [ LOOKAHEAD({ getToken(1).kind != RBRACE }) stmts=block_elements() ] eols() "}" {
+    leaveCondition();
     body = new AST.BlockExpression(p(t), stmts, leaveAssignScope());
     ty = new AST.TypeNode(p(t), new AST.ReferenceType("onion.Function" + args.size(), true), true);
     leaveDefault();
     return new AST.ClosureExpression(p(t), ty, "call", args, null, body);
   }
+}
+
+/** The trailing lambda that may follow a call: the arrow form anywhere, the arrow-less form outside a condition. */
+AST.ClosureExpression trailing_lambda_opt() :{ AST.ClosureExpression tl = null; }{
+  [ LOOKAHEAD(trailing_lambda_head()) tl=trailing_lambda() ]
+  [ LOOKAHEAD({ tl == null && bareTrailingBlockAhead() }) tl=trailing_lambda() ]
+  { return tl; }
 }
 
 // Look-ahead for trailing lambda: { [args] -> ... }

--- a/src/main/scala/onion/compiler/parser/OnionParser.scala
+++ b/src/main/scala/onion/compiler/parser/OnionParser.scala
@@ -339,6 +339,44 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
 
   // The sets are allocated on first use: most blocks assign and capture nothing.
   private def enterAssignScope(): Unit = assignedScopes += null
+
+  // Condition positions (see the grammar): where a bare `{` after a call is the statement
+  // block, not an arrow-less trailing lambda. Parentheses, argument lists, index brackets and
+  // blocks (including lambda bodies) push a fresh operand context.
+  private val conditionContexts = new ArrayBuffer[Boolean]()
+  private def enterCondition(): Unit = conditionContexts += true
+  private def enterOperand(): Unit = conditionContexts += false
+  private def leaveCondition(): Unit = if (conditionContexts.nonEmpty) conditionContexts.remove(conditionContexts.length - 1)
+  private def inCondition(): Boolean = conditionContexts.nonEmpty && conditionContexts(conditionContexts.length - 1)
+  private inline def inOperand[A](inline body: A): A = { enterOperand(); try body finally leaveCondition() }
+  private inline def inConditionOf[A](inline body: A): A = { enterCondition(); try body finally leaveCondition() }
+
+  private def isLambdaHeadKind(k: Int): Boolean =
+    k == K.ID || k == K.COMMA || k == K.COLON || k == K.LBRACKET || k == K.RBRACKET || k == K.QUESTION || k == K.FQCN || k == K.DOT
+
+  /** After the `{` of an arrow-less trailing lambda: `(a, b) ->`, the slip the JavaCC hint names. */
+  private def parenthesizedLambdaHeadAhead(): Boolean = {
+    if (kind(1) != K.LPAREN) return false
+    var i = 2
+    while (i < 64) {
+      val k = kind(i)
+      if (k == K.RPAREN) return kind(i + 1) == K.ARROW
+      if (!isLambdaHeadKind(k)) return false
+      i += 1
+    }
+    false
+  }
+
+  /** After the `{` of an arrow-less trailing lambda: `a, b =>`, the old arrow lexed as `=` `>`. */
+  private def oldArrowLambdaHeadAhead(): Boolean = {
+    var i = 1
+    var k = kind(i)
+    if (k == K.LPAREN) { i += 1; k = kind(i) }
+    while (i < 64 && (isLambdaHeadKind(k) || k == K.RPAREN)) { i += 1; k = kind(i) }
+    if (k != K.ASSIGN) return false
+    val eq = peek(i); val gt = peek(i + 1)
+    gt.kind == K.GT && gt.beginLine == eq.endLine && gt.beginColumn == eq.endColumn + 1
+  }
   private def addTo(scopes: ArrayBuffer[java.util.HashSet[String]], i: Int, name: String): Unit = {
     var s = scopes(i)
     if (s == null) { s = new java.util.HashSet[String](); scopes(i) = s }
@@ -608,10 +646,12 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
   private def block(): AST.BlockExpression = {
     val t = expect(K.LBRACE)
     enterAssignScope()
+    enterOperand()
     eols()
     val elements = if (kind(1) != K.RBRACE) blockElements() else Nil
     eols()
     expect(K.RBRACE)
+    leaveCondition()
     AST.BlockExpression(p(t), elements, leaveAssignScope())
   }
 
@@ -1203,6 +1243,11 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
 
   private def trailingLambdaHead(): Unit = {
     expect(K.LBRACE)
+    trailingLambdaHeadAfterBrace()
+  }
+
+  /** `[params] ->` after the `{`: the arrow form of a trailing lambda. */
+  private def trailingLambdaHeadAfterBrace(): Unit = {
     eols()
     if (isId(kind(1))) {
       trailingLambdaArgHead()
@@ -1404,7 +1449,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
 
   private def ifExpression(): AST.IfExpression = {
     val t = expect(K.K_IF)
-    val e = term()
+    val e = inConditionOf(term())
     val b1 = block()
     var b2: AST.BlockExpression = null
     if (elseFollows()) {
@@ -1491,7 +1536,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
 
   private def selectExpression(): AST.SelectExpression = {
     val t1 = expect(K.K_SELECT)
-    val e1 = term()
+    val e1 = inConditionOf(term())
     eols()
     expect(K.LBRACE)
     eols()
@@ -1546,7 +1591,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
 
   private def whileExpression(): AST.WhileExpression = {
     val t = expect(K.K_WHILE)
-    val e = term()
+    val e = inConditionOf(term())
     AST.WhileExpression(p(t), e, block())
   }
 
@@ -1555,7 +1600,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     val b = block()
     expect(K.K_WHILE)
     enterSection()
-    val e = term()
+    val e = inConditionOf(term())
     eosOrBlockEnd()
     AST.DoWhileExpression(p(t), b, e)
   }
@@ -1569,13 +1614,13 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
       val v = id()
       expect(K.RPAREN)
       if (la("in")) id()
-      val e = term()
+      val e = inConditionOf(term())
       val b = block()
       desugarMapForeach(p(t), c(k), c(v), e, b)
     } else {
       val a = argument()
       if (la("in")) id()
-      val e = term()
+      val e = inConditionOf(term())
       val b = block()
       AST.ForeachExpression(p(t), a, e, b)
     }
@@ -1607,10 +1652,12 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
 
   private def forExpression(): AST.ForExpression = {
     val t = expect(K.K_FOR)
+    enterCondition()
     val init = forInitializer()
     val e1 = if (kind(1) != K.SEMI) term() else null
     expect(K.SEMI)
     val e2 = if (!la("{")) term() else null
+    leaveCondition()
     AST.ForExpression(p(t), init, e1, e2, block())
   }
 
@@ -1841,10 +1888,10 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
       eols()
       kind(1) match {
         case K.LBRACKET =>
-          val t = next(); eols(); val a = term(); eols(); expect(K.RBRACKET)
+          val t = next(); val a = inOperand { eols(); val x = term(); eols(); x }; expect(K.RBRACKET)
           e = AST.Indexing(p(t), e, a)
         case K.SAFE_INDEX =>
-          val t = next(); eols(); val a = term(); eols(); expect(K.RBRACKET)
+          val t = next(); val a = inOperand { eols(); val x = term(); eols(); x }; expect(K.RBRACKET)
           e = AST.SafeIndexing(p(t), e, a)
         case K.DOT => e = dotSuffix(e)
         case K.SAFE_ACCESS => e = safeAccessSuffix(e)
@@ -1864,7 +1911,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
   }
 
   private def trailingLambdaOpt(): AST.ClosureExpression =
-    if (kind(1) == K.LBRACE && looksLike(trailingLambdaHead())) trailingLambda() else null
+    if (kind(1) == K.LBRACE && (looksLike(trailingLambdaHead()) || !inCondition())) trailingLambda() else null
 
   private def typeArgsThenParen(): Boolean =
     kind(1) == K.LBRACKET && looksLike { typeArguments(); eols(); expect(K.LPAREN) }
@@ -2046,9 +2093,9 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
   private def lambdaOrParen(): AST.Expression = {
     if (looksLike(lambdaHead())) arrowAnonymousFunction()
     else {
-      expect(K.LPAREN); eols()
-      val e = term()
-      eols(); expect(K.RPAREN)
+      expect(K.LPAREN)
+      val e = inOperand { eols(); val x = term(); eols(); x }
+      expect(K.RPAREN)
       e
     }
   }
@@ -2091,22 +2138,22 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
       }
       if (kind(2) == K.ARROW) return arrowAnonymousFunction()
       val t = id()
-      return AST.Id(p(t), c(t))
+      val tl = trailingLambdaOpt()
+      return if (tl == null) AST.Id(p(t), c(t)) else new AST.UnqualifiedMethodCall(through(t), c(t), List(tl))
     }
     k match {
       case K.LBRACKET =>
         enterDefault()
         val t = next()
-        eols()
-        val e = bracketLiteralRest(t)
+        val e = inOperand { eols(); bracketLiteralRest(t) }
         leaveDefault()
         e
       case K.LPAREN =>
         if (arrowAfterParenAhead()) lambdaOrParen()
         else {
-          next(); eols()
-          val e = term()
-          eols(); expect(K.RPAREN)
+          next()
+          val e = inOperand { eols(); val x = term(); eols(); x }
+          expect(K.RPAREN)
           e
         }
       case K.K_DO if kind(2) == K.LBRACKET => doExpression()
@@ -2231,14 +2278,16 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     } else term()
   }
 
-  private def terms(): List[AST.Expression] = {
+  private def terms(): List[AST.Expression] = inOperand {
     eols()
-    if (kind(1) == K.RPAREN) return Nil
-    val args = new ArrayBuffer[AST.Expression]()
-    args += argumentExpr()
-    while (accept(K.COMMA)) { eols(); args += argumentExpr() }
-    eols()
-    args.toList
+    if (kind(1) == K.RPAREN) Nil
+    else {
+      val args = new ArrayBuffer[AST.Expression]()
+      args += argumentExpr()
+      while (accept(K.COMMA)) { eols(); args += argumentExpr() }
+      eols()
+      args.toList
+    }
   }
 
   private def bracketLiteralRest(t: Token): AST.Expression = {
@@ -2345,14 +2394,26 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     enterDefault()
     val t = expect(K.LBRACE)
     eols()
-    val args = lambdaArgs(false)
-    eols()
-    expect(K.ARROW)
-    eols()
+    val args =
+      if (looksLike(trailingLambdaHeadAfterBrace())) {
+        val a = lambdaArgs(false)
+        eols()
+        expect(K.ARROW)
+        eols()
+        a
+      } else {
+        // No arrow: a zero-parameter lambda. The slips that have hints (`{ (k, v) -> }`,
+        // `{ x => }`, `switch (x) { case ... }`) are left to the JavaCC parser, which reports
+        // them at the `{`.
+        if (kind(1) == K.K_CASE || parenthesizedLambdaHeadAhead() || oldArrowLambdaHeadAhead()) throw fail
+        Nil
+      }
+    enterOperand()
     enterAssignScope()
     val stmts = if (kind(1) != K.RBRACE) blockElements() else Nil
     eols()
     expect(K.RBRACE)
+    leaveCondition()
     val body = AST.BlockExpression(p(t), stmts, leaveAssignScope())
     val ty = functionTypeNode(t, args.length)
     leaveDefault()

--- a/src/test/scala/onion/compiler/tools/BareTrailingLambdaSpec.scala
+++ b/src/test/scala/onion/compiler/tools/BareTrailingLambdaSpec.scala
@@ -1,0 +1,120 @@
+package onion.compiler.tools
+
+import onion.compiler.parser.{JJOnionParser, OnionParser}
+import onion.tools.Shell
+
+import java.io.StringReader
+
+/**
+ * A trailing lambda with no parameters needs no arrow: `Future::async { compute() }` is
+ * the zero-parameter closure `{ -> compute() }`. The `{` is read as a lambda only where a
+ * block could not follow the call anyway; in a condition position (the condition of `if`,
+ * `while` and `do ... while`, the collection of `foreach ... in`, the scrutinee of `select`,
+ * the `for` header) a bare `{` still opens the statement block, so `if flag { ... }` and
+ * `foreach x in xs { ... }` keep their meaning. The arrow form `{ x -> ... }` is
+ * recognised everywhere, as before.
+ */
+class BareTrailingLambdaSpec extends AbstractShellSpec {
+
+  private def run(src: String, name: String): Shell.Result = shell.run(src, name, Array())
+
+  private def parity(src: String): Unit = {
+    val fast = OnionParser.parse(src)
+    val jj = new JJOnionParser(new StringReader(src)).unit()
+    assert(fast == jj, "fast-path AST diverged from the JavaCC AST")
+  }
+
+  describe("a trailing lambda without an arrow") {
+    it("is a zero-parameter closure on a static call, with `return` or a final expression") {
+      val src =
+        """
+          |class Test {
+          |public:
+          |  static def fetchUser(): Int = 20
+          |  static def main(args: String[]): Int {
+          |    val a: Future[Int] = Future::async { return fetchUser() }
+          |    val b: Future[Int] = Future::async { 21 + 1 }
+          |    val c: Future[Int] = Future::async {
+          |      val base = a.await()
+          |      base + b.await()
+          |    }
+          |    return c.await()
+          |  }
+          |}
+          |""".stripMargin
+      parity(src)
+      assert(Shell.Success(42) == run(src, "BareStatic.on"))
+    }
+
+    it("attaches to instance and unqualified calls, with and without an argument list") {
+      val src =
+        """
+          |class Runner {
+          |public:
+          |  def this {}
+          |  def twice(f: Function0[Int]): Int = f.call() + f.call()
+          |  def plus(n: Int, f: Function0[Int]): Int = n + f.call()
+          |}
+          |class Test {
+          |public:
+          |  static def once(f: Function0[Int]): Int = f.call()
+          |  static def main(args: String[]): Int {
+          |    val r = new Runner()
+          |    return r.twice { 10 } + r.plus(1) { 2 } + once { 3 }
+          |  }
+          |}
+          |""".stripMargin
+      parity(src)
+      assert(Shell.Success(26) == run(src, "BareInstance.on"))
+    }
+
+    it("keeps `{` as the statement block in every condition position") {
+      val src =
+        """
+          |class Test {
+          |public:
+          |  static def flag(): Boolean = true
+          |  static def main(args: String[]): Int {
+          |    var n = 0
+          |    val ok = true
+          |    if ok { n += 1 }
+          |    if flag() { n += 10 }
+          |    var i = 0
+          |    while i < 2 { i += 1; n += 100 }
+          |    do { n += 1000 } while flag() == false
+          |    val xs = [1, 2]
+          |    foreach x: Int in xs { n += 10000 * x }
+          |    select xs.size {
+          |      case 2: n += 100000
+          |      else: n += 0
+          |    }
+          |    for var j = 0; j < xs.size; j++ { n += 1000000 }
+          |    if xs.any { x -> x > 1 } { n += 10000000 }
+          |    return n
+          |  }
+          |}
+          |""".stripMargin
+      parity(src)
+      assert(Shell.Success(12131211) == run(src, "BareConditions.on"))
+    }
+
+    it("is a lambda again inside parentheses or a nested block within a condition") {
+      val src =
+        """
+          |class Test {
+          |public:
+          |  static def once(f: Function0[Int]): Int = f.call()
+          |  static def main(args: String[]): Int {
+          |    var n = 0
+          |    if (once { 1 }) == 1 { n += 1 }
+          |    if (Test::once { 2 }) == 2 { n += 10 }
+          |    if [1, 2].any { x -> once { x } == 2 } { n += 100 }
+          |    return n
+          |  }
+          |}
+          |""".stripMargin
+      parity(src)
+      assert(Shell.Success(111) == run(src, "BareNested.on"))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `Future::async { return fetchUser() }`, `Helper::twice { x -> x + 1 }` and `once { 3 }` now parse. A trailing lambda with no parameters needs no arrow: `{ body }` is the zero-parameter closure `{ -> body }` (the arrow form still works), and the block's last expression is its value. A bare name also takes a trailing lambda now, like instance and static calls.
- The `{` is read as a lambda only where a block could not follow the call anyway. In a **condition position** — the condition of `if`/`while`/`do ... while`, the collection of `foreach ... in`, the scrutinee of `select`, the `for` header — a bare `{` is still the statement block, so `if flag { ... }` and `foreach x in xs { ... }` keep their meaning; the arrow form is a lambda there as before. Parentheses, argument lists, index brackets, collection literals and blocks (including lambda bodies) restore the arrow-less form: `if (once { 1 }) == 1 { ... }`, `if xs.any { x -> g { x } } { ... }`. This is the Swift rule rather than requiring parentheses on `if`/`while`, so no existing program changes meaning.
- Both parsers keep a condition-context stack; JavaCC gates the arrow-less form with a semantic lookahead in a shared `trailing_lambda_opt` production, the handwritten fast path mirrors it. The `{ (k, v) -> ... }`, `{ x => ... }` and `switch (x) { case ... }` hints are still reported at the `{`: the arrow-less path recognises those heads and fails there, so the existing hint classifier sees the same error.
- Docs: README, the lambda guide (new "Trailing Lambdas" section with the condition rule, EN/JA), `docs/grammar.txt`, the specification and stdlib references, the examples and `CLAUDE.md` (EN/JA) use the arrow-less form for zero-parameter callbacks.

## Test plan

- [x] New `BareTrailingLambdaSpec`: static/instance/unqualified calls with and without an argument list, `return` and final-expression bodies, every condition position keeping its block, parentheses and nested lambda bodies restoring the lambda; each case also asserts fast-path == JavaCC AST parity
- [x] Existing hint specs (`TrailingLambdaParenHintSpec`, `OldTrailingArrowHintI18nSpec`, `SwitchStatementHintSpec`, `MatchStatementHintSpec`, `HintMessageFormatSpec`) still green
- [x] `FastPathParserParitySpec`, `DocExamplesCompileSpec`, `RunSamplesSpec` green
- [x] `sbt -Duser.language=ja testFull` and `-Duser.language=en testFull`: 5279 passed, 0 failed each
- [x] README and lambda-guide snippets run end to end on the assembled jar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc
