### PR TITLE
refactor: second pass over the measured duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helpers live once in `ArgumentHelpers`. A `-Wunused:all` pass then removed
   61 unused imports, 30 unused pattern variables, never-used default
   arguments and constructor parameters, and private members nothing called.
-  About 900 lines gone.
+  A second pass folded `AsmRefs`' class/method signature visitors, the
+  method-call receiver normalisation, the parser's method-signature, pattern
+  and `conforms` helpers, the backend's boxed-local assignment and the
+  bidirectional call paths' preliminary argument typing. About 1200 lines
+  gone in all.
 
 ### Added
 

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -767,6 +767,51 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
     withVisitor(gen, className, localVars)(_.visitTerm(expr))
 
 
+  /**
+   * Assignment to a boxed local (one a closure captures and mutates): the box is created on
+   * the first assignment and its `value` field updated afterwards, leaving the assigned value
+   * on the stack. `slots` is where the box lives -- the method's own locals, or the closure
+   * body's -- while `localVars` is the context the value expression is emitted in.
+   */
+  private def emitBoxedSet(gen: GeneratorAdapter, set: SetLocal, className: String, localVars: LocalVarContext, slots: LocalVarContext): Unit =
+    val boxType = boxAsmType(set.`type`)
+    val valueType = boxedValueType(set.`type`)
+    slots.slotOf(set.index) match
+      case Some(slot) =>
+        // Update: load box, compute value, put into box.value.
+        // If the value may run its own try/catch, the box reference can't
+        // stay on the operand stack across it -- see the boxed-captured-
+        // variable branch above for why (issue #745/#669 sibling).
+        if TermContainsTry.contains(set.value) then
+          emitExpressionWithContext(gen, set.value, className, localVars)
+          val valueSlot = gen.newLocal(valueType)
+          gen.storeLocal(valueSlot)
+          gen.loadLocal(slot)
+          gen.loadLocal(valueSlot)
+          gen.putField(boxType, "value", valueType)
+          gen.loadLocal(valueSlot)
+        else
+          gen.loadLocal(slot)
+          emitExpressionWithContext(gen, set.value, className, localVars)
+          if valueType.getSize() == 2 then
+            gen.dup2X1()
+          else
+            gen.dupX1()
+          gen.putField(boxType, "value", valueType)
+      case None =>
+        // Initialize: compute value, create box, store box, return value
+        emitExpressionWithContext(gen, set.value, className, localVars)
+        val tempSlot = gen.newLocal(valueType)
+        gen.storeLocal(tempSlot)
+        gen.newInstance(boxType)
+        gen.dup()
+        gen.loadLocal(tempSlot)
+        val ctorDesc = AsmType.getMethodDescriptor(AsmType.VOID_TYPE, valueType)
+        gen.invokeConstructor(boxType, AsmMethod("<init>", ctorDesc))
+        val slot = slots.allocateSlot(set.index, boxType)
+        gen.storeLocal(slot)
+        gen.loadLocal(tempSlot) // Return the value
+
   // Helper methods for visitor pattern
   def emitRefLocal(gen: GeneratorAdapter, ref: RefLocal, localVars: LocalVarContext): Unit =
     localVars match
@@ -896,39 +941,7 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
               // this one): mirror the top-level-method boxed-local path below --
               // box-reference-then-value ordering, with the try/catch guard for
               // the same operand-stack-clearing reason as issue #745/#669.
