### PR TITLE
docs: add FileResource stdlib reference section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`docs/reference/stdlib.md` and its Japanese translation never had a section for
+  `FileResource`, the object behind the `file"…"` literal.** `path()`, `exists()`,
+  `read(shape)`, `readLossless(shape)`, `eachLine(shape)`, `write(content)` and
+  `append(content)` are all real, callable members with no API-reference coverage at
+  all -- only `text`/`lines`/`json`/`csv`/`csvRows` were mentioned, and only in
+  `docs/reference/specification.md`'s syntax guide, not the stdlib reference. Both docs
+  now carry a `## FileResource` section documenting every member, and a new
+  `FileResourceDocCoverageSpec` regression guard fails the build if this regresses.
+
 - **`docs/reference/specification.md` and its Japanese translation claimed `http"…"`
   exposes the same fixed menu as `file"…"` (`text`/`lines`/`json`/`csv`/`csvRows`);
   it doesn't.** `onion.HttpResource` (the runtime type behind the `http"…"` literal)

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1965,6 +1965,49 @@ Files::stem("report.txt")              // "report"
 Files::withExtension("report.txt", "md")   // "report.md"
 ```
 
+## FileResource
+
+`file"…"` リテラル（動的な形式: `file(path)`）が返すオブジェクトで、`onion.Resources::file`
+が生成する。1つのファイルパスと、そのファイルに対する読み書き操作をまとめたもの——どの
+ゲッターを呼ぶかでパース方法が決まる:
+
+```onion
+val f = file"data.csv"
+f.path()                               // 元のパス文字列、"data.csv"
+f.exists()                             // Boolean
+
+f.text()                               // ファイル全体を String として（UTF-8）
+f.lines()                              // List[String]
+f.json()                               // パース済みの JSON 値（Json::parse を参照）
+f.csv()                                // List of List of String（Csv::parse を参照）
+f.csvRows()                            // List of Map、ヘッダー -> 値（Csv::parseWithHeader を参照）
+
+f.write("new content")                 // ファイルの内容を置き換える
+f.append("more\n")                     // 追記。ファイルが無ければ新規作成
+```
+
+上記の固定ゲッターは、ファイルを何として読めるかの集合を閉じている。`read(shape)` は
+その集合を開く——パース方法は渡した `Shape[T]` が決め、読み取りに失敗すると生成される
+`Defect` にこのファイルのパスが乗る（＝*どのファイルか*がわかる）:
+
+```onion
+val o: Outcome[Config] = file"app.json".read(shape)     // 例外ではなく Outcome[T]
+```
+
+`readLossless(shape)` はロスレス版——`Lossless::edit`/`render` と組み合わせて、コメント・
+空白・キー順序を保ったまま1つの値だけを書き換える、設定用レンズの読み取り半分:
+
+```onion
+val lossless: Outcome[Lossless[Config]] = file"app.conf".readLossless(shape)
+```
+
+`eachLine(shape)` は1行につき1つの値を読み、パースできた行と、できなかった行それぞれの
+`Defect`（ファイル中の該当行に位置づけられる）を両方保持する:
+
+```onion
+val results: List[Outcome[Row]] = file"data.log".eachLine(shape)
+```
+
 ## Csv モジュール
 
 RFC 4180 準拠の自己完結型 CSV パース・シリアライズ（`onion.Csv`、自動インポート済み）——引用フィールド・カンマ/改行を含む値・二重引用符に対応。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1460,6 +1460,50 @@ Files::stem("report.txt")              // "report"
 Files::withExtension("report.txt", "md")   // "report.md"
 ```
 
