### PR TITLE
docs: document HttpResource's members in stdlib.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`onion.HttpResource` (the object behind the `http"…"` literal) had no `##
+  HttpResource` section in `docs/reference/stdlib.md` (or its Japanese translation),
+  unlike its sibling `file"…"` literal's `## FileResource` section.** `url()`,
+  `get(headers)`, `getJson()`, `read(shape)`, `eachLine(shape)`, `post(body)`,
+  `postJson(jsonBody)`, `put(body)` and `delete()` were undiscoverable from the API
+  reference. A new `HttpResourceStdlibDocCoverageSpec` guards both docs now carry a
+  `## HttpResource` section mentioning every public member.
+
 - **`Shape::describe()` was undocumented in the `## Shape` section of
   `docs/reference/stdlib.md` (and its Japanese translation), even though every other
   `Shape` instance method was covered there.** The word "describe" did appear

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -2234,6 +2234,42 @@ val postResponse: String = Http::postJson(
 );
 ```
 
+## HttpResource
+
+`http"…"` リテラル（動的な形式: `http(url)`）が返すオブジェクトで、`onion.Resources::http`
+が生成する。1つの URL と、そのエンドポイントに対するリクエストメソッドをまとめたもの——
+フェッチしてパースするパイプラインが1つの式で書ける:
+
+```onion
+val h = http"https://api.example.com/users"
+h.url()                                 // 元の URL 文字列
+
+h.get()                                 // GET、レスポンスボディを String として
+h.get(["Authorization", "Bearer t"])    // ヘッダー付き GET（名前と値を交互に並べる）
+h.getJson()                             // GET、ボディを JSON としてパース（Json::parse を参照）
+
+h.post("body text")                     // POST、レスポンスボディを String として
+h.postJson("{\"name\": \"Bob\"}")       // Content-Type: application/json を付けて POST
+h.put("body text")                      // PUT、レスポンスボディを String として
+h.delete()                              // DELETE、レスポンスボディを String として
+```
+
+`read(shape)` はエンドポイントに GET し、渡した `Shape[T]` でボディをパースする——
+失敗（通信エラーでもパース失敗でも）した場合に生成される `Defect` にこの URL が乗る
+（＝*どのエンドポイントか*がわかる）:
+
+```onion
+val o: Outcome[Config] = http"https://api.example.com/config".read(shape)   // 例外ではなく Outcome[T]
+```
+
+`eachLine(shape)` はエンドポイントに GET し、レスポンスボディの1行につき1つの値を読む。
+パースできた行と、できなかった行それぞれの `Defect`（レスポンス中の該当行に位置づけ
+られる）を両方保持する。通信エラーは単一の defect になり、例外にはならない:
+
+```onion
+val results: List[Outcome[Row]] = http"https://api.example.com/feed".eachLine(shape)
+```
+
 ---
 
 ## DateTime

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2070,6 +2070,43 @@ val postResponse: String = Http::postJson(
 );
 ```
 
+## HttpResource
+
+The object behind the `http"…"` literal (dynamic form: `http(url)`), returned by
+`onion.Resources::http`. It bundles a URL with the request methods for that one
+endpoint, so a fetch-and-parse pipeline is one expression:
+
+```onion
+val h = http"https://api.example.com/users"
+h.url()                                // the underlying URL string
+
+h.get()                                // GET, response body as String
+h.get(["Authorization", "Bearer t"])   // GET with headers (alternating names/values)
+h.getJson()                            // GET, body parsed as JSON (see Json::parse)
+
+h.post("body text")                    // POST, response body as String
+h.postJson("{\"name\": \"Bob\"}")      // POST with Content-Type: application/json
+h.put("body text")                     // PUT, response body as String
+h.delete()                             // DELETE, response body as String
+```
+
+`read(shape)` GETs the endpoint and parses the body through the `Shape[T]` you pass —
+the parse step comes from the shape, and a failure (transport or parse) carries this
+URL into the resulting `Defect` (so it says *which endpoint*):
+
+```onion
+val o: Outcome[Config] = http"https://api.example.com/config".read(shape)   // Outcome[T], not an exception
+```
+
+`eachLine(shape)` GETs the endpoint and reads one value per line of the response body,
+keeping both the lines that parsed and the `Defect`s for the ones that didn't — each
+positioned on its own line of the response. A transport failure is a single defect, not
+an exception:
+
+```onion
+val results: List[Outcome[Row]] = http"https://api.example.com/feed".eachLine(shape)
+```
+
 ---
 
 ## DateTime

