### PR TITLE
docs: document Strings equalsIgnoreCase/lastIndexOf extension-call shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documented that `Strings::equalsIgnoreCase`'s and `Strings::lastIndexOf`'s
+  extension-call forms are shadowed by native `String.equalsIgnoreCase`/
+  `String.lastIndexOf`.** `java.lang.String` already declares instance
+  methods with these same names, and instance-method resolution always wins
+  over the extension fallback, so `s.equalsIgnoreCase(x)` and
+  `s.lastIndexOf(x)` silently reach the native methods instead of
+  `onion.Strings`'s -- the same shadowing pattern already documented for
+  `trim`/`startsWith`/`endsWith`/`indexOf`/`replace` in the same section.
+  This is invisible on a non-null `String`, but on a null platform-typed
+  `String` the native methods throw `NullPointerException` while
+  `Strings::equalsIgnoreCase`/`Strings::lastIndexOf` are null-safe. Added
+  the note to the Strings Module section of both `docs/reference/stdlib.md`
+  and `docs/ja/reference/stdlib.md`, and a new
+  `StringsEqualsIgnoreCaseLastIndexOfShadowingSpec` regression test.
+
 - **Documented that `Colls::forEach`'s extension-call form is shadowed by
   native `List.forEach`, and that -- unlike `Maps::forEach`/`Sets::forEach`
   -- this hides no null-safety gap.** `java.util.List` conforms to

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1418,6 +1418,20 @@ EM SPACE だけからなる文字列は `s.isBlank()`（拡張呼び出し構文
 空白扱いになりません。`trim()` ベースの ASCII 空白の意味論が必要な
 場合は `Strings::isBlank(...)` の静的呼び出し形式を使ってください。
 
+**`equalsIgnoreCase` と `lastIndexOf` も、上の
+`trim`・`startsWith`・`endsWith`・`indexOf`・`replace` と同様に遮蔽され
+ます**: `java.lang.String` にはすでに `equalsIgnoreCase(String)`・
+`lastIndexOf(String)` というインスタンスメソッドが定義されているため、
+`s.equalsIgnoreCase(x)` と `s.lastIndexOf(x)` も `onion.Strings` 側では
+なく **JDK 標準の同名メソッド** を暗黙のうちに呼び出します。上と同様、
+`null` でない `String` では見分けが付かず、差が表面化するのはプラット
+フォーム型の `null` を受け手にした場合だけです: このとき JDK 側の
+メソッドは `NullPointerException` を投げますが、`onion.Strings` の版は
+null 安全です（`Strings::equalsIgnoreCase(null, x) == false`、
+`Strings::lastIndexOf(null, x) == -1`）。受け手が未検査のプラット
+フォーム `null` になり得る場合は `Strings::equalsIgnoreCase(...)` /
+`Strings::lastIndexOf(...)` の静的呼び出し形式を使ってください。
+
 ## Maps モジュール
 
 Map ユーティリティ（`onion.Maps`）。結果 Map は挿入順を保持（`LinkedHashMap`）。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1409,6 +1409,19 @@ string consisting only of an EM SPACE is blank under `s.isBlank()`
 (static-call syntax). Use the `Strings::isBlank(...)` static-call form for
 `trim()`-based, ASCII-whitespace semantics.
 
+**`equalsIgnoreCase` and `lastIndexOf` are shadowed the same way as
+`trim`/`startsWith`/`endsWith`/`indexOf`/`replace` above**:
+`java.lang.String` already defines `equalsIgnoreCase(String)` and
+`lastIndexOf(String)` instance methods, so `s.equalsIgnoreCase(x)` and
+`s.lastIndexOf(x)` also silently reach the *native JDK method* instead of
+`onion.Strings`'s. As above, this is invisible for a non-null `String` and
+only becomes observable for a platform-typed `null` receiver, where the
+native methods throw `NullPointerException` while `onion.Strings`'s
+versions are null-safe (`Strings::equalsIgnoreCase(null, x) == false`,
+`Strings::lastIndexOf(null, x) == -1`). Use the
+`Strings::equalsIgnoreCase(...)` / `Strings::lastIndexOf(...)` static-call
+form when the receiver may be an unchecked platform `null`.
+
 ## Files Module
 
 File I/O (`onion.Files`):

