### PR TITLE
test(stdlib): add ArgsDocCoverageSpec regression guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Documented the single-argument `Args.Parsed::option(name)` overload and added an
+  `ArgsDocCoverageSpec` regression guard.** `onion.Args.Parsed::option(String)` --
+  returning the raw `--name`/`--name=value` value or `null` when absent -- is a real,
+  callable method alongside the two-argument `option(name, defaultValue)` form, but
+  docs/reference/stdlib.md and its Japanese translation only ever showed
+  `parsed.option("out", "a.out")`, never the one-argument call, making the
+  nullable-return overload undiscoverable without reading the Java source. Both docs
+  now show `parsed.option("out")` and a new spec fails the build if this regresses.
+
 - **Added a `ConfigDocCoverageSpec` regression guard checking that every public
   `onion.Config` member is documented in both `docs/reference/stdlib.md` and
   `docs/ja/reference/stdlib.md`.** `onion.Config` is a genuine, default-imported

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1997,6 +1997,7 @@ Proc::execIn("/tmp", "make", "build")   // exec と同様だが、指定した�
 val parsed = Args::parse(args)
 parsed.flag("verbose")                  // --verbose
 parsed.option("out", "a.out")           // --out path（デフォルト値付き）
+parsed.option("out")                    // --out path。無ければ null
 parsed.intOption("level", 3)
 parsed.positional()                     // オプション以外の引数の List
 ```

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1834,6 +1834,7 @@ Command-line argument parsing (`onion.Args`):
 val parsed = Args::parse(args)
 parsed.flag("verbose")                  // --verbose
 parsed.option("out", "a.out")           // --out path (with default)
+parsed.option("out")                    // --out path, or null if absent
 parsed.intOption("level", 3)
 parsed.positional()                     // List of non-option arguments
 ```

--- a/src/test/scala/onion/compiler/tools/ArgsDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ArgsDocCoverageSpec.scala
@@ -1,0 +1,41 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Args` module docs.
+ *
+ * `onion.Args.Parsed::option(String)` -- the single-argument overload that returns the
+ * raw value of `--name`/`--name=value` or `null` when absent -- is a real, callable
+ * method (see src/main/java/onion/Args.java) alongside the two-argument
+ * `option(name, defaultValue)` form, but docs/reference/stdlib.md and its Japanese
+ * translation only ever show `parsed.option("out", "a.out")`, never the one-argument
+ * `parsed.option("out")` call, making the nullable-return overload undiscoverable
+ * without reading the Java source.
+ */
+class ArgsDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def hasSingleArgOptionCall(doc: String): Boolean =
+    """parsed\.option\("\w+"\)""".r.findFirstIn(doc).isDefined
+
+  it("actual onion.Args.Parsed exposes the single-argument option(name) overload (sanity check)") {
+    val hasSingleArgOption = classOf[onion.Args.Parsed].getDeclaredMethods.exists { m =>
+      m.getName == "option" && m.getParameterCount == 1
+    }
+    assert(hasSingleArgOption,
+      "reflection on onion.Args.Parsed found no one-argument option method -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents the single-argument Parsed::option(name) overload") {
+    assert(hasSingleArgOptionCall(read("docs/reference/stdlib.md")),
+      "docs/reference/stdlib.md never shows parsed.option(\"name\") with no default argument")
+  }
+
+  it("docs/ja/reference/stdlib.md documents the single-argument Parsed::option(name) overload") {
+    assert(hasSingleArgOptionCall(read("docs/ja/reference/stdlib.md")),
+      "docs/ja/reference/stdlib.md never shows parsed.option(\"name\") with no default argument")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Args.Parsed::option(String)` — the single-argument overload returning the raw `--name`/`--name=value` value or `null` when absent — is a real, callable method (see `src/main/java/onion/Args.java`) alongside the two-argument `option(name, defaultValue)` form, but `docs/reference/stdlib.md` and its Japanese translation only ever showed `parsed.option("out", "a.out")`, never the one-argument call.
- Documents `parsed.option("out")` in both doc files and adds `ArgsDocCoverageSpec` to guard against this regressing.
- Notes the change in `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en 'testOnly onion.compiler.tools.ArgsDocCoverageSpec'` — confirmed red before the doc fix, green after
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5329 succeeded, 0 failed, 1 canceled (an environment-gated distribution smoke test requiring `-Donion.dist.path`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DHKtoDxTc6tWe8RXQ5Jae

---
_Generated by [Claude Code](https://claude.ai/code/session_016DHKtoDxTc6tWe8RXQ5Jae)_