### PR TITLE
refactor: fold duplicated code into single owners and remove dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **Duplicated code folded into single owners, and dead code removed (no
+  behaviour change).** The untyped-AST child walk that `CapturedVariableScanner`
+  and `ReturnNodeDetector` each carried is one `ASTWalk`; `onionc` and `onion`
+  share their option names, validators, `CompilerConfig` assembly and output
+  emitters through `CompilerOptions` (this also makes `onionc` report a
+  non-positive `-maxErrorReport` instead of failing silently, as `onion`
+  already did); `GenericMethodTypeArguments.infer` and `inferWithoutDefaults`
+  drive one constraint collector; the closure-argument and named-argument
+  helpers live once in `ArgumentHelpers`. A `-Wunused:all` pass then removed
+  61 unused imports, 30 unused pattern variables, never-used default
+  arguments and constructor parameters, and private members nothing called.
+  About 900 lines gone.
+
 ### Added
 
 - **A trailing lambda with no parameters needs no arrow, and attaches to a

--- a/src/main/scala/onion/compiler/ASTWalk.scala
+++ b/src/main/scala/onion/compiler/ASTWalk.scala
@@ -1,0 +1,118 @@
+package onion.compiler
+
+/**
+ * Structural traversal of the untyped AST: `visitChildren(n)(visit)` calls `visit` on each
+ * direct child of `n`, and nothing else. A scan decides at each node whether to recurse
+ * (usually by calling `visitChildren(n)(visit)` again from its own `visit`), so that stopping
+ * at closures, declarations or any other node kind is the scan's decision, not the walk's.
+ *
+ * Shared by [[CapturedVariableScanner]] and `typing.ReturnNodeDetector`, which each used to
+ * carry an identical copy of this match.
+ */
+object ASTWalk {
+  def visitChildren(n: AST.Node)(visit: AST.Node => Unit): Unit = n match {
+    case block: AST.BlockExpression =>
+      block.elements.foreach(visit)
+
+    case ifExpr: AST.IfExpression =>
+      visit(ifExpr.condition)
+      visit(ifExpr.thenBlock)
+      if (ifExpr.elseBlock != null) visit(ifExpr.elseBlock)
+
+    case whileExpr: AST.WhileExpression =>
+      visit(whileExpr.condition)
+      visit(whileExpr.block)
+
+    case foreachExpr: AST.ForeachExpression =>
+      visit(foreachExpr.collection)
+      visit(foreachExpr.statement)
+
+    case forExpr: AST.ForExpression =>
+      if (forExpr.init != null) visit(forExpr.init)
+      if (forExpr.condition != null) visit(forExpr.condition)
+      if (forExpr.update != null) visit(forExpr.update)
+      visit(forExpr.block)
+
+    case assign: AST.Assignment =>
+      visit(assign.lhs)
+      visit(assign.rhs)
+
+    case localVar: AST.LocalVariableDeclaration =>
+      if (localVar.init != null) visit(localVar.init)
+
+    case binary: AST.BinaryExpression =>
+      visit(binary.lhs)
+      visit(binary.rhs)
+
+    case unary: AST.UnaryExpression =>
+      visit(unary.term)
+
+    case call: AST.MethodCall =>
+      if (call.target != null) visit(call.target)
+      call.args.foreach(visit)
+
+    case call: AST.UnqualifiedMethodCall =>
+      call.args.foreach(visit)
+
+    case call: AST.StaticMethodCall =>
+      call.args.foreach(visit)
+
+    case call: AST.SuperMethodCall =>
+      call.args.foreach(visit)
+
+    case newObj: AST.NewObject =>
+      newObj.args.foreach(visit)
+
+    case newArray: AST.NewArray =>
+      newArray.args.foreach(visit)
+
+    case newArrayWithValues: AST.NewArrayWithValues =>
+      newArrayWithValues.values.foreach(visit)
+
+    case listLit: AST.ListLiteral =>
+      listLit.elements.foreach(visit)
+
+    case mapLit: AST.MapLiteral =>
+      mapLit.entries.foreach { case (k, v) => visit(k); visit(v) }
+
+    case cast: AST.Cast =>
+      visit(cast.src)
+
+    case isInstance: AST.IsInstance =>
+      visit(isInstance.target)
+
+    case memberSel: AST.MemberSelection =>
+      if (memberSel.target != null) visit(memberSel.target)
+
+    case returnExpr: AST.ReturnExpression =>
+      if (returnExpr.result != null) visit(returnExpr.result)
+
+    case throwExpr: AST.ThrowExpression =>
+      visit(throwExpr.target)
+
+    case tryExpr: AST.TryExpression =>
+      visit(tryExpr.tryBlock)
+      tryExpr.recClauses.foreach { case (_, block) =>
+        visit(block)
+      }
+      if (tryExpr.finBlock != null) visit(tryExpr.finBlock)
+
+    case syncExpr: AST.SynchronizedExpression =>
+      visit(syncExpr.condition)
+      visit(syncExpr.block)
+
+    case selectExpr: AST.SelectExpression =>
+      visit(selectExpr.condition)
+      selectExpr.cases.foreach { case (exprs, block) =>
+        exprs.foreach(visit)
+        visit(block)
+      }
+      if (selectExpr.elseBlock != null) visit(selectExpr.elseBlock)
+
+    case stringInterp: AST.StringInterpolation =>
+      stringInterp.expressions.foreach(visit)
+
+    case _ =>
+      // Literals, identifiers, closures, etc. - no children to visit
+  }
+}

--- a/src/main/scala/onion/compiler/AssignedVariableScanner.scala
+++ b/src/main/scala/onion/compiler/AssignedVariableScanner.scala
@@ -1,6 +1,5 @@
 package onion.compiler
 
-import scala.collection.mutable
 
 /**
  * Scans untyped AST for simple names that are targets of assignments,
@@ -71,7 +70,7 @@ object AssignedVariableScanner {
             acc = union(acc, visitAny(p.productElement(i)))
             i += 1
           }
-        case _ =>
+        case null =>
       }
       if (remember) memo.put(n, acc)
       acc

--- a/src/main/scala/onion/compiler/CapturedVariableScanner.scala
+++ b/src/main/scala/onion/compiler/CapturedVariableScanner.scala
@@ -49,112 +49,6 @@ object CapturedVariableScanner {
     captured.toSet
   }
 
-  /** Traverse children of an AST node - common traversal logic extracted */
-  private def visitChildren(n: AST.Node)(visit: AST.Node => Unit): Unit = n match {
-    case block: AST.BlockExpression =>
-      block.elements.foreach(visit)
-
-    case ifExpr: AST.IfExpression =>
-      visit(ifExpr.condition)
-      visit(ifExpr.thenBlock)
-      if (ifExpr.elseBlock != null) visit(ifExpr.elseBlock)
-
-    case whileExpr: AST.WhileExpression =>
-      visit(whileExpr.condition)
-      visit(whileExpr.block)
-
-    case foreachExpr: AST.ForeachExpression =>
-      visit(foreachExpr.collection)
-      visit(foreachExpr.statement)
-
-    case forExpr: AST.ForExpression =>
-      if (forExpr.init != null) visit(forExpr.init)
-      if (forExpr.condition != null) visit(forExpr.condition)
-      if (forExpr.update != null) visit(forExpr.update)
-      visit(forExpr.block)
-
-    case assign: AST.Assignment =>
-      visit(assign.lhs)
-      visit(assign.rhs)
-
-    case localVar: AST.LocalVariableDeclaration =>
-      if (localVar.init != null) visit(localVar.init)
-
-    case binary: AST.BinaryExpression =>
-      visit(binary.lhs)
-      visit(binary.rhs)
-
-    case unary: AST.UnaryExpression =>
-      visit(unary.term)
-
-    case call: AST.MethodCall =>
-      if (call.target != null) visit(call.target)
-      call.args.foreach(visit)
-
-    case call: AST.UnqualifiedMethodCall =>
-      call.args.foreach(visit)
-
-    case call: AST.StaticMethodCall =>
-      call.args.foreach(visit)
-
-    case call: AST.SuperMethodCall =>
-      call.args.foreach(visit)
-
-    case newObj: AST.NewObject =>
-      newObj.args.foreach(visit)
-
-    case newArray: AST.NewArray =>
-      newArray.args.foreach(visit)
-
-    case newArrayWithValues: AST.NewArrayWithValues =>
-      newArrayWithValues.values.foreach(visit)
-
-    case listLit: AST.ListLiteral =>
-      listLit.elements.foreach(visit)
-
-    case mapLit: AST.MapLiteral =>
-      mapLit.entries.foreach { case (k, v) => visit(k); visit(v) }
-
-    case cast: AST.Cast =>
-      visit(cast.src)
-
-    case isInstance: AST.IsInstance =>
-      visit(isInstance.target)
-
-    case memberSel: AST.MemberSelection =>
-      if (memberSel.target != null) visit(memberSel.target)
-
-    case returnExpr: AST.ReturnExpression =>
-      if (returnExpr.result != null) visit(returnExpr.result)
-
-    case throwExpr: AST.ThrowExpression =>
-      visit(throwExpr.target)
-
-    case tryExpr: AST.TryExpression =>
-      visit(tryExpr.tryBlock)
-      tryExpr.recClauses.foreach { case (_, block) =>
-        visit(block)
-      }
-      if (tryExpr.finBlock != null) visit(tryExpr.finBlock)
-
-    case syncExpr: AST.SynchronizedExpression =>
-      visit(syncExpr.condition)
-      visit(syncExpr.block)
-
-    case selectExpr: AST.SelectExpression =>
-      visit(selectExpr.condition)
-      selectExpr.cases.foreach { case (exprs, block) =>
-        exprs.foreach(visit)
-        visit(block)
-      }
-      if (selectExpr.elseBlock != null) visit(selectExpr.elseBlock)
-
-    case stringInterp: AST.StringInterpolation =>
-      stringInterp.expressions.foreach(visit)
-
-    case _ =>
-      // Literals, identifiers, closures, etc. - no children to visit
-  }
 
   /**
    * Find all closure expressions in a block (recursively)
@@ -170,7 +64,7 @@ object CapturedVariableScanner {
         result += closure
         // Don't descend into nested closures - they will be handled separately
       case _ =>
-        visitChildren(n)(visitF)
+        ASTWalk.visitChildren(n)(visitF)
     }
     visitF = visit
 
@@ -229,7 +123,7 @@ object CapturedVariableScanner {
 
         case _ =>
       }
-      visitChildren(n)(visitF)
+      ASTWalk.visitChildren(n)(visitF)
     }
     visitF = visit
 

--- a/src/main/scala/onion/compiler/LocalFrame.scala
+++ b/src/main/scala/onion/compiler/LocalFrame.scala
@@ -138,9 +138,4 @@ class LocalFrame(val parent: LocalFrame) {
 
   def depth: Int = frames.length - 1
 
-  private def entrySet: mutable.Set[LocalBinding] = {
-    val entries = new mutable.HashSet[LocalBinding]()
-    mutable.Set[LocalBinding]() ++ (for (s1 <- allScopes; s2 <- s1.entries) yield s2)
-  }
-
 }

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -180,7 +180,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
    * (complete strings lex as a single STRING token); report it as such
    * instead of listing unrelated expected tokens.
    */
-  private def syntaxErrorMessage(found: String, expected: String, context: String = "", sourceLine: String = "", expectedAll: String = null): String = {
+  private def syntaxErrorMessage(found: String, expected: String, context: String, sourceLine: String, expectedAll: String): String = {
     // At EOF the expected-token list is a large, unhelpful dump; report the real
     // problem (an unclosed block/paren) instead.
     if (found == null || found.isEmpty) return Message("error.parsing.unexpected_eof")

--- a/src/main/scala/onion/compiler/Parsing.scala
+++ b/src/main/scala/onion/compiler/Parsing.scala
@@ -1,8 +1,7 @@
 package onion.compiler
 
 import collection.mutable.ArrayBuffer
-import scala.jdk.CollectionConverters._
-import java.io.{IOException, Reader, StringReader}
+import java.io.{IOException}
 
 import _root_.onion.compiler.toolbox.Message
 import _root_.onion.compiler.exceptions.CompilationException
@@ -112,7 +111,7 @@ class Parsing(config: CompilerConfig) extends AnyRef
           addParseException(e, source.name, sourceText, problems)
       }
     } catch {
-      case e: IOException =>
+      case _: IOException =>
         problems += CompileError(null, null, Message("error.parsing.read_error", source.name))
     }
   }

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -7,19 +7,14 @@
  * ************************************************************** */
 package onion.compiler
 
-import java.util.{TreeSet => JTreeSet}
 
-import _root_.onion.compiler.TypedAST.BinaryTerm.Kind._
-import _root_.onion.compiler.TypedAST.UnaryTerm.Kind._
-import _root_.onion.compiler.TypedAST._
 import _root_.onion.compiler.SemanticError._
 import _root_.onion.compiler.exceptions.CompilationException
-import _root_.onion.compiler.toolbox.{Boxing, Classes, Message, Paths, Systems}
+import _root_.onion.compiler.toolbox.{Message}
 import onion.compiler.AST.{ClassDeclaration, InterfaceDeclaration, RecordDeclaration}
 import onion.compiler.rewrite.AdtEnumLowering
 
-import _root_.scala.jdk.CollectionConverters._
-import scala.collection.mutable.{Buffer, Map, Set => MutableSet}
+import scala.collection.mutable.Buffer
 
 /**
  * AST Rewriting Phase - Syntax Sugar Desugaring
@@ -270,7 +265,7 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
     // Overloading is fine for functions, but the CLI selects a tool by NAME alone, so a
     // second tool with the same name is unreachable and the contract lists it twice
     // with no way to address either (issue #436). Reject it here.
-    val duplicateNames = tools.groupBy(_.name).collect { case (n, ts) if ts.size > 1 => ts.tail }.flatten
+    val duplicateNames = tools.groupBy(_.name).collect { case (_, ts) if ts.size > 1 => ts.tail }.flatten
     if (duplicateNames.nonEmpty) {
       throw new CompilationException(duplicateNames.toSeq.map { t =>
         CompileError("", t.location,
@@ -913,7 +908,7 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
         // Lead with "" so the whole chain is String-typed even when the first
         // segment is a slot or a non-String component.
         val chain = parts match {
-          case (s: AST.StringLiteral) :: _ => parts
+          case (_: AST.StringLiteral) :: _ => parts
           case _ => AST.StringLiteral(loc, "") :: parts
         }
         val body = chain.reduceLeft((a, b) => AST.Addition(loc, a, b))
@@ -1287,8 +1282,8 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
     case AST.Cast(loc, src, to) => AST.Cast(loc, rewriteExpression(src), to)
     case AST.ClosureExpression(loc, typeRef, mname, args, returns, body) =>
       AST.ClosureExpression(loc, typeRef, mname, args, returns, rewriteBlockExpression(body))
-    case AST.CurrentInstance(loc) => expr
-    case AST.Id(loc, name) => expr
+    case AST.CurrentInstance(_) => expr
+    case AST.Id(_, name) => expr
     case AST.IsInstance(loc, target, typeRef) => AST.IsInstance(loc, rewriteExpression(target), typeRef)
     case AST.ListLiteral(loc, elements) => AST.ListLiteral(loc, elements.map(rewriteExpression))
     case AST.MapLiteral(loc, entries) =>
@@ -1305,11 +1300,11 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
     case AST.NewArray(loc, typeRef, args) => AST.NewArray(loc, typeRef, args.map(rewriteExpression))
     case AST.NewArrayWithValues(loc, typeRef, values) => AST.NewArrayWithValues(loc, typeRef, values.map(rewriteExpression))
     case AST.NewObject(loc, typeRef, args) => AST.NewObject(loc, typeRef, args.map(rewriteExpression))
-    case AST.UnqualifiedFieldReference(loc, name) => expr
+    case AST.UnqualifiedFieldReference(_, name) => expr
     case AST.UnqualifiedMethodCall(loc, name, args, typeArgs) =>
       AST.UnqualifiedMethodCall(loc, name, args.map(rewriteExpression), typeArgs)
     case AST.NamedArgument(loc, name, value) => AST.NamedArgument(loc, name, rewriteExpression(value))
-    case AST.StaticMemberSelection(loc, typeRef, name) => expr
+    case AST.StaticMemberSelection(_, typeRef, name) => expr
     case AST.StaticMethodCall(loc, typeRef, name, args, typeArgs) =>
       AST.StaticMethodCall(loc, typeRef, name, args.map(rewriteExpression), typeArgs)
     case node: AST.TraitMethodCall =>
@@ -1483,7 +1478,7 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
       case None => statements
       case Some(typeNode) =>
         statements.map {
-          case b @ AST.DoBinding(loc, name, expr) if isEmptyGenerativeCall(expr) =>
+          case _ @ AST.DoBinding(loc, name, expr) if isEmptyGenerativeCall(expr) =>
             AST.DoBinding(loc, name, withTypeArgument(expr, typeNode))
           case other => other
         }

--- a/src/main/scala/onion/compiler/StaticImportList.scala
+++ b/src/main/scala/onion/compiler/StaticImportList.scala
@@ -7,8 +7,6 @@
  * ************************************************************** */
 package onion.compiler
 