--- a/src/test/scala/onion/compiler/tools/StringsEqualsIgnoreCaseLastIndexOfShadowingSpec.scala
+++ b/src/test/scala/onion/compiler/tools/StringsEqualsIgnoreCaseLastIndexOfShadowingSpec.scala
@@ -1,0 +1,121 @@
+package onion.compiler.tools
+
+import onion.compiler.exceptions.ScriptException
+import onion.tools.Shell
+
+/**
+ * `docs/reference/stdlib.md`'s Strings Module section documents that several
+ * `onion.Strings` methods are shadowed by identically-named `java.lang.String`
+ * instance methods when called via extension-call syntax (`trim`,
+ * `startsWith`, `endsWith`, `indexOf`, `replace`, ...), but omits two more
+ * methods with the exact same hazard: `equalsIgnoreCase` and `lastIndexOf`.
+ * `java.lang.String` already defines `equalsIgnoreCase(String)` and
+ * `lastIndexOf(String)` instance methods, so `a.equalsIgnoreCase(b)` and
+ * `s.lastIndexOf(x)` also silently reach the *native JDK method* instead of
+ * `onion.Strings`'s, the same as `indexOf` a few lines above them in the same
+ * doc section.
+ *
+ * For a non-null receiver the native method and `onion.Strings`'s agree, so
+ * the shadowing is invisible there. It becomes observable for a receiver
+ * that is `null` at runtime but was never checked at compile time: a value
+ * read back from unparameterized Java interop (a "platform type", per
+ * CLAUDE.md) carries no compile-time nullability tracking, so Onion's
+ * null-safety typechecking does not force a null check before
+ * `.equalsIgnoreCase(...)`/`.lastIndexOf(...)` on it. `onion.Strings`'s
+ * versions are null-safe (`equalsIgnoreCase(null, "x") == false`,
+ * `lastIndexOf(null, x) == -1`); the native methods that extension-call
+ * syntax actually reaches throw `NullPointerException` instead. Locks in the
+ * shadowing and checks that both docs carry an accurate warning
+ * (docs/reference/stdlib.md and its Japanese translation, Strings Module
+ * section).
+ */
+class StringsEqualsIgnoreCaseLastIndexOfShadowingSpec extends AbstractShellSpec {
+
+  private def nullPlatformString: String =
+    """
+      |val m: HashMap[String, String] = new HashMap[String, String]
+      |val s: String = m.get("missing") as String
+      |""".stripMargin
+
+  private def runBool(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Boolean {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsEqIgnLastIdxShadowBool.on", Array()))
+  }
+
+  private def runInt(body: String, expect: Shell.Result): Unit = {
+    val src =
+      "class Test {\npublic:\n  static def main(args: String[]): Int {\n" + body + "\n  }\n}\n"
+    assert(expect == shell.run(src, "StringsEqIgnLastIdxShadowInt.on", Array()))
+  }
+
+  private def expectNpe(body: String, fileName: String): Unit = {
+    val thrown = intercept[ScriptException] {
+      shell.run(
+        "class Test {\npublic:\n  static def main(args: String[]): void {\n" + body + "\n  }\n}\n",
+        fileName, Array())
+    }
+    assert(thrown.getCause.isInstanceOf[NullPointerException])
+  }
+
+  describe("extension-call syntax for equalsIgnoreCase()/lastIndexOf() on a null platform String shadows onion.Strings") {
+    it("s.equalsIgnoreCase(x) on a null platform String reaches the native String.equalsIgnoreCase and throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.equalsIgnoreCase(\"x\")\n", "StringsEqualsIgnoreCaseShadowNpe.on")
+    }
+
+    it("Strings::equalsIgnoreCase(s, x) on the same null platform String is null-safe and returns false instead") {
+      runBool(nullPlatformString + "    return Strings::equalsIgnoreCase(s, \"x\")", Shell.Success(false))
+    }
+
+    it("s.lastIndexOf(x) on a null platform String reaches the native String.lastIndexOf and throws NullPointerException") {
+      expectNpe(nullPlatformString + "    s.lastIndexOf(\"x\")\n", "StringsLastIndexOfShadowNpe.on")
+    }
+
+    it("Strings::lastIndexOf(s, x) on the same null platform String is null-safe and returns -1 instead") {
+      runInt(nullPlatformString + "    return Strings::lastIndexOf(s, \"x\")", Shell.Success(-1))
+    }
+
+    it("for a non-null receiver, extension-call and static-call syntax agree") {
+      runBool("return \"Hello\".equalsIgnoreCase(\"HELLO\")", Shell.Success(true))
+      runInt("return \"hello\".lastIndexOf(\"l\")", Shell.Success(3))
+    }
+  }
+
+  describe("docs carry an accurate equalsIgnoreCase()/lastIndexOf() shadowing warning in the Strings Module section") {
+    def read(p: String): String =
+      java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+    def section(doc: String, heading: String): String = {
+      val lines = doc.linesIterator.toIndexedSeq
+      val start = lines.indexWhere(_.contains(heading))
+      assert(start >= 0, s"""could not find a "$heading" heading -- the scan has rotted""")
+      val rest = lines.drop(start + 1)
+      val end = rest.indexWhere(_.startsWith("## "))
+      (if (end < 0) rest else rest.take(end)).mkString("\n")
+    }
+
+    val enMarkers =
+      Set("equalsIgnoreCase", "lastIndexOf", "NullPointerException")
+
+    val jaMarkers =
+      Set("equalsIgnoreCase", "lastIndexOf", "NullPointerException")
+
+    it("docs/reference/stdlib.md's Strings Module section warns about equalsIgnoreCase()/lastIndexOf() shadowing") {
+      val doc = section(read("docs/reference/stdlib.md"), "## Strings Module")
+      val missing = enMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/reference/stdlib.md's Strings Module section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+      assert(doc.contains("s.equalsIgnoreCase(") && doc.contains("s.lastIndexOf("),
+        "docs/reference/stdlib.md's Strings Module section does not warn about equalsIgnoreCase()/lastIndexOf() extension-call shadowing")
+    }
+
+    it("docs/ja/reference/stdlib.md's Strings section warns about equalsIgnoreCase()/lastIndexOf() shadowing") {
+      val doc = section(read("docs/ja/reference/stdlib.md"), "## Strings モジュール")
+      val missing = jaMarkers.filterNot(doc.contains)
+      assert(missing.isEmpty,
+        s"docs/ja/reference/stdlib.md's Strings section is missing shadowing-warning markers: ${missing.toSeq.sorted.mkString(", ")}")
+      assert(doc.contains("s.equalsIgnoreCase(") && doc.contains("s.lastIndexOf("),
+        "docs/ja/reference/stdlib.md's Strings section does not warn about equalsIgnoreCase()/lastIndexOf() extension-call shadowing")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md`'s Strings Module section already documents that `trim`/`startsWith`/`endsWith`/`indexOf`/`replace`/`isBlank`/`contains`/`isEmpty` are shadowed by identically-named `java.lang.String` instance methods when called via extension-call syntax, but omitted two more methods with the exact same hazard: `equalsIgnoreCase` and `lastIndexOf`.
- `java.lang.String` already declares `equalsIgnoreCase(String)` and `lastIndexOf(String)` instance methods, so `s.equalsIgnoreCase(x)` and `s.lastIndexOf(x)` silently reach the native JDK method instead of `onion.Strings`'s. This is invisible for a non-null `String`, but on a platform-typed `null` receiver the native methods throw `NullPointerException` while `Strings::equalsIgnoreCase`/`Strings::lastIndexOf` are null-safe.
- Added the warning to both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md` (Strings Module section), a `CHANGELOG.md` entry, and a new `StringsEqualsIgnoreCaseLastIndexOfShadowingSpec` regression test that locks in both the runtime behavior and the doc content.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5214 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGJqzR5QTf4RdnvoqArbU7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGJqzR5QTf4RdnvoqArbU7)_