-              val boxType = boxAsmType(set.`type`)
-              val valueType = boxedValueType(set.`type`)
-              closureCtx.slotOf(set.index) match
-                case Some(slot) =>
-                  if TermContainsTry.contains(set.value) then
-                    emitExpressionWithContext(gen, set.value, className, localVars)
-                    val valueSlot = gen.newLocal(valueType)
-                    gen.storeLocal(valueSlot)
-                    gen.loadLocal(slot)
-                    gen.loadLocal(valueSlot)
-                    gen.putField(boxType, "value", valueType)
-                    gen.loadLocal(valueSlot)
-                  else
-                    gen.loadLocal(slot)
-                    emitExpressionWithContext(gen, set.value, className, localVars)
-                    if valueType.getSize() == 2 then
-                      gen.dup2X1()
-                    else
-                      gen.dupX1()
-                    gen.putField(boxType, "value", valueType)
-                case None =>
-                  // Initialize: compute value, create box, store box, return value
-                  emitExpressionWithContext(gen, set.value, className, localVars)
-                  val tempSlot = gen.newLocal(valueType)
-                  gen.storeLocal(tempSlot)
-                  gen.newInstance(boxType)
-                  gen.dup()
-                  gen.loadLocal(tempSlot)
-                  val ctorDesc = AsmType.getMethodDescriptor(AsmType.VOID_TYPE, valueType)
-                  gen.invokeConstructor(boxType, AsmMethod("<init>", ctorDesc))
-                  val slot = closureCtx.allocateSlot(set.index, boxType)
-                  gen.storeLocal(slot)
-                  gen.loadLocal(tempSlot) // Return the value
+              emitBoxedSet(gen, set, className, localVars, closureCtx)
             else
               emitExpressionWithContext(gen, set.value, className, localVars)
               val valueType = asmType(set.`type`)
@@ -942,43 +955,7 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
           if setValueType.getSize() == 2 then gen.dup2() else gen.dup()
           gen.storeArg(set.index)
         else if localVars.isBoxed(set.index) then
-          val boxType = boxAsmType(set.`type`)
-          val valueType = boxedValueType(set.`type`)
-          localVars.slotOf(set.index) match
-            case Some(slot) =>
-              // Update: load box, compute value, put into box.value.
-              // If the value may run its own try/catch, the box reference can't
-              // stay on the operand stack across it -- see the boxed-captured-
-              // variable branch above for why (issue #745/#669 sibling).
-              if TermContainsTry.contains(set.value) then
-                emitExpressionWithContext(gen, set.value, className, localVars)
-                val valueSlot = gen.newLocal(valueType)
-                gen.storeLocal(valueSlot)
-                gen.loadLocal(slot)
-                gen.loadLocal(valueSlot)
-                gen.putField(boxType, "value", valueType)
-                gen.loadLocal(valueSlot)
-              else
-                gen.loadLocal(slot)
-                emitExpressionWithContext(gen, set.value, className, localVars)
-                if valueType.getSize() == 2 then
-                  gen.dup2X1()
-                else
-                  gen.dupX1()
-                gen.putField(boxType, "value", valueType)
-            case None =>
-              // Initialize: compute value, create box, store box, return value
-              emitExpressionWithContext(gen, set.value, className, localVars)
-              val tempSlot = gen.newLocal(valueType)
-              gen.storeLocal(tempSlot)
-              gen.newInstance(boxType)
-              gen.dup()
-              gen.loadLocal(tempSlot)
-              val ctorDesc = AsmType.getMethodDescriptor(AsmType.VOID_TYPE, valueType)
-              gen.invokeConstructor(boxType, AsmMethod("<init>", ctorDesc))
-              val slot = localVars.allocateSlot(set.index, boxType)
-              gen.storeLocal(slot)
-              gen.loadLocal(tempSlot) // Return the value
+          emitBoxedSet(gen, set, className, localVars, localVars)
         else
           emitExpressionWithContext(gen, set.value, className, localVars)
           if setValueType.getSize() == 2 then gen.dup2() else gen.dup()

--- a/src/main/scala/onion/compiler/environment/AsmRefs.scala
+++ b/src/main/scala/onion/compiler/environment/AsmRefs.scala
@@ -129,19 +129,17 @@ object AsmRefs {
       }
     }
 