--- a/src/test/scala/onion/compiler/tools/HttpResourceStdlibDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HttpResourceStdlibDocCoverageSpec.scala
@@ -1,0 +1,47 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for `onion.HttpResource`, the object behind the `http"…"` resource
+ * literal, in `docs/reference/stdlib.md`. That file documents the static `onion.Http`
+ * module (`## Http`) but never the instance returned by `http"…"` itself -- there is no
+ * `## HttpResource` section at all, so `url()`, `get(headers)`, `getJson()`,
+ * `read(shape)`, `eachLine(shape)`, `post(body)`, `postJson(jsonBody)`, `put(body)` and
+ * `delete()` are undiscoverable from the stdlib API reference, unlike the sibling
+ * `file"…"` literal's `## FileResource` section. (`HttpResourceDocCoverageSpec` guards a
+ * separate, narrower claim in `docs/reference/specification.md`'s fixed-menu paragraph;
+ * this spec is about stdlib.md having no section for `HttpResource` at all.)
+ */
+class HttpResourceStdlibDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private val members = Seq(
+    "url", "get", "getJson", "read", "eachLine", "post", "postJson", "put", "delete"
+  )
+
+  it("actual onion.HttpResource exposes every documented-below member (sanity check)") {
+    val names = classOf[onion.HttpResource].getDeclaredMethods.map(_.getName).toSet
+    members.foreach { name =>
+      assert(names.contains(name), s"onion.HttpResource lost method $name -- the scan has rotted")
+    }
+  }
+
+  it("docs/reference/stdlib.md has a HttpResource section mentioning every public member") {
+    val doc = read("docs/reference/stdlib.md")
+    assert(doc.contains("## HttpResource"), "docs/reference/stdlib.md has no '## HttpResource' section")
+    members.foreach { name =>
+      assert(doc.contains(name), s"docs/reference/stdlib.md doesn't mention $name, a public onion.HttpResource member")
+    }
+  }
+
+  it("docs/ja/reference/stdlib.md has a HttpResource section mentioning every public member") {
+    val doc = read("docs/ja/reference/stdlib.md")
+    assert(doc.contains("## HttpResource"), "docs/ja/reference/stdlib.md has no '## HttpResource' section")
+    members.foreach { name =>
+      assert(doc.contains(name), s"docs/ja/reference/stdlib.md doesn't mention $name, a public onion.HttpResource member")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `onion.HttpResource` (the object behind the `http"…"` literal) had no `## HttpResource` section in `docs/reference/stdlib.md` or its Japanese translation, unlike the sibling `file"…"` literal's `## FileResource` section — `url()`, `get(headers)`, `getJson()`, `read(shape)`, `eachLine(shape)`, `post(body)`, `postJson(jsonBody)`, `put(body)` and `delete()` were undiscoverable from the stdlib API reference.
- Adds a `## HttpResource` section to both docs, mirroring `FileResource`'s style.
- Adds a new `HttpResourceStdlibDocCoverageSpec` regression guard (kept separate from the existing `HttpResourceDocCoverageSpec`, which guards a different, narrower claim in `docs/reference/specification.md`'s fixed-menu paragraph).
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en "testOnly onion.compiler.tools.HttpResourceDocCoverageSpec onion.compiler.tools.HttpResourceStdlibDocCoverageSpec"` — 7/7 passed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5381 tests, 0 failed, 1 canceled (pre-existing environment-gated smoke test, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TA9BP1DupmGGBFkRzcJtt

---
_Generated by [Claude Code](https://claude.ai/code/session_016TA9BP1DupmGGBFkRzcJtt)_