### PR TITLE
docs: document HttpResource's stdlib.md coverage for the http"..." literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`docs/reference/stdlib.md` and its Japanese translation never had a section for
+  `HttpResource`, the object behind the `http"…"` literal.** `url()`, `get()`,
+  `get(headers)`, `getJson()`, `read(shape)`, `eachLine(shape)`, `post(body)`,
+  `postJson(jsonBody)`, `put(body)` and `delete()` are all real, callable members with
+  no API-reference coverage at all -- the existing `## Http` section documents only the
+  static `onion.Http` module, not the instance returned by the literal. Both docs now
+  carry a `## HttpResource` section documenting every member, and the existing
+  `HttpResourceDocCoverageSpec` (previously guarding only the `specification.md`
+  fixed-menu wording) gained new cases that fail the build if this regresses.
+
 ## [0.57.0] - 2026-09-06
 
 ### Internal

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -2229,6 +2229,40 @@ val postResponse: String = Http::postJson(
 
 ---
 
+## HttpResource
+
+`http"…"` リテラル（動的な形式: `http(url)`）が返すオブジェクトで、`onion.Resources::http`
+が生成する。1つの URL と、そのエンドポイントに対する各動詞メソッドをまとめたもの——
+`Http` をラップしているので、取得してパースする処理を1つの式で書ける:
+
+```onion
+val h = http"https://api.example.com/users"
+h.url()                                 // 元の URL 文字列
+h.get()                                 // レスポンスボディを String として
+h.get(["Authorization", "Bearer t"])    // ヘッダー付き GET（名前と値を交互に並べる）
+h.getJson()                             // レスポンスボディを JSON としてパース（Json::parse を参照）
+
+h.post("payload")                       // ボディを POST し、レスポンスボディを返す
+h.postJson("{\"id\":1}")                // Content-Type: application/json 付きで POST
+h.put("payload")                        // ボディを PUT
+h.delete()                              // DELETE
+```
+
+`read(shape)` はレスポンスボディを `Shape[T]` 経由で読む——パース方法は渡した `Shape[T]`
+が決め、通信に失敗した場合もこの URL を乗せた `Defect`（＝*どのエンドポイントか*がわかる）
+になる。例外にはならない:
+
+```onion
+val o: Outcome[Config] = http"https://api.example.com/config".read(shape)
+```
+
+`eachLine(shape)` はレスポンスボディの1行につき1つの値を読み、パースできた行と、できなかった
+行それぞれの `Defect`（レスポンス中の該当行に位置づけられる）を両方保持する:
+
+```onion
+val results: List[Outcome[Row]] = http"https://api.example.com/feed".eachLine(shape)
+```
+
 ## DateTime
 
 エポックミリ秒を使った日時ユーティリティ。

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -2065,6 +2065,41 @@ val postResponse: String = Http::postJson(
 
 ---
 
+## HttpResource
+
+The object behind the `http"…"` literal (dynamic form: `http(url)`), returned by
+`onion.Resources::http`. It bundles a URL with the verb methods for that one endpoint,
+wrapping `Http` so a fetch-and-parse pipeline is one expression:
+
+```onion
+val h = http"https://api.example.com/users"
+h.url()                                 // the underlying URL string
+h.get()                                 // response body as String
+h.get(["Authorization", "Bearer t"])    // GET with headers (alternating names/values)
+h.getJson()                             // response body parsed as JSON (see Json::parse)
+
+h.post("payload")                       // POST a body, returning the response body
+h.postJson("{\"id\":1}")                // POST with Content-Type: application/json
+h.put("payload")                        // PUT a body
+h.delete()                              // DELETE
+```
+
+`read(shape)` reads the response body through a `Shape[T]` — the parse step comes from
+the shape you pass, and a transport failure carries this URL into the resulting
+`Defect` too (so it says *which endpoint*), not an exception:
+
+```onion
+val o: Outcome[Config] = http"https://api.example.com/config".read(shape)
+```
+
+`eachLine(shape)` reads one value per line of the response body, keeping both the lines
+that parsed and the `Defect`s for the ones that didn't — each positioned on its own line
+of the response:
+
+```onion
+val results: List[Outcome[Row]] = http"https://api.example.com/feed".eachLine(shape)
+```
+
 ## DateTime
 
 Date and time utilities using epoch milliseconds.

--- a/src/test/scala/onion/compiler/tools/HttpResourceDocCoverageSpec.scala
+++ b/src/test/scala/onion/compiler/tools/HttpResourceDocCoverageSpec.scala
@@ -57,4 +57,35 @@ class HttpResourceDocCoverageSpec extends AnyFunSpec {
       "docs/ja/reference/specification.md describes http\"…\"'s fixed menu as file\"…\"'s " +
         "text/lines/csv/csvRows instead of http\"…\"'s own get/getJson/post/postJson/put/delete")
   }
+
+  // docs/reference/stdlib.md documents the static `onion.Http` module (`## Http`) but,
+  // until now, never the instance returned by `http"…"` itself: there was no `## HttpResource`
+  // section, so `url()`, `read(shape)` and `eachLine(shape)` were undiscoverable from the API
+  // reference (only the verb methods were mentioned, and only in specification.md's syntax guide).
+  private val stdlibMembers = Seq(
+    "url", "get", "getJson", "read", "eachLine", "post", "postJson", "put", "delete"
+  )
+
+  it("actual onion.HttpResource exposes every stdlib.md-documented-below member (sanity check)") {
+    val names = methodNames(classOf[onion.HttpResource])
+    stdlibMembers.foreach { name =>
+      assert(names.contains(name), s"onion.HttpResource lost method $name -- the scan has rotted")
+    }
+  }
+
+  it("docs/reference/stdlib.md has an HttpResource section mentioning every public member") {
+    val doc = read("docs/reference/stdlib.md")
+    assert(doc.contains("## HttpResource"), "docs/reference/stdlib.md has no '## HttpResource' section")
+    stdlibMembers.foreach { name =>
+      assert(doc.contains(name), s"docs/reference/stdlib.md doesn't mention $name, a public onion.HttpResource member")
+    }
+  }
+
+  it("docs/ja/reference/stdlib.md has an HttpResource section mentioning every public member") {
+    val doc = read("docs/ja/reference/stdlib.md")
+    assert(doc.contains("## HttpResource"), "docs/ja/reference/stdlib.md has no '## HttpResource' section")
+    stdlibMembers.foreach { name =>
+      assert(doc.contains(name), s"docs/ja/reference/stdlib.md doesn't mention $name, a public onion.HttpResource member")
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `docs/reference/stdlib.md` and its Japanese translation documented the static `onion.Http` module (`## Http`) but never the instance returned by the `http"…"` literal itself — `url()`, `get()`, `get(headers)`, `getJson()`, `read(shape)`, `eachLine(shape)`, `post(body)`, `postJson(jsonBody)`, `put(body)` and `delete()` had no API-reference coverage at all.
- Adds a `## HttpResource` section to both `docs/reference/stdlib.md` and `docs/ja/reference/stdlib.md`, mirroring the existing `## FileResource` section's structure.
- Extends the existing `HttpResourceDocCoverageSpec` (previously guarding only the `specification.md` fixed-menu wording) with new regression-guard cases for the `stdlib.md` sections, instead of replacing the file's existing coverage.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5369 succeeded, 0 failed, 1 canceled (pre-existing `-Donion.dist.path`-gated smoke test, unrelated to this change), 0 ignored. All tests passed.
- [x] `sbt -Duser.language=en 'testOnly onion.compiler.tools.HttpResourceDocCoverageSpec'` — 7/7 green (4 pre-existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtBNHCkSayH9z9R4uQiT6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtBNHCkSayH9z9R4uQiT6r)_