### PR TITLE
docs: fix DateTime/Http Javadoc still claiming bare-call support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`onion.DateTime` and `onion.Http`'s class-level Javadoc still claimed "All
+  methods are static and can be used without import," even though #360
+  narrowed the default static import set to pure classes and deliberately
+  dropped both (effectful stdlib members must be called qualified, e.g.
+  `DateTime::now()`, `Http::get(url)`).** `DefaultStaticImportSpec` already
+  enforces that bare `now()`/`get(url)` don't resolve, but the class doc
+  comments still told readers the opposite. Updated both to point at the
+  qualified call form, and added `EffectfulStdlibJavadocSpec` to guard
+  against the claim resurfacing.
+
 - **`docs/tools/project-cli.md` (and its Japanese translation) still listed
   "formatter ... integration" among the features "intentionally out of scope for
   this first version," even though `onion fmt` has shipped as a fully documented

--- a/src/main/java/onion/DateTime.java
+++ b/src/main/java/onion/DateTime.java
@@ -7,7 +7,8 @@ import java.time.temporal.ChronoUnit;
 /**
  * Date and time utilities for Onion programs.
  * Uses epoch milliseconds as the primary time representation.
- * All methods are static and can be used without import.
+ * All methods are static; call them qualified, e.g. {@code DateTime::now()}
+ * (DateTime is not in the default static import set).
  */
 public final class DateTime {
     private DateTime() {} // Prevent instantiation

--- a/src/main/java/onion/Http.java
+++ b/src/main/java/onion/Http.java
@@ -12,7 +12,8 @@ import java.util.List;
 
 /**
  * HTTP client utilities for Onion programs.
- * All methods are static and can be used without import.
+ * All methods are static; call them qualified, e.g. {@code Http::get(url)}
+ * (Http is not in the default static import set).
  */
 public final class Http {
     private Http() {} // Prevent instantiation

--- a/src/test/scala/onion/compiler/tools/EffectfulStdlibJavadocSpec.scala
+++ b/src/test/scala/onion/compiler/tools/EffectfulStdlibJavadocSpec.scala
@@ -1,0 +1,44 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Guards against `DateTime` and `Http`'s class-level Javadoc still claiming
+ * "All methods are static and can be used without import" after #360 narrowed
+ * the default static import set to pure classes only. Both classes are
+ * effectful and were deliberately dropped from
+ * `src/main/resources/onion/default-static-imports.txt`; their own doc
+ * comment must not tell readers the opposite of what
+ * `DefaultStaticImportSpec` ("no longer resolves bare calls into ... Http,
+ * DateTime") actually enforces.
+ */
+class EffectfulStdlibJavadocSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  describe("class Javadoc for stdlib classes narrowed out of the default static imports (#360)") {
+    it("does not claim DateTime methods can be used without import") {
+      val src = read("src/main/java/onion/DateTime.java")
+      assert(
+        !src.contains("can be used without import"),
+        "onion.DateTime is not in default-static-imports.txt; its class doc must not claim bare calls work"
+      )
+      assert(src.contains("DateTime::"), "DateTime's class doc should show the qualified call form")
+    }
+
+    it("does not claim Http methods can be used without import") {
+      val src = read("src/main/java/onion/Http.java")
+      assert(
+        !src.contains("can be used without import"),
+        "onion.Http is not in default-static-imports.txt; its class doc must not claim bare calls work"
+      )
+      assert(src.contains("Http::"), "Http's class doc should show the qualified call form")
+    }
+
+    it("still lets Regex's doc claim it, since Regex genuinely is a default import") {
+      val src = read("src/main/java/onion/Regex.java")
+      assert(src.contains("can be used without import"))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.DateTime` and `onion.Http`'s class-level Javadoc still said "All methods are static and can be used without import," even though #360 narrowed the default static import set to pure classes and deliberately dropped both effectful classes (see `src/main/resources/onion/default-static-imports.txt`).
- `DefaultStaticImportSpec` already enforces that bare `now()` / `get(url)` no longer resolve, but the class doc comments told readers the opposite. `onion.Regex`'s identical claim is correct and left untouched (it genuinely is a default import).
- Updated both doc comments to point at the qualified call form (`DateTime::now()`, `Http::get(url)`), added `EffectfulStdlibJavadocSpec` to guard against the stale claim resurfacing, and added a `CHANGELOG.md` entry.

## Test plan

- [x] New spec (`EffectfulStdlibJavadocSpec`) verified red before the fix, green after.
- [x] Full suite, English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5402 succeeded, 0 failed, 1 canceled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6yiLCoBzsJzSn7drnefW9

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6yiLCoBzsJzSn7drnefW9)_