### PR TITLE
docs: document onion.Resources (file/http/re) module, add coverage guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`onion.Resources` — the default-imported factory module backing the `file"…"`,
+  `http"…"` and `re"…"` literals (`file`, `http`, `re`) — had no `## Resources Module`
+  section in `docs/reference/stdlib.md` (or its Japanese translation), and was missing
+  from both languages' "Modules at a glance" table and from `CLAUDE.md`/`CLAUDE_ja.md`'s
+  "Standard Library" list, even though every other default-static-imported class
+  (`Strings`, `Iterables`, `Regex`, `Csv`) has all three. Added the module section, the
+  glance-table entries and the CLAUDE.md list entries, pinned by a new
+  `ResourcesDocCoverageSpec`.
+
 ### Added
 
 - **`run/DateTimeDemo.on`, a runnable example for `onion.DateTime`.** `DateTime`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,7 @@ All phases extend `Processor[A, B]` trait and can be composed using `andThen()`:
 - `Scalars` - Strict scalar parsing for boundary derivations
 - `Range` - The runtime type behind `a..b`/`a..<b` range literals, `Iterable[Int]`
 - `FileResource`, `HttpResource` - The objects behind the `file"…"`/`http"…"` literals: bundle a path/URL with its read/write or request operations
+- `Resources` - The default-imported factory functions (`file`, `http`, `re`) backing the `file"…"`/`http"…"`/`re"…"` literals; the literal and the bare function call are exactly equivalent
 - `Lossless`, `Residue` - Round-trip-preserving lens pair for lossless shape parsing (`parseLossless`/`printLossless`)
 
 ## Testing

--- a/docs/ja/CLAUDE_ja.md
+++ b/docs/ja/CLAUDE_ja.md
@@ -178,6 +178,7 @@ Onionコンパイラは、古典的なコンパイラアーキテクチャに従
 - `Scalars` - 境界導出のための厳密なスカラー値パース
 - `Range` - `a..b`/`a..<b` 範囲リテラルの実体型、`Iterable[Int]`
 - `FileResource`, `HttpResource` - `file"…"`/`http"…"` リテラルの実体: パス/URLと読み書き・リクエスト操作を束ねる
+- `Resources` - `file"…"`/`http"…"`/`re"…"` リテラルを支えるデフォルトインポート済みのファクトリ関数（`file`, `http`, `re`）。リテラルと素の関数呼び出しは完全に等価
 - `Lossless`, `Residue` - ロスレスなshapeパース (`parseLossless`/`printLossless`) のための往復変換レンズ
 
 ## テスト

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -6,7 +6,7 @@ Onionの標準ライブラリは、一般的な機能のための組み込みモ
 
 | 領域 | モジュール |
 |------|-----------|
-| **I/O・システム** | `IO`（コンソール）, `Files`（ファイル・パス）, `FileResource`（`file"…"`リテラル）, `System`, `Proc`（サブプロセス）, `Args`（CLI） |
+| **I/O・システム** | `IO`（コンソール）, `Files`（ファイル・パス）, `FileResource`（`file"…"`リテラル）, `Resources`（`file"…"`/`http"…"`/`re"…"`リテラルを非修飾関数として支える）, `System`, `Proc`（サブプロセス）, `Args`（CLI） |
 | **ネットワーク** | `Http`（HTTPクライアント）, `HttpResource`（`http"…"`リテラル）, `Net`（TCPソケット）, `Server`（HTTPサーバ） |
 | **データストア** | `Db`（JDBC経由のSQL） |
 | **アーカイブ** | `Archive`（zip・gzip） |
