### PR TITLE
test: add FormatDocCoverageSpec regression guard for onion.Format stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Added a `FormatDocCoverageSpec` regression guard checking that every public
+  `onion.Format` member is documented in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`.** `onion.Format` is a genuine, default-imported
+  stdlib module (`Format::integer`, `Format::number`, `Format::fixed`,
+  `Format::percent`, `Format::bytes`, `Format::duration`, `Format::ordinal`)
+  with 7 distinct public static member names, but -- unlike `OnionMath`,
+  `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv`, `Hash`
+  and `Codec`, each already guarded by its own coverage spec -- it never had
+  one. All 7 members were already documented in both files; this guard now
+  fails the build if a future addition to `onion.Format` goes undocumented.
+
 - **Added an `AssertDocCoverageSpec` regression guard checking that every public
   `onion.Assert` member is documented in both `docs/reference/stdlib.md` and
   `docs/ja/reference/stdlib.md`.** `onion.Assert` is a genuine, default-imported

--- a/src/test/scala/onion/compiler/tools/FormatDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FormatDocCoverageSpec.scala
@@ -1,0 +1,62 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Format` module docs.
+ *
+ * `onion.Format` is a genuine, default-imported stdlib module (`Format::integer`,
+ * `Format::number`, `Format::fixed`, `Format::percent`, `Format::bytes`, `Format::duration`,
+ * `Format::ordinal`) with 7 distinct public static member names, but -- unlike `OnionMath`,
+ * `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv`, `Hash` and `Codec`, each
+ * guarded by its own `*DocCoverageSpec` -- it has never had a regression test checking that
+ * every member is still documented in both docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md. Every public member is checked here so a future addition to
+ * onion.Format fails the build instead of silently staying undocumented.
+ */
+class FormatDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Format::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Format]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    val fieldNames = c.getFields
+      .filter(f => java.lang.reflect.Modifier.isStatic(f.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    (methodNames ++ fieldNames).toSet
+  }
+
+  it("actual onion.Format exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Format found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Format member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Format:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Format member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Format:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Format in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Format"),
+      "docs/reference/stdlib.md's overview table should mention Format")
+    assert(read("docs/ja/reference/stdlib.md").contains("Format"),
+      "docs/ja/reference/stdlib.md's overview table should mention Format")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Format` (`integer`/`number`/`fixed`/`percent`/`bytes`/`duration`/`ordinal`) is a genuine, default-imported stdlib module that was already fully documented in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, but unlike `OnionMath`, `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv`, `Hash` and `Codec`, it had no regression test guarding that documentation coverage.
- Adds `FormatDocCoverageSpec`, following the same pattern as the existing `*DocCoverageSpec` suites: reflects over `onion.Format`'s public static members and asserts every one is mentioned in both stdlib references, plus a sanity check and a "modules at a glance" mention check.
- Records the addition in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en "testOnly onion.compiler.tools.FormatDocCoverageSpec"` — 4/4 green
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5306 succeeded, 0 failed, 1 canceled (an unrelated smoke test gated behind an unset system property)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuWAJ5yQXHnsQRZEpfHATp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuWAJ5yQXHnsQRZEpfHATp)_