### PR TITLE
internal: narrow onion.View to package-private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **`onion.View` was a public class with a public `asCollection` method, but it is a
+  pure internal adapter** -- it turns a `Map` into a mutable `Collection[Map.Entry]`
+  so `Iterables.mapMap` can reuse its `Collection`-based loop -- used from nowhere
+  outside `onion.Iterables` in the same package, mentioned in no documentation, and
+  covered by no test, unlike every other class under `src/main/java/onion`. Both the
+  class and its method are now package-private; a new `ViewInternalVisibilitySpec`
+  guards against the visibility widening back out. No behaviour change.
+
 - **Duplicated code folded into single owners, and dead code removed (no
   behaviour change).** The untyped-AST child walk that `CapturedVariableScanner`
   and `ReturnNodeDetector` each carried is one `ASTWalk`; `onionc` and `onion`

--- a/src/main/java/onion/View.java
+++ b/src/main/java/onion/View.java
@@ -5,8 +5,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-public class View {
-  public static <A, B> Collection<Map.Entry<A, B>> asCollection(
+final class View {
+  static <A, B> Collection<Map.Entry<A, B>> asCollection(
     final Map<A, B> map
   ) {
     return new Collection<Map.Entry<A, B>>() {

--- a/src/test/scala/onion/compiler/tools/ViewInternalVisibilitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/ViewInternalVisibilitySpec.scala
@@ -1,0 +1,35 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+import java.lang.reflect.Modifier
+
+/**
+ * `onion.View` is a pure internal adapter used only by `Iterables.mapMap` to view a
+ * `Map` as a mutable `Collection[Map.Entry]` (see src/main/java/onion/Iterables.java).
+ * Unlike every other class under src/main/java/onion, it is not part of the documented
+ * stdlib surface (no mention in docs/reference/stdlib.md or the Japanese translation),
+ * has no dedicated coverage spec, and is referenced from nowhere outside the `onion`
+ * package -- so it has no reason to be public. This guards the narrowed visibility so
+ * it does not silently widen back out.
+ */
+class ViewInternalVisibilitySpec extends AnyFunSpec {
+
+  private val viewClass = Class.forName("onion.View")
+
+  it("keeps onion.View package-private, not a public stdlib class") {
+    assert(
+      !Modifier.isPublic(viewClass.getModifiers),
+      "onion.View is a Map-to-Collection adapter used only by onion.Iterables in the " +
+        "same package; it should not be public API"
+    )
+  }
+
+  it("keeps onion.View#asCollection package-private, not a public stdlib method") {
+    val method = viewClass.getDeclaredMethod("asCollection", classOf[java.util.Map[_, _]])
+    assert(
+      !Modifier.isPublic(method.getModifiers),
+      "onion.View#asCollection should not be public API"
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.View` and its sole method `asCollection` were `public`, but the class is a pure internal adapter: it turns a `Map` into a mutable `Collection[Map.Entry]` so `Iterables.mapMap` can reuse its `Collection`-based loop.
- It is referenced from nowhere outside `onion.Iterables` (same package), is not mentioned in `docs/reference/stdlib.md` or the Japanese translation, and — unlike every other class under `src/main/java/onion` — had no dedicated test.
- Both the class and method are now package-private (`final class View`, package-private `asCollection`). No behavior change.
- Added `ViewInternalVisibilitySpec` (reflection-based) to guard against the visibility widening back out; confirmed red before the change, green after.
- Added a CHANGELOG `[Unreleased]` entry.

## Test plan
- [x] `ViewInternalVisibilitySpec` fails before the fix (public), passes after (package-private)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5366 tests, all passed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 5366 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S62FUCFUZqbVEkR4pQ9Nvg

---
_Generated by [Claude Code](https://claude.ai/code/session_01S62FUCFUZqbVEkR4pQ9Nvg)_