@@ -1990,6 +1990,22 @@ Files::ext("report.txt")               // "txt"（拡張子。予約語を避け
 Files::stem("report.txt")              // "report"
 Files::withExtension("report.txt", "md")   // "report.md"
 ```
+
+## Resources Module
+
+Onionのスキームプレフィックス文字列リテラルの実体（`onion.Resources`）。デフォルトの静的
+インポート対象なので、3つのファクトリ関数はすべて非修飾で解決する——リテラル糖衣構文と
+まったく同じように:
+
+```onion
+Resources::file(path)                  // file"path" / file(path) と同じ、FileResourceを返す
+Resources::http(url)                   // http"url" / http(url) と同じ、HttpResourceを返す
+Resources::re(pattern)                 // re"pattern" / re(pattern) と同じ、コンパイル済みPattern
+```
+
+`file"x"` は非修飾呼び出し `file("x")` に脱糖される。動的なパスには関数形式をそのまま使う
+（`file(pathVariable)`）——リテラルと関数呼び出しは完全に等価。`http"…"` / `http(url)`、
+`re"…"` / `re(pattern)` も同様。
 
 ## FileResource
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -6,7 +6,7 @@ Onion's standard library consists of built-in modules and interfaces for common 
 
 | Area | Modules |
 |------|---------|
-| **I/O & system** | `IO` (console), `Files` (files + paths), `FileResource` (the `file"…"` literal), `System`, `Proc` (subprocesses), `Args` (CLI) |
+| **I/O & system** | `IO` (console), `Files` (files + paths), `FileResource` (the `file"…"` literal), `Resources` (backs the `file"…"`/`http"…"`/`re"…"` literals as bare functions), `System`, `Proc` (subprocesses), `Args` (CLI) |
 | **Network** | `Http` (HTTP client), `HttpResource` (the `http"…"` literal), `Net` (TCP sockets), `Server` (HTTP server) |
 | **Data stores** | `Db` (SQL over JDBC) |
 | **Archives** | `Archive` (zip, gzip) |
@@ -1485,6 +1485,22 @@ Files::ext("report.txt")               // "txt"   (extension, keyword-safe name)
 Files::stem("report.txt")              // "report"
 Files::withExtension("report.txt", "md")   // "report.md"
 ```
+
+## Resources Module
+
+The entry points behind Onion's scheme-prefixed string literals (`onion.Resources`), on
+the default static import list — so all three factory functions resolve unqualified,
+exactly like the literal sugar they back:
+
+```onion
+Resources::file(path)                  // same as file"path" / file(path), a FileResource
+Resources::http(url)                   // same as http"url" / http(url), an HttpResource
+Resources::re(pattern)                 // same as re"pattern" / re(pattern), a compiled Pattern
+```
+
+`file"x"` desugars to the unqualified call `file("x")`; a dynamic path uses the function
+form directly (`file(pathVariable)`) — the literal and the function are exactly
+equivalent. Same for `http"…"` / `http(url)` and `re"…"` / `re(pattern)`.
 
 ## FileResource
 

