### PR TITLE
fix: translate hardcoded Japanese type-class coherence error to English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The type-class "duplicate instance" coherence error was hardcoded in Japanese**,
+  unlike every other diagnostic in `Rewriting.scala`, so English-locale users (and
+  release CI, which runs in English) saw `instance Numeric[Integer] は既に定義され
+  ています（型クラスの instance は (trait, 型) ごとに1つまでです）` instead of an
+  English message. Translated it to English, matching the plain-English literals
+  used by the sibling diagnostics in the same function/file, and added a regression
+  test (`TypeClassCoherenceSpec`) asserting on the message content so this can't
+  silently regress back to a locale-only string.
+
 - **`onion.Resources` — the default-imported factory module backing the `file"…"`,
   `http"…"` and `re"…"` literals (`file`, `http`, `re`) — had no `## Resources Module`
   section in `docs/reference/stdlib.md` (or its Japanese translation), and was missing

--- a/src/main/scala/onion/compiler/Rewriting.scala
+++ b/src/main/scala/onion/compiler/Rewriting.scala
@@ -536,7 +536,7 @@ class Rewriting(config: CompilerConfig) extends AnyRef with Processor[Seq[AST.Co
         val key = mangleInstanceClassName(inst.traitType.desc)
         if (seen.contains(key)) {
           throw new CompilationException(Seq(CompileError("", inst.location,
-            s"instance ${inst.traitType.desc} は既に定義されています（型クラスの instance は (trait, 型) ごとに1つまでです）")))
+            s"instance ${inst.traitType.desc} is already defined (at most one instance is allowed per (trait, type))")))
         }
         seen(key) = inst
       case _ =>

--- a/src/test/scala/onion/compiler/tools/TypeClassCoherenceSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TypeClassCoherenceSpec.scala
@@ -1,6 +1,8 @@
 package onion.compiler.tools
 
+import onion.compiler.{OnionCompiler, CompilerConfig, StreamInputSource, CompilationOutcome}
 import onion.tools.Shell
+import java.io.StringReader
 
 /**
  * Type classes stage 1: coherence -- at most one instance per (trait, type) in a
@@ -9,10 +11,24 @@ import onion.tools.Shell
  * leaked internal class name; verified manually via the CLI.)
  */
 class TypeClassCoherenceSpec extends AbstractShellSpec {
+  private def errorMessages(src: String): Seq[String] = {
+    val config = new CompilerConfig(List("."), null, "UTF-8", "", 10)
+    new OnionCompiler(config).compile(Seq(new StreamInputSource(() => new StringReader(src), "test.on"))) match {
+      case CompilationOutcome.Failure(errs) => errs.map(_.message)
+      case _ => Seq.empty
+    }
+  }
+
   describe("instance coherence") {
     it("rejects two instances for the same trait application") {
       assert(Shell.Failure(-1) == shell.run(
         "trait Numeric[T] { def zero(): T }\ninstance Numeric[Integer] { def zero(): Integer = 0 }\ninstance Numeric[Integer] { def zero(): Integer = 1 }\ndef main(args: String[]): void { IO::println(\"x\") }", "None", Array()))
+    }
+    it("reports the duplicate-instance message in English regardless of JVM locale") {
+      val messages = errorMessages(
+        "trait Numeric[T] { def zero(): T }\ninstance Numeric[Integer] { def zero(): Integer = 0 }\ninstance Numeric[Integer] { def zero(): Integer = 1 }\ndef main(args: String[]): void { IO::println(\"x\") }")
+      assert(messages.exists(_.toLowerCase.contains("already defined")))
+      assert(!messages.exists(_.contains("は既に定義されています")))
     }
     it("allows distinct type arguments of the same trait") {
       assert(Shell.Success("ok") == shell.run(


### PR DESCRIPTION
## Summary
- The duplicate-instance type-class coherence check in `Rewriting.scala` (`checkInstanceCoherence`) always threw its error message in Japanese, regardless of JVM locale — unlike every other diagnostic in the same file, which are either plain English literals or routed through the bilingual `Message()`/properties mechanism. English-locale users, and release CI (which runs in English), saw the raw Japanese text.
- Translated the message to English, matching the plain-English literals used by sibling diagnostics in the same function/file (e.g. the "enum cannot take type parameters" error a few lines above).
- Strengthened `TypeClassCoherenceSpec` with a regression test that asserts on the message content (English present, Japanese-only text absent), so this can't silently regress back to a locale-only string. Previously the spec only asserted on `Shell.Failure(-1)`, so this exact issue went undetected.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.TypeClassCoherenceSpec'` — new test passes, confirms English message
- [x] Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5425 succeeded, 0 failed, 1 canceled (expected: distribution smoke test gated behind `-Donion.dist.path`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xdmho9rSAtsH3wKGRSVG8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xdmho9rSAtsH3wKGRSVG8T)_