### PR TITLE
test: add HashDocCoverageSpec regression guard for onion.Hash stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Added a `HashDocCoverageSpec` regression guard checking that every public
+  `onion.Hash` member is documented in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`.** `onion.Hash` is a genuine, default-imported
+  stdlib module (`Hash::md5`, `Hash::sha1`, `Hash::sha256`, `Hash::sha512`)
+  with 4 distinct public static member names, but -- unlike `OnionMath`,
+  `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand` and `Csv`,
+  each already guarded by its own coverage spec -- it never had one. All 4
+  members were already documented in both files; this guard now fails the
+  build if a future addition to `onion.Hash` goes undocumented.
+
 - **A trailing lambda with no parameters needs no arrow, and attaches to a
   static or bare call without an empty argument list:
   `Future::async { return fetchUser() }`, `Helper::twice { x -> x + 1 }`,

--- a/src/test/scala/onion/compiler/tools/HashDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HashDocCoverageSpec.scala
@@ -1,0 +1,65 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Hash` module docs.
+ *
+ * `onion.Hash` is a genuine, default-imported stdlib module (`Hash::md5`, `Hash::sha1`,
+ * `Hash::sha256`, `Hash::sha512`) with 4 distinct public static member names, but -- unlike
+ * `OnionMath`, `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand` and `Csv`, each
+ * guarded by its own `*DocCoverageSpec` -- it has never had a regression test checking that
+ * every member is still documented in both docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md. `Hash` is also registered as a builtin extension container
+ * (`"pw".sha256()` works, guarded separately by `HashCodecTextFormatExtensionCallDocSpec`), but
+ * that spec only checks the extension-call spelling in the Hash Module section -- it does not
+ * check that every member of `onion.Hash` is documented at all. Every public member is checked
+ * here so a future addition to onion.Hash fails the build instead of silently staying
+ * undocumented.
+ */
+class HashDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Hash::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Hash]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    val fieldNames = c.getFields
+      .filter(f => java.lang.reflect.Modifier.isStatic(f.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    (methodNames ++ fieldNames).toSet
+  }
+
+  it("actual onion.Hash exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Hash found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Hash member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Hash:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Hash member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Hash:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Hash in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Hash"),
+      "docs/reference/stdlib.md's overview table should mention Hash")
+    assert(read("docs/ja/reference/stdlib.md").contains("Hash"),
+      "docs/ja/reference/stdlib.md's overview table should mention Hash")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Hash` (`md5`/`sha1`/`sha256`/`sha512`) had no regression test checking that every public member stays documented in `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, unlike other stdlib modules (`Csv`, `Rand`, `DateTime`, ...) that already have their own `*DocCoverageSpec`.
- Adds `HashDocCoverageSpec`, following the established pattern. All 4 members were already documented in both files, so this only adds a guard against future undocumented additions.
- Notes the CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.HashDocCoverageSpec'` — 4/4 pass
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5287 succeeded, 0 failed (1 unrelated pre-existing cancellation in `ProjectDistributionSpec`)

Co-Authored-By: 音羽ここね <kokone.ai.main@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL1GFtKjSTvN7DBpGqv1r2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL1GFtKjSTvN7DBpGqv1r2)_