### PR TITLE
docs: fix RELEASING.md drift, add workflow_dispatch parity guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`docs/RELEASING.md` and its Japanese translation `docs/ja/RELEASING.md` — the copies
+  actually published by mkdocs — still told a reader to `git push origin vX.Y.Z` as the
+  only way to cut a release, with no mention of the tag-protection HTTP 403 (issue #334,
+  re-confirmed by #1184) or the `workflow_dispatch` fallback that works around it.** Only
+  the repo-root `RELEASING.md` had been updated when that fallback was added, so the
+  published docs/ pair silently drifted back to the exact failure mode #1184 spent 12
+  attempts rediscovering. Brought both copies up to date with the root file (and named
+  the GitHub API/MCP equivalent of `gh workflow run` for sessions without the `gh` CLI),
+  and fixed the root file's own leftover pre-sbt-2 `target/scala-3.3.7/...` artifact
+  paths and single-locale test command while at it. Added
+  `ReleasingDocWorkflowDispatchParitySpec` so the three copies can't lose the
+  `workflow_dispatch`/403 guidance, the bilingual `testFull` step, or the sbt 2 target
+  layout independently again.
+
 - **The type-class "duplicate instance" coherence error was hardcoded in Japanese**,
   unlike every other diagnostic in `Rewriting.scala`, so English-locale users (and
   release CI, which runs in English) saw `instance Numeric[Integer] は既に定義され

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,10 +6,17 @@ is no manual `version := ...` line to update in `build.sbt`.
 
 ## Release checklist
 
-1. **Make sure `develop` is green.**
+1. **Make sure `develop` is green — in both locales.**
    ```bash
-   sbt test
+   sbt shutdown && sbt -Duser.language=en testFull
+   sbt shutdown && sbt -Duser.language=ja testFull
    ```
+   Both parts matter. Diagnostics are bilingual, and release CI runs in English while
+   local development is usually `ja_JP`, so a test asserting on message text can pass
+   in one locale and fail in the other. Under sbt 2, `test` delegates to `testQuick`
+   and reports `No tests to run` on an unchanged tree, and `-D` is only picked up by a
+   *freshly started* server — so without `shutdown` and `testFull` this step can look
+   green having run nothing.
 
 2. **Decide the next version.**
    Onion follows [Semantic Versioning](https://semver.org/) with milestone and
@@ -25,15 +32,23 @@ is no manual `version := ...` line to update in `build.sbt`.
 
 4. **Start the release.**
 
-   Preferred — let the release workflow create the tag. Pushing a `v*` tag from
-   a client is rejected by the repository's tag protection (HTTP 403), which is
-   what left releases stuck for months (issue #334), so the workflow creates the
-   tag itself with the Actions token:
+   Preferred — trigger the release workflow's `workflow_dispatch` event and let
+   it create the tag itself. Pushing a `v*` tag from a client is rejected by the
+   repository's tag protection (HTTP 403), which is what left releases stuck for
+   months (issue #334), so the workflow creates the tag itself with the Actions
+   token instead of relying on a client-side push:
 
    ```bash
    gh workflow run release.yml -f version=v0.2.0 --ref develop
    gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
    ```
+
+   Without the `gh` CLI (e.g. a session with only the GitHub API/MCP tools), the
+   same `workflow_dispatch` event is `POST
+   /repos/{owner}/{repo}/actions/workflows/release.yml/dispatches` with
+   `{"ref": "develop", "inputs": {"version": "v0.2.0"}}` — a GitHub MCP server
+   typically exposes this as an "run workflow" action taking `workflow_id:
+   "release.yml"`, `ref: "develop"`, `inputs: {version: "v0.2.0"}`.
 
    The tag-push path still works for anyone whose credentials are allowed to
    create `v*` refs:
@@ -71,12 +86,12 @@ is no manual `version := ...` line to update in `build.sbt`.
 To build the same artifacts locally without creating a release:
 
 ```bash
-sbt assembly dist
+sbt "assembly; dist"
 ```
 
-Outputs:
-- `target/scala-3.3.7/onion-<version>.jar` (fat jar)
-- `target/onion-dist-<version>.zip` (distribution archive)
+Outputs (sbt 2's default layout nests build products under `target/out/<platform>/<scalaVersion>/<project>/`):
+- `target/out/jvm/scala-3.3.7/onion/onion-<version>.jar` (fat jar)
+- `target/out/jvm/scala-3.3.7/onion/onion-dist-<version>.zip` (distribution archive)
 
 ## Hotfix releases
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,13 +30,40 @@ is no manual `version := ...` line to update in `build.sbt`.
    Add a new section for the release with the date and a summary of user-facing
    changes, bug fixes, and internal improvements.
 
-4. **Create and push a tag.**
+4. **Start the release.**
+
+   Preferred — trigger the release workflow's `workflow_dispatch` event and let
+   it create the tag itself. Pushing a `v*` tag from a client is rejected by the
+   repository's tag protection (HTTP 403), which is what left releases stuck for
+   months (issue #334), so the workflow creates the tag itself with the Actions
+   token instead of relying on a client-side push:
+
+   ```bash
+   gh workflow run release.yml -f version=v0.2.0 --ref develop
+   gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+   ```
+
+   Without the `gh` CLI (e.g. a session with only the GitHub API/MCP tools), the
+   same `workflow_dispatch` event is `POST
+   /repos/{owner}/{repo}/actions/workflows/release.yml/dispatches` with
+   `{"ref": "develop", "inputs": {"version": "v0.2.0"}}` — a GitHub MCP server
+   typically exposes this as an "run workflow" action taking `workflow_id:
+   "release.yml"`, `ref: "develop"`, `inputs: {version: "v0.2.0"}`.
+
+   The tag-push path still works for anyone whose credentials are allowed to
+   create `v*` refs:
+
    ```bash
    git checkout develop
    git pull
    git tag -a v0.2.0 -m "Release v0.2.0"
    git push origin v0.2.0
    ```
+
+   Do **not** commit a `## [X.Y.Z]` CHANGELOG heading before the tag exists: if
+   the release then fails, the heading has to be reverted, which is exactly the
+   release-and-revert loop #334 describes. Confirm the release first, then
+   finalize the heading.
 
 5. **Let CI do the rest.**
    The [release workflow](https://github.com/onion-lang/onion/blob/main/.github/workflows/release.yml) will:

--- a/docs/ja/RELEASING.md
+++ b/docs/ja/RELEASING.md
@@ -25,13 +25,41 @@ Onion は **git タグ** をリリースの起点としています。バージ�
 3. **`CHANGELOG.md` を更新する。**
    リリース日と、ユーザーに影響する変更、バグ修正、内部改善の概要を含む新しいセクションを追加します。
 
-4. **タグを作成してプッシュする。**
+4. **リリースを開始する。**
+
+   推奨: リリースワークフローの `workflow_dispatch` イベントを起動し、タグは
+   ワークフロー自身に作らせる。クライアントから `v*` タグをプッシュすると、
+   リポジトリのタグ保護によって HTTP 403 で拒否され、これが何ヶ月もリリースを
+   止めていた原因でした（issue #334）。そのためクライアント側のプッシュに頼らず、
+   ワークフロー自身が Actions トークンでタグを作成します:
+
+   ```bash
+   gh workflow run release.yml -f version=v0.2.0 --ref develop
+   gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+   ```
+
+   `gh` CLI が無い場合（GitHub API/MCP ツールしか無いセッションなど）は、同じ
+   `workflow_dispatch` イベントを `POST
+   /repos/{owner}/{repo}/actions/workflows/release.yml/dispatches` に
+   `{"ref": "develop", "inputs": {"version": "v0.2.0"}}` を渡して呼び出せます。
+   GitHub MCP サーバでは通常 `workflow_id: "release.yml"`、`ref: "develop"`、
+   `inputs: {version: "v0.2.0"}` を取る「ワークフロー実行」アクションとして
+   公開されています。
+
+   `v*` refをプッシュできる権限を持つ認証情報であれば、タグをプッシュする方法も
+   引き続き使えます:
+
    ```bash
    git checkout develop
    git pull
    git tag -a v0.2.0 -m "Release v0.2.0"
    git push origin v0.2.0
    ```
+
+   タグが存在する前に `## [X.Y.Z]` の CHANGELOG 見出しをコミットしては
+   **いけません**。リリースが失敗した場合に見出しを元に戻す必要が生じ、これは
+   まさに #334 が説明しているリリース・差し戻しループです。まずリリースを
+   確定させてから、見出しを確定してください。
 
 5. **CI に残りの作業を任せる。**
    [release workflow](https://github.com/onion-lang/onion/blob/main/.github/workflows/release.yml) は以下を実行します。

--- a/src/test/scala/onion/compiler/tools/ReleasingDocWorkflowDispatchParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/ReleasingDocWorkflowDispatchParitySpec.scala
@@ -1,0 +1,58 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Drift guard across the three copies of the release checklist: `RELEASING.md` (repo root),
+ * `docs/RELEASING.md` (English, published by mkdocs) and `docs/ja/RELEASING.md` (Japanese
+ * translation of the latter).
+ *
+ * Pushing a `v*` tag from a client is rejected by the repository's tag-protection ruleset
+ * with an HTTP 403 (issue #334, re-confirmed by #1184) — the only reliable path is
+ * `workflow_dispatch` on `.github/workflows/release.yml`, which creates the tag itself with
+ * the Actions token. The root file documents this; the docs/ pair was never updated when it
+ * was added and still tells a reader to `git push origin vX.Y.Z` as the only option, with no
+ * mention of the 403 or the workaround — the exact failure mode #1184 spent 12 attempts
+ * rediscovering. All three must mention the `workflow_dispatch` fallback so this can't
+ * silently drop out of one copy again.
+ */
+class ReleasingDocWorkflowDispatchParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  private val docs = Seq(
+    "RELEASING.md",
+    "docs/RELEASING.md",
+    "docs/ja/RELEASING.md"
+  )
+
+  it("documents the workflow_dispatch fallback for the tag-push 403 in every copy") {
+    for (doc <- docs) {
+      val text = read(doc)
+      assert(text.contains("workflow_dispatch"),
+        s"$doc does not mention workflow_dispatch — a reader following it would hit the " +
+        "tag-push 403 with no documented way out")
+      assert(text.contains("403"),
+        s"$doc does not explain the tag-push HTTP 403, so a reader can't tell why " +
+        "`git push origin vX.Y.Z` alone isn't reliable")
+    }
+  }
+
+  it("documents the bilingual testFull verification step in every copy") {
+    for (doc <- docs) {
+      val text = read(doc)
+      assert(text.contains("testFull"),
+        s"$doc does not mention testFull — `test` delegates to `testQuick` under sbt 2 " +
+        "and can silently report 'No tests to run'")
+    }
+  }
+
+  it("documents the sbt 2 nested target layout for local artifacts in every copy") {
+    for (doc <- docs) {
+      val text = read(doc)
+      assert(text.contains("target/out/jvm/scala-3.3.7/onion/"),
+        s"$doc still points at the pre-sbt-2 flat target/ layout for local jar/zip output")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `docs/RELEASING.md` and its Japanese translation `docs/ja/RELEASING.md` — the copies actually published by mkdocs — still told a reader to `git push origin vX.Y.Z` as the only way to cut a release, with no mention of the tag-protection HTTP 403 (issue #334, re-confirmed by #1184) or the `workflow_dispatch` fallback that works around it. Only the repo-root `RELEASING.md` had been updated when that fallback was added, so the published docs/ pair silently drifted back to the exact failure mode #1184 spent 12 attempts rediscovering.
- Brought `docs/RELEASING.md` and `docs/ja/RELEASING.md` up to date with the root file, and additionally named the GitHub API/MCP equivalent of `gh workflow run` for sessions that only have GitHub MCP tools (no `gh` CLI).
- Fixed the root `RELEASING.md`'s own leftover drift: pre-sbt-2 `target/scala-3.3.7/...` artifact paths (sbt 2 nests build products under `target/out/jvm/scala-3.3.7/onion/...`) and a single-locale `sbt test` step instead of the bilingual `sbt shutdown && sbt -Duser.language=<xx> testFull`.
- Added `ReleasingDocWorkflowDispatchParitySpec` (TDD: confirmed red against the pre-fix docs, green after) so the three copies can't lose the `workflow_dispatch`/403 guidance, the bilingual `testFull` step, or the sbt 2 target layout independently again.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

This is a docs-only change; no compiler or runtime behavior changes.

## Test plan

- [x] New spec `ReleasingDocWorkflowDispatchParitySpec` fails before the fix (missing `workflow_dispatch`/`403`/`testFull`/`target/out/jvm/scala-3.3.7/onion/` markers), passes after.
- [x] Full suite: `sbt shutdown && sbt -Duser.language=en testFull` → 5428 tests, 0 failed, 1 cancelled (expected — distribution smoke test gated behind `-Donion.dist.path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AE3HfXTmgkGUY7X4emmzqE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE3HfXTmgkGUY7X4emmzqE)_