-import java.util.ArrayList
-import java.util.List
 import collection.mutable.ArrayBuffer
 
 /**

--- a/src/main/scala/onion/compiler/TermWalk.scala
+++ b/src/main/scala/onion/compiler/TermWalk.scala
@@ -136,7 +136,7 @@ object TermWalk:
             while it.hasNext do
               it.next() match
                 case r: AnyRef => out += r
-                case _ =>
+                case null => ()
           case other: AnyRef => out += other
       catch case _: Throwable => ()
       i += 1

--- a/src/main/scala/onion/compiler/TypedAST.scala
+++ b/src/main/scala/onion/compiler/TypedAST.scala
@@ -1201,8 +1201,8 @@ object TypedAST {
    * @author Kota Mizushima
    */
   abstract class AbstractObjectType extends ObjectType {
-    private var methodRefFinder: TypedAST.MethodFinder = new TypedAST.MethodFinder
-    private var fieldRefFinder: TypedAST.FieldFinder   = new TypedAST.FieldFinder
+    private val methodRefFinder: TypedAST.MethodFinder = new TypedAST.MethodFinder
+    private val fieldRefFinder: TypedAST.FieldFinder   = new TypedAST.FieldFinder
 
     def findField(name: String): TypedAST.FieldRef = fieldRefFinder.find(this, name)
 
@@ -1777,7 +1777,7 @@ object TypedAST {
         case (tv: TypedAST.TypeVariableType, r: TypedAST.NullableType) if tv.acceptsNullable =>
           return isSuperType(tv.upperBound, r.innerType)
         // T ← T? : NOT allowed (requires explicit unwrap)
-        case (_, r: TypedAST.NullableType) =>
+        case (_, _: TypedAST.NullableType) =>
           return false
         case _ => // continue with normal logic
       }

--- a/src/main/scala/onion/compiler/Typing.scala
+++ b/src/main/scala/onion/compiler/Typing.scala
@@ -7,16 +7,13 @@
  * ************************************************************** */
 package onion.compiler
 
-import scala.jdk.CollectionConverters.*
 
 import _root_.scala.jdk.CollectionConverters._
 import _root_.onion.compiler.toolbox.{Paths, Systems}
-import _root_.onion.compiler.exceptions.CompilationException
 import _root_.onion.compiler.typing.{NameResolver, TypeAliasEntry, TypeParam, TypeParamScope, TypingDiagnostics, TypingTypeSupport}
 import _root_.onion.compiler.typing.session.{AstBindingIndex, ExtensionRegistry, TypeAliasRegistry, TypingGlobalState, TypingSession, TypingUnitContext}
 import _root_.onion.compiler.TypedAST._
-import _root_.onion.compiler.SemanticError._
-import collection.mutable.{HashMap, Map}
+import collection.mutable.{Map}
 
 /**
  * Type Checking Phase - Static Type Analysis and Type Inference

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -195,7 +195,7 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
     for method <- classDef.methods do
       val methodDef = method.asInstanceOf[MethodDefinition]
       if Modifier.isAbstract(methodDef.modifier) || (classDef.isInterface && methodDef.getBlock == null) then
-        codeInterfaceMethod(cw, methodDef, name)
+        codeInterfaceMethod(cw, methodDef)
       else
         codeMethod(cw, methodDef, name)
 
@@ -322,7 +322,7 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
     gen.returnValue()
     gen.endMethod()
 
-  private def codeInterfaceMethod(cw: ClassWriter, node: MethodDefinition, className: String): Unit =
+  private def codeInterfaceMethod(cw: ClassWriter, node: MethodDefinition): Unit =
     // Interface methods are abstract, so no method body
     var access = toAsmModifier(node.modifier) | Opcodes.ACC_ABSTRACT
     if (node.isVararg) access |= Opcodes.ACC_VARARGS

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -1,9 +1,8 @@
 package onion.compiler.backend.asm
 
-import org.objectweb.asm.{ClassWriter, Label, Opcodes, Type => AsmType}
+import org.objectweb.asm.{ClassWriter, Opcodes, Type => AsmType}
 import org.objectweb.asm.commons.{GeneratorAdapter, Method => AsmMethod}
-import onion.compiler.{AST, BytecodeGenerator, CompiledClass, CompilerConfig, Modifier, TypedAST}
-import scala.jdk.CollectionConverters._
+import onion.compiler.{BytecodeGenerator, CompiledClass, CompilerConfig, Modifier, TypedAST}
 import scala.collection.mutable
 
 /**
@@ -745,9 +744,6 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
     val ctorDesc = AsmType.getMethodDescriptor(AsmType.VOID_TYPE, argTypes*)
     gen.invokeConstructor(classType, AsmMethod("<init>", ctorDesc))
 
-  private def emitStatements(gen: GeneratorAdapter, stmts: Array[ActionStatement], className: String): Unit =
-    emitStatementsWithContext(gen, stmts, className, new LocalVarContext(gen))
-
   // One visitor per (generator, locals): local-variable emission re-enters here mid-body,
   // and a fresh visitor each time threw away its per-method caches (call shapes, the last
   // emitted line) and re-allocated its emitters.
@@ -764,14 +760,8 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
   private def emitStatementsWithContext(gen: GeneratorAdapter, stmts: Array[ActionStatement], className: String, localVars: LocalVarContext): Unit =
     withVisitor(gen, className, localVars)(visitor => stmts.foreach(visitor.visitStatement))
 
-  private def emitStatement(gen: GeneratorAdapter, stmt: ActionStatement, className: String): Unit =
-    emitStatementsWithContext(gen, Array(stmt), className, new LocalVarContext(gen))
-    
   private[compiler] def emitStatementWithContext(gen: GeneratorAdapter, stmt: ActionStatement, className: String, localVars: LocalVarContext): Unit =
     emitStatementsWithContext(gen, Array(stmt), className, localVars)
-    
-  private def emitExpression(gen: GeneratorAdapter, expr: Term, className: String): Unit =
-    emitExpressionWithContext(gen, expr, className, new LocalVarContext(gen))
     
   private def emitExpressionWithContext(gen: GeneratorAdapter, expr: Term, className: String, localVars: LocalVarContext): Unit =
     withVisitor(gen, className, localVars)(_.visitTerm(expr))
@@ -1075,7 +1065,7 @@ object AsmCodeGeneration:
         fresh
     case _: NullType       => AsmUtil.objectType(AsmUtil.JavaLangObject)
     case _: BottomType     => AsmType.VOID_TYPE
-    case unknown =>
+    case _ =>
       // Defensive fallback: unknown types should not reach codegen, but emitting
       // java.lang.Object keeps the compiler from crashing with an internal error.
       AsmUtil.objectType(AsmUtil.JavaLangObject)

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGenerationVisitor.scala
@@ -1,8 +1,8 @@
 package onion.compiler.backend.asm
 
-import org.objectweb.asm.{Label, Opcodes, Type => AsmType}
+import org.objectweb.asm.{Opcodes, Type => AsmType}
 import org.objectweb.asm.commons.{GeneratorAdapter, Method => AsmMethod}
-import onion.compiler.{Location, Modifier, TypedAST, TypedASTVisitor}
+import onion.compiler.{Location, TypedAST, TypedASTVisitor}
 import TypedAST.*
 
 /**
@@ -254,7 +254,6 @@ class AsmCodeGenerationVisitor(
     pendingReceiver(0) = asmType(node.target.`type`)
     emitArgumentsWithAdaptation(node.parameters, argTypes, pendingReceiver)
     val ownerType = shape.owner
-    val methodDesc = shape.descriptor
     val isInterface = node.method.affiliation.isInterface
 
     // Select correct invoke instruction based on method type

--- a/src/main/scala/onion/compiler/backend/asm/ControlFlowEmitter.scala
+++ b/src/main/scala/onion/compiler/backend/asm/ControlFlowEmitter.scala
@@ -243,7 +243,7 @@ final class ControlFlowEmitter(
     // リソースを逆順でclose()するコードを生成するヘルパー
     def emitCloseResources(): Unit =
       for i <- (node.resources.length - 1) to 0 by -1 do
-        val (binding, _) = node.resources(i)
+        val (_, _) = node.resources(i)
         val slot = resourceSlots(i)
         // if (resource != null) resource.close()
         val skipClose = gen.newLabel()
@@ -251,7 +251,6 @@ final class ControlFlowEmitter(
         gen.ifNull(skipClose)
         gen.loadLocal(slot)
         // AutoCloseableのclose()を呼び出し
-        val closeMethod = AsmType.getType(classOf[AutoCloseable]).getInternalName
         gen.invokeInterface(
           AsmType.getType(classOf[AutoCloseable]),
           new org.objectweb.asm.commons.Method("close", "()V")

--- a/src/main/scala/onion/compiler/backend/asm/GenericSignatureEncoder.scala
+++ b/src/main/scala/onion/compiler/backend/asm/GenericSignatureEncoder.scala
@@ -36,7 +36,7 @@ object GenericSignatureEncoder:
   private def isGeneric(tp: Type): Boolean = tp match
     case _: TypeVariableType => true
     case _: AppliedClassType => true
-    case w: WildcardType     => true
+    case _: WildcardType     => true
     case at: ArrayType       => isGeneric(at.component)
     case nt: NullableType    => isGeneric(nt.innerType)
     case _                   => false
@@ -76,7 +76,7 @@ object GenericSignatureEncoder:
       "V"
     case ct: ClassType =>
       s"L${internal(ct.name)};"
-    case other =>
+    case _ =>
       // Defensive fallback (unknown types should not reach codegen): erase to
       // java.lang.Object so we never emit a malformed signature.
       "Ljava/lang/Object;"

--- a/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
+++ b/src/main/scala/onion/compiler/backend/asm/LocalVarContext.scala
@@ -1,6 +1,5 @@
 package onion.compiler.backend.asm
 
-import onion.compiler.LocalBinding
 import org.objectweb.asm.{Type as AsmType}
 import org.objectweb.asm.commons.GeneratorAdapter
 

--- a/src/main/scala/onion/compiler/environment/AsmRefs.scala
+++ b/src/main/scala/onion/compiler/environment/AsmRefs.scala
@@ -189,7 +189,7 @@ object AsmRefs {
 
         override def visitSuperclass(): SignatureVisitor = {
           finishTypeParam()
-          val (params, nextEnv) = {
+          val (_, nextEnv) = {
             val arr = typeParamsBuf.toArray
             (arr, typeParamEnv(arr))
           }

--- a/src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala
+++ b/src/main/scala/onion/compiler/optimization/MutualRecursionOptimization.scala
@@ -195,7 +195,7 @@ class MutualRecursionOptimization(config: CompilerConfig)
 
     // Check 5: All tail calls must be to methods in the group
     val groupNames = group.map(_.name).toSet
-    var validationError: Option[String] = None
+    val validationError: Option[String] = None
     val iterator = group.iterator
     while (iterator.hasNext && validationError.isEmpty) {
       val method = iterator.next()

--- a/src/main/scala/onion/compiler/optimization/TailCallOptimization.scala
+++ b/src/main/scala/onion/compiler/optimization/TailCallOptimization.scala
@@ -105,14 +105,6 @@ class TailCallOptimization(config: CompilerConfig)
   }
 
   /**
-   * Check if method is private
-   */
-  private def isPrivate(method: MethodDefinition): Boolean = {
-    // Use Onion's M_PRIVATE constant, not Java's Modifier.PRIVATE
-    (method.modifier & AST.M_PRIVATE) != 0
-  }
-
-  /**
    * A method is safe to convert to a loop when it cannot be overridden, so a
    * self-call is always this exact method: private, static, or final.
    */
@@ -624,7 +616,7 @@ class TailCallOptimization(config: CompilerConfig)
     // Check if the last statement is an unreachable return
     // (a return that follows a statement containing a tail call)
     stmts.last match {
-      case ret: Return =>
+      case _: Return =>
         // If there are previous statements and the last one contains returns,
         // this return is likely unreachable
         if (stmts.length > 1) {
@@ -827,7 +819,7 @@ class TailCallOptimization(config: CompilerConfig)
           stmtTerm.statement match {
             case exprStmt: ExpressionActionStatement =>
               extractCall(exprStmt.term, depth + 1)
-            case ifStmt: IfStatement =>
+            case _: IfStatement =>
               trace(s"$indent[TCO extractCall] IfStatement - should have been handled in transformStatement")
               None
             case _ => None

--- a/src/main/scala/onion/compiler/parser/OnionLexer.scala
+++ b/src/main/scala/onion/compiler/parser/OnionLexer.scala
@@ -50,12 +50,11 @@ final class OnionLexer(text: String)
   private var cursorIndex = -1
   private var cursorLine = 1
   private var cursorColumn = 0
-  private var cursorPrevCR = false
   private var cursorPrevLF = false
 
   private def advanceTo(index: Int): Unit =
     if index < cursorIndex then
-      cursorIndex = -1; cursorLine = 1; cursorColumn = 0; cursorPrevCR = false; cursorPrevLF = false
+      cursorIndex = -1; cursorLine = 1; cursorColumn = 0; cursorPrevLF = false
     // `cursorPrevLF` doubles as "the next character starts a new line": a line terminator is
     // counted on its own line and the character after it opens the next one. A CR followed by
     // LF is one terminator: the CR defers to the LF (JavaCC's SimpleCharStream does the same).
@@ -614,7 +613,6 @@ object OnionLexer:
   private val unusedStream: JavaCharStream = new JavaCharStream(new java.io.StringReader(""), 1, 1, 1)
 
   private val TabSize = 8
-  private val DEFAULT = 0
   private val IN_STATEMENT = 1
 
   private def isIdentStart(c: Char): Boolean =

--- a/src/main/scala/onion/compiler/parser/OnionParser.scala
+++ b/src/main/scala/onion/compiler/parser/OnionParser.scala
@@ -266,11 +266,6 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     next()
   }
 
-  private def expectImage(s: String): Token = {
-    if (image(1) != s) throw fail
-    next()
-  }
-
   private def accept(k: Int): Boolean = if (kind(1) == k) { next(); true } else false
 
   /** `eols()`: swallow visible EOL tokens. */

--- a/src/main/scala/onion/compiler/pipeline/PipelineRunner.scala
+++ b/src/main/scala/onion/compiler/pipeline/PipelineRunner.scala
@@ -2,7 +2,6 @@ package onion.compiler.pipeline
 
 import onion.compiler.*
 import onion.compiler.backend.BytecodeGenerationPhase
-import onion.compiler.diagnostics.DiagnosticBag
 import onion.compiler.exceptions.CompilationException
 import onion.compiler.parser.ParsingPhase
 import onion.compiler.rewrite.RewritingPhase
@@ -111,7 +110,7 @@ final class PipelineRunner(phases: CompilationPhases) {
   ): CompilationResult =
     runPhase(phases.mutualRecursionOptimization, optimizedTail, ctx)(_ => ()) match {
       case None => result(Seq.empty, ctx, request)
-      case Some(optimizedMutual) if request.config.warningLevel == WarningLevel.Error && ctx.diagnostics.warnings.nonEmpty =>
+      case Some(_) if request.config.warningLevel == WarningLevel.Error && ctx.diagnostics.warnings.nonEmpty =>
         ctx.addErrors(promoteWarnings(ctx.diagnostics.warnings))
         result(Seq.empty, ctx, request)
       case Some(optimizedMutual) =>

--- a/src/main/scala/onion/compiler/typing/AdditionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/AdditionTyping.scala
@@ -90,8 +90,8 @@ private[typing] class AdditionTyping(
     val rightBoxed = boxForConcat(node.rhs, right)
     if (leftBoxed.isEmpty || rightBoxed.isEmpty) return None
 
-    val leftString = toStringCall(node.lhs, leftBoxed.get)
-    val rightString = toStringCall(node.rhs, rightBoxed.get)
+    val leftString = toStringCall(leftBoxed.get)
+    val rightString = toStringCall(rightBoxed.get)
     // Unwrap NullableType to get the inner type for method lookup
     val leftStringType = leftString.`type` match {
       case nullableType: NullableType => nullableType.innerType.asInstanceOf[ObjectType]
@@ -128,7 +128,7 @@ private[typing] class AdditionTyping(
    * Convert a term to String via String.valueOf(Object), which matches Java's
    * concatenation semantics for null ("a" + null == "anull") and never NPEs.
    */
-  private def toStringCall(node: AST.Expression, term: Term): Term = {
+  private def toStringCall(term: Term): Term = {
     val arg: Term = new AsInstanceOf(term, bodyContext.rootClass)
     // String.valueOf(Object) always exists on the JDK; the argument is always the Object
     // upcast, so the overload chosen is the same every time.

--- a/src/main/scala/onion/compiler/typing/AdditionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/AdditionTyping.scala
@@ -1,7 +1,6 @@
 package onion.compiler.typing
 
 import onion.compiler.*
-import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
 import onion.compiler.TypedAST.BinaryTerm.Kind.*
 import onion.compiler.toolbox.Boxing
@@ -18,7 +17,6 @@ import onion.compiler.typing.session.TypingBodyContext
  * String concatenation auto-boxes primitives and calls toString().
  */
 private[typing] class AdditionTyping(
-  private val typing: Typing,
   private val bodyContext: TypingBodyContext,
   private val body: TypingBodyPass
 ) {

--- a/src/main/scala/onion/compiler/typing/ArgumentHelpers.scala
+++ b/src/main/scala/onion/compiler/typing/ArgumentHelpers.scala
@@ -115,4 +115,27 @@ private[typing] object ArgumentHelpers {
       Some(result)
     }
   }
+
+  /** A lambda argument whose parameter types must come from the callee (bidirectional inference), or whose body never returns normally. */
+  def hasUntypedParams(closure: AST.ClosureExpression): Boolean =
+    closure.args.exists(_.typeRef == null) || ClosureBodyAnalysis.neverReturnsNormally(closure)
+
+  /** Positions of arguments that are lambdas with untyped parameters; the shared empty set when there are none (the common case). */
+  def untypedClosureIndicesOf(args: List[AST.Expression]): Set[Int] = {
+    var i = 0
+    var found: Set[Int] = null
+    var rest = args
+    while (rest.nonEmpty) {
+      if (isClosureWithUntypedParams(rest.head)) { if (found == null) found = Set.empty; found = found + i }
+      i += 1
+      rest = rest.tail
+    }
+    if (found == null) Set.empty else found
+  }
+
+  def isClosureWithUntypedParams(expr: AST.Expression): Boolean =
+    expr match {
+      case closure: AST.ClosureExpression => hasUntypedParams(closure)
+      case _ => false
+    }
 }

--- a/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
+++ b/src/main/scala/onion/compiler/typing/AssignabilitySupport.scala
@@ -7,7 +7,6 @@ import onion.compiler.toolbox.Boxing
 import onion.compiler.typing.session.TypingBodyContext
 
 private[compiler] final class AssignabilitySupport(
-  typing: Typing,
   bodyContext: TypingBodyContext
 ) {
 

--- a/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
+++ b/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
@@ -5,7 +5,6 @@ import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
 import onion.compiler.TypedAST.BinaryTerm.Kind.*
 import onion.compiler.typing.session.TypingBodyContext
-import onion.compiler.toolbox.Boxing
 
 import scala.collection.mutable.Buffer
 
@@ -40,7 +39,7 @@ final class BlockElementLowering(
   }
 
   def translate(node: AST.BlockElement, context: LocalContext): ActionStatement = node match {
-    case AST.BlockExpression(loc, elements, _) =>
+    case AST.BlockExpression(_, elements, _) =>
       context.openScope {
         // Guard-clause narrowings (see IfExpression) leak forward to later
         // statements in this block; bound them so they don't escape it.
@@ -624,9 +623,6 @@ final class BlockElementLowering(
   // annotations) forbid raw generic types.
   private def mapFrom(typeNode: AST.TypeNode): Option[Type] =
     typing.mapFromDeclared(typeNode)
-
-  private def processNodes(nodes: Array[AST.Expression], typeRef: Type, bind: ClosureLocalBinding, context: LocalContext): Term =
-    body.processNodes(nodes, typeRef, bind, context)
 
   private def findMethod(node: AST.Node, target: ObjectType, name: String): Method =
     body.findMethod(node, target, name)

--- a/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
+++ b/src/main/scala/onion/compiler/typing/BlockElementLowering.scala
@@ -577,7 +577,7 @@ final class BlockElementLowering(
    * getKey/getValue return the unsubstituted type variables. Recovering the
    * element type from the collection (`Set[Map.Entry[K, V]]`) restores K and V.
    */
-  private def addForeachElement(arg: AST.Argument, collection: Term, context: LocalContext, isMutable: Boolean = true): Unit = {
+  private def addForeachElement(arg: AST.Argument, collection: Term, context: LocalContext, isMutable: Boolean): Unit = {
     if (context.lookupOnlyCurrentScope(arg.name) != null) {
       bodyContext.report(DUPLICATE_LOCAL_VARIABLE, arg, arg.name)
     } else typing.mapFrom(arg.typeRef) match { // raw-exempt: `foreach (k,v)` desugars to a raw Map$Entry placeholder that refineElementType restores

--- a/src/main/scala/onion/compiler/typing/CallOverloadSupport.scala
+++ b/src/main/scala/onion/compiler/typing/CallOverloadSupport.scala
@@ -5,7 +5,6 @@ import onion.compiler.TypedAST.*
 
 import java.util.{TreeSet => JTreeSet}
 
-import scala.jdk.CollectionConverters.*
 
 import ArgumentHelpers.{extractNamedArgInfo, filterByNamedArgs, fillDefaultArguments}
 

--- a/src/main/scala/onion/compiler/typing/ClosureTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ClosureTyping.scala
@@ -304,7 +304,7 @@ final class ClosureTyping(
       }
       Some(argTypes)
     } else if (inferredTarget == null) {
-      args.zipWithIndex.foreach { case (arg, idx) =>
+      args.zipWithIndex.foreach { case (arg, _) =>
         if (arg.typeRef == null) bodyContext.report(LAMBDA_PARAM_TYPE_REQUIRED, arg, arg.name)
       }
       None
@@ -463,9 +463,6 @@ final class ClosureTyping(
     }
     true
   }
-
-  private def sameTypes(left: Array[Type], right: Array[Type]): Boolean =
-    TypeCheckingHelpers.sameTypes(left, right)
 
   private def inferFunctionType(
     rawType: ClassType,

--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -1,5 +1,7 @@
 package onion.compiler.typing
 
+import ArgumentHelpers.hasNamedArguments
+
 import onion.compiler.*
 import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
@@ -624,12 +626,6 @@ final class ConstructionTyping(
       }
     }
   }
-
-  /**
-   * Check if argument list contains named arguments
-   */
-  private def hasNamedArguments(args: List[AST.Expression]): Boolean =
-    args.exists(_.isInstanceOf[AST.NamedArgument])
 
   /**
    * Extract (positionalCount, namedNames) from argument list

--- a/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ConstructionTyping.scala
@@ -566,7 +566,7 @@ final class ConstructionTyping(
   ): Option[Term] = {
     // Extract named argument info
     val namedInfo = extractNamedArgInfo(node.args)
-    val (positionalCount, namedNames) = namedInfo
+    val (_, _) = namedInfo
 
     // Filter constructors by named argument compatibility
     val candidates = filterConstructorsByNamedArgs(typeRef.constructors.toIndexedSeq, namedInfo)

--- a/src/main/scala/onion/compiler/typing/ControlExpressionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ControlExpressionTyping.scala
@@ -3,7 +3,6 @@ package onion.compiler.typing
 import onion.compiler.*
 import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
-import onion.compiler.toolbox.Boxing
 import onion.compiler.typing.session.TypingBodyContext
 
 import scala.collection.mutable.Buffer

--- a/src/main/scala/onion/compiler/typing/ExpressionFormTyping.scala
+++ b/src/main/scala/onion/compiler/typing/ExpressionFormTyping.scala
@@ -13,7 +13,7 @@ final class ExpressionFormTyping(
   private val body: TypingBodyPass
 ) {
   private val constructionTyping = new ConstructionTyping(typing, bodyContext, body)
-  private val stringInterpolationTyping = new StringInterpolationTyping(typing, bodyContext, body)
+  private val stringInterpolationTyping = new StringInterpolationTyping(bodyContext, body)
 
   def typeIndexing(node: AST.Indexing, context: LocalContext): Option[Term] =
     constructionTyping.typeIndexing(node, context)
@@ -158,7 +158,7 @@ final class ExpressionFormTyping(
   private def isValidCast(source: Type, destination: Type): Boolean = {
     if (source eq destination) return true
     (source, destination) match {
-      case (_: NullType, bt: BasicType) =>
+      case (_: NullType, _: BasicType) =>
         false
       case (bt: BasicType, ct: ClassType) =>
         // The exact wrapper (`Int as JInteger`) and boxing supertypes

--- a/src/main/scala/onion/compiler/typing/GenericMethodTypeArguments.scala
+++ b/src/main/scala/onion/compiler/typing/GenericMethodTypeArguments.scala
@@ -112,172 +112,9 @@ private[typing] object GenericMethodTypeArguments {
     args: Array[Term],
     classSubst: scala.collection.immutable.Map[String, Type],
     expectedReturn: Type = null
-  ): scala.collection.immutable.Map[String, Type] = {
-    val rootClass = typing.rootClass
-    def reportError(node: AST.Node, error: SemanticError, items: AnyRef*): Unit =
-      typing.report(error, node, items*)
-    def boxedTypeArg(arg: Type): Type = typing.boxedTypeArgument(arg)
-    val typeParams = method.typeParameters
-    if (typeParams.isEmpty) return scala.collection.immutable.Map.empty
-
-    def isSuperTypeForBounds(left: Type, right: Type): Boolean =
-      if (!left.isBasicType && right.isBasicType) TypeRules.isSuperType(left, boxedTypeArg(right))
-      else TypeRules.isSuperType(left, right)
-
-    val inferred = HashMap[String, Type]()
-    val upperConstraints = HashMap[String, Type]()
-    val lowerConstraints = HashMap[String, Type]()
-    val paramNames = typeParams.iterator.map(_.name).toSet
-
-    def addUpper(name: String, bound: Type, position: AST.Node): Unit = {
-      if (bound == null || bound.isNullType) return
-      upperConstraints.get(name) match
-        case None =>
-          upperConstraints += name -> bound
-        case Some(prev) =>
-          if (isSuperTypeForBounds(prev, bound)) upperConstraints += name -> bound
-          else if (isSuperTypeForBounds(bound, prev)) ()
-          else reportError(position, INCOMPATIBLE_TYPE, prev, bound)
-    }
-
-    def addLower(name: String, bound: Type): Unit = {
-      if (bound == null || bound.isNullType) return
-      lowerConstraints.get(name) match
-        case None =>
-          lowerConstraints += name -> bound
-        case Some(prev) =>
-          if (isSuperTypeForBounds(prev, bound)) ()
-          else if (isSuperTypeForBounds(bound, prev)) lowerConstraints += name -> bound
-          else lowerConstraints += name -> rootClass
-    }
-
-    def unify(formal: Type, actual: Type, position: AST.Node): Unit = {
-      if (actual.isNullType) return
-      formal match
-        case w: TypedAST.WildcardType =>
-          w.lowerBound match
-            case Some(lb) =>
-              lb match
-                case tv: TypedAST.TypeVariableType if paramNames.contains(tv.name) =>
-                  addUpper(tv.name, actual, position)
-                case _ =>
-                  unify(lb, actual, position)
-            case None =>
-              w.upperBound match
-                case tv: TypedAST.TypeVariableType if paramNames.contains(tv.name) =>
-                  addLower(tv.name, actual)
-                case _ =>
-                  unify(w.upperBound, actual, position)
-        case tv: TypedAST.TypeVariableType if paramNames.contains(tv.name) =>
-          // Type arguments are reference types: box primitives (Future::async
-          // of an Int-returning lambda is a Future[Integer], not Future[int])
-          val bound = actual match {
-            case bt: BasicType if bt != BasicType.VOID => typing.boxedTypeArgument(bt)
-            // A smart-cast non-null view of a variable still binds the
-            // declared variable, so occurrences across arguments stay eq
-            case tva: TypedAST.TypeVariableType => tva.widen
-            case other => other
-          }
-          inferred.get(tv.name) match {
-            case Some(prev) =>
-              if (!(prev eq bound)) {
-                val merged = mergeNullability(prev, bound)
-                if (merged != null) inferred += tv.name -> merged
-                else reportError(position, INCOMPATIBLE_TYPE, prev, bound)
-              }
-            case None =>
-              inferred += tv.name -> bound
-          }
-        case fn: TypedAST.NullableType =>
-          // A nullable formal such as `T?` (e.g. a `List[T?]` parameter) must
-          // still bind its type variable: unwrap the formal's nullability and
-          // unify the inner type against the actual's non-null view. Without
-          // this, `T?` matched no case and T was left unbound (defaulting to
-          // Object), so a generic call over `List[T?]` never inferred T.
-          val innerActual = actual match {
-            case an: TypedAST.NullableType => an.innerType
-            case _ => actual
-          }
-          unify(fn.innerType, innerActual, position)
-        case af: TypedAST.ArrayType =>
-          actual match {
-            case aa: TypedAST.ArrayType => unify(af.base, aa.base, position)
-            case _ =>
-          }
-        case apf: TypedAST.AppliedClassType =>
-          def sameRawClass(c1: TypedAST.ClassType, c2: TypedAST.ClassType): Boolean =
-            (c1 eq c2) || (c1.name == c2.name)
-
-          def unifyWithApplied(apa: TypedAST.AppliedClassType): Unit =
-            if sameRawClass(apf.raw, apa.raw) && apf.typeArguments.length == apa.typeArguments.length then
-              apf.typeArguments.zip(apa.typeArguments).foreach { (f, a) => unify(f, a, position) }
-
-          actual match
-            case apa: TypedAST.AppliedClassType =>
-              if sameRawClass(apf.raw, apa.raw) then unifyWithApplied(apa)
-              else
-                val views = AppliedTypeViews.collectAppliedViewsFrom(apa)
-                views.get(apf.raw).orElse(views.find((k, _) => k.name == apf.raw.name).map(_._2)) match
-                  case Some(view) => unifyWithApplied(view)
-                  case None =>
-            case ct: ClassType =>
-              val views = AppliedTypeViews.collectAppliedViewsFrom(ct)
-              views.get(apf.raw).orElse(views.find((k, _) => k.name == apf.raw.name).map(_._2)) match
-                case Some(view) => unifyWithApplied(view)
-                case None =>
-            case _ =>
-        case _ =>
-    }
-
-    val formalArgs =
-      method.arguments.map(t => TypeSubstitution.substituteType(t, classSubst, scala.collection.immutable.Map.empty, defaultToBound = false))(using onion.compiler.TypedAST.typeTag)
-    if (method.isVararg && formalArgs.nonEmpty) {
-      // Vararg methods: unify fixed params positionally, then unify the vararg
-      // component with each trailing argument (boxing primitives), unless the
-      // caller already passes a packed array. Null slots (untyped closures not
-      // yet resolved) are skipped so positions stay aligned (issue #256).
-      val fixedCount = formalArgs.length - 1
-      formalArgs.take(fixedCount).zip(args.take(fixedCount)).foreach { (formal, actual) => if (actual != null) unify(formal, actual.`type`, callNode) }
-      val packed = args.length == formalArgs.length && (args.last != null) && args.last.`type`.isArrayType
-      if (packed) {
-        unify(formalArgs.last, args.last.`type`, callNode)
-      } else {
-        val component = formalArgs.last match {
-          case at: ArrayType => at.base
-          case other => other
-        }
-        args.drop(fixedCount).foreach { actual =>
-          if (actual != null) {
-            val actualType = if (actual.`type`.isBasicType) typing.boxedTypeArgument(actual.`type`.asInstanceOf[BasicType]) else actual.`type`
-            unify(component, actualType, callNode)
-          }
-        }
-      }
-    } else {
-      // Skip null actuals (untyped closures whose SAM parameter types are still
-      // being inferred): remaining arguments stay aligned to their formals so a
-      // determining argument after a closure is still unified (issue #256).
-      formalArgs.zip(args).foreach { (formal, actual) => if (actual != null) unify(formal, actual.`type`, callNode) }
-    }
-
-    if (expectedReturn != null) {
-      val formalReturn =
-        TypeSubstitution.substituteType(method.returnType, classSubst, scala.collection.immutable.Map.empty, defaultToBound = false)
-      unify(formalReturn, expectedReturn, callNode)
-    }
-
-    // Only include type parameters that were actually constrained
-    // (either directly inferred or have lower constraints)
-    val result = HashMap[String, Type]()
-    for (tp <- typeParams) {
-      val name = tp.name
-      inferred.get(name).orElse(lowerConstraints.get(name)).foreach { t =>
-        result += name -> t
-      }
-    }
-
-    result.toMap
-  }
+  ): scala.collection.immutable.Map[String, Type] =
+    if (method.typeParameters.isEmpty) scala.collection.immutable.Map.empty
+    else new Constraints(typing, callNode, method, args, classSubst, expectedReturn, reportErrors = true).constrainedOnly()
 
   def explicit(
     typing: Typing,
@@ -309,20 +146,41 @@ private[typing] object GenericMethodTypeArguments {
     classSubst: scala.collection.immutable.Map[String, Type],
     expectedReturn: Type,
     reportErrors: Boolean = true
-  ): scala.collection.immutable.Map[String, Type] = {
+  ): scala.collection.immutable.Map[String, Type] =
+    if (method.typeParameters.isEmpty) scala.collection.immutable.Map.empty
+    else new Constraints(typing, callNode, method, args, classSubst, expectedReturn, reportErrors).withDefaults()
+
+  /**
+   * The type-argument constraints one call places on a generic method: every formal
+   * parameter (and the expected return type, when known) unified against the actual, into
+   * direct bindings (`inferred`), lower bounds from wildcard uppers and upper bounds from
+   * wildcard lowers. `constrainedOnly()` and `withDefaults()` are the two ways of reading
+   * the result; the collection itself is the same for both.
+   *
+   * `args` MAY contain `null` slots for arguments not yet typed (untyped-parameter closures
+   * whose SAM parameter types are still being inferred). Those slots are skipped, so the
+   * remaining arguments still unify against their correct formal positions (issue #256).
+   *
+   * `reportErrors`: during overload-applicability collection this inference runs over EVERY
+   * candidate, including ones a later arity/specificity check discards. Emitting bound-check
+   * errors there leaks a bounded overload's constraint onto the call even when an unbounded
+   * overload is the one selected (issue #298), so the collection phase passes false; the
+   * final resolution of the SELECTED method keeps errors on.
+   */
+  private final class Constraints(
+    typing: Typing,
+    callNode: AST.Node,
+    method: Method,
+    args: Array[Term],
+    classSubst: scala.collection.immutable.Map[String, Type],
+    expectedReturn: Type,
+    reportErrors: Boolean
+  ) {
     val rootClass = typing.rootClass
-    // During overload-applicability collection this inference is run over EVERY
-    // candidate, including ones a later arity/specificity check discards. Emitting
-    // bound-check errors here leaks a bounded overload's constraint onto the call
-    // even when an unbounded overload is the one actually selected (issue #298).
-    // Callers in the collection phase pass reportErrors = false; the final
-    // resolution of the SELECTED method keeps errors on so real bound violations
-    // are still rejected.
     def reportError(node: AST.Node, error: SemanticError, items: AnyRef*): Unit =
       if (reportErrors) typing.report(error, node, items*)
     def boxedTypeArg(arg: Type): Type = typing.boxedTypeArgument(arg)
     val typeParams = method.typeParameters
-    if (typeParams.isEmpty) return scala.collection.immutable.Map.empty
 
     def isSuperTypeForBounds(left: Type, right: Type): Boolean =
       if (!left.isBasicType && right.isBasicType) TypeRules.isSuperType(left, boxedTypeArg(right))
@@ -444,76 +302,107 @@ private[typing] object GenericMethodTypeArguments {
         case _ =>
     }
 
-    val formalArgs =
-      method.arguments.map(t => TypeSubstitution.substituteType(t, classSubst, scala.collection.immutable.Map.empty, defaultToBound = false))(using onion.compiler.TypedAST.typeTag)
-    if (method.isVararg && formalArgs.nonEmpty) {
-      // Vararg methods: unify fixed params positionally, then unify the vararg
-      // component with each trailing argument (boxing primitives), unless the
-      // caller already passes a packed array.
-      val fixedCount = formalArgs.length - 1
-      formalArgs.take(fixedCount).zip(args.take(fixedCount)).foreach { (formal, actual) => unify(formal, actual.`type`, callNode) }
-      val packed = args.length == formalArgs.length && args.last.`type`.isArrayType
-      if (packed) {
-        unify(formalArgs.last, args.last.`type`, callNode)
-      } else {
-        val component = formalArgs.last match {
-          case at: ArrayType => at.base
-          case other => other
-        }
-        args.drop(fixedCount).foreach { actual =>
-          val actualType = if (actual.`type`.isBasicType) typing.boxedTypeArgument(actual.`type`.asInstanceOf[BasicType]) else actual.`type`
-          unify(component, actualType, callNode)
-        }
-      }
-    } else {
-      formalArgs.zip(args).foreach { (formal, actual) => unify(formal, actual.`type`, callNode) }
-    }
 
-    if (expectedReturn != null) {
-      val formalReturn =
-        TypeSubstitution.substituteType(method.returnType, classSubst, scala.collection.immutable.Map.empty, defaultToBound = false)
-      unify(formalReturn, expectedReturn, callNode)
-    }
-
-    for (tp <- typeParams) {
-      val name = tp.name
-      val bound0 = bounds(name)
-      val bound =
-        upperConstraints.get(name) match
-          case None => bound0
-          case Some(upper) =>
-            if (isSuperTypeForBounds(bound0, upper)) upper
-            else if (isSuperTypeForBounds(upper, bound0)) bound0
-            else {
-              reportError(callNode, INCOMPATIBLE_TYPE, bound0, upper)
-              bound0
-            }
-
-      val inferredType0 =
-        inferred.get(name)
-          .orElse(lowerConstraints.get(name))
-          .getOrElse(bound)
-
-      // Nullable inferences satisfy the bound through their inner type and
-      // are rejected outright for non-null parameters (the Object top-type
-      // rule would otherwise let String? through an Object bound)
-      val boundsOk = inferredType0 match {
-        case n: NullableType =>
-          tp.nullability != Nullability.NonNull && isAssignableForBounds(bound, n.innerType)
-        case other =>
-          isAssignableForBounds(bound, other)
-      }
-      val inferredType =
-        if (!boundsOk) {
-          reportError(callNode, INCOMPATIBLE_TYPE, bound, inferredType0)
-          bound
+    /** Unifies every formal parameter, and the expected return type when known, against the actuals. */
+    private def collect(): Unit = {
+      val formalArgs =
+        method.arguments.map(t => TypeSubstitution.substituteType(t, classSubst, scala.collection.immutable.Map.empty, defaultToBound = false))(using onion.compiler.TypedAST.typeTag)
+      if (method.isVararg && formalArgs.nonEmpty) {
+        // Vararg methods: unify fixed params positionally, then unify the vararg
+        // component with each trailing argument (boxing primitives), unless the
+        // caller already passes a packed array. Null slots (untyped closures not
+        // yet resolved) are skipped so positions stay aligned (issue #256).
+        val fixedCount = formalArgs.length - 1
+        formalArgs.take(fixedCount).zip(args.take(fixedCount)).foreach { (formal, actual) => if (actual != null) unify(formal, actual.`type`, callNode) }
+        val packed = args.length == formalArgs.length && (args.last != null) && args.last.`type`.isArrayType
+        if (packed) {
+          unify(formalArgs.last, args.last.`type`, callNode)
         } else {
-          inferredType0
+          val component = formalArgs.last match {
+            case at: ArrayType => at.base
+            case other => other
+          }
+          args.drop(fixedCount).foreach { actual =>
+            if (actual != null) {
+              val actualType = if (actual.`type`.isBasicType) typing.boxedTypeArgument(actual.`type`.asInstanceOf[BasicType]) else actual.`type`
+              unify(component, actualType, callNode)
+            }
+          }
         }
+      } else {
+        // Skip null actuals (untyped closures whose SAM parameter types are still
+        // being inferred): remaining arguments stay aligned to their formals so a
+        // determining argument after a closure is still unified (issue #256).
+        formalArgs.zip(args).foreach { (formal, actual) => if (actual != null) unify(formal, actual.`type`, callNode) }
+      }
 
-      inferred += name -> inferredType
+      if (expectedReturn != null) {
+        val formalReturn =
+          TypeSubstitution.substituteType(method.returnType, classSubst, scala.collection.immutable.Map.empty, defaultToBound = false)
+        unify(formalReturn, expectedReturn, callNode)
+      }
+
     }
 
-    inferred.toMap
+    /** Only the type parameters that were actually constrained: no defaults to bounds, so closure return inference still sees type variables. */
+    def constrainedOnly(): scala.collection.immutable.Map[String, Type] = {
+      collect()
+      // Only include type parameters that were actually constrained
+      // (either directly inferred or have lower constraints)
+      val result = HashMap[String, Type]()
+      for (tp <- typeParams) {
+        val name = tp.name
+        inferred.get(name).orElse(lowerConstraints.get(name)).foreach { t =>
+          result += name -> t
+        }
+      }
+
+      result.toMap
+    }
+
+    /** Every type parameter: inferred, else its lower constraint, else its (upper-constrained) bound; violations reported. */
+    def withDefaults(): scala.collection.immutable.Map[String, Type] = {
+      collect()
+      for (tp <- typeParams) {
+        val name = tp.name
+        val bound0 = bounds(name)
+        val bound =
+          upperConstraints.get(name) match
+            case None => bound0
+            case Some(upper) =>
+              if (isSuperTypeForBounds(bound0, upper)) upper
+              else if (isSuperTypeForBounds(upper, bound0)) bound0
+              else {
+                reportError(callNode, INCOMPATIBLE_TYPE, bound0, upper)
+                bound0
+              }
+
+        val inferredType0 =
+          inferred.get(name)
+            .orElse(lowerConstraints.get(name))
+            .getOrElse(bound)
+
+        // Nullable inferences satisfy the bound through their inner type and
+        // are rejected outright for non-null parameters (the Object top-type
+        // rule would otherwise let String? through an Object bound)
+        val boundsOk = inferredType0 match {
+          case n: NullableType =>
+            tp.nullability != Nullability.NonNull && isAssignableForBounds(bound, n.innerType)
+          case other =>
+            isAssignableForBounds(bound, other)
+        }
+        val inferredType =
+          if (!boundsOk) {
+            reportError(callNode, INCOMPATIBLE_TYPE, bound, inferredType0)
+            bound
+          } else {
+            inferredType0
+          }
+
+        inferred += name -> inferredType
+      }
+
+      inferred.toMap
+    }
   }
 }

--- a/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
@@ -11,7 +11,7 @@ import scala.jdk.CollectionConverters.*
 import scala.util.boundary
 import scala.util.boundary.break
 
-import ArgumentHelpers.hasNamedArguments
+import ArgumentHelpers.{hasNamedArguments, hasUntypedParams, isClosureWithUntypedParams, untypedClosureIndicesOf}
 
 private[compiler] final class InstanceMethodCallSupport(
   bodyContext: TypingBodyContext,
@@ -243,25 +243,4 @@ private[compiler] final class InstanceMethodCallSupport(
     }
   }
 
-  private def hasUntypedParams(closure: AST.ClosureExpression): Boolean =
-    closure.args.exists(_.typeRef == null) || ClosureBodyAnalysis.neverReturnsNormally(closure)
-
-  /** Positions of arguments that are lambdas with untyped parameters; the shared empty set when there are none (the common case). */
-  private def untypedClosureIndicesOf(args: List[AST.Expression]): Set[Int] = {
-    var i = 0
-    var found: Set[Int] = null
-    var rest = args
-    while (rest.nonEmpty) {
-      if (isClosureWithUntypedParams(rest.head)) { if (found == null) found = Set.empty; found = found + i }
-      i += 1
-      rest = rest.tail
-    }
-    if (found == null) Set.empty else found
-  }
-
-  private def isClosureWithUntypedParams(expr: AST.Expression): Boolean =
-    expr match {
-      case closure: AST.ClosureExpression => hasUntypedParams(closure)
-      case _ => false
-    }
 }

--- a/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/InstanceMethodCallSupport.scala
@@ -11,7 +11,7 @@ import scala.jdk.CollectionConverters.*
 import scala.util.boundary
 import scala.util.boundary.break
 
-import ArgumentHelpers.{hasNamedArguments, hasUntypedParams, isClosureWithUntypedParams, untypedClosureIndicesOf}
+import ArgumentHelpers.{hasNamedArguments, untypedClosureIndicesOf}
 
 private[compiler] final class InstanceMethodCallSupport(
   bodyContext: TypingBodyContext,

--- a/src/main/scala/onion/compiler/typing/MemberSelectionTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MemberSelectionTypingSupport.scala
@@ -2,7 +2,6 @@ package onion.compiler.typing
 
 import onion.compiler.*
 import onion.compiler.TypedAST.*
-import onion.compiler.typing.session.TypingBodyContext
 
 private[compiler] final class MemberSelectionTypingSupport(
   calls: MethodCallTyping

--- a/src/main/scala/onion/compiler/typing/MemberSelectionTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MemberSelectionTypingSupport.scala
@@ -5,7 +5,6 @@ import onion.compiler.TypedAST.*
 import onion.compiler.typing.session.TypingBodyContext
 
 private[compiler] final class MemberSelectionTypingSupport(
-  bodyContext: TypingBodyContext,
   calls: MethodCallTyping
 ) {
   def typeMemberSelection(node: AST.MemberSelection, context: LocalContext): Option[Term] = {

--- a/src/main/scala/onion/compiler/typing/MethodCallFallbackSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallFallbackSupport.scala
@@ -3,7 +3,6 @@ package onion.compiler.typing
 import onion.compiler.*
 import onion.compiler.TypedAST.*
 
-import java.util.{TreeSet => JTreeSet}
 
 import scala.jdk.CollectionConverters.*
 

--- a/src/main/scala/onion/compiler/typing/MethodCallReportingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallReportingSupport.scala
@@ -6,8 +6,7 @@ import onion.compiler.TypedAST.*
 import onion.compiler.typing.session.TypingBodyContext
 
 private[compiler] final class MethodCallReportingSupport(
-  bodyContext: TypingBodyContext,
-  calls: MethodCallTyping
+  bodyContext: TypingBodyContext
 ) {
   def reportMethodNotFound(
     node: AST.Node,

--- a/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
@@ -5,7 +5,6 @@ import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
 import onion.compiler.typing.session.TypingBodyContext
 
-import ArgumentHelpers.hasNamedArguments
 import java.util.{TreeSet => JTreeSet}
 
 final class MethodCallTyping(

--- a/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
@@ -14,10 +14,10 @@ final class MethodCallTyping(
 ) {
   private val callArgumentTypingSupport = new CallArgumentTypingSupport(bodyContext, typed(_, _, _), processAssignable)
   private val methodInvocationBuilderSupport = new MethodInvocationBuilderSupport(typing, this)
-  private val methodCallReportingSupport = new MethodCallReportingSupport(bodyContext, this)
+  private val methodCallReportingSupport = new MethodCallReportingSupport(bodyContext)
   private val methodTargetTypingSupport = new MethodTargetTypingSupport(bodyContext)
   private val memberSelectionResolutionSupport = new MemberSelectionResolutionSupport(typing, bodyContext, this)
-  private val memberSelectionTypingSupport = new MemberSelectionTypingSupport(bodyContext, this)
+  private val memberSelectionTypingSupport = new MemberSelectionTypingSupport(this)
   private val methodCallFallbackSupport = new MethodCallFallbackSupport(typing, this)
   private val instanceMethodCallSupport = new InstanceMethodCallSupport(bodyContext, this, methodCallFallbackSupport)
   private val safeNavigationTypingSupport = new SafeNavigationTypingSupport(bodyContext, this)

--- a/src/main/scala/onion/compiler/typing/MethodInvocationBuilderSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodInvocationBuilderSupport.scala
@@ -138,7 +138,7 @@ private[compiler] final class MethodInvocationBuilderSupport(
         // type (which unboxes primitives and NPEs on the null path)
         castType match {
           case _: NullableType | _: NullType => TypeSubst.withCast(call, castType)
-          case bt: BasicType => call // SafeCall.type is already NullableType(bt)
+          case _: BasicType => call // SafeCall.type is already NullableType(bt)
           case other if other eq method.returnType => call
           case other => TypeSubst.withCast(call, NullableType.of(other))
         }

--- a/src/main/scala/onion/compiler/typing/MethodResolution.scala
+++ b/src/main/scala/onion/compiler/typing/MethodResolution.scala
@@ -8,7 +8,7 @@
 package onion.compiler.typing
 
 import onion.compiler.TypedAST.*
-import onion.compiler.{ClassTable, toolbox}
+import onion.compiler.{ClassTable}
 
 import java.util.{TreeSet => JTreeSet}
 

--- a/src/main/scala/onion/compiler/typing/OperatorTyping.scala
+++ b/src/main/scala/onion/compiler/typing/OperatorTyping.scala
@@ -11,7 +11,6 @@ import onion.compiler.toolbox.Boxing
 import onion.compiler.typing.session.TypingBodyContext
 
 final class OperatorTyping(
-  private val typing: Typing,
   private val bodyContext: TypingBodyContext,
   private val body: TypingBodyPass
 ) {

--- a/src/main/scala/onion/compiler/typing/ReturnNodeDetector.scala
+++ b/src/main/scala/onion/compiler/typing/ReturnNodeDetector.scala
@@ -1,6 +1,6 @@
 package onion.compiler.typing
 
-import onion.compiler.AST
+import onion.compiler.{AST, ASTWalk}
 
 /**
  * Detects return statements in AST nodes.
@@ -20,111 +20,6 @@ private[typing] object ReturnNodeDetector {
   def containsReturn(node: AST.Node): Boolean = {
     var found = false
 
-    def visitChildren(n: AST.Node)(visit: AST.Node => Unit): Unit = n match {
-      case block: AST.BlockExpression =>
-        block.elements.foreach(visit)
-
-      case ifExpr: AST.IfExpression =>
-        visit(ifExpr.condition)
-        visit(ifExpr.thenBlock)
-        if (ifExpr.elseBlock != null) visit(ifExpr.elseBlock)
-
-      case whileExpr: AST.WhileExpression =>
-        visit(whileExpr.condition)
-        visit(whileExpr.block)
-
-      case foreachExpr: AST.ForeachExpression =>
-        visit(foreachExpr.collection)
-        visit(foreachExpr.statement)
-
-      case forExpr: AST.ForExpression =>
-        if (forExpr.init != null) visit(forExpr.init)
-        if (forExpr.condition != null) visit(forExpr.condition)
-        if (forExpr.update != null) visit(forExpr.update)
-        visit(forExpr.block)
-
-      case assign: AST.Assignment =>
-        visit(assign.lhs)
-        visit(assign.rhs)
-
-      case localVar: AST.LocalVariableDeclaration =>
-        if (localVar.init != null) visit(localVar.init)
-
-      case binary: AST.BinaryExpression =>
-        visit(binary.lhs)
-        visit(binary.rhs)
-
-      case unary: AST.UnaryExpression =>
-        visit(unary.term)
-
-      case call: AST.MethodCall =>
-        if (call.target != null) visit(call.target)
-        call.args.foreach(visit)
-
-      case call: AST.UnqualifiedMethodCall =>
-        call.args.foreach(visit)
-
-      case call: AST.StaticMethodCall =>
-        call.args.foreach(visit)
-
-      case call: AST.SuperMethodCall =>
-        call.args.foreach(visit)
-
-      case newObj: AST.NewObject =>
-        newObj.args.foreach(visit)
-
-      case newArray: AST.NewArray =>
-        newArray.args.foreach(visit)
-
-      case newArrayWithValues: AST.NewArrayWithValues =>
-        newArrayWithValues.values.foreach(visit)
-
-      case listLit: AST.ListLiteral =>
-        listLit.elements.foreach(visit)
-
-      case mapLit: AST.MapLiteral =>
-        mapLit.entries.foreach { case (k, v) => visit(k); visit(v) }
-
-      case cast: AST.Cast =>
-        visit(cast.src)
-
-      case isInstance: AST.IsInstance =>
-        visit(isInstance.target)
-
-      case memberSel: AST.MemberSelection =>
-        if (memberSel.target != null) visit(memberSel.target)
-
-      case returnExpr: AST.ReturnExpression =>
-        if (returnExpr.result != null) visit(returnExpr.result)
-
-      case throwExpr: AST.ThrowExpression =>
-        visit(throwExpr.target)
-
-      case tryExpr: AST.TryExpression =>
-        visit(tryExpr.tryBlock)
-        tryExpr.recClauses.foreach { case (_, block) =>
-          visit(block)
-        }
-        if (tryExpr.finBlock != null) visit(tryExpr.finBlock)
-
-      case syncExpr: AST.SynchronizedExpression =>
-        visit(syncExpr.condition)
-        visit(syncExpr.block)
-
-      case selectExpr: AST.SelectExpression =>
-        visit(selectExpr.condition)
-        selectExpr.cases.foreach { case (exprs, block) =>
-          exprs.foreach(visit)
-          visit(block)
-        }
-        if (selectExpr.elseBlock != null) visit(selectExpr.elseBlock)
-
-      case stringInterp: AST.StringInterpolation =>
-        stringInterp.expressions.foreach(visit)
-
-      case _ =>
-        ()
-    }
 
     // One function object for the whole walk (passing the local def eta-expanded a lambda per node).
     var visitF: AST.Node => Unit = null
@@ -134,7 +29,7 @@ private[typing] object ReturnNodeDetector {
       case _: AST.ClosureExpression =>
         () // do not inspect nested closures
       case _ =>
-        visitChildren(n)(visitF)
+        ASTWalk.visitChildren(n)(visitF)
     }
     visitF = visit
 

--- a/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
@@ -587,7 +587,7 @@ final class SelectExpressionTyping(
   private def typed(node: AST.Expression, context: LocalContext): Option[Term] =
     body.typed(node, context)
 
-  private def typeBlockExpression(node: AST.BlockExpression, context: LocalContext, expected: Type = null): Option[Term] =
+  private def typeBlockExpression(node: AST.BlockExpression, context: LocalContext, expected: Type): Option[Term] =
     control.typeBlockExpression(node, context, expected)
 
   /**

--- a/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
+++ b/src/main/scala/onion/compiler/typing/SelectExpressionTyping.scala
@@ -507,7 +507,7 @@ final class SelectExpressionTyping(
             break((null, NoBindings, false, None))
         }
 
-      case AST.GuardedPattern(loc, innerPattern, guard) =>
+      case AST.GuardedPattern(_, innerPattern, guard) =>
         // Process the inner pattern recursively
         val (innerCond, innerBindingInfo, innerHasWildcard, _) = processPatterns(Array(innerPattern), conditionType, bind, context)
         if (innerCond == null) break((null, NoBindings, false, None))
@@ -524,7 +524,7 @@ final class SelectExpressionTyping(
               context.add(varName, varType, isMutable = false)
               typed(guard, context)
             }
-          case MultiBindings(recordType, bindings, _) =>
+          case MultiBindings(_, bindings, _) =>
             context.openScope {
               bindings.foreach { case BindingEntry(varName, varType, _) =>
                 context.add(varName, varType, isMutable = false)

--- a/src/main/scala/onion/compiler/typing/SimpleExpressionTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/SimpleExpressionTypingSupport.scala
@@ -224,7 +224,7 @@ private[compiler] final class SimpleExpressionTypingSupport(
     case _ => null
   }
 
-  private def typeListLiteral(node: AST.ListLiteral, context: LocalContext, expected: Type = null): Option[Term] = {
+  private def typeListLiteral(node: AST.ListLiteral, context: LocalContext, expected: Type): Option[Term] = {
     val typedElements = new Array[Term](node.elements.size)
     val expectedElem = expectedListElement(expected)
     var elementType: Type = null
@@ -426,7 +426,7 @@ private[compiler] final class SimpleExpressionTypingSupport(
     case _ => (null, null)
   }
 
-  private def typeMapLiteral(node: AST.MapLiteral, context: LocalContext, expected: Type = null): Option[Term] = {
+  private def typeMapLiteral(node: AST.MapLiteral, context: LocalContext, expected: Type): Option[Term] = {
     val keys = new Array[Term](node.entries.size)
     val values = new Array[Term](node.entries.size)
     val (expectedKey, expectedValue) = expectedMapKeyValue(expected)

--- a/src/main/scala/onion/compiler/typing/SimpleExpressionTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/SimpleExpressionTypingSupport.scala
@@ -60,9 +60,9 @@ private[compiler] final class SimpleExpressionTypingSupport(
         typeMapLiteral(node, context, expected)
       case node@AST.NullLiteral(loc) =>
         Some(new NullValue(loc))
-      case node@AST.CurrentInstance(loc) =>
+      case node@AST.CurrentInstance(_) =>
         typeCurrentInstance(node, context)
-      case node@AST.Id(loc, name) =>
+      case node@AST.Id(_, name) =>
         typeIdentifier(node, context)
       case node: AST.UnqualifiedFieldReference =>
         typeUnqualifiedFieldReference(node, context)

--- a/src/main/scala/onion/compiler/typing/StringInterpolationTyping.scala
+++ b/src/main/scala/onion/compiler/typing/StringInterpolationTyping.scala
@@ -9,7 +9,6 @@ import onion.compiler.TypedAST.*
 import onion.compiler.typing.session.TypingBodyContext
 
 final class StringInterpolationTyping(
-  private val typing: Typing,
   private val bodyContext: TypingBodyContext,
   private val body: TypingBodyPass
 ) {

--- a/src/main/scala/onion/compiler/typing/TypeNarrowingAnalysis.scala
+++ b/src/main/scala/onion/compiler/typing/TypeNarrowingAnalysis.scala
@@ -138,7 +138,7 @@ private[typing] object TypeNarrowingAnalysis {
    */
   private def extractNullCheckNarrowing(
     name: String, context: LocalContext, positive: Boolean, fieldNarrow: String => Option[Type],
-    fieldOnly: Boolean = false
+    fieldOnly: Boolean
   ): NarrowingInfo = {
     val binding = if (fieldOnly) null else context.lookup(name)
     // The non-null view of a nullable local/field type, or None if not nullable.

--- a/src/main/scala/onion/compiler/typing/TypeSubstitution.scala
+++ b/src/main/scala/onion/compiler/typing/TypeSubstitution.scala
@@ -10,7 +10,6 @@ package onion.compiler.typing
 import onion.compiler.TypedAST
 import onion.compiler.TypedAST.{ArrayType, Type}
 
-import scala.collection.mutable.HashMap
 
 /**
  * Type Substitution Utilities for Generic Type Handling

--- a/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
@@ -6,11 +6,8 @@ import onion.compiler.TypedAST.*
 import onion.compiler.TypedAST.BinaryTerm.Kind as BinaryKind
 import onion.compiler.TypedAST.BinaryTerm.Kind.*
 import onion.compiler.TypedAST.UnaryTerm.Kind as UnaryKind
-import onion.compiler.TypedAST.UnaryTerm.Kind.*
 import onion.compiler.typing.session.{TypingBodyContext, TypingUnitContext}
 
-import scala.jdk.CollectionConverters.*
-import scala.collection.mutable.{Buffer, HashMap, Map, Set => MutableSet, Stack}
 
 import TypeNarrowingAnalysis.NarrowingInfo
 
@@ -19,12 +16,12 @@ final class TypingBodyPass(private val typing: Typing, private val unitContext: 
   private val bodyContext = TypingBodyContext.fromTyping(typing, unitContext)
   private val methodCallTyping = new MethodCallTyping(typing, bodyContext, this)
   private val assignmentTyping = new AssignmentTyping(typing, bodyContext, this)
-  private[typing] val operatorTyping = new OperatorTyping(typing, bodyContext, this)
+  private[typing] val operatorTyping = new OperatorTyping(bodyContext, this)
   private val expressionFormTyping = new ExpressionFormTyping(typing, bodyContext, this)
   private val closureTyping = new ClosureTyping(typing, bodyContext, this)
   private val blockElementLowering = new BlockElementLowering(typing, bodyContext, this)
   private[typing] val controlExpressionTyping = new ControlExpressionTyping(typing, bodyContext, this)
-  private val additionTyping = new AdditionTyping(typing, bodyContext, this)
+  private val additionTyping = new AdditionTyping(bodyContext, this)
   private val methodLookupSupport = new MethodLookupSupport(typing, bodyContext)
   private val classInitializerSupport = new ClassInitializerSupport(typing, typed(_, _, _), processAssignable)
   private val methodBodySupport = new MethodBodySupport(typing, unitContext, bodyContext, typed(_, _, _), typedTerms, translate, addReturnNode)
@@ -431,8 +428,6 @@ final class TypingBodyPass(private val typing: Typing, private val unitContext: 
   private[typing] def tryExtensionOperatorMethod(node: AST.Node, name: String, target: Term, targetType: ObjectType, param: Term, expected: Type): Option[Term] =
     methodCallTyping.tryExtensionOperatorMethod(node, name, target, targetType, param, expected)
 
-  private def processNumericExpression(kind: BinaryKind, node: AST.BinaryExpression, lt: Term, rt: Term): Term =
-    operatorTyping.processNumericExpression(kind, node, lt, rt)
   private[typing] def addArgument(arg: AST.Argument, context: LocalContext): Type =
     methodLookupSupport.addArgument(arg, context)
   private[typing] def typeClosureNode(node: AST.ClosureExpression, context: LocalContext, expected: Type): Option[Term] =

--- a/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingBodyPass.scala
@@ -26,7 +26,7 @@ final class TypingBodyPass(private val typing: Typing, private val unitContext: 
   private val classInitializerSupport = new ClassInitializerSupport(typing, typed(_, _, _), processAssignable)
   private val methodBodySupport = new MethodBodySupport(typing, unitContext, bodyContext, typed(_, _, _), typedTerms, translate, addReturnNode)
   private val entryPointSupport = new EntryPointSupport(typing, addReturnNode)
-  private val assignabilitySupport = new AssignabilitySupport(typing, bodyContext)
+  private val assignabilitySupport = new AssignabilitySupport(bodyContext)
   private val expressionDispatchSupport = new ExpressionDispatchSupport(this)
   private val patternMatchSupport = new PatternMatchSupport(bodyContext, (node, context) => typed(node, context), createEqualsForRef)
   private val simpleExpressionTypingSupport = new SimpleExpressionTypingSupport(

--- a/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
+++ b/src/main/scala/onion/compiler/typing/TypingOutlinePass.scala
@@ -6,7 +6,6 @@ import onion.compiler.typing.session.NameResolutionContext
 import onion.compiler.typing.session.TypingUnitContext
 import onion.compiler.toolbox.Boxing
 
-import scala.jdk.CollectionConverters.*
 import scala.collection.mutable.{Buffer, Set => MutableSet}
 
 final class TypingOutlinePass(private val typing: Typing, private val unitContext: TypingUnitContext) {
@@ -393,7 +392,7 @@ final class TypingOutlinePass(private val typing: Typing, private val unitContex
     val paramTypes: Array[Type] = typesOf(node.params).map(_.toArray).getOrElse(Array.empty)
 
     // Create static final fields for each enum constant
-    node.constants.zipWithIndex.foreach { case (constant, ordinal) =>
+    node.constants.zipWithIndex.foreach { case (constant, _) =>
       val fieldModifier = Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL
       val field = new FieldDefinition(constant.location, fieldModifier, definition_, constant.name, definition_)
       definition_.add(field)

--- a/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
@@ -1,5 +1,7 @@
 package onion.compiler.typing
 
+import ArgumentHelpers.{hasUntypedParams, isClosureWithUntypedParams, untypedClosureIndicesOf}
+
 import onion.compiler.*
 import onion.compiler.SemanticError.*
 import onion.compiler.TypedAST.*
@@ -196,28 +198,6 @@ private[compiler] final class UnqualifiedMethodCallSupport(
         }
     }
   }
-
-  private def hasUntypedParams(closure: AST.ClosureExpression): Boolean =
-    closure.args.exists(_.typeRef == null) || ClosureBodyAnalysis.neverReturnsNormally(closure)
-
-  /** Positions of arguments that are lambdas with untyped parameters; the shared empty set when there are none (the common case). */
-  private def untypedClosureIndicesOf(args: List[AST.Expression]): Set[Int] = {
-    var i = 0
-    var found: Set[Int] = null
-    var rest = args
-    while (rest.nonEmpty) {
-      if (isClosureWithUntypedParams(rest.head)) { if (found == null) found = Set.empty; found = found + i }
-      i += 1
-      rest = rest.tail
-    }
-    if (found == null) Set.empty else found
-  }
-
-  private def isClosureWithUntypedParams(expr: AST.Expression): Boolean =
-    expr match {
-      case closure: AST.ClosureExpression => hasUntypedParams(closure)
-      case _ => false
-    }
 
   /**
    * An unqualified call to an instance method needs 'this'; in a static

--- a/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/UnqualifiedMethodCallSupport.scala
@@ -1,6 +1,6 @@
 package onion.compiler.typing
 
-import ArgumentHelpers.{hasUntypedParams, isClosureWithUntypedParams, untypedClosureIndicesOf}
+import ArgumentHelpers.{untypedClosureIndicesOf}
 
 import onion.compiler.*
 import onion.compiler.SemanticError.*

--- a/src/main/scala/onion/compiler/typing/session/TypingSession.scala
+++ b/src/main/scala/onion/compiler/typing/session/TypingSession.scala
@@ -5,7 +5,6 @@ import scala.jdk.CollectionConverters.*
 import onion.compiler.{AST, CompilerConfig}
 import onion.compiler.typing.TypeParamScope
 
-import scala.collection.mutable.HashMap
 
 final class TypingSession(
   val config: CompilerConfig,

--- a/src/main/scala/onion/tools/CompilerFrontend.scala
+++ b/src/main/scala/onion/tools/CompilerFrontend.scala
@@ -7,15 +7,11 @@
  * ************************************************************** */
 package onion.tools
 
-import java.io.UnsupportedEncodingException
-import onion.compiler.{CompiledClass, CompilerConfig, OnionCompiler, WarningCategory, WarningLevel}
-import onion.compiler.diagnostics.DiagnosticRenderer
+import onion.compiler.{CompiledClass, CompilerConfig}
 import onion.compiler.exceptions.ScriptException
-import onion.compiler.pipeline.{CompilationResult, CompileProfileFormat, CompileProfileReporter, CompileProfileSettings}
 import onion.compiler.toolbox.Message
-import onion.compiler.toolbox.Systems
-import onion.compiler.verification.ArgGenerator
 import onion.tools.option._
+import onion.tools.CompilerOptions.*
 
 /**
  *
@@ -24,12 +20,6 @@ import onion.tools.option._
  */
 object CompilerFrontend {
   val VERSION = OnionVersion.value
-
-  private def config(option: String, requireArg: Boolean): OptionConfig = new OptionConfig(option, requireArg)
-
-  private def pathArray(path: String): Array[String] = path.split(Systems.pathSeparator)
-
-  private def printError(message: String): Unit = System.err.println(message)
 
   def main(args: Array[String]): Unit = {
     // With ONION_DAEMON set, the command line goes to the resident compile daemon (see
@@ -61,29 +51,6 @@ object CompilerFrontend {
     }
   }
 
-  private final val CLASSPATH: String = "-classpath"
-  private final val SCRIPT_SUPER_CLASS: String = "-super"
-  private final val ENCODING: String = "-encoding"
-  private final val OUTPUT: String = "-d"
-  private final val MAX_ERROR: String = "-maxErrorReport"
-  private final val VERBOSE: String = "--verbose"
-  private final val DUMP_AST: String = "--dump-ast"
-  private final val DUMP_TYPED_AST: String = "--dump-typed-ast"
-  private final val PROFILE_COMPILE: String = "--profile-compile"
-  private final val PROFILE_FORMAT: String = "--profile-format"
-  private final val PROFILE_OUTPUT: String = "--profile-output"
-  private final val WARN_LEVEL: String = "--warn"
-  private final val SUPPRESS_WARNINGS: String = "--Wno"
-  private final val NO_CHECK_LAWS: String = "--no-check-laws"
-  private final val LAW_SEED: String = "--law-seed"
-  private final val LAW_SAMPLES: String = "--law-samples"
-  private final val SHOW_EFFECTS: String = "--effects"
-  // Named after javac's -g:none, and meaning the same thing: no LocalVariableTable.
-  private final val NO_DEBUG_INFO: String = "-g:none"
-  private final val DEFAULT_CLASSPATH: Array[String] = Array[String](".")
-  private final val DEFAULT_ENCODING: String = System.getProperty("file.encoding")
-  private final val DEFAULT_OUTPUT: String = "."
-  private final val DEFAULT_MAX_ERROR: Int = 10
 }
 
 class CompilerFrontend {
@@ -91,23 +58,7 @@ class CompilerFrontend {
   import CompilerFrontend._
 
   private val commandLineParser = new CommandLineParser(
-    config(CLASSPATH, true),
-    config(SCRIPT_SUPER_CLASS, true),
-    config(ENCODING, true),
-    config(OUTPUT, true),
-    config(MAX_ERROR, true),
-    config(DUMP_AST, false),
-    config(DUMP_TYPED_AST, false),
-    config(PROFILE_COMPILE, false),
-    config(PROFILE_FORMAT, true),
-    config(PROFILE_OUTPUT, true),
-    config(WARN_LEVEL, true),
-    config(SUPPRESS_WARNINGS, true),
-    config(NO_CHECK_LAWS, false),
-    config(LAW_SEED, true),
-    config(LAW_SAMPLES, true),
-    config(SHOW_EFFECTS, false),
-    config(NO_DEBUG_INFO, false)
+    (sharedOptionConfigs :+ OptionConfig(OUTPUT, true) :+ OptionConfig(NO_DEBUG_INFO, false))*
   )
 
   def run(commandLine: Array[String], verbose: Boolean = false): Int = {
@@ -183,201 +134,14 @@ class CompilerFrontend {
     result match {
       case success: ParseSuccess => Some(success)
       case failure: ParseFailure =>
-        val lackedOptions = failure.lackedOptions
-        val invalidOptions = failure.invalidOptions
-        invalidOptions.foreach{opt => printError(Message.apply("error.command.invalidArgument", opt.value)) }
-        lackedOptions.foreach{opt => printError(Message.apply("error.command.noArgument", opt.value)) }
+        printFailure(failure)
         None
     }
   }
 
   private def createConfig(result: ParseSuccess, verbose: Boolean = false): Option[CompilerConfig] = {
     val option: Map[String, CommandLineParam] = result.options.toMap
-    val classpath: Array[String] = checkClasspath(
-      option.get(CLASSPATH).collect{ case ValuedParam(value) => value }
-    )
-    val encoding: Option[String] = checkEncoding(
-      option.get(ENCODING).collect{ case ValuedParam(value) => value }
-    )
-    val outputDirectory: String = checkOutputDirectory(
-      option.get(OUTPUT).collect{ case ValuedParam(value) => value}
-    )
-    val maxErrorReport: Option[Int] = checkMaxErrorReport(
-      option.get(MAX_ERROR).collect{ case ValuedParam(value) => value}
-    )
-    val dumpAst = option.get(DUMP_AST).contains(NoValuedParam)
-    val noCheckLaws = option.get(NO_CHECK_LAWS).contains(NoValuedParam)
-    val noDebugInfo = option.get(NO_DEBUG_INFO).contains(NoValuedParam)
-    val lawSeed = longParam(option, LAW_SEED, ArgGenerator.DefaultSeed)
-    val lawSamples = intParam(option, LAW_SAMPLES, ArgGenerator.DefaultSamples)
-    val dumpTypedAst = option.get(DUMP_TYPED_AST).contains(NoValuedParam)
-    val compileProfile = parseCompileProfile(option)
-    val warningLevel = parseWarningLevel(option.get(WARN_LEVEL))
-    val suppressedWarnings = parseSuppressedWarnings(option.get(SUPPRESS_WARNINGS))
-    for {
-      e <- encoding
-      m <- maxErrorReport
-      profile <- compileProfile
-      level <- warningLevel
-      suppressed <- suppressedWarnings
-    } yield {
-      new CompilerConfig(
-        classpath.toIndexedSeq,
-        "",
-        e,
-        outputDirectory,
-        m,
-        verbose = verbose,
-        warningLevel = level,
-        suppressedWarnings = suppressed,
-        dumpAst = dumpAst,
-        dumpTypedAst = dumpTypedAst,
-        compileProfile = profile,
-        checkLaws = !noCheckLaws,
-        emitDebugInfo = !noDebugInfo,
-        lawSeed = lawSeed,
-        lawSamples = lawSamples
-      )
-    }
+    val outputDirectory = option.get(OUTPUT).collect { case ValuedParam(value) => value }.getOrElse(DEFAULT_OUTPUT)
+    configFrom(option, outputDirectory, verbose, emitDebugInfo = !option.get(NO_DEBUG_INFO).contains(NoValuedParam))
   }
-
-
-  /** A positive integer option, falling back to `default` when absent or unparsable. */
-  private def intParam(option: Map[String, CommandLineParam], name: String, default: Int): Int =
-    option.get(name).collect { case ValuedParam(v) => v }
-      .flatMap(v => v.toIntOption).filter(_ > 0).getOrElse(default)
-
-  /** A long option, falling back to `default` when absent or unparsable. */
-  private def longParam(option: Map[String, CommandLineParam], name: String, default: Long): Long =
-    option.get(name).collect { case ValuedParam(v) => v }
-      .flatMap(v => v.toLongOption).getOrElse(default)
-
-  private def parseCompileProfile(option: Map[String, CommandLineParam]): Option[CompileProfileSettings] = {
-    val enabled = option.get(PROFILE_COMPILE).contains(NoValuedParam)
-    val format = option.get(PROFILE_FORMAT) match {
-      case None => Some(CompileProfileFormat.Text)
-      case Some(ValuedParam(value)) =>
-        value.toLowerCase match {
-          case "text" => Some(CompileProfileFormat.Text)
-          case "json" => Some(CompileProfileFormat.Json)
-          case _ =>
-            printError(s"Invalid profile format: $value")
-            None
-        }
-      case Some(NoValuedParam) =>
-        Some(CompileProfileFormat.Text)
-    }
-    format.map { selected =>
-      CompileProfileSettings(
-        enabled = enabled,
-        format = selected,
-        output = option.get(PROFILE_OUTPUT).collect { case ValuedParam(value) => value }
-      )
-    }
-  }
-
-  private def compile(config: CompilerConfig, fileNames: Array[String]): CompilationResult =
-    new OnionCompiler(config).compileDetailed(fileNames)
-
-  private def emitDiagnostics(result: CompilationResult): Unit =
-    DiagnosticRenderer.printDiagnostics(result.diagnostics)
-
-  /** `--effects`: the inferred effect set of every compiled method, to stderr. */
-  private def emitEffects(result: CompilationResult): Unit = {
-    val classes = result.debugArtifacts.typedClasses.getOrElse(Seq.empty)
-    onion.compiler.effects.EffectInference.infer(classes).foreach { me =>
-      System.err.println(me.render)
-    }
-  }
-
-  /** `--dump-ast`: the parsed AST, to stderr. Available even if a later phase fails. */
-  private def emitAstDump(result: CompilationResult): Unit =
-    result.debugArtifacts.parsedUnits.foreach(DiagnosticRenderer.dumpAst(_))
-
-  /** `--dump-typed-ast`: the typed AST summary, to stderr. */
-  private def emitTypedAstDump(result: CompilationResult): Unit =
-    result.debugArtifacts.typedClasses.foreach(DiagnosticRenderer.dumpTyped(_))
-
-  private def emitProfile(config: CompilerConfig, result: CompilationResult): Unit = {
-    if (config.verbose) {
-      System.err.println(CompileProfileReporter.renderVerbose(result.toCompileProfile))
-    }
-    if (config.compileProfile.enabled) {
-      CompileProfileReporter.report(result.toCompileProfile, config.compileProfile)
-    }
-  }
-
-  private def checkClasspath(classpath: Option[String]): Array[String] = {
-    (for (c <- classpath) yield pathArray(c)).getOrElse(DEFAULT_CLASSPATH)
-  }
-
-  private def checkOutputDirectory(outputDirectory: Option[String]): String = outputDirectory.getOrElse(DEFAULT_OUTPUT)
-
-  private def checkEncoding(encoding: Option[String]): Option[String] = {
-    try {
-      (for (e <- encoding) yield {
-        "".getBytes(e)
-        e
-      }).orElse(Some(DEFAULT_ENCODING))
-    } catch {
-      case e: UnsupportedEncodingException => {
-        printError(Message.apply("error.command.invalidEncoding", ENCODING))
-        None
-      }
-    }
-  }
-
-  private def checkMaxErrorReport(maxErrorReport: Option[String]): Option[Int] = {
-    try {
-      maxErrorReport match {
-        case Some(m) =>
-          val value = Integer.parseInt(m)
-          if (value > 0) Some(value) else None
-        case None => Some(DEFAULT_MAX_ERROR)
-      }
-    } catch {
-      case e: NumberFormatException =>
-        printError(Message.apply("error.command.requireNaturalNumber", MAX_ERROR))
-        None
-    }
-  }
-
-  private def parseWarningLevel(param: Option[CommandLineParam]): Option[WarningLevel] = {
-    param match {
-      case Some(ValuedParam(value)) =>
-        value.toLowerCase match {
-          case "off" => Some(WarningLevel.Off)
-          case "on" => Some(WarningLevel.On)
-          case "error" => Some(WarningLevel.Error)
-          case _ =>
-            printError(Message.apply("error.command.invalidArgument", WARN_LEVEL))
-            None
-        }
-      case Some(NoValuedParam) =>
-        printError(Message.apply("error.command.noArgument", WARN_LEVEL))
-        None
-      case None =>
-        Some(WarningLevel.On)
-    }
-  }
-
-  private def parseSuppressedWarnings(param: Option[CommandLineParam]): Option[Set[WarningCategory]] = {
-    param match {
-      case Some(ValuedParam(value)) =>
-        val tokens = value.split(",").map(_.trim).filter(_.nonEmpty)
-        val parsed = tokens.flatMap(t => WarningCategory.fromString(t))
-        if (parsed.length != tokens.length) {
-          printError(Message.apply("error.command.invalidArgument", SUPPRESS_WARNINGS))
-          None
-        } else {
-          Some(parsed.toSet)
-        }
-      case Some(NoValuedParam) =>
-        printError(Message.apply("error.command.noArgument", SUPPRESS_WARNINGS))
-        None
-      case None =>
-        Some(Set.empty)
-    }
-  }
-
 }

--- a/src/main/scala/onion/tools/CompilerFrontend.scala
+++ b/src/main/scala/onion/tools/CompilerFrontend.scala
@@ -9,7 +9,6 @@ package onion.tools
 
 import onion.compiler.{CompiledClass, CompilerConfig}
 import onion.compiler.exceptions.ScriptException
-import onion.compiler.toolbox.Message
 import onion.tools.option._
 import onion.tools.CompilerOptions.*
 
@@ -55,7 +54,6 @@ object CompilerFrontend {
 
 class CompilerFrontend {
 
-  import CompilerFrontend._
 
   private val commandLineParser = new CommandLineParser(
     (sharedOptionConfigs :+ OptionConfig(OUTPUT, true) :+ OptionConfig(NO_DEBUG_INFO, false))*

--- a/src/main/scala/onion/tools/CompilerFrontend.scala
+++ b/src/main/scala/onion/tools/CompilerFrontend.scala
@@ -137,7 +137,7 @@ class CompilerFrontend {
     }
   }
 
-  private def createConfig(result: ParseSuccess, verbose: Boolean = false): Option[CompilerConfig] = {
+  private def createConfig(result: ParseSuccess, verbose: Boolean): Option[CompilerConfig] = {
     val option: Map[String, CommandLineParam] = result.options.toMap
     val outputDirectory = option.get(OUTPUT).collect { case ValuedParam(value) => value }.getOrElse(DEFAULT_OUTPUT)
     configFrom(option, outputDirectory, verbose, emitDebugInfo = !option.get(NO_DEBUG_INFO).contains(NoValuedParam))

--- a/src/main/scala/onion/tools/CompilerOptions.scala
+++ b/src/main/scala/onion/tools/CompilerOptions.scala
@@ -1,0 +1,230 @@
+package onion.tools
+
+import java.io.UnsupportedEncodingException
+import onion.compiler.{CompilerConfig, OnionCompiler, WarningCategory, WarningLevel}
+import onion.compiler.diagnostics.DiagnosticRenderer
+import onion.compiler.pipeline.{CompilationResult, CompileProfileFormat, CompileProfileReporter, CompileProfileSettings}
+import onion.compiler.toolbox.{Message, Systems}
+import onion.compiler.verification.ArgGenerator
+import onion.tools.option._
+
+/**
+ * The command-line options `onionc` and `onion` share: their names, how each is validated,
+ * and how a parsed command line becomes a [[CompilerConfig]]. The two front ends differ only
+ * in what they do with the result (write class files / run the script) and in a few options
+ * of their own (`-d` and `-g:none` for `onionc`, `--watch` and `--stacktrace` for `onion`).
+ */
+object CompilerOptions {
+  final val CLASSPATH: String = "-classpath"
+  final val SCRIPT_SUPER_CLASS: String = "-super"
+  final val ENCODING: String = "-encoding"
+  final val OUTPUT: String = "-d"
+  final val MAX_ERROR: String = "-maxErrorReport"
+  final val VERBOSE: String = "--verbose"
+  final val DUMP_AST: String = "--dump-ast"
+  final val DUMP_TYPED_AST: String = "--dump-typed-ast"
+  final val PROFILE_COMPILE: String = "--profile-compile"
+  final val PROFILE_FORMAT: String = "--profile-format"
+  final val PROFILE_OUTPUT: String = "--profile-output"
+  final val WARN_LEVEL: String = "--warn"
+  final val SUPPRESS_WARNINGS: String = "--Wno"
+  final val NO_CHECK_LAWS: String = "--no-check-laws"
+  final val LAW_SEED: String = "--law-seed"
+  final val LAW_SAMPLES: String = "--law-samples"
+  final val SHOW_EFFECTS: String = "--effects"
+  /** Named after javac's -g:none, and meaning the same thing: no LocalVariableTable. */
+  final val NO_DEBUG_INFO: String = "-g:none"
+  final val STACKTRACE: String = "--stacktrace"
+
+  final val DEFAULT_CLASSPATH: Array[String] = Array[String](".")
+  final val DEFAULT_ENCODING: String = System.getProperty("file.encoding")
+  final val DEFAULT_OUTPUT: String = "."
+  final val DEFAULT_MAX_ERROR: Int = 10
+
+  /** The option configurations both front ends accept, in `onionc`'s order. */
+  def sharedOptionConfigs: Seq[OptionConfig] = Seq(
+    OptionConfig(CLASSPATH, true),
+    OptionConfig(SCRIPT_SUPER_CLASS, true),
+    OptionConfig(ENCODING, true),
+    OptionConfig(MAX_ERROR, true),
+    OptionConfig(DUMP_AST, false),
+    OptionConfig(DUMP_TYPED_AST, false),
+    OptionConfig(PROFILE_COMPILE, false),
+    OptionConfig(PROFILE_FORMAT, true),
+    OptionConfig(PROFILE_OUTPUT, true),
+    OptionConfig(WARN_LEVEL, true),
+    OptionConfig(SUPPRESS_WARNINGS, true),
+    OptionConfig(NO_CHECK_LAWS, false),
+    OptionConfig(LAW_SEED, true),
+    OptionConfig(LAW_SAMPLES, true),
+    OptionConfig(SHOW_EFFECTS, false)
+  )
+
+  /** The shared options that take a value (their value is skipped when locating a script file). */
+  final val VALUE_OPTIONS: Set[String] = Set(
+    CLASSPATH, SCRIPT_SUPER_CLASS, ENCODING, MAX_ERROR,
+    PROFILE_FORMAT, PROFILE_OUTPUT, WARN_LEVEL, SUPPRESS_WARNINGS,
+    LAW_SEED, LAW_SAMPLES
+  )
+
+  private def printError(message: String): Unit = System.err.println(message)
+
+  def pathArray(path: String): Array[String] = path.split(Systems.pathSeparator)
+
+  /** Reports the invalid and value-less options of a failed parse, one line each. */
+  def printFailure(failure: ParseFailure): Unit = {
+    failure.invalidOptions.foreach { opt => printError(Message("error.command.invalidArgument", opt.value)) }
+    failure.lackedOptions.foreach { opt => printError(Message("error.command.noArgument", opt.value)) }
+  }
+
+  /**
+   * The [[CompilerConfig]] for a parsed command line, or None after reporting the first invalid
+   * option. `outputDirectory` and `emitDebugInfo` are the two settings only `onionc` exposes.
+   */
+  def configFrom(
+    option: Map[String, CommandLineParam],
+    outputDirectory: String,
+    verbose: Boolean,
+    emitDebugInfo: Boolean = true
+  ): Option[CompilerConfig] = {
+    val classpath = checkClasspath(option.get(CLASSPATH))
+    val dumpAst = option.get(DUMP_AST).contains(NoValuedParam)
+    val dumpTypedAst = option.get(DUMP_TYPED_AST).contains(NoValuedParam)
+    val checkLaws = !option.get(NO_CHECK_LAWS).contains(NoValuedParam)
+    for {
+      encoding <- checkEncoding(option.get(ENCODING))
+      maxErrorReport <- checkMaxErrorReport(option.get(MAX_ERROR))
+      profile <- parseCompileProfile(option)
+      level <- parseWarningLevel(option.get(WARN_LEVEL))
+      suppressed <- parseSuppressedWarnings(option.get(SUPPRESS_WARNINGS))
+    } yield new CompilerConfig(
+      classpath.toIndexedSeq,
+      "",
+      encoding,
+      outputDirectory,
+      maxErrorReport,
+      verbose = verbose,
+      warningLevel = level,
+      suppressedWarnings = suppressed,
+      dumpAst = dumpAst,
+      dumpTypedAst = dumpTypedAst,
+      compileProfile = profile,
+      checkLaws = checkLaws,
+      emitDebugInfo = emitDebugInfo,
+      lawSeed = longParam(option, LAW_SEED, ArgGenerator.DefaultSeed),
+      lawSamples = intParam(option, LAW_SAMPLES, ArgGenerator.DefaultSamples)
+    )
+  }
+
+  /** A positive integer option, falling back to `default` when absent or unparsable. */
+  def intParam(option: Map[String, CommandLineParam], name: String, default: Int): Int =
+    option.get(name).collect { case ValuedParam(v) => v }
+      .flatMap(v => v.toIntOption).filter(_ > 0).getOrElse(default)
+
+  /** A long option, falling back to `default` when absent or unparsable. */
+  def longParam(option: Map[String, CommandLineParam], name: String, default: Long): Long =
+    option.get(name).collect { case ValuedParam(v) => v }
+      .flatMap(v => v.toLongOption).getOrElse(default)
+
+  def parseCompileProfile(option: Map[String, CommandLineParam]): Option[CompileProfileSettings] = {
+    val enabled = option.get(PROFILE_COMPILE).contains(NoValuedParam)
+    val format = option.get(PROFILE_FORMAT) match {
+      case None | Some(NoValuedParam) => Some(CompileProfileFormat.Text)
+      case Some(ValuedParam(value)) =>
+        value.toLowerCase match {
+          case "text" => Some(CompileProfileFormat.Text)
+          case "json" => Some(CompileProfileFormat.Json)
+          case _ =>
+            printError(s"Invalid profile format: $value")
+            None
+        }
+    }
+    format.map { selected =>
+      CompileProfileSettings(
+        enabled = enabled,
+        format = selected,
+        output = option.get(PROFILE_OUTPUT).collect { case ValuedParam(value) => value }
+      )
+    }
+  }
+
+  def compile(config: CompilerConfig, fileNames: Array[String]): CompilationResult =
+    new OnionCompiler(config).compileDetailed(fileNames)
+
+  def emitDiagnostics(result: CompilationResult): Unit =
+    DiagnosticRenderer.printDiagnostics(result.diagnostics)
+
+  /** `--effects`: the inferred effect set of every compiled method, to stderr. */
+  def emitEffects(result: CompilationResult): Unit = {
+    val classes = result.debugArtifacts.typedClasses.getOrElse(Seq.empty)
+    onion.compiler.effects.EffectInference.infer(classes).foreach { me => System.err.println(me.render) }
+  }
+
+  /** `--dump-ast`: the parsed AST, to stderr. Available even if a later phase fails. */
+  def emitAstDump(result: CompilationResult): Unit =
+    result.debugArtifacts.parsedUnits.foreach(DiagnosticRenderer.dumpAst(_))
+
+  /** `--dump-typed-ast`: the typed AST summary, to stderr. */
+  def emitTypedAstDump(result: CompilationResult): Unit =
+    result.debugArtifacts.typedClasses.foreach(DiagnosticRenderer.dumpTyped(_))
+
+  def emitProfile(config: CompilerConfig, result: CompilationResult): Unit = {
+    if (config.verbose) System.err.println(CompileProfileReporter.renderVerbose(result.toCompileProfile))
+    if (config.compileProfile.enabled) CompileProfileReporter.report(result.toCompileProfile, config.compileProfile)
+  }
+
+  def checkClasspath(param: Option[CommandLineParam]): Array[String] = param match {
+    case Some(ValuedParam(classpath)) => pathArray(classpath)
+    case Some(NoValuedParam) | None => DEFAULT_CLASSPATH
+  }
+
+  def checkEncoding(param: Option[CommandLineParam]): Option[String] = param match {
+    case None | Some(NoValuedParam) => Some(DEFAULT_ENCODING)
+    case Some(ValuedParam(encoding)) =>
+      try { "".getBytes(encoding); Some(encoding) }
+      catch {
+        case _: UnsupportedEncodingException =>
+          printError(Message("error.command.invalidEncoding", ENCODING))
+          None
+      }
+  }
+
+  def checkMaxErrorReport(param: Option[CommandLineParam]): Option[Int] = param match {
+    case None | Some(NoValuedParam) => Some(DEFAULT_MAX_ERROR)
+    case Some(ValuedParam(text)) =>
+      text.toIntOption.filter(_ > 0).orElse {
+        printError(Message("error.command.requireNaturalNumber", MAX_ERROR))
+        None
+      }
+  }
+
+  def parseWarningLevel(param: Option[CommandLineParam]): Option[WarningLevel] = param match {
+    case Some(ValuedParam(value)) =>
+      value.toLowerCase match {
+        case "off" => Some(WarningLevel.Off)
+        case "on" => Some(WarningLevel.On)
+        case "error" => Some(WarningLevel.Error)
+        case _ =>
+          printError(Message("error.command.invalidArgument", WARN_LEVEL))
+          None
+      }
+    case Some(NoValuedParam) =>
+      printError(Message("error.command.noArgument", WARN_LEVEL))
+      None
+    case None => Some(WarningLevel.On)
+  }
+
+  def parseSuppressedWarnings(param: Option[CommandLineParam]): Option[Set[WarningCategory]] = param match {
+    case Some(ValuedParam(value)) =>
+      val tokens = value.split(",").map(_.trim).filter(_.nonEmpty)
+      val parsed = tokens.flatMap(t => WarningCategory.fromString(t))
+      if (parsed.length != tokens.length) {
+        printError(Message("error.command.invalidArgument", SUPPRESS_WARNINGS))
+        None
+      } else Some(parsed.toSet)
+    case Some(NoValuedParam) =>
+      printError(Message("error.command.noArgument", SUPPRESS_WARNINGS))
+      None
+    case None => Some(Set.empty)
+  }
+}

--- a/src/main/scala/onion/tools/Repl.scala
+++ b/src/main/scala/onion/tools/Repl.scala
@@ -13,7 +13,6 @@ import onion.compiler.diagnostics.DiagnosticRenderer
 import org.objectweb.asm.ClassReader
 import org.jline.reader._
 import org.jline.reader.impl.DefaultParser
-import org.jline.reader.impl.completer.StringsCompleter
 import org.jline.terminal.{Terminal, TerminalBuilder}
 import org.jline.utils.AttributedStringBuilder
 import org.jline.utils.AttributedStyle
@@ -23,7 +22,6 @@ import java.io.{BufferedReader, ByteArrayOutputStream, File, FileInputStream, Fi
 import java.nio.file.Paths
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.jdk.CollectionConverters._
 
 /**
  * Interactive REPL for Onion language with JLine3 support.
@@ -662,7 +660,7 @@ class Repl(classpath: Seq[String]) {
   private def parseSnippet(code: String, fileName: String): Option[AST.CompilationUnit] = {
     tryParse(code, fileName) match {
       case Right(unit) => Some(unit)
-      case Left(errors) if looksLikeHeaderOnly(code) =>
+      case Left(_) if looksLikeHeaderOnly(code) =>
         dummyCounter += 1
         val dummyName = s"__ReplDummy${dummyCounter}__"
         val wrapped = s"$code\nclass $dummyName {}"
@@ -866,8 +864,6 @@ class Repl(classpath: Seq[String]) {
     }
   }
 
-  private def terminalWriter(): java.io.PrintStream = Console.out
-
   private def loadFile(path: String, terminal: Terminal, readerOpt: Option[LineReader]): Unit = {
     val file = new File(path)
     if (!file.exists()) {
@@ -912,18 +908,6 @@ class Repl(classpath: Seq[String]) {
       Console.err.println(Colors.RED + error + Colors.RESET)
     }
     Console.err.println(Colors.RED + onion.compiler.toolbox.Message("error.count", errors.size) + Colors.RESET)
-  }
-
-  private def capturePrintStream(render: PrintStream => Unit): String = {
-    val buffer = new ByteArrayOutputStream()
-    val out = new PrintStream(buffer, true, encoding)
-    try {
-      render(out)
-      out.flush()
-      buffer.toString(encoding).trim
-    } finally {
-      out.close()
-    }
   }
 
   private def renderBytecode(classes: Seq[CompiledClass]): String =

--- a/src/main/scala/onion/tools/Repl.scala
+++ b/src/main/scala/onion/tools/Repl.scala
@@ -18,7 +18,7 @@ import org.jline.utils.AttributedStringBuilder
 import org.jline.utils.AttributedStyle
 import org.objectweb.asm.util.TraceClassVisitor
 
-import java.io.{BufferedReader, ByteArrayOutputStream, File, FileInputStream, FileOutputStream, InputStreamReader, PrintStream, PrintWriter, StringReader, StringWriter}
+import java.io.{BufferedReader, File, FileInputStream, FileOutputStream, InputStreamReader, PrintWriter, StringReader, StringWriter}
 import java.nio.file.Paths
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -7,16 +7,12 @@
  * ************************************************************** */
 package onion.tools
 
-import java.io.UnsupportedEncodingException
 import java.lang.System.err
 import onion.compiler._
-import onion.compiler.diagnostics.DiagnosticRenderer
 import onion.compiler.exceptions.ScriptException
-import onion.compiler.pipeline.{CompilationResult, CompileProfileFormat, CompileProfileReporter, CompileProfileSettings}
 import onion.compiler.toolbox.Message
-import onion.compiler.toolbox.Systems
-import onion.compiler.verification.ArgGenerator
 import onion.tools.option._
+import onion.tools.CompilerOptions.*
 
 /**
  *
@@ -28,10 +24,6 @@ object ScriptRunner {
   final case class Prepared(scriptName: String, classPath: Seq[String], classes: Seq[CompiledClass], scriptArgs: Array[String])
 
   val VERSION = OnionVersion.value
-
-  private def conf(optionName: String, requireArgument: Boolean) = OptionConfig(optionName, requireArgument)
-
-  private def pathArray(path: String): Array[String] =  path.split(Systems.pathSeparator)
 
   /**
    * Index of the script-file argument: walks the leading runner options
@@ -154,52 +146,11 @@ object ScriptRunner {
     }
   }
 
-  private final val CLASSPATH: String = "-classpath"
-  private final val SCRIPT_SUPER_CLASS: String = "-super"
-  private final val ENCODING: String = "-encoding"
-  private final val MAX_ERROR: String = "-maxErrorReport"
-  private final val DUMP_AST: String = "--dump-ast"
-  private final val DUMP_TYPED_AST: String = "--dump-typed-ast"
-  private final val PROFILE_COMPILE: String = "--profile-compile"
-  private final val PROFILE_FORMAT: String = "--profile-format"
-  private final val PROFILE_OUTPUT: String = "--profile-output"
-  private final val WARN_LEVEL: String = "--warn"
-  private final val SUPPRESS_WARNINGS: String = "--Wno"
-  private final val NO_CHECK_LAWS: String = "--no-check-laws"
-  private final val LAW_SEED: String = "--law-seed"
-  private final val LAW_SAMPLES: String = "--law-samples"
-  private final val SHOW_EFFECTS: String = "--effects"
-  private final val STACKTRACE: String = "--stacktrace"
-  private final val DEFAULT_CLASSPATH: Array[String] = Array[String](".")
-  private final val DEFAULT_ENCODING: String = System.getProperty("file.encoding")
-  private final val DEFAULT_MAX_ERROR: Int = 10
-  /** Runner options that take a value (their value is skipped when locating the script file). */
-  private final val VALUE_OPTIONS: Set[String] = Set(
-    CLASSPATH, SCRIPT_SUPER_CLASS, ENCODING, MAX_ERROR,
-    PROFILE_FORMAT, PROFILE_OUTPUT, WARN_LEVEL, SUPPRESS_WARNINGS,
-    LAW_SEED, LAW_SAMPLES
-  )
 }
 
 class ScriptRunner {
   import ScriptRunner._
-  private[this] val parser = new CommandLineParser(
-    conf(CLASSPATH, true),
-    conf(SCRIPT_SUPER_CLASS, true),
-    conf(ENCODING, true),
-    conf(MAX_ERROR, true),
-    conf(DUMP_AST, false),
-    conf(DUMP_TYPED_AST, false),
-    conf(PROFILE_COMPILE, false),
-    conf(PROFILE_FORMAT, true),
-    conf(PROFILE_OUTPUT, true),
-    conf(WARN_LEVEL, true),
-    conf(SUPPRESS_WARNINGS, true),
-    conf(NO_CHECK_LAWS, false),
-    conf(LAW_SEED, true),
-    conf(LAW_SAMPLES, true),
-    conf(SHOW_EFFECTS, false)
-  )
+  private[this] val parser = new CommandLineParser(sharedOptionConfigs*)
 
   def run(commandLine: Array[String], verbose: Boolean = false): Int =
     prepare(commandLine, verbose) match {
@@ -241,8 +192,8 @@ class ScriptRunner {
           case Some(config) =>
             val scriptArgs = passThroughArgs
             val result = compile(config, Array(params.head))
-            if (config.dumpAst) result.debugArtifacts.parsedUnits.foreach(DiagnosticRenderer.dumpAst(_))
-            if (config.dumpTypedAst) result.debugArtifacts.typedClasses.foreach(DiagnosticRenderer.dumpTyped(_))
+            if (config.dumpAst) emitAstDump(result)
+            if (config.dumpTypedAst) emitTypedAstDump(result)
             emitDiagnostics(result)
             emitProfile(config, result)
             if (!result.hasErrors && success.options.contains(SHOW_EFFECTS)) {
@@ -306,173 +257,6 @@ class ScriptRunner {
          |  onion -classpath lib/*.jar Script.on arg1 arg2""".stripMargin)
   }
 
-  private def printFailure(failure: ParseFailure): Unit = {
-    failure.invalidOptions.foreach { invalidOption =>
-      err.println(Message("error.command.invalidArgument", invalidOption.value))
-    }
-    failure.lackedOptions.foreach { lackedOption =>
-      err.println(Message("error.command.noArgument", lackedOption.value))
-    }
-  }
-
-  private def createConfig(result: ParseSuccess, verbose: Boolean = false): Option[CompilerConfig] = {
-    val option: Map[String, CommandLineParam] = result.options.toMap
-    val classpath: Array[String] = checkClasspath(option.get(CLASSPATH))
-    val dumpAst = option.get(DUMP_AST).contains(NoValuedParam)
-    val dumpTypedAst = option.get(DUMP_TYPED_AST).contains(NoValuedParam)
-    val compileProfile = parseCompileProfile(option)
-    val warningLevel = parseWarningLevel(option.get(WARN_LEVEL))
-    val suppressedWarnings = parseSuppressedWarnings(option.get(SUPPRESS_WARNINGS))
-    for(
-      encoding <- checkEncoding(option.get(ENCODING));
-      maxErrorReport <- checkMaxErrorReport(option.get(MAX_ERROR));
-      profile <- compileProfile;
-      level <- warningLevel;
-      suppressed <- suppressedWarnings
-    ) yield (new CompilerConfig(
-      classpath.toIndexedSeq,
-      "",
-      encoding,
-      ".",
-      maxErrorReport,
-      verbose = verbose,
-      warningLevel = level,
-      suppressedWarnings = suppressed,
-      dumpAst = dumpAst,
-      dumpTypedAst = dumpTypedAst,
-      compileProfile = profile,
-      checkLaws = !option.get(NO_CHECK_LAWS).contains(NoValuedParam),
-      lawSeed = longParam(option, LAW_SEED, ArgGenerator.DefaultSeed),
-      lawSamples = intParam(option, LAW_SAMPLES, ArgGenerator.DefaultSamples)
-    ))
-  }
-
-
-  /** A positive integer option, falling back to `default` when absent or unparsable. */
-  private def intParam(option: Map[String, CommandLineParam], name: String, default: Int): Int =
-    option.get(name).collect { case ValuedParam(v) => v }
-      .flatMap(v => v.toIntOption).filter(_ > 0).getOrElse(default)
-
-  /** A long option, falling back to `default` when absent or unparsable. */
-  private def longParam(option: Map[String, CommandLineParam], name: String, default: Long): Long =
-    option.get(name).collect { case ValuedParam(v) => v }
-      .flatMap(v => v.toLongOption).getOrElse(default)
-
-  private def parseCompileProfile(option: Map[String, CommandLineParam]): Option[CompileProfileSettings] = {
-    val enabled = option.get(PROFILE_COMPILE).contains(NoValuedParam)
-    val format = option.get(PROFILE_FORMAT) match {
-      case None => Some(CompileProfileFormat.Text)
-      case Some(ValuedParam(value)) =>
-        value.toLowerCase match {
-          case "text" => Some(CompileProfileFormat.Text)
-          case "json" => Some(CompileProfileFormat.Json)
-          case _ =>
-            err.println(s"Invalid profile format: $value")
-            None
-        }
-      case Some(NoValuedParam) =>
-        Some(CompileProfileFormat.Text)
-    }
-    format.map { selected =>
-      CompileProfileSettings(
-        enabled = enabled,
-        format = selected,
-        output = option.get(PROFILE_OUTPUT).collect { case ValuedParam(value) => value }
-      )
-    }
-  }
-
-  private def compile(config: CompilerConfig, fileNames: Array[String]): CompilationResult =
-    new OnionCompiler(config).compileDetailed(fileNames)
-
-  private def emitDiagnostics(result: CompilationResult): Unit =
-    DiagnosticRenderer.printDiagnostics(result.diagnostics)
-
-  private def emitProfile(config: CompilerConfig, result: CompilationResult): Unit = {
-    if (config.verbose) {
-      System.err.println(CompileProfileReporter.renderVerbose(result.toCompileProfile))
-    }
-    if (config.compileProfile.enabled) {
-      CompileProfileReporter.report(result.toCompileProfile, config.compileProfile)
-    }
-  }
-
-  private def checkClasspath(optClasspath: Option[CommandLineParam]): Array[String] = {
-    optClasspath match {
-      case Some(ValuedParam(classpath)) => pathArray(classpath)
-      case Some(NoValuedParam) | None => DEFAULT_CLASSPATH
-    }
-  }
-
-  private def checkEncoding(optEncoding: Option[CommandLineParam]): Option[String] = {
-    optEncoding match {
-      case None | Some(NoValuedParam) => 
-        Some(System.getProperty("file.encoding"))
-      case Some(ValuedParam(encoding)) => 
-        try {
-          "".getBytes(encoding)
-          Some(encoding)
-        } catch {
-          case e: UnsupportedEncodingException =>
-            err.println(Message.apply("error.command.invalidEncoding", ENCODING))
-            None
-        }
-    }
-  }
-
-  private def checkMaxErrorReport(optMaxErrorReport: Option[CommandLineParam]): Option[Int] = {
-    optMaxErrorReport match {
-      case None | Some(NoValuedParam) => Some(DEFAULT_MAX_ERROR)
-      case Some(ValuedParam(maxErrorReport)) => 
-        val value: Option[Int] = try {
-          Some(Integer.parseInt(maxErrorReport))
-        } catch {
-          case e: NumberFormatException => None
-        }
-        value match {
-          case Some(v) if v > 0 => Some(v)
-          case Some(_) | None =>
-            err.println(Message("error.command.requireNaturalNumber", MAX_ERROR))
-            None
-        }
-    }
-  }
-
-  private def parseWarningLevel(param: Option[CommandLineParam]): Option[WarningLevel] = {
-    param match {
-      case Some(ValuedParam(value)) =>
-        value.toLowerCase match {
-          case "off" => Some(WarningLevel.Off)
-          case "on" => Some(WarningLevel.On)
-          case "error" => Some(WarningLevel.Error)
-          case _ =>
-            err.println(Message.apply("error.command.invalidArgument", WARN_LEVEL))
-            None
-        }
-      case Some(NoValuedParam) =>
-        err.println(Message.apply("error.command.noArgument", WARN_LEVEL))
-        None
-      case None =>
-        Some(WarningLevel.On)
-    }
-  }
-
-  private def parseSuppressedWarnings(param: Option[CommandLineParam]): Option[Set[WarningCategory]] = {
-    param match {
-      case Some(ValuedParam(value)) =>
-        val tokens = value.split(",").map(_.trim).filter(_.nonEmpty)
-        val parsed = tokens.flatMap(t => WarningCategory.fromString(t))
-        if (parsed.length != tokens.length) {
-          err.println(Message.apply("error.command.invalidArgument", SUPPRESS_WARNINGS))
-          None
-        } else {
-          Some(parsed.toSet)
-        }
-      case Some(NoValuedParam) =>
-        err.println(Message.apply("error.command.noArgument", SUPPRESS_WARNINGS))
-        None
-      case None =>
-        Some(Set.empty)
-    }
-  }
+  private def createConfig(result: ParseSuccess, verbose: Boolean = false): Option[CompilerConfig] =
+    configFrom(result.options.toMap, ".", verbose)
 }

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -254,6 +254,6 @@ class ScriptRunner {
          |  onion -classpath lib/*.jar Script.on arg1 arg2""".stripMargin)
   }
 
-  private def createConfig(result: ParseSuccess, verbose: Boolean = false): Option[CompilerConfig] =
+  private def createConfig(result: ParseSuccess, verbose: Boolean): Option[CompilerConfig] =
     configFrom(result.options.toMap, ".", verbose)
 }

--- a/src/main/scala/onion/tools/ScriptRunner.scala
+++ b/src/main/scala/onion/tools/ScriptRunner.scala
@@ -7,10 +7,8 @@
  * ************************************************************** */
 package onion.tools
 
-import java.lang.System.err
 import onion.compiler._
 import onion.compiler.exceptions.ScriptException
-import onion.compiler.toolbox.Message
 import onion.tools.option._
 import onion.tools.CompilerOptions.*
 
@@ -149,7 +147,6 @@ object ScriptRunner {
 }
 
 class ScriptRunner {
-  import ScriptRunner._
   private[this] val parser = new CommandLineParser(sharedOptionConfigs*)
 
   def run(commandLine: Array[String], verbose: Boolean = false): Int =

--- a/src/main/scala/onion/tools/doc/DocModel.scala
+++ b/src/main/scala/onion/tools/doc/DocModel.scala
@@ -1,6 +1,5 @@
 package onion.tools.doc
 
-import java.io.StringReader
 import onion.compiler.AST
 import onion.compiler.parser.{JJOnionParser, OnionLexer}
 
@@ -193,7 +192,7 @@ object DocModel {
         fields += DocMember("field", d.name, SignatureRenderer.renderDelegatedField(d), locLine(d.location), docFor(comments, d.location))
       case ct: AST.ConstructorDeclaration =>
         ctors += DocMember("constructor", "new", SignatureRenderer.renderConstructor(ct), locLine(ct.location), docFor(comments, ct.location))
-      case _ => // ignore other member kinds
+      case null => ()
     }
     (ctors.toList, methods.toList, fields.toList)
   }

--- a/src/main/scala/onion/tools/doc/SignatureRenderer.scala
+++ b/src/main/scala/onion/tools/doc/SignatureRenderer.scala
@@ -28,7 +28,7 @@ object SignatureRenderer {
         case (None, Some(l)) => s"? super ${renderDesc(l)}"
         case _               => "?"
       }
-    case other => other.toString
+    case null => "null"
   }
 
   /** Strip a package qualifier for a compact display name. */

--- a/src/main/scala/onion/tools/format/OnionFormatter.scala
+++ b/src/main/scala/onion/tools/format/OnionFormatter.scala
@@ -1,6 +1,5 @@
 package onion.tools.format
 
-import java.io.StringReader
 
 import onion.compiler.parser.{JJOnionParserConstants as K, OnionLexer, Token}
 

--- a/src/main/scala/onion/tools/lsp/OnionLanguageServer.scala
+++ b/src/main/scala/onion/tools/lsp/OnionLanguageServer.scala
@@ -13,7 +13,6 @@ import org.eclipse.lsp4j.jsonrpc.Launcher
 
 import java.io.{InputStream, OutputStream}
 import java.util.concurrent.CompletableFuture
-import scala.jdk.CollectionConverters._
 
 /**
  * Onion Language Server implementing LSP protocol.

--- a/src/main/scala/onion/tools/lsp/OnionSemanticTokens.scala
+++ b/src/main/scala/onion/tools/lsp/OnionSemanticTokens.scala
@@ -1,6 +1,5 @@
 package onion.tools.lsp
 
-import java.io.StringReader
 
 import onion.compiler.parser.{JJOnionParserConstants as K, OnionLexer, Token}
 

--- a/src/main/scala/onion/tools/option/ParseResult.scala
+++ b/src/main/scala/onion/tools/option/ParseResult.scala
@@ -1,5 +1,5 @@
 package onion.tools.option
-import scala.collection.mutable.{Map, Seq}
+import scala.collection.mutable.{Map}
 
 sealed trait ParseResult {
   def status: Int

--- a/src/main/scala/onion/tools/project/ProjectCommands.scala
+++ b/src/main/scala/onion/tools/project/ProjectCommands.scala
@@ -159,7 +159,7 @@ class ProjectCommands:
             err.println(s"error: ${error.message}")
             err.println("Name source files explicitly, or run inside a project.")
             2
-          case Right((paths, layout)) if layout.productionSources.isEmpty =>
+          case Right((_, layout)) if layout.productionSources.isEmpty =>
             err.println("error: Project has no production sources")
             1
           case Right((paths, layout)) =>


### PR DESCRIPTION
## Summary

No behaviour change (one message-level fix noted below). Targets were picked by measurement: a duplicated-window scan over `src/main/scala` (8-line windows) and a `-Wunused:all` compile.

- **`ASTWalk`**: `CapturedVariableScanner` and `typing.ReturnNodeDetector` each carried an identical 100-line `visitChildren` over `AST.Node` (78 duplicated windows, the largest pair in the tree). It lives once now; both scans delegate.
- **`CompilerOptions`**: `CompilerFrontend` (`onionc`) and `ScriptRunner` (`onion`) shared 200 near-identical lines of option constants, validators, `CompilerConfig` assembly and diagnostics/profile/dump emitters, already drifted. One object now; the front ends keep only what differs (`-d`/`-g:none` vs `--watch`/`--stacktrace` and the script split). Side effect: `onionc -maxErrorReport 0` now reports the error the way `onion` already did, instead of failing silently.
- **`GenericMethodTypeArguments`**: `infer` and `inferWithoutDefaults` each contained the whole unification machinery (170 lines, drifted: only one skipped null argument slots). A private `Constraints` collector runs once; the two entry points differ only in `constrainedOnly()` vs `withDefaults()`.
- **`ArgumentHelpers`**: the closure-argument trio duplicated between `InstanceMethodCallSupport` and `UnqualifiedMethodCallSupport`, and `ConstructionTyping`'s private `hasNamedArguments`, consolidated.
- **Dead code** (`-Wunused:all`): 61 unused imports, 30 unused pattern variables (now `_`), 3 never-reassigned vars (now vals), unused private members (`LocalFrame.entrySet`, three `AsmCodeGeneration.emit*` wrappers, `TailCallOptimization.isPrivate`, `OnionParser.expectImage`, two lexer fields, uncalled delegates, two REPL helpers, two backend locals), never-used default arguments and constructor parameters (with call sites), the never-read `typing` field of three typing classes, and four match arms reachable only by `null` now written as `case null`.

61 files, +624 / −1155.

## Test plan

- [x] Each step compiled and ran the specs of the area it touched before the next step
- [x] `sbt -Duser.language=ja testFull` and `-Duser.language=en testFull`: 5283 passed, 0 failed each
- [x] `FastPathParserParitySpec`, `RunSamplesSpec`, `DocExamplesCompileSpec` green (parser/lexer touched only by dead-field removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc
