### PR TITLE
docs: merge the duplicate Fixed heading left in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **`docs/tools/project-cli.md` (and its Japanese translation) still listed
-  "formatter ... integration" among the features "intentionally out of scope for
-  this first version," even though `onion fmt` has shipped as a fully documented
-  subcommand for a while (same file, `### \`onion fmt\`` section).** The page
-  contradicted itself: one section explained the formatter's CLI contract in
-  detail, the other disclaimed it as unbuilt. Removed "formatter" from the
-  Deferred list on both pages (linter integration is still genuinely absent), and
-  added a `ProjectCliDocCoverageSpec` guard so a shipped command can't be
-  re-listed as deferred again.
-
 ### Added
 
 - **A syntax hint for an annotation written before a modifier, e.g.
@@ -33,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Pinned by a new `AnnotationBeforeModifierHintI18nSpec`.
 
 ### Fixed
+
+- **`docs/tools/project-cli.md` (and its Japanese translation) still listed
+  "formatter ... integration" among the features "intentionally out of scope for
+  this first version," even though `onion fmt` has shipped as a fully documented
+  subcommand for a while (same file, `### \`onion fmt\`` section).** The page
+  contradicted itself: one section explained the formatter's CLI contract in
+  detail, the other disclaimed it as unbuilt. Removed "formatter" from the
+  Deferred list on both pages (linter integration is still genuinely absent), and
+  added a `ProjectCliDocCoverageSpec` guard so a shipped command can't be
+  re-listed as deferred again.
 
 - **The operator precedence table in `docs/reference/specification.md` (and its
   Japanese translation) claimed `&`, `^` and `|` share one precedence level, and


### PR DESCRIPTION
## Summary

- PR #1186 inserted a new `### Fixed` heading ahead of the existing `### Added` section in `CHANGELOG.md`'s `[Unreleased]`, instead of appending to the `### Fixed` section already below it — leaving `Added` sandwiched between two separate `Fixed` headings.
- Consolidates back into a single `### Added` section followed by a single `### Fixed` section, with no content changes (pure reordering).

## Test plan

- [x] No test parses `CHANGELOG.md` structure (`grep -rl CHANGELOG src/test/scala/` is empty), and this is a docs-only reorder with no code changes, so the previously-passing `testFull` run stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6gaJ3qNCKuWyZusHZVV9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6gaJ3qNCKuWyZusHZVV9G)_