### PR TITLE
test(stdlib): add TextDocCoverageSpec regression guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Added a `TextDocCoverageSpec` regression guard checking that every public
+  `onion.Text` member is documented in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`.** `onion.Text` is a genuine, default-imported
+  stdlib module (`Text::wrap`, `Text::indent`, `Text::dedent`, `Text::table`)
+  with 4 distinct public static member names, but -- unlike `OnionMath`,
+  `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv`, `Hash`
+  and `Codec`, each already guarded by its own coverage spec -- it never had
+  one. All 4 members were already documented in both files; this guard now
+  fails the build if a future addition to `onion.Text` goes undocumented.
+
 - **Added a `FormatDocCoverageSpec` regression guard checking that every public
   `onion.Format` member is documented in both `docs/reference/stdlib.md` and
   `docs/ja/reference/stdlib.md`.** `onion.Format` is a genuine, default-imported

--- a/src/test/scala/onion/compiler/tools/TextDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TextDocCoverageSpec.scala
@@ -1,0 +1,61 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Text` module docs.
+ *
+ * `onion.Text` is a genuine, default-imported stdlib module (`Text::wrap`, `Text::indent`,
+ * `Text::dedent`, `Text::table`) with 4 distinct public static member names, but -- unlike
+ * `OnionMath`, `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv`, `Hash` and
+ * `Codec`, each guarded by its own `*DocCoverageSpec` -- it has never had a regression test
+ * checking that every member is still documented in both docs/reference/stdlib.md and
+ * docs/ja/reference/stdlib.md. All 4 members were already documented in both files; this guard
+ * now fails the build if a future addition to onion.Text goes undocumented.
+ */
+class TextDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Text::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Text]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    val fieldNames = c.getFields
+      .filter(f => java.lang.reflect.Modifier.isStatic(f.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    (methodNames ++ fieldNames).toSet
+  }
+
+  it("actual onion.Text exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Text found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Text member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Text:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Text member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Text:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Text in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Text"),
+      "docs/reference/stdlib.md's overview table should mention Text")
+    assert(read("docs/ja/reference/stdlib.md").contains("Text"),
+      "docs/ja/reference/stdlib.md's overview table should mention Text")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Text` (console text layout: `wrap`/`indent`/`dedent`/`table`) is a genuine, default-imported stdlib module registered as a builtin extension container, but unlike `OnionMath`, `Stats`, `Net`, `Proc`, `Scalars`, `DateTime`, `Files`, `Rand`, `Csv`, `Hash` and `Codec` — each already guarded by its own `*DocCoverageSpec` — it never had a regression test checking that every public member stays documented in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- Adds `TextDocCoverageSpec`, following the same pattern as `HashDocCoverageSpec`/`CodecDocCoverageSpec`. All 4 members (`wrap`, `indent`, `dedent`, `table`) were already documented in both files, so this is purely a regression guard — it fails the build if a future addition to `onion.Text` goes undocumented.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5310 succeeded, 0 failed, 1 canceled (pre-existing environment-conditional `ProjectDistributionSpec` smoke test that requires `-Donion.dist.path`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XrsijW7S3secsz6pWXEZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_018XrsijW7S3secsz6pWXEZ4)_