### PR TITLE
test: add CodecDocCoverageSpec regression guard for onion.Codec stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Added a `CodecDocCoverageSpec` regression guard checking that every public
+  `onion.Codec` member is documented in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`.** `onion.Codec` is a genuine, default-imported
+  stdlib module (`Codec::base64Encode`, `Codec::base64Decode`,
+  `Codec::hexEncode`, `Codec::hexDecode`, `Codec::urlEncode`,
+  `Codec::urlDecode`) with 6 distinct public static member names, but --
+  unlike `OnionMath`, `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`,
+  `Rand`, `Csv` and `Hash`, each already guarded by its own coverage spec --
+  it never had one. All 6 members were already documented in both files;
+  this guard now fails the build if a future addition to `onion.Codec` goes
+  undocumented.
+
 - **Added a `HashDocCoverageSpec` regression guard checking that every public
   `onion.Hash` member is documented in both `docs/reference/stdlib.md` and
   `docs/ja/reference/stdlib.md`.** `onion.Hash` is a genuine, default-imported

--- a/src/test/scala/onion/compiler/tools/CodecDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/CodecDocCoverageSpec.scala
@@ -1,0 +1,60 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Codec` module docs.
+ *
+ * `onion.Codec` is a genuine, default-imported stdlib module (`Codec::base64Encode`,
+ * `Codec::hexEncode`, `Codec::urlEncode`, ...) with 6 distinct public static member names, but --
+ * unlike `OnionMath`, `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv` and
+ * `Hash`, each already guarded by its own `*DocCoverageSpec` -- it never had one. All 6 members
+ * were already documented in both files; this guard now fails the build if a future addition to
+ * onion.Codec goes undocumented.
+ */
+class CodecDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Codec::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Codec]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    val fieldNames = c.getFields
+      .filter(f => java.lang.reflect.Modifier.isStatic(f.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    (methodNames ++ fieldNames).toSet
+  }
+
+  it("actual onion.Codec exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Codec found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Codec member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Codec:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Codec member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Codec:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Codec in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Codec"),
+      "docs/reference/stdlib.md's overview table should mention Codec")
+    assert(read("docs/ja/reference/stdlib.md").contains("Codec"),
+      "docs/ja/reference/stdlib.md's overview table should mention Codec")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Codec` is a genuine, default-imported stdlib module (`Codec::base64Encode`, `Codec::base64Decode`, `Codec::hexEncode`, `Codec::hexDecode`, `Codec::urlEncode`, `Codec::urlDecode`) with 6 distinct public static member names, but unlike `OnionMath`, `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv` and `Hash` (each already guarded by its own `*DocCoverageSpec`), it never had one.
- Adds `CodecDocCoverageSpec` following the established pattern: reflects on `onion.Codec`'s public static members and asserts every one is documented in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, plus that the "Modules at a glance" overview mentions `Codec` in both languages.
- All 6 members are already documented in both files, so this is a pure regression guard — it fails the build only if a future addition to `onion.Codec` goes undocumented.

## Test plan
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.CodecDocCoverageSpec"` — 4/4 pass
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5291 succeeded, 0 failed, 1 canceled (pre-existing, environment-gated `ProjectDistributionSpec` smoke test, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBgUyh3YP9coAU5PcjDriN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBgUyh3YP9coAU5PcjDriN)_