### PR TITLE
diag: hint when an annotation precedes a modifier before `def`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A syntax hint for an annotation written before a modifier, e.g.
+  `@TailRecursive static def foo() { ... }`.** The grammar requires
+  `[modifiers] [annotations] "def"` in that exact order — an annotation must sit
+  immediately before `def`, after any `static`/`final`/etc. Writing them in the
+  natural Java/Kotlin order failed right at the annotation with a generic
+  "expecting one of the modifier keywords" error that never mentioned annotations
+  at all, and gave no guidance for what is otherwise a completely natural pattern
+  (a `@TailRecursive` mutually-recursive **static** helper). `SyntaxHintClassifier`
+  now recognizes `@Ann modifier+ def` and points at `modifier @Ann def` instead.
+  Pinned by a new `AnnotationBeforeModifierHintI18nSpec`.
+
 ### Fixed
 
 - **The operator precedence table in `docs/reference/specification.md` (and its

--- a/src/main/resources/errorMessage.properties
+++ b/src/main/resources/errorMessage.properties
@@ -164,6 +164,7 @@ error.parsing.hint.java_style_record_body=Hint: a record''s components are decla
 error.parsing.hint.java_style_try_resource=Hint: a try-with-resources declaration starts with `val` before the name, not with the type before it, and is always `val` (never `var`) — write `try (val {1}: {0} = ...)`, not `try ({0} {1} = ...)`.
 error.parsing.hint.java_style_implements=Hint: interfaces are named with `conforms`, not Java''s `implements` — write `class {0} conforms {1}`, not `class {0} implements {1}`.
 error.parsing.hint.java_style_annotated_method=Hint: an annotation like `@{0}` is written directly before `def` — the method still needs `def` and its return type after the name — write `@{0} def method(): void '{' ... '}'`, not `@{0} void method() '{' ... '}'`.
+error.parsing.hint.annotation_before_modifier=Hint: an annotation like `@{0}` goes after the modifier(s), directly before `def` — write `{1} @{0} def method(...)`, not `@{0} {1} def method(...)`.
 error.parsing.hint.reserved_word_identifier=Hint: `{0}` is a reserved word and can''t be used as an identifier directly — escape it with backticks, writing `{0}` (with backticks) instead.
 error.parsing.hint.js_style_const=Hint: Onion has no `const` keyword — declare a variable with `val` (immutable) or `var` (mutable) instead — write `val name: Type = value`, not `const name = value`.
 error.parsing.hint.nullable_union_type=Hint: a nullable type is written with a trailing `?`, not a TypeScript-style union with `null` — write `{0}?`, not `{0} | null`.

--- a/src/main/resources/errorMessage_ja.properties
+++ b/src/main/resources/errorMessage_ja.properties
@@ -164,6 +164,7 @@ error.parsing.hint.java_style_record_body=ヒント: レコードのコンポー
 error.parsing.hint.java_style_try_resource=ヒント: try-with-resources の宣言は名前の前に型ではなく `val` を書きます。常に `val`（`var` は不可）です — `try ({0} {1} = ...)` ではなく `try (val {1}: {0} = ...)` と書いてください。
 error.parsing.hint.java_style_implements=ヒント: インターフェースは Java の `implements` ではなく `conforms` で指定します — `class {0} implements {1}` ではなく `class {0} conforms {1}` と書いてください。
 error.parsing.hint.java_style_annotated_method=ヒント: `@{0}` のようなアノテーションは `def` の直前に書きます — メソッドには依然として `def` と、名前の後ろの戻り値の型が必要です — `@{0} void method() '{' ... '}'` ではなく `@{0} def method(): void '{' ... '}'` と書いてください。
+error.parsing.hint.annotation_before_modifier=ヒント: `@{0}` のようなアノテーションは修飾子の後ろ、`def` の直前に書きます — `@{0} {1} def method(...)` ではなく `{1} @{0} def method(...)` と書いてください。
 error.parsing.hint.reserved_word_identifier=ヒント: `{0}` は予約語のため、そのままでは識別子として使えません — バッククォートでエスケープして `{0}`（バッククォート付き）と書いてください。
 error.parsing.hint.js_style_const=ヒント: Onion に `const` キーワードはありません — 変数は `val`（不変）または `var`（可変）で宣言します — `const name = value` ではなく `val name: Type = value` と書いてください。
 error.parsing.hint.nullable_union_type=ヒント: nullable な型は末尾に `?` を付けて書きます — TypeScript 風に `null` との union で書くのではなく — `{0} | null` ではなく `{0}?` と書いてください。

--- a/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
+++ b/src/main/scala/onion/compiler/parser/SyntaxHintClassifier.scala
@@ -153,6 +153,15 @@ private[compiler] object SyntaxHintClassifier {
     """^\s*class\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*(?:extends\s+[A-Za-z_][\w.\[\]]*(?:\([^)]*\))?\s*)?implements\s+([A-Za-z_][\w.\[\], ]*?)\s*\{?\s*$""".r
   private val JavaStyleAnnotatedMethod =
     """\A@([A-Za-z_]\w*)\s+(?:public|private|protected)?\s*(?!public\b|private\b|protected\b)[A-Za-z_]\w*\s+[A-Za-z_]\w*\s*\(""".r
+  // The grammar requires `[modifiers] [annotations] "def"` in that exact order --
+  // an annotation must sit immediately before `def`, after any `static`/`final`/...
+  // Writing them in the natural Java/Kotlin order (`@Ann static def foo()`) fails
+  // right at the annotation with a generic "expecting one of the modifier keywords"
+  // error that never mentions annotations at all. Distinct from JavaStyleAnnotatedMethod
+  // above, which has no `def` in its shape (a whole Java-style method with no `def`).
+  private val ModifierWord = "static|final|override|abstract|synchronized|volatile|internal|sealed"
+  private val AnnotationBeforeModifierMethod =
+    s"""\\A@([A-Za-z_]\\w*)\\s+((?:$ModifierWord)(?:\\s+(?:$ModifierWord))*)\\s+def\\b""".r
   private val ReservedWords = Set(
     "abstract", "and", "as", "Boolean", "break", "Byte", "case", "catch", "Char", "class",
     "const", "continue", "def", "do", "Double", "else", "enum", "extends", "extension",
@@ -231,6 +240,9 @@ private[compiler] object SyntaxHintClassifier {
       case _ if JavaStyleImplements.findFirstMatchIn(sourceLine).isDefined =>
         val matched = JavaStyleImplements.findFirstMatchIn(sourceLine).get
         hint("error.parsing.hint.java_style_implements", matched.group(1), matched.group(2).trim)
+      case _ if found.startsWith("@") && AnnotationBeforeModifierMethod.findFirstMatchIn(context).isDefined =>
+        val matched = AnnotationBeforeModifierMethod.findFirstMatchIn(context).get
+        hint("error.parsing.hint.annotation_before_modifier", matched.group(1), matched.group(2).trim)
       case _ if found.startsWith("@") && JavaStyleAnnotatedMethod.findFirstMatchIn(context).isDefined =>
         val matched = JavaStyleAnnotatedMethod.findFirstMatchIn(context).get
         hint("error.parsing.hint.java_style_annotated_method", matched.group(1))

--- a/src/test/scala/onion/compiler/AnnotationBeforeModifierHintI18nSpec.scala
+++ b/src/test/scala/onion/compiler/AnnotationBeforeModifierHintI18nSpec.scala
@@ -1,0 +1,76 @@
+package onion.compiler
+
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.funspec.AnyFunSpec
+
+import java.io.StringReader
+
+/**
+ * The annotation-before-modifier hint (`SyntaxHintClassifier`'s
+ * `AnnotationBeforeModifierMethod` case) must resolve through the bilingual
+ * `error.parsing.hint.*` bundle in both locales, like every other hint in that
+ * match -- see JavaStyleAnnotatedMethodHintI18nSpec for the same pattern.
+ */
+class AnnotationBeforeModifierHintI18nSpec extends AnyFunSpec with Diagrams {
+  private val key = "error.parsing.hint.annotation_before_modifier"
+  private val en = MessageBundles.english
+  private val ja = MessageBundles.japanese
+
+  it("resolves in the English bundle") {
+    assert(en.getString(key).contains("Hint:"))
+  }
+
+  it("resolves in the Japanese bundle with actual Japanese text") {
+    val text = ja.getString(key)
+    assert(text.contains("ヒント"), s"expected a Japanese hint, got: $text")
+    assert(!text.contains("Hint:"), s"hint leaked untranslated English, got: $text")
+    assert(text != en.getString(key))
+  }
+
+  it("leaves no unfilled placeholder and no leaked MessageFormat quoting when formatted") {
+    val formattedEn = java.text.MessageFormat.format(en.getString(key), "TailRecursive", "static")
+    val formattedJa = java.text.MessageFormat.format(ja.getString(key), "TailRecursive", "static")
+    assert(!formattedEn.matches("(?s).*\\{\\d+\\}.*"), s"unfilled placeholder: $formattedEn")
+    assert(!formattedJa.matches("(?s).*\\{\\d+\\}.*"), s"unfilled placeholder: $formattedJa")
+    assert(!formattedEn.contains("'{'") && !formattedEn.contains("'}'"), s"leaked MessageFormat quoting: $formattedEn")
+    assert(!formattedJa.contains("'{'") && !formattedJa.contains("'}'"), s"leaked MessageFormat quoting: $formattedJa")
+  }
+
+  it("fires for a `@TailRecursive static def foo() { ... }` declaration (annotation before the modifier)") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |private:
+        |  @TailRecursive
+        |  static def isEven(n: Int): Boolean { if n == 0 { return true }; return isOdd(n - 1) }
+        |  @TailRecursive
+        |  static def isOdd(n: Int): Boolean { if n == 0 { return false }; return isEven(n - 1) }
+        |public:
+        |  static def main(args: String[]): Int { return 0 }
+        |}
+        |""".stripMargin
+    val msgs = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errors) => errors.map(_.message).mkString("\n")
+      case _ => ""
+    }
+    // The captured annotation name and modifier are literal, identical in both
+    // bundles, so this assertion holds regardless of the JVM's default locale.
+    assert(msgs.contains("@TailRecursive"), s"expected the hint to name @TailRecursive, got: $msgs")
+    assert(msgs.contains("static"), s"expected the hint to name the modifier, got: $msgs")
+  }
+
+  it("does not fire when the annotation is already correctly placed after the modifier") {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    val src =
+      """
+        |class Main {
+        |public:
+        |  static @TailRecursive def isEven(n: Int): Boolean { return true }
+        |  static def main(args: String[]): Int { return 0 }
+        |}
+        |""".stripMargin
+    val result = new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on")))
+    assert(result.isInstanceOf[CompilationOutcome.Success], s"expected success, got: $result")
+  }
+}


### PR DESCRIPTION
## Summary

- The grammar requires `[modifiers] [annotations] "def"` in that exact order — an annotation must sit immediately before `def`, after any `static`/`final`/etc (see `grammar/JJOnionParser.jj`'s `access_section()`/`method_decl()`: `[mset=modifiers()] m=member_decl(mset)` where `member_decl` parses `annotations()` right before `"def"`).
- Writing them in the natural Java/Kotlin order (`@TailRecursive static def foo()`) failed right at the annotation with a generic "expecting one of the modifier keywords" error that never mentioned annotations at all — no guidance for what is otherwise a completely natural pattern: a `@TailRecursive` mutually-recursive **static** helper.
- `SyntaxHintClassifier` now recognizes `@Ann modifier+ def` and points at `modifier @Ann def` instead, with a new bilingual (en/ja) message key `error.parsing.hint.annotation_before_modifier`.

## Test plan

- [x] New `AnnotationBeforeModifierHintI18nSpec` (5 cases): resolves in both locale bundles, no unfilled placeholders/leaked quoting, fires for the misplaced-annotation case, does *not* fire when the annotation is correctly placed after the modifier.
- [x] `HintMessageKeyCoverageSpec` still green (no orphaned/missing bilingual keys).
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5391 tests, 0 failed, 1 canceled (pre-existing conditional distribution smoke test, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rd73jo69uWuUvdn5C2PSeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rd73jo69uWuUvdn5C2PSeX)_