### PR TITLE
fix: Timing::formatNanos docs claimed "μs", implementation emits "us"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Timing::formatNanos`'s microsecond band claimed to render the Greek mu sign
+  (`"45.67μs"`) in its Javadoc and both `docs/reference/stdlib.md` copies, but the
+  implementation (`String.format("%.2fus", ...)`) has only ever emitted the ASCII
+  `"us"`** — `TimerSpec`'s own `endsWith("us")` assertion already pinned the real
+  behavior, so this was doc/impl drift, not a live bug. Corrected the Javadoc and
+  both doc copies to `"us"` and added `TimingFormatNanosDocParitySpec`, which asserts
+  the actual output of all four formatting bands against both docs so they can't
+  drift back to a unit sign the implementation never produces.
+
 ## [0.61.0] - 2026-09-07
 
 ### Added

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -914,7 +914,7 @@ val elapsedMillis: Long = Timing::elapsedMillis(start) // Timing::millis()起点
 ```onion
 val nanos: Long = 1234567890L
 val formatted: String = Timing::formatNanos(nanos)   // "1.23s"
-// 出力形式: "123ns", "45.67μs", "12.34ms", "1.23s"
+// 出力形式: "123ns", "45.67us", "12.34ms", "1.23s"
 
 val millis: Long = 125000L
 val formattedMs: String = Timing::formatMillis(millis)  // "2m5s"

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -1282,7 +1282,7 @@ val elapsedMillis: Long = Timing::elapsedMillis(start) // Elapsed in millisecond
 ```onion
 val nanos: Long = 1234567890L
 val formatted: String = Timing::formatNanos(nanos)   // "1.23s"
-// Output formats: "123ns", "45.67μs", "12.34ms", "1.23s"
+// Output formats: "123ns", "45.67us", "12.34ms", "1.23s"
 
 val millis: Long = 125000L
 val formattedMs: String = Timing::formatMillis(millis)  // "2m5s"

--- a/src/main/java/onion/Timing.java
+++ b/src/main/java/onion/Timing.java
@@ -60,7 +60,7 @@ public final class Timing {
 
     /**
      * Formats nanoseconds to a human-readable string.
-     * Examples: "500ns", "1.23μs", "4.56ms", "1.23s"
+     * Examples: "500ns", "1.23us", "4.56ms", "1.23s"
      */
     public static String formatNanos(long nanos) {
         if (nanos < 1_000) {

--- a/src/test/scala/onion/compiler/tools/TimingFormatNanosDocParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/TimingFormatNanosDocParitySpec.scala
@@ -1,0 +1,38 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * `Timing::formatNanos`'s microsecond band formats with a literal ASCII `"us"`
+ * (`String.format("%.2fus", ...)` in `Timing.formatNanos`), but its own Javadoc and
+ * both `docs/reference/stdlib.md` copies claimed the Greek `"μs"` instead. Pinned here
+ * against the actual runtime output -- not just the doc text -- so the docs can't
+ * drift back to a unit sign the implementation never produces.
+ */
+class TimingFormatNanosDocParitySpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  it("Timing::formatNanos never emits the Greek mu sign (sanity check)") {
+    assert(onion.Timing.formatNanos(123L) == "123ns")
+    assert(onion.Timing.formatNanos(45670L) == "45.67us")
+    assert(onion.Timing.formatNanos(12340000L) == "12.34ms")
+    assert(onion.Timing.formatNanos(1230000000L) == "1.23s")
+  }
+
+  it("Timing.java's Javadoc example matches the actual unit signs") {
+    assert(read("src/main/java/onion/Timing.java").contains(
+      """Examples: "500ns", "1.23us", "4.56ms", "1.23s""""))
+  }
+
+  it("docs/reference/stdlib.md's formatNanos example matches the actual unit signs") {
+    assert(read("docs/reference/stdlib.md").contains(
+      """// Output formats: "123ns", "45.67us", "12.34ms", "1.23s""""))
+  }
+
+  it("docs/ja/reference/stdlib.md's formatNanos example matches the actual unit signs") {
+    assert(read("docs/ja/reference/stdlib.md").contains(
+      """// 出力形式: "123ns", "45.67us", "12.34ms", "1.23s""""))
+  }
+}


### PR DESCRIPTION
## Summary
- `Timing::formatNanos`'s microsecond band has always formatted with a literal ASCII `"us"` (`String.format("%.2fus", ...)` in `src/main/java/onion/Timing.java`), but the method's own Javadoc and both `docs/reference/stdlib.md` / `docs/ja/reference/stdlib.md` copies claimed it renders the Greek mu sign (`"45.67μs"`). `TimerSpec`'s existing `endsWith("us")` assertion already pinned the real behavior, so this was doc/implementation drift rather than a live bug — fixed the docs (and Javadoc) to match the implementation, the lower-risk direction since changing the implementation to emit `μs` would have broken that existing test and any code matching on the suffix.
- Added `TimingFormatNanosDocParitySpec`, asserting the actual output of all four `formatNanos` bands (`ns`/`us`/`ms`/`s`) against both doc copies and the Javadoc, so they can't drift back to a unit sign the implementation never produces.
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5456 succeeded, 0 failed, 1 canceled (the known gated distribution smoke test)
- [x] New `TimingFormatNanosDocParitySpec` verified red before the fix (asserted actual `"us"` output while docs still claimed `"μs"`), green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011trRegRf5NXg16muxRgbPb

---
_Generated by [Claude Code](https://claude.ai/code/session_011trRegRf5NXg16muxRgbPb)_