### PR TITLE
test: add regression coverage for E0057 (bare type parameter dereference)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`E0057` (`TYPE_PARAMETER_MAY_BE_NULL`, "a bare type parameter may be null and
+  cannot be dereferenced directly") is documented in `docs/reference/error-codes.md`
+  with a worked example, and has live report sites in `MemberSelectionResolutionSupport`,
+  `ConstructionTyping` and `MethodTargetTypingSupport`, but had zero regression
+  coverage — no test in the suite ever compiled a program and asserted the code
+  actually fires, unlike the ~60 other codes `SemanticErrorCodeCoverageSpec` already
+  pins. Added a case compiling the doc's own example (`class Box[T] { def size(x: T):
+  Int = x.toString().length() }`) and asserting `E0057` appears in the diagnostics.
+
 ## [0.60.0] - 2026-09-07
 
 ### Fixed

--- a/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/SemanticErrorCodeCoverageSpec.scala
@@ -460,6 +460,14 @@ class SemanticErrorCodeCoverageSpec extends AbstractShellSpec {
           |}
           |""".stripMargin)
     }
+    it("E0057 a bare type parameter may be null and cannot be dereferenced directly") {
+      failsWith("E0057",
+        """class Box[T] {
+          |public:
+          |  def size(x: T): Int = x.toString().length()
+          |}
+          |""".stripMargin)
+    }
   }
 
   describe("statements and expressions") {


### PR DESCRIPTION
## Summary

- `E0057` (`TYPE_PARAMETER_MAY_BE_NULL`) is documented in `docs/reference/error-codes.md` with a worked example, and has live report sites in `MemberSelectionResolutionSupport`, `ConstructionTyping` and `MethodTargetTypingSupport` — but had zero regression coverage anywhere in the test suite. `SemanticErrorCodeCoverageSpec` already pins ~60 other diagnostic codes this same way; E0057 was simply missing.
- Adds one case to `SemanticErrorCodeCoverageSpec` compiling the doc's own example (`class Box[T] { def size(x: T): Int = x.toString().length() }`) and asserting `E0057` appears in the diagnostics. No source change — emission already worked, this only closes the test gap.
- Bumped `CHANGELOG.md`'s `[Unreleased]` section.

## Test plan

- [x] `sbt -Duser.language=en 'testOnly *SemanticErrorCodeCoverageSpec'` — 62/62 pass (new case included)
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5442/5442 pass
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=ja testFull` — 5442/5442 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01874KVQQZDQ7QiE3Uu9ZX1A

---
_Generated by [Claude Code](https://claude.ai/code/session_01874KVQQZDQ7QiE3Uu9ZX1A)_