### PR TITLE
test: cover malformed-lambda hint for bare/parenless-static trailing lambdas

### DIFF
--- a/src/test/scala/onion/compiler/tools/TrailingLambdaParenHintSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TrailingLambdaParenHintSpec.scala
@@ -85,6 +85,76 @@ class TrailingLambdaParenHintSpec extends AbstractShellSpec {
       assert(msgs.contains("=>"), s"expected the arrow hint first, got: $msgs")
     }
 
+    it("hints at the unparenthesized form for a bare (unqualified) call") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def once(f: Function1[Int, Int]): Int = f.call(1)
+          |  static def main(args: String[]): Int {
+          |    val r = once { (x) -> x + 1 }
+          |    return r
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("x ->"), s"expected a hint naming the unparenthesized form, got: $msgs")
+    }
+
+    it("names the arrow when a bare call's trailing lambda uses the old `=>`") {
+      val msgs = messages(
+        """
+          |class Main {
+          |public:
+          |  static def once(f: Function1[Int, Int]): Int = f.call(1)
+          |  static def main(args: String[]): Int {
+          |    val r = once { x => x + 1 }
+          |    return r
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("->"), s"expected the arrow hint, got: $msgs")
+      assert(msgs.contains("=>"), s"expected the hint to name the old arrow, got: $msgs")
+    }
+
+    it("hints at the unparenthesized form for a parenless static call") {
+      val msgs = messages(
+        """
+          |class Helper {
+          |public:
+          |  static def twice(f: Function1[Int, Int]): Int = f.call(f.call(1))
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return Helper::twice { (x) -> x + 1 }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("x ->"), s"expected a hint naming the unparenthesized form, got: $msgs")
+    }
+
+    it("names the arrow when a parenless static call's trailing lambda uses the old `=>`") {
+      val msgs = messages(
+        """
+          |class Helper {
+          |public:
+          |  static def twice(f: Function1[Int, Int]): Int = f.call(f.call(1))
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    return Helper::twice { x => x + 1 }
+          |  }
+          |}
+          |""".stripMargin
+      ).mkString("\n")
+      assert(msgs.contains("->"), s"expected the arrow hint, got: $msgs")
+      assert(msgs.contains("=>"), s"expected the hint to name the old arrow, got: $msgs")
+    }
+
     it("does not add the hint for an unrelated unexpected brace") {
       val msgs = messages(
         """


### PR DESCRIPTION
## Summary
- `TrailingLambdaParenHintSpec` only exercised the "parenthesized params" (`{ (k, v) -> ... }`) and "old arrow" (`{ x => ... }`) mistake hints on dot-calls (`m.filter { ... }`).
- The bare-identifier call form (`once { ... }`) and parenless static-call form (`Helper::twice { ... }`) added in earlier commits (`ba1a4502`, `689f5f50`) route through the exact same `trailing_lambda()` / `trailingLambda()` hint detection in `grammar/JJOnionParser.jj` and `OnionParser.scala`, but neither had a test pinning the hint for those two call sites.
- Added four new cases to `TrailingLambdaParenHintSpec` mirroring the existing dot-call cases, for the bare-call and parenless-static-call forms.

No implementation code changed — all four new cases pass against current behavior, confirming the shared hint path already works correctly for these call sites. This closes a coverage gap so a future refactor of the shared hint helper can't silently regress it for `once { (x) -> x }` / `Helper::twice { x => x }` without a test catching it.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly *TrailingLambdaParenHintSpec'` — 9/9 passed
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5406 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjmGvsv5QRiecHycHTfuVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjmGvsv5QRiecHycHTfuVo)_