-    final case class ClassInfo(
-      typeParameters: Array[TypedAST.TypeParameter],
-      superClass: TypedAST.ClassType,
-      interfaces: Seq[TypedAST.ClassType],
-      env: Map[String, TypedAST.TypeVariableType]
-    )
-
-    def parseClass(signature: String, fallbackSuper: String, fallbackIfaces: java.util.List[String]): ClassInfo = {
+    /**
+     * The `<T extends B, ...>` prefix a class or method signature may start with, collected
+     * into `typeParamsBuf` (each bound resolved against the parameters seen so far); a
+     * subclass adds what follows the prefix. `finishTypeParam()` closes the parameter being
+     * read and must be called before the buffer is used.
+     */
+    abstract class FormalTypeParamsVisitor extends SignatureVisitor(Opcodes.ASM9) {
       val typeParamsBuf = mutable.ArrayBuffer[TypedAST.TypeParameter]()
-      var currentName: String = null
-      var currentUpper: TypedAST.ClassType = null
-      var parsedSuper: TypedAST.ClassType = null
-      val parsedIfaces = mutable.ArrayBuffer[TypedAST.ClassType]()
+      private var currentName: String = null
+      private var currentUpper: TypedAST.ClassType = null
+      private val tmpEnv = mutable.HashMap[String, TypedAST.TypeVariableType]() ++ baseEnv
 
       def finishTypeParam(): Unit = {
         if (currentName == null) return
@@ -151,48 +149,45 @@ object AsmRefs {
         currentUpper = null
       }
 
-      val tmpEnv = mutable.HashMap[String, TypedAST.TypeVariableType]() ++ baseEnv
+      override def visitFormalTypeParameter(name: String): Unit = {
+        finishTypeParam()
+        currentName = name
+        tmpEnv += name -> new TypedAST.TypeVariableType(name, root)
+      }
 
-      val reader = new SignatureReader(signature)
-      reader.accept(new SignatureVisitor(Opcodes.ASM9) {
-        override def visitFormalTypeParameter(name: String): Unit = {
-          finishTypeParam()
-          currentName = name
-          tmpEnv += name -> new TypedAST.TypeVariableType(name, root)
-        }
+      /** The first bound is the upper bound; further interface bounds are not tracked. */
+      private def boundVisitor(): SignatureVisitor =
+        new TypeRefVisitor(
+          t =>
+            if (currentUpper == null) {
+              currentUpper = t match {
+                case ap: TypedAST.AppliedClassType => ap.raw
+                case ct: TypedAST.ClassType => ct
+                case _ => root
+              }
+            },
+          tmpEnv.toMap
+        )
 
-        override def visitClassBound(): SignatureVisitor =
-          new TypeRefVisitor(
-            t =>
-              if (currentUpper == null) {
-                currentUpper = t match {
-                  case ap: TypedAST.AppliedClassType => ap.raw
-                  case ct: TypedAST.ClassType => ct
-                  case _ => root
-                }
-              },
-            tmpEnv.toMap
-          )
+      override def visitClassBound(): SignatureVisitor = boundVisitor()
+      override def visitInterfaceBound(): SignatureVisitor = boundVisitor()
+    }
 
-        override def visitInterfaceBound(): SignatureVisitor =
-          new TypeRefVisitor(
-            t =>
-              if (currentUpper == null) {
-                currentUpper = t match {
-                  case ap: TypedAST.AppliedClassType => ap.raw
-                  case ct: TypedAST.ClassType => ct
-                  case _ => root
-                }
-              },
-            tmpEnv.toMap
-          )
 
+    final case class ClassInfo(
+      typeParameters: Array[TypedAST.TypeParameter],
+      superClass: TypedAST.ClassType,
+      interfaces: Seq[TypedAST.ClassType],
+      env: Map[String, TypedAST.TypeVariableType]
+    )
+
+    def parseClass(signature: String, fallbackSuper: String, fallbackIfaces: java.util.List[String]): ClassInfo = {
+      var parsedSuper: TypedAST.ClassType = null
+      val parsedIfaces = mutable.ArrayBuffer[TypedAST.ClassType]()
+      val visitor = new FormalTypeParamsVisitor {
         override def visitSuperclass(): SignatureVisitor = {
           finishTypeParam()
-          val (_, nextEnv) = {
-            val arr = typeParamsBuf.toArray
-            (arr, typeParamEnv(arr))
-          }
+          val nextEnv = typeParamEnv(typeParamsBuf.toArray)
           new TypeRefVisitor(
             t =>
               parsedSuper = t match {
@@ -203,22 +198,20 @@ object AsmRefs {
           )
         }
 
-        override def visitInterface(): SignatureVisitor = {
-          val arr = typeParamsBuf.toArray
-          val nextEnv = typeParamEnv(arr)
+        override def visitInterface(): SignatureVisitor =
           new TypeRefVisitor(
             t =>
               t match {
                 case ct: TypedAST.ClassType => parsedIfaces += ct
                 case _ =>
               },
-            nextEnv
+            typeParamEnv(typeParamsBuf.toArray)
           )
-        }
-      })
+      }
+      new SignatureReader(signature).accept(visitor)
 
-      finishTypeParam()
-      val typeParams = typeParamsBuf.toArray
+      visitor.finishTypeParam()
+      val typeParams = visitor.typeParamsBuf.toArray
       val finalEnv = typeParamEnv(typeParams)
 
       val superClass0 =
@@ -242,71 +235,22 @@ object AsmRefs {
     )
 
     def parseMethod(signature: String, desc: String): MethodInfo = {
-      val typeParamsBuf = mutable.ArrayBuffer[TypedAST.TypeParameter]()
-      var currentName: String = null
-      var currentUpper: TypedAST.ClassType = null
       val argsBuf = mutable.ArrayBuffer[TypedAST.Type]()
       var return0: TypedAST.Type = null
-
-      def finishTypeParam(): Unit = {
-        if (currentName == null) return
-        val upper = if (currentUpper == null) root else currentUpper
-        typeParamsBuf += TypedAST.TypeParameter(currentName, Some(upper))
-        currentName = null
-        currentUpper = null
-      }
-
-      val tmpEnv = mutable.HashMap[String, TypedAST.TypeVariableType]() ++ baseEnv
-      val reader = new SignatureReader(signature)
-      reader.accept(new SignatureVisitor(Opcodes.ASM9) {
-        override def visitFormalTypeParameter(name: String): Unit = {
-          finishTypeParam()
-          currentName = name
-          tmpEnv += name -> new TypedAST.TypeVariableType(name, root)
-        }
-
-        override def visitClassBound(): SignatureVisitor =
-          new TypeRefVisitor(
-            t =>
-              if (currentUpper == null) {
-                currentUpper = t match {
-                  case ap: TypedAST.AppliedClassType => ap.raw
-                  case ct: TypedAST.ClassType => ct
-                  case _ => root
-                }
-              },
-            tmpEnv.toMap
-          )
-
-        override def visitInterfaceBound(): SignatureVisitor =
-          new TypeRefVisitor(
-            t =>
-              if (currentUpper == null) {
-                currentUpper = t match {
-                  case ap: TypedAST.AppliedClassType => ap.raw
-                  case ct: TypedAST.ClassType => ct
-                  case _ => root
-                }
-              },
-            tmpEnv.toMap
-          )
-
+      val visitor = new FormalTypeParamsVisitor {
         override def visitParameterType(): SignatureVisitor = {
           finishTypeParam()
-          val typeParams = typeParamsBuf.toArray
-          val env = typeParamEnv(typeParams)
-          new TypeRefVisitor(t => argsBuf += t, env)
+          new TypeRefVisitor(t => argsBuf += t, typeParamEnv(typeParamsBuf.toArray))
         }
 
         override def visitReturnType(): SignatureVisitor = {
           finishTypeParam()
-          val typeParams = typeParamsBuf.toArray
-          val env = typeParamEnv(typeParams)
-          new TypeRefVisitor(t => return0 = t, env)
+          new TypeRefVisitor(t => return0 = t, typeParamEnv(typeParamsBuf.toArray))
         }
-      })
+      }
+      new SignatureReader(signature).accept(visitor)
 
-      val typeParams = typeParamsBuf.toArray
+      val typeParams = visitor.typeParamsBuf.toArray
       val env = typeParamEnv(typeParams)
 
       if (argsBuf.isEmpty && return0 == null) {

--- a/src/main/scala/onion/compiler/parser/OnionParser.scala
+++ b/src/main/scala/onion/compiler/parser/OnionParser.scala
@@ -850,12 +850,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
         }
       } else going = false
     }
-    val superTypes = new ArrayBuffer[AST.TypeNode]()
-    if (kind(1) == K.ID && image(1) == "conforms") {
-      next()
-      superTypes += typ()
-      while (accept(K.COMMA)) superTypes += typ()
-    }
+    val superTypes = conformsClause()
     val sections = new ArrayBuffer[AST.AccessSection]()
     if (accept(K.LBRACE)) {
       while (isAccessSectionStart(kind(1))) sections += accessSection()
@@ -870,12 +865,7 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     val start = expect(K.K_INTERFACE)
     val name = id()
     val tparams = if (kind(1) == K.LBRACKET) typeParams() else Nil
-    val superTypes = new ArrayBuffer[AST.TypeNode]()
-    if (kind(1) == K.ID && image(1) == "conforms") {
-      next()
-      superTypes += typ()
-      while (accept(K.COMMA)) superTypes += typ()
-    }
+    val superTypes = conformsClause()
     val signatures = new ArrayBuffer[AST.MethodDeclaration]()
     if (kind(1) == K.LBRACE) {
       next()
@@ -886,16 +876,22 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     AST.InterfaceDeclaration(p(start), mset, c(name), superTypes.toList, signatures.toList, tparams)
   }
 
-  private def traitDecl(mset: Int): AST.InterfaceDeclaration = {
-    val start = expect(K.K_TRAIT)
-    val name = id()
-    val tparams = if (kind(1) == K.LBRACKET) typeParams() else Nil
+  /** `conforms T1, T2, ...` when present, else empty. */
+  private def conformsClause(): ArrayBuffer[AST.TypeNode] = {
     val superTypes = new ArrayBuffer[AST.TypeNode]()
     if (kind(1) == K.ID && image(1) == "conforms") {
       next()
       superTypes += typ()
       while (accept(K.COMMA)) superTypes += typ()
     }
+    superTypes
+  }
+
+  private def traitDecl(mset: Int): AST.InterfaceDeclaration = {
+    val start = expect(K.K_TRAIT)
+    val name = id()
+    val tparams = if (kind(1) == K.LBRACKET) typeParams() else Nil
+    val superTypes = conformsClause()
     expect(K.LBRACE)
     val signatures = new ArrayBuffer[AST.MethodDeclaration]()
     while (kind(1) == K.K_DEF) signatures += interfaceMethodDecl()
@@ -975,6 +971,18 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     enterSection()
     expect(K.K_DEF)
     val t = id()
+    methodDeclRest(t, mset, anns)
+  }
+
+  private def interfaceMethodDecl(): AST.MethodDeclaration = {
+    enterSection()
+    expect(K.K_DEF)
+    val n = id()
+    methodDeclRest(n, AST.M_PUBLIC, Nil)
+  }
+
+  /** Everything after a method's name: type parameters, parameters, return type, throws, and an `=` body, a block or none. */
+  private def methodDeclRest(t: Token, mset: Int, anns: List[AST.Annotation]): AST.MethodDeclaration = {
     val tparams = if (kind(1) == K.LBRACKET) typeParams() else Nil
     val args = if (accept(K.LPAREN)) { val a = argsList(); expect(K.RPAREN); a } else Nil
     val ty = if (accept(K.COLON)) returnType() else null
@@ -995,33 +1003,6 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
       case _ =>
         eosOrBlockEnd()
         AST.MethodDeclaration(p(t), mset, c(t), args, ty, null, tparams, throwsTypes, anns)
-    }
-  }
-
-  private def interfaceMethodDecl(): AST.MethodDeclaration = {
-    enterSection()
-    expect(K.K_DEF)
-    val n = id()
-    val tparams = if (kind(1) == K.LBRACKET) typeParams() else Nil
-    val args = if (accept(K.LPAREN)) { val a = argsList(); expect(K.RPAREN); a } else Nil
-    val ty = if (accept(K.COLON)) returnType() else null
-    val throwsTypes = if (kind(1) == K.K_THROWS) throwsClause() else Nil
-    kind(1) match {
-      case K.ASSIGN =>
-        next()
-        eols()
-        enterAssignScope()
-        val e = term()
-        eosOrBlockEnd()
-        AST.MethodDeclaration(p(n), AST.M_PUBLIC, c(n), args, ty,
-          AST.BlockExpression(p(n), List(AST.ReturnExpression(p(n), e)), leaveAssignScope()), tparams, throwsTypes, Nil)
-      case K.LBRACE =>
-        leaveSection()
-        val b = block()
-        AST.MethodDeclaration(p(n), AST.M_PUBLIC, c(n), args, ty, b, tparams, throwsTypes, Nil)
-      case _ =>
-        eosOrBlockEnd()
-        AST.MethodDeclaration(p(n), AST.M_PUBLIC, c(n), args, ty, null, tparams, throwsTypes, Nil)
     }
   }
 
@@ -1472,19 +1453,8 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
 
   private def simplePattern(): AST.Pattern = {
     val k = kind(1)
-    if (k == K.ID && image(1) == "_") { val t = next(); return AST.WildcardPattern(p(t)) }
-    if (isId(k) && kind(2) == K.LPAREN) {
-      val t = id()
-      expect(K.LPAREN)
-      val bindings = destructuringBindings()
-      expect(K.RPAREN)
-      return AST.DestructuringPattern(p(t), c(t), bindings)
-    }
-    if (isId(k) && kind(2) == K.K_IS) {
-      val t = id()
-      expect(K.K_IS)
-      return AST.TypePattern(p(t), c(t), typ())
-    }
+    val structured = structuredPatternOpt(k)
+    if (structured != null) return structured
     if (isId(k) && kind(2) == K.K_WHEN) {
       val t = id()
       return AST.BindingPattern(p(t), c(t))
@@ -1502,8 +1472,8 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
     AST.ExpressionPattern(term())
   }
 
-  private def destructuringFieldPattern(): AST.Pattern = {
-    val k = kind(1)
+  /** The patterns select and destructuring share: `_`, `Name(...)` and `name is Type`; null when the next tokens are something else. */
+  private def structuredPatternOpt(k: Int): AST.Pattern = {
     if (k == K.ID && image(1) == "_") { val t = next(); return AST.WildcardPattern(p(t)) }
     if (isId(k) && kind(2) == K.LPAREN) {
       val t = id()
@@ -1517,6 +1487,13 @@ final class OnionParser(text: String, lineBase: Int = 0, colBase: Int = 0) {
       expect(K.K_IS)
       return AST.TypePattern(p(t), c(t), typ())
     }
+    null
+  }
+
+  private def destructuringFieldPattern(): AST.Pattern = {
+    val k = kind(1)
+    val structured = structuredPatternOpt(k)
+    if (structured != null) return structured
     val t = expect(K.ID)
     AST.BindingPattern(p(t), c(t))
   }

--- a/src/main/scala/onion/compiler/typing/MethodCallFallbackSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallFallbackSupport.scala
@@ -76,23 +76,7 @@ private[compiler] final class MethodCallFallbackSupport(
     val problemsBeforeClosures = calls.problemCount
     def closureBodyReportedError: Boolean = calls.problemCount > problemsBeforeClosures
 
-    val preliminaryParams = new Array[Term](args.length)
-    var hasNonClosureError = false
-
-    for (i <- args.indices) {
-      if (untypedClosureIndices.contains(i)) {
-        preliminaryParams(i) = null
-      } else {
-        calls.typed(args(i), context) match {
-          case Some(term) => preliminaryParams(i) = term
-          case None =>
-            hasNonClosureError = true
-            preliminaryParams(i) = null
-        }
-      }
-    }
-
-    if (hasNonClosureError) return None
+    val preliminaryParams = calls.typePreliminaryParams(args, context, untypedClosureIndices).getOrElse(return None)
 
     // Report the outer method-not-found only if no closure body already errored
     // (see #316): a broken closure body makes the outer report redundant.
@@ -152,10 +136,7 @@ private[compiler] final class MethodCallFallbackSupport(
     val disambiguated = overloadSupport.disambiguateClosureOverloads(
       applicableMethods,
       untypedClosureIndices,
-      (i, samType) => args(i) match {
-        case c: AST.ClosureExpression => calls.closureMatchesSam(c, context, samType)
-        case _ => None
-      }
+      calls.closureSamMatcher(args, context)
     )
 
     val method = overloadSupport.selectMostSpecificApplicable(

--- a/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
+++ b/src/main/scala/onion/compiler/typing/MethodCallTyping.scala
@@ -382,4 +382,32 @@ final class MethodCallTyping(
    */
   def typeSafeMethodCall(node: AST.SafeMethodCall, context: LocalContext, expected: Type = null): Option[Term] =
     safeNavigationTypingSupport.typeSafeMethodCall(node, context, expected)
+
+  /**
+   * The arguments typed ahead of overload resolution for a call with untyped-parameter
+   * closures: null at the closure positions (their parameter types come from the callee),
+   * None when any other argument fails to type (already reported).
+   */
+  private[typing] def typePreliminaryParams(args: Seq[AST.Expression], context: LocalContext, untypedClosureIndices: Set[Int]): Option[Array[Term]] = {
+    val params = new Array[Term](args.length)
+    var failed = false
+    var i = 0
+    val it = args.iterator
+    while (it.hasNext) {
+      val arg = it.next()
+      if (!untypedClosureIndices.contains(i)) typed(arg, context) match {
+        case Some(term) => params(i) = term
+        case None => failed = true
+      }
+      i += 1
+    }
+    if (failed) None else Some(params)
+  }
+
+  /** For overload disambiguation: whether the closure at argument `i` fits a candidate's SAM parameter type. */
+  private[typing] def closureSamMatcher(args: Seq[AST.Expression], context: LocalContext): (Int, Type) => Option[Boolean] =
+    (i, samType) => args(i) match {
+      case c: AST.ClosureExpression => closureMatchesSam(c, context, samType)
+      case _ => None
+    }
 }

--- a/src/main/scala/onion/compiler/typing/MethodTargetTypingSupport.scala
+++ b/src/main/scala/onion/compiler/typing/MethodTargetTypingSupport.scala
@@ -27,45 +27,30 @@ private[compiler] final class MethodTargetTypingSupport(private val bodyContext:
       case nullable: NullableType =>
         bodyContext.report(NULLABLE_MEMBER_ACCESS, node, nullable.displayName)
         None
-      case targetType: ObjectType =>
-        Some(ResolvedMethodTarget(target, targetType))
-      case basicType: BasicType =>
-        if (basicType == BasicType.VOID) {
-          bodyContext.report(CANNOT_CALL_METHOD_ON_PRIMITIVE, node, basicType, node.name)
-          None
-        } else {
-          val boxed = Boxing.boxing(bodyContext.table, target)
-          Some(ResolvedMethodTarget(boxed, boxed.`type`.asInstanceOf[ObjectType]))
-        }
-      case wildcardType: WildcardType =>
-        wildcardType.upperBound match {
-          case objType: ObjectType =>
-            Some(ResolvedMethodTarget(new AsInstanceOf(target, objType), objType))
-          case _ =>
-            bodyContext.report(INVALID_METHOD_CALL_TARGET, node, target.`type`)
-            None
-        }
-      case _ =>
-        bodyContext.report(INVALID_METHOD_CALL_TARGET, node, target.`type`)
-        None
+      case targetType =>
+        resolve(node, node.name, target, targetType, isNullablePrimitive = false)
     }
 
+  /** `?.` accepts a nullable receiver: the call is typed against the inner type. */
   def normalizeSafeMethodCallTarget(
     node: AST.SafeMethodCall,
     target: Term
   ): Option[ResolvedMethodTarget] = {
-    val isNullablePrimitive = target.`type`.isInstanceOf[NullableType]
-    val targetType = target.`type` match {
-      case nullableType: NullableType => nullableType.innerType
-      case other => other
+    val (targetType, isNullablePrimitive) = target.`type` match {
+      case nullableType: NullableType => (nullableType.innerType, true)
+      case other => (other, false)
     }
+    resolve(node, node.name, target, targetType, isNullablePrimitive)
+  }
 
+  /** The receiver a method can be looked up on: an object type as is, a primitive boxed, a wildcard through its upper bound. */
+  private def resolve(node: AST.Node, name: String, target: Term, targetType: Type, isNullablePrimitive: Boolean): Option[ResolvedMethodTarget] =
     targetType match {
       case objType: ObjectType =>
         Some(ResolvedMethodTarget(target, objType))
       case basicType: BasicType =>
         if (basicType == BasicType.VOID) {
-          bodyContext.report(CANNOT_CALL_METHOD_ON_PRIMITIVE, node, basicType, node.name)
+          bodyContext.report(CANNOT_CALL_METHOD_ON_PRIMITIVE, node, basicType, name)
           None
         } else if (isNullablePrimitive) {
           // A nullable primitive (e.g. Int?) is already a boxed value at runtime,
@@ -89,5 +74,4 @@ private[compiler] final class MethodTargetTypingSupport(private val bodyContext:
         bodyContext.report(INVALID_METHOD_CALL_TARGET, node, target.`type`)
         None
     }
-  }
 }

--- a/src/main/scala/onion/compiler/typing/StaticMethodCallSupport.scala
+++ b/src/main/scala/onion/compiler/typing/StaticMethodCallSupport.scala
@@ -168,21 +168,7 @@ private[compiler] final class StaticMethodCallSupport(
   ): Option[Term] = {
     val args = argList.toArray
 
-    val preliminaryParams = new Array[Term](args.length)
-    var hasNonClosureError = false
-    for (i <- args.indices) {
-      if (untypedClosureIndices.contains(i)) {
-        preliminaryParams(i) = null
-      } else {
-        calls.typed(args(i), context) match {
-          case Some(term) => preliminaryParams(i) = term
-          case None =>
-            hasNonClosureError = true
-            preliminaryParams(i) = null
-        }
-      }
-    }
-    if (hasNonClosureError) return None
+    val preliminaryParams = calls.typePreliminaryParams(args, context, untypedClosureIndices).getOrElse(return None)
 
     val candidates = new JTreeSet[Method](new MethodComparator)
     calls.collectMethodsMatching(typeRef, name, candidates, calls.isStaticMethod)
@@ -210,10 +196,7 @@ private[compiler] final class StaticMethodCallSupport(
     val disambiguated = overloadSupport.disambiguateClosureOverloads(
       applicableMethods,
       untypedClosureIndices,
-      (i, samType) => args(i) match {
-        case c: AST.ClosureExpression => calls.closureMatchesSam(c, context, samType)
-        case _ => None
-      }
+      calls.closureSamMatcher(args, context)
     )
 
     val method = overloadSupport.selectMostSpecificApplicable(


### PR DESCRIPTION
## Summary

Follow-up to #1170, same method: the duplicated-window scan re-run on the merged tree, each remaining pair folded into a single owner. No behaviour change.

- **`AsmRefs`**: `parseClass` and `parseMethod` built the same anonymous `SignatureVisitor` for the `<T extends B, ...>` prefix; `FormalTypeParamsVisitor` holds it once and the two parsers subclass it with only what follows the prefix.
- **`MethodTargetTypingSupport`**: the receiver normalisation for `obj.m()` and `obj?.m()` shared a 30-line match; one `resolve()` with the nullable-primitive flag as the sole difference.
- **`OnionParser`**: `methodDecl`/`interfaceMethodDecl` share `methodDeclRest`; `simplePattern`/`destructuringFieldPattern` share `structuredPatternOpt`; interface/trait/class headers share `conformsClause`. Fast-path/JavaCC parity unchanged.
- **`AsmCodeGeneration`**: the boxed-local assignment sequence (create box or update `box.value`, with the try/catch-safe stack ordering) was written twice, for a closure body's own locals and a method's; `emitBoxedSet` takes the slot context.
- **`MethodCallFallbackSupport` / `StaticMethodCallSupport`**: the preliminary argument-typing loop and the closure/SAM matcher live on `MethodCallTyping`.

8 files, +178 / −304 (plus CHANGELOG).

## Test plan

- [x] Area specs after each step (interop/generics, parser parity + samples + docs, closures/captures, select/patterns, interfaces/traits, safe calls, method-call overloads)
- [x] `sbt -Duser.language=ja testFull` and `-Duser.language=en testFull`: 5329 passed, 0 failed each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ54ZB2gM6EnCvy1j5Drc
