### PR TITLE
test: add HttpDocCoverageSpec regression guard for onion.Http stdlib docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were already documented in both files; this guard now fails the build if a
   future addition to `onion.Archive` goes undocumented.
 
+- **Added an `HttpDocCoverageSpec` regression guard checking that every public
+  `onion.Http` member is documented in both `docs/reference/stdlib.md` and
+  `docs/ja/reference/stdlib.md`.** `onion.Http` is a genuine, default-imported
+  stdlib module (`Http::get`, `Http::post`, `Http::postJson`,
+  `Http::getResponse`, `Http::postResponse`, `Http::put`, `Http::delete`,
+  `Http::encodeUrl`, `Http::decodeUrl`, `Http::buildQuery`, `Http::buildUrl`)
+  with 11 distinct public static member names, but -- unlike `HttpResource`
+  (the `http"..."` resource literal), `OnionMath`, `Stats`, `Net`, `Proc`,
+  `Scalars`, `DateTime`, `Files`, `Rand`, `Csv`, `Hash`, `Codec`, `Text`,
+  `Format`, `Assert`, `Yaml`, `Archive`, `Server` and `Config`, each already
+  guarded by its own coverage spec -- it never had one. All 11 members were
+  already documented in both files; this guard now fails the build if a
+  future addition to `onion.Http` goes undocumented.
+
 ## [0.56.0] - 2026-09-05
 
 ### Added

--- a/src/test/scala/onion/compiler/tools/HttpDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HttpDocCoverageSpec.scala
@@ -1,0 +1,63 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Http` module docs.
+ *
+ * `onion.Http` is a genuine, default-imported stdlib module (`Http::get`, `Http::post`,
+ * `Http::postJson`, `Http::getResponse`, `Http::postResponse`, `Http::put`, `Http::delete`,
+ * `Http::encodeUrl`, `Http::decodeUrl`, `Http::buildQuery`, `Http::buildUrl`) with 11 distinct
+ * public static member names, but -- unlike `HttpResource` (the `http"..."` resource literal,
+ * guarded by `HttpResourceDocCoverageSpec`), `Hash`, `OnionMath`, `Stats`, `Net`, `Proc`,
+ * `Scalars`, `DateTime`, `Files`, `Rand` and `Csv`, each guarded by its own `*DocCoverageSpec`
+ * -- it has never had a regression test checking that every member is still documented in both
+ * docs/reference/stdlib.md and docs/ja/reference/stdlib.md. Every public member is checked here
+ * so a future addition to onion.Http fails the build instead of silently staying undocumented.
+ */
+class HttpDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Http::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Http]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    val fieldNames = c.getFields
+      .filter(f => java.lang.reflect.Modifier.isStatic(f.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    (methodNames ++ fieldNames).toSet
+  }
+
+  it("actual onion.Http exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Http found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Http member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Http:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Http member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Http:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Http in both languages") {
+    assert(read("docs/reference/stdlib.md").contains("Http"),
+      "docs/reference/stdlib.md's overview table should mention Http")
+    assert(read("docs/ja/reference/stdlib.md").contains("Http"),
+      "docs/ja/reference/stdlib.md's overview table should mention Http")
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Http` (`Http::get`/`post`/`postJson`/`getResponse`/`postResponse`/`put`/`delete`/`encodeUrl`/`decodeUrl`/`buildQuery`/`buildUrl`) was the last default-imported stdlib module without its own `*DocCoverageSpec`, unlike `HttpResource`, `Hash`, `Config`, `Server`, `Archive` and the others already guarded.
- Adds `HttpDocCoverageSpec`, following the exact pattern of the existing `*DocCoverageSpec` guards, checking that every public `onion.Http` member is documented in both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`.
- All 11 members were already fully documented in both files; this is a pure regression-guard addition (no doc or production code changes), so a future undocumented addition to `onion.Http` now fails the build instead of staying silent.
- Adds a `CHANGELOG.md` entry under `[Unreleased] / Added`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5337/5337 passed (1 expected cancellation: the opt-in `-Donion.dist.path` distribution smoke test)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 5337/5337 passed (same expected cancellation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cDtdVbpsh1kGicWrxJCXc

---
_Generated by [Claude Code](https://claude.ai/code/session_013cDtdVbpsh1kGicWrxJCXc)_