+## FileResource
+
+The object behind the `file"…"` literal (dynamic form: `file(path)`), returned by
+`onion.Resources::file`. It bundles a path with the read/write operations for that one
+file, so the parse step is chosen by which getter you call:
+
+```onion
+val f = file"data.csv"
+f.path()                               // the underlying path string, "data.csv"
+f.exists()                             // Boolean
+
+f.text()                               // whole file as String (UTF-8)
+f.lines()                              // List[String]
+f.json()                               // parsed JSON value (see Json::parse)
+f.csv()                                // List of List of String (see Csv::parse)
+f.csvRows()                            // List of Map, header -> value (see Csv::parseWithHeader)
+
+f.write("new content")                 // replaces the file's contents
+f.append("more\n")                     // appends, creating the file if needed
+```
+
+The fixed getters above close the set of things a file can be read as. `read(shape)`
+opens it — the parse step comes from the `Shape[T]` you pass, and a read failure carries
+this file's path into the resulting `Defect` (so it says *which file*):
+
+```onion
+val o: Outcome[Config] = file"app.json".read(shape)     // Outcome[T], not an exception
+```
+
+`readLossless(shape)` is the lossless counterpart — the read half of a config lens,
+pairing with `Lossless::edit`/`render` to rewrite one value in place while preserving
+comments, spacing and key order:
+
+```onion
+val lossless: Outcome[Lossless[Config]] = file"app.conf".readLossless(shape)
+```
+
+`eachLine(shape)` reads one value per line, keeping both the lines that parsed and the
+`Defect`s for the ones that didn't — each positioned on its own line of the file:
+
+```onion
+val results: List[Outcome[Row]] = file"data.log".eachLine(shape)
+```
+
 ## Json Module
 
 JSON parsing and serialization (`onion.Json`). The intermediate representation is

--- a/src/test/scala/onion/compiler/tools/FileResourceDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FileResourceDocCoverageSpec.scala
@@ -1,0 +1,46 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for `onion.FileResource`, the object behind the `file"…"` resource
+ * literal. docs/reference/stdlib.md documents the static `onion.Files` module (`## Files
+ * Module`) but never the instance returned by `file"…"` itself -- there is no `##
+ * FileResource` section at all, so `path()`, `readLossless(shape)`, `eachLine(shape)`,
+ * `exists()`, `write(content)` and `append(content)` are undiscoverable from the API
+ * reference (only `text`/`lines`/`json`/`csv`/`csvRows`/`read(shape)` are mentioned, and
+ * only in docs/reference/specification.md's syntax guide, not stdlib.md).
+ */
+class FileResourceDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private val members = Seq(
+    "path", "text", "lines", "json", "csv", "csvRows",
+    "read", "readLossless", "eachLine", "exists", "write", "append"
+  )
+
+  it("actual onion.FileResource exposes every documented-below member (sanity check)") {
+    val names = classOf[onion.FileResource].getDeclaredMethods.map(_.getName).toSet
+    members.foreach { name =>
+      assert(names.contains(name), s"onion.FileResource lost method $name -- the scan has rotted")
+    }
+  }
+
+  it("docs/reference/stdlib.md has a FileResource section mentioning every public member") {
+    val doc = read("docs/reference/stdlib.md")
+    assert(doc.contains("## FileResource"), "docs/reference/stdlib.md has no '## FileResource' section")
+    members.foreach { name =>
+      assert(doc.contains(name), s"docs/reference/stdlib.md doesn't mention $name, a public onion.FileResource member")
+    }
+  }
+
+  it("docs/ja/reference/stdlib.md has a FileResource section mentioning every public member") {
+    val doc = read("docs/ja/reference/stdlib.md")
+    assert(doc.contains("## FileResource"), "docs/ja/reference/stdlib.md has no '## FileResource' section")
+    members.foreach { name =>
+      assert(doc.contains(name), s"docs/ja/reference/stdlib.md doesn't mention $name, a public onion.FileResource member")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md` and its Japanese translation never had a section for `FileResource`, the object returned by the `file"…"` literal (`onion.Resources::file`) — `path()`, `exists()`, `read(shape)`, `readLossless(shape)`, `eachLine(shape)`, `write(content)` and `append(content)` were all real, callable members with zero API-reference coverage; only `text`/`lines`/`json`/`csv`/`csvRows` were mentioned, and only in `docs/reference/specification.md`'s syntax guide, not the stdlib reference.
- Adds a `## FileResource` section to both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md` documenting every public member.
- Adds a `FileResourceDocCoverageSpec` regression guard (same pattern as the existing `HttpResourceDocCoverageSpec`/`OutcomeDefectOriginDocCoverageSpec`) that fails the build if this doc coverage regresses.
- Adds a `[Unreleased]` CHANGELOG entry.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5349 succeeded, 0 failed, 1 canceled (pre-existing, unrelated)
- [x] New `FileResourceDocCoverageSpec` confirmed red before the doc changes, green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvmTNtzBCiVLgxzBP1Xa1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvmTNtzBCiVLgxzBP1Xa1s)_