### PR TITLE
docs: add Range stdlib reference section (en/ja)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`docs/reference/stdlib.md` and its Japanese translation never had a section for
+  `onion.Range`, the runtime type behind the `a..b` / `a..<b` range literals.**
+  `start()`, `endExclusive()`, `isEmpty()`, `size()` and `contains(value)` are all real,
+  callable members with no API-reference coverage at all -- only the `a..b`/`a..<b`
+  literal syntax itself was mentioned, in `docs/reference/specification.md`'s syntax
+  guide. Both docs now carry a `## Range` section documenting every member, and a new
+  `RangeDocCoverageSpec` regression guard fails the build if this regresses.
+
+- **`docs/reference/stdlib.md` and its Japanese translation never had a section for
   `FileResource`, the object behind the `file"…"` literal.** `path()`, `exists()`,
   `read(shape)`, `readLossless(shape)`, `eachLine(shape)`, `write(content)` and
   `append(content)` are all real, callable members with no API-reference coverage at

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -1803,6 +1803,25 @@ System::exit(0)  // 成功
 System::exit(1)  // エラー
 ```
 
+## Range
+
+範囲リテラル `a..b`（両端を含む）と `a..<b`（終端を含まない）の実行時表現である
+`onion.Range`。`Iterable[Int]` なので `foreach` や `Iterables`／拡張呼び出し系の
+メソッドでそのまま使えるが、それに加えて独自のメンバーも持つ:
+
+```onion
+val r = 2..5                 // Range(2..<6)、両端を含む終端は内部で畳み込まれる
+r.start()                    // 2、最初の値
+r.endExclusive()             // 6、最後の値の次（a..<b でも同じ）
+r.isEmpty()                  // false
+r.size()                     // 4
+r.contains(3)                // true
+r.contains(9)                // false
+r.toString()                 // "Range(2..<6)"; 空の範囲は "Range(empty)"
+
+foreach i: Int in r { IO::println(i) }   // 2 3 4 5
+```
+
 ## Iterables モジュール
 
 `onion.Iterables`（Java インターフェース）で提供。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -831,6 +831,25 @@ writer.newLine()
 writer.close()
 ```
 
+## Range
+
+The runtime type behind the range literals `a..b` (inclusive) and `a..<b` (exclusive),
+`onion.Range`. It is `Iterable[Int]`, so it works directly in `foreach` and with the
+`Iterables`/extension pipeline methods, but it also exposes its own small set of members:
+
+```onion
+val r = 2..5                 // Range(2..<6), inclusive endpoint folded in
+r.start()                    // 2, the first value
+r.endExclusive()             // 6, one past the last value (works the same for a..<b)
+r.isEmpty()                  // false
+r.size()                     // 4
+r.contains(3)                // true
+r.contains(9)                // false
+r.toString()                 // "Range(2..<6)"; empty ranges print "Range(empty)"
+
+foreach i: Int in r { IO::println(i) }   // 2 3 4 5
+```
+
 ## Iterables Module
 
 Provided via `onion.Iterables` (Java interface).

--- a/src/test/scala/onion/compiler/tools/RangeDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/RangeDocCoverageSpec.scala
@@ -1,0 +1,40 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for `onion.Range`, the runtime type behind the `a..b` / `a..<b` range
+ * literals. Only the literal syntax itself was documented (specification.md); `start()`,
+ * `endExclusive()`, `isEmpty()`, `size()` and `contains(value)` had no API-reference
+ * coverage in either stdlib.md.
+ */
+class RangeDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private val members = Seq("start", "endExclusive", "isEmpty", "size", "contains", "toString")
+
+  it("actual onion.Range exposes every documented-below member (sanity check)") {
+    val names = classOf[onion.Range].getDeclaredMethods.map(_.getName).toSet
+    members.foreach { name =>
+      assert(names.contains(name), s"onion.Range lost method $name -- the scan has rotted")
+    }
+  }
+
+  it("docs/reference/stdlib.md has a Range section mentioning every public member") {
+    val doc = read("docs/reference/stdlib.md")
+    assert(doc.contains("## Range"), "docs/reference/stdlib.md has no '## Range' section")
+    members.foreach { name =>
+      assert(doc.contains(name), s"docs/reference/stdlib.md doesn't mention $name, a public onion.Range member")
+    }
+  }
+
+  it("docs/ja/reference/stdlib.md has a Range section mentioning every public member") {
+    val doc = read("docs/ja/reference/stdlib.md")
+    assert(doc.contains("## Range"), "docs/ja/reference/stdlib.md has no '## Range' section")
+    members.foreach { name =>
+      assert(doc.contains(name), s"docs/ja/reference/stdlib.md doesn't mention $name, a public onion.Range member")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.Range` (the runtime type behind the `a..b` / `a..<b` range literals) had no API-reference section in `docs/reference/stdlib.md` or its Japanese translation — only the literal syntax itself was documented in `specification.md`.
- `start()`, `endExclusive()`, `isEmpty()`, `size()` and `contains(value)` were all real, callable, undocumented members.
- Added a `## Range` section to both stdlib docs, and a `RangeDocCoverageSpec` regression guard (same pattern as `FileResourceDocCoverageSpec`/`HttpResourceDocCoverageSpec`) so this can't silently regress.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5352 succeeded, 0 failed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 5352 succeeded, 0 failed
- [x] Manually verified `onion.Range`'s methods at runtime via a script (`start`, `endExclusive`, `isEmpty`, `size`, `contains`, `toString`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJagrB2R4kaddNF3W3G2r2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJagrB2R4kaddNF3W3G2r2)_