--- a/src/test/scala/onion/compiler/tools/ResourcesDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ResourcesDocCoverageSpec.scala
@@ -1,0 +1,73 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Coverage guard for the `Resources` module docs.
+ *
+ * `onion.Resources` is on the default static import list (`default-static-imports.txt`),
+ * alongside `Strings`, `Iterables`, `Regex` and `Csv` -- so its three factory functions
+ * (`file`, `http`, `re`) resolve unqualified, exactly like the scheme-prefixed literals
+ * (`file"…"`, `http"…"`, `re"…"`) they back. Every other default-imported class has its own
+ * `## ClassName Module` section in `docs/reference/stdlib.md`, but `Resources` has never had
+ * one, and it is missing from the "Modules at a glance" table too -- so a reader relying on
+ * either the table or the module list never learns the bare `file(...)`/`http(...)`/`re(...)`
+ * calls exist independently of the literal sugar.
+ */
+class ResourcesDocCoverageSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private def documentedNames(doc: String): Set[String] =
+    """Resources::(\w+)""".r.findAllMatchIn(doc).map(_.group(1)).toSet
+
+  private lazy val actualNames: Set[String] = {
+    val c = classOf[onion.Resources]
+    val methodNames = c.getMethods
+      .filter(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .filter(_.getDeclaringClass == c)
+      .map(_.getName)
+    methodNames.toSet
+  }
+
+  it("actual onion.Resources exposes the names this guard assumes (sanity check)") {
+    assert(actualNames.nonEmpty, "reflection on onion.Resources found no static members -- the scan has rotted")
+  }
+
+  it("docs/reference/stdlib.md documents every onion.Resources member") {
+    val documented = documentedNames(read("docs/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/reference/stdlib.md is missing Resources:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("docs/ja/reference/stdlib.md documents every onion.Resources member") {
+    val documented = documentedNames(read("docs/ja/reference/stdlib.md"))
+    val missing = actualNames -- documented
+    assert(missing.isEmpty,
+      s"docs/ja/reference/stdlib.md is missing Resources:: members: ${missing.toSeq.sorted.mkString(", ")}")
+  }
+
+  it("\"Modules at a glance\" mentions Resources in both languages") {
+    val enTable = read("docs/reference/stdlib.md").linesIterator.toSeq
+    val enStart = enTable.indexWhere(_.contains("## Modules at a glance"))
+    assert(enStart >= 0, "docs/reference/stdlib.md has no 'Modules at a glance' section -- the scan has rotted")
+    val en = enTable.drop(enStart + 1).takeWhile(!_.trim.startsWith("Most helpers")).mkString("\n")
+    assert(en.contains("`Resources`"), "docs/reference/stdlib.md's glance table should mention `Resources`")
+
+    val jaTable = read("docs/ja/reference/stdlib.md").linesIterator.toSeq
+    val jaStart = jaTable.indexWhere(_.contains("## モジュール一覧"))
+    assert(jaStart >= 0, "docs/ja/reference/stdlib.md has no 'モジュール一覧' section -- the scan has rotted")
+    val ja = jaTable.drop(jaStart + 1).takeWhile(!_.trim.startsWith("ほとんど")).mkString("\n")
+    assert(ja.contains("`Resources`"), "docs/ja/reference/stdlib.md's glance table should mention `Resources`")
+  }
+
+  it("CLAUDE.md's Standard Library list mentions Resources") {
+    assert(read("CLAUDE.md").contains("`Resources`"), "CLAUDE.md's Standard Library list should mention `Resources`")
+  }
+
+  it("CLAUDE_ja.md's 標準ライブラリ list mentions Resources") {
+    assert(read("docs/ja/CLAUDE_ja.md").contains("`Resources`"), "CLAUDE_ja.md's stdlib list should mention `Resources`")
+  }
+}


### PR DESCRIPTION
## Summary

- `onion.Resources` is on the default static import list (`default-static-imports.txt`) alongside `Strings`, `Iterables`, `Regex` and `Csv`, so its three factory functions (`file`, `http`, `re`) resolve unqualified — exactly like the `file"…"`/`http"…"`/`re"…"` literals they back.
- Unlike every other default-imported class, `Resources` had no dedicated `## Resources Module` section in `docs/reference/stdlib.md` (or its Japanese translation), and was missing from both languages' "Modules at a glance" table and from `CLAUDE.md`/`CLAUDE_ja.md`'s "Standard Library" list.
- Added the module section (EN/JA), the glance-table entries (EN/JA), and the CLAUDE.md list entries (EN/JA).
- Added `ResourcesDocCoverageSpec` (TDD: written first, confirmed red, then made green by the doc changes) so a future `onion.Resources` member can't go undocumented again.

## Test plan

- [x] `ResourcesDocCoverageSpec` written first and confirmed failing before the doc changes
- [x] `ResourcesDocCoverageSpec` passes after the doc changes
- [x] `ModulesAtAGlanceCoverageSpec`, `StdlibDocDriftSpec`, `FileResourceDocCoverageSpec`, `HttpResourceDocCoverageSpec` still pass
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5424 succeeded, 0 failed, 1 canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hTEUiUfNkf2pkAD6ADK91

---
_Generated by [Claude Code](https://claude.ai/code/session_017hTEUiUfNkf2pkAD6ADK91)_