### PR TITLE
docs: add Range, FileResource, HttpResource, Lossless/Residue to the stdlib glance table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Range`, `FileResource`, `HttpResource` and `Lossless`/`Residue` each have a
+  dedicated section in `docs/reference/stdlib.md` (and its Japanese translation), but
+  none of them appeared in the "Modules at a glance" summary table at the top of
+  either file, and the same omission propagated into `CLAUDE.md`/`CLAUDE_ja.md`'s
+  "Standard Library" list (`StdlibDocDriftSpec` derives that check from the glance
+  table, so the gap in the table hid the gap in CLAUDE.md too).** Added the four to
+  both glance tables and both CLAUDE.md lists, and pinned the table itself with a new
+  `ModulesAtAGlanceCoverageSpec`.
+
 ## [0.58.0] - 2026-09-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,9 @@ All phases extend `Processor[A, B]` trait and can be composed using `andThen()`:
 - `Origin` - Where a value came from, in the text it was read out of
 - `Shape`, `Shapes` - Bidirectional correspondence between external text and a typed value
 - `Scalars` - Strict scalar parsing for boundary derivations
+- `Range` - The runtime type behind `a..b`/`a..<b` range literals, `Iterable[Int]`
+- `FileResource`, `HttpResource` - The objects behind the `file"…"`/`http"…"` literals: bundle a path/URL with its read/write or request operations
+- `Lossless`, `Residue` - Round-trip-preserving lens pair for lossless shape parsing (`parseLossless`/`printLossless`)
 
 ## Testing
 

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -176,6 +176,9 @@ Onionコンパイラは、古典的なコンパイラアーキテクチャに従
 - `Origin` - 値がどこから来たか（読み取り元のテキスト上の位置）
 - `Shape`, `Shapes` - 外部テキストと型付きの値との双方向対応
 - `Scalars` - 境界導出のための厳密なスカラー値パース
+- `Range` - `a..b`/`a..<b` 範囲リテラルの実体型、`Iterable[Int]`
+- `FileResource`, `HttpResource` - `file"…"`/`http"…"` リテラルの実体: パス/URLと読み書き・リクエスト操作を束ねる
+- `Lossless`, `Residue` - ロスレスなshapeパース (`parseLossless`/`printLossless`) のための往復変換レンズ
 
 ## テスト
 

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -6,19 +6,19 @@ Onionの標準ライブラリは、一般的な機能のための組み込みモ
 
 | 領域 | モジュール |
 |------|-----------|
-| **I/O・システム** | `IO`（コンソール）, `Files`（ファイル・パス）, `System`, `Proc`（サブプロセス）, `Args`（CLI） |
-| **ネットワーク** | `Http`（HTTPクライアント）, `Net`（TCPソケット）, `Server`（HTTPサーバ） |
+| **I/O・システム** | `IO`（コンソール）, `Files`（ファイル・パス）, `FileResource`（`file"…"`リテラル）, `System`, `Proc`（サブプロセス）, `Args`（CLI） |
+| **ネットワーク** | `Http`（HTTPクライアント）, `HttpResource`（`http"…"`リテラル）, `Net`（TCPソケット）, `Server`（HTTPサーバ） |
 | **データストア** | `Db`（JDBC経由のSQL） |
 | **アーカイブ** | `Archive`（zip・gzip） |
 | **並行処理** | `Future`, `Concurrent`（プール・カウンタ・ロック・チャネル） |
-| **コレクション** | `Colls`（リスト: map/filter/fold, chunked/windowed, sumBy/maxBy）, `Iterables`, `Maps`, `Sets` |
+| **コレクション** | `Colls`（リスト: map/filter/fold, chunked/windowed, sumBy/maxBy）, `Iterables`, `Maps`, `Sets`, `Range`（`a..b`/`a..<b`リテラルの型） |
 | **テキスト** | `Strings`（大小文字・分割・パディング・パース）, `Text`（wrap/indent/table）, `Regex` |
 | **数値** | `Math`, `OnionMath`（双曲線関数, `clamp`, `hypot`, 範囲付き`randomInt`）, `Stats`（sum/average/median/stddev）, `Format`（桁区切り・bytes・duration） |
 | **データ形式** | `Json`, `Yaml`, `Csv`, `Config`（ドット記法での設定値アクセス） |
 | **エンコード** | `Codec`（base64/hex/url）, `Hash`（md5/sha256/…） |
 | **関数型** | `Option`, `Result`, `Future`, `Outcome`・`Defect`（外部データの読み取り） |
 | **位置情報** | `Origin`（値がどのテキストのどこから来たか） |
-| **境界** | `Shape`・`Shapes`（テキスト↔型付き値）, `Scalars` |
+| **境界** | `Shape`・`Shapes`（テキスト↔型付き値）, `Scalars`, `Lossless`・`Residue`（ロスレスshapeの往復変換レンズ） |
 | **日時・乱数** | `DateTime`, `Rand`（choice/shuffle/sample/uuid） |
 | **テスト・計測** | `Assert`, `Timing` |
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -6,19 +6,19 @@ Onion's standard library consists of built-in modules and interfaces for common 
 
 | Area | Modules |
 |------|---------|
-| **I/O & system** | `IO` (console), `Files` (files + paths), `System`, `Proc` (subprocesses), `Args` (CLI) |
-| **Network** | `Http` (HTTP client), `Net` (TCP sockets), `Server` (HTTP server) |
+| **I/O & system** | `IO` (console), `Files` (files + paths), `FileResource` (the `file"…"` literal), `System`, `Proc` (subprocesses), `Args` (CLI) |
+| **Network** | `Http` (HTTP client), `HttpResource` (the `http"…"` literal), `Net` (TCP sockets), `Server` (HTTP server) |
 | **Data stores** | `Db` (SQL over JDBC) |
 | **Archives** | `Archive` (zip, gzip) |
 | **Concurrency** | `Future`, `Concurrent` (pools, counters, locks, channels) |
-| **Collections** | `Colls` (lists: map/filter/fold, chunked/windowed, sumBy/maxBy), `Iterables`, `Maps`, `Sets` |
+| **Collections** | `Colls` (lists: map/filter/fold, chunked/windowed, sumBy/maxBy), `Iterables`, `Maps`, `Sets`, `Range` (the `a..b`/`a..<b` literal type) |
 | **Text** | `Strings` (case, split, pad, parse), `Text` (wrap/indent/table), `Regex` |
 | **Numbers** | `Math`, `OnionMath` (hyperbolic trig, `clamp`, `hypot`, bounded `randomInt`), `Stats` (sum/average/median/stddev), `Format` (grouping, bytes, durations) |
 | **Data formats** | `Json`, `Yaml`, `Csv`, `Config` (dot-notation config access) |
 | **Encoding** | `Codec` (base64/hex/url), `Hash` (md5/sha256/…) |
 | **Functional** | `Option`, `Result`, `Future`, `Outcome` + `Defect` (reading external data) |
 | **Positions** | `Origin` (where a value came from, in the text it was read out of) |
-| **Boundaries** | `Shape` + `Shapes` (text <-> typed value), `Scalars` |
+| **Boundaries** | `Shape` + `Shapes` (text <-> typed value), `Scalars`, `Lossless` + `Residue` (round-trip-preserving lens over a lossless shape) |
 | **Date & random** | `DateTime`, `Rand` (choice/shuffle/sample/uuid) |
 | **Testing & timing** | `Assert`, `Timing` |
 

--- a/src/test/scala/onion/compiler/tools/ModulesAtAGlanceCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ModulesAtAGlanceCoverageSpec.scala
@@ -1,0 +1,42 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the "Modules at a glance" summary table in `docs/reference/stdlib.md`
+ * (and its Japanese "モジュール一覧" counterpart). `Range`, `FileResource`, `HttpResource`
+ * and `Lossless` each have their own dedicated `## ClassName` section further down both
+ * files -- covered by `RangeDocCoverageSpec`, `FileResourceDocCoverageSpec` and
+ * `HttpResourceDocCoverageSpec` -- but none of the four appear in the summary table, so a
+ * reader skimming just the table never learns these classes exist. The same omission
+ * propagates to `CLAUDE.md`'s "Standard Library" list and its Japanese twin, which
+ * `StdlibDocDriftSpec` derives from this very table.
+ */
+class ModulesAtAGlanceCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def glanceTable(doc: String, marker: String, stopAt: String): String = {
+    val lines = doc.linesIterator.toSeq
+    val start = lines.indexWhere(_.contains(marker))
+    assert(start >= 0, s"doc has no '$marker' section -- the scan has rotted")
+    lines.drop(start + 1).takeWhile(!_.trim.startsWith(stopAt)).mkString("\n")
+  }
+
+  private val classes = Seq("Range", "FileResource", "HttpResource", "Lossless")
+
+  it("docs/reference/stdlib.md's Modules at a glance table mentions Range, FileResource, HttpResource and Lossless") {
+    val table = glanceTable(read("docs/reference/stdlib.md"), "## Modules at a glance", "Most helpers")
+    classes.foreach { name =>
+      assert(table.contains(s"`$name`"), s"'Modules at a glance' table doesn't mention `$name`")
+    }
+  }
+
+  it("docs/ja/reference/stdlib.md's モジュール一覧 table mentions Range, FileResource, HttpResource and Lossless") {
+    val table = glanceTable(read("docs/ja/reference/stdlib.md"), "## モジュール一覧", "ほとんど")
+    classes.foreach { name =>
+      assert(table.contains(s"`$name`"), s"'モジュール一覧' table doesn't mention `$name`")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `Range`, `FileResource`, `HttpResource` and `Lossless`/`Residue` each have their own dedicated `## ClassName` section in `docs/reference/stdlib.md` (and its Japanese translation), but none of the four appeared in the "Modules at a glance" summary table at the top of either file.
- The same gap silently propagated into `CLAUDE.md`/`CLAUDE_ja.md`'s "Standard Library" list, since `StdlibDocDriftSpec` derives its expected module set from that same glance table — a gap in the table hid the gap in CLAUDE.md too.
- Added the four to both glance tables and both CLAUDE.md lists.
- Added a new `ModulesAtAGlanceCoverageSpec` (TDD: confirmed red before the doc fix, green after) so the glance table itself can't silently drift again.
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] New spec confirmed to fail before the fix (`ModulesAtAGlanceCoverageSpec`)
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.ModulesAtAGlanceCoverageSpec onion.compiler.tools.StdlibDocDriftSpec onion.compiler.tools.RangeDocCoverageSpec onion.compiler.tools.FileResourceDocCoverageSpec onion.compiler.tools.HttpResourceDocCoverageSpec'` — all green
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5408 succeeded, 0 failed, 1 pre-existing environment-gated cancellation (`ProjectDistributionSpec`'s dist-journey test, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TufGS3pKoL7pnSnjZ4xNNi

---
_Generated by [Claude Code](https://claude.ai/code/session_01TufGS3pKoL7pnSnjZ4xNNi)_