### PR TITLE
fix: Args's class Javadoc implied -v aliases flag("verbose")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Args`'s class Javadoc read `if opts.flag("verbose") { ... } // --verbose / -v style`**, which
+  reads as though a short flag like `-v` sets `flag("verbose")`. It doesn't: `-v` registers under
+  the literal single-character name `"v"`, independent of any long flag with a similar-sounding
+  name (`flag("verbose")` stays `false`). Reworded the Javadoc to state that short flags are their
+  own names, not aliases, and added `ArgsSpec`'s "does not alias a short flag to a long flag's
+  name" regression test pinning the real behavior.
+
 ## [0.62.0] - 2026-09-07
 
 ### Fixed

--- a/src/main/java/onion/Args.java
+++ b/src/main/java/onion/Args.java
@@ -10,7 +10,7 @@ import java.util.Map;
  *
  * Usage:
  *   val opts = Args::parse(args)
- *   if opts.flag("verbose") { ... }            // --verbose / -v style
+ *   if opts.flag("verbose") { ... }            // --verbose
  *   val out = opts.option("output", "a.txt")   // --output=x / --output x
  *   val files = opts.positional()              // everything else
  *
@@ -18,7 +18,10 @@ import java.util.Map;
  *   --name           boolean flag
  *   --name=value     option with value
  *   --name value     option with value (when the next token is not an option)
- *   -abc             short flags a, b, c
+ *   -abc             short flags a, b, c (each registered under its own
+ *                    single-character name, e.g. flag("a"); NOT an alias for
+ *                    any same-named long flag, e.g. -v does not satisfy
+ *                    flag("verbose"))
  *   --               everything after is positional
  */
 public final class Args {

--- a/src/test/scala/onion/compiler/tools/ArgsSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ArgsSpec.scala
@@ -40,5 +40,26 @@ class ArgsSpec extends AbstractShellSpec {
       )
       assert(Shell.Success("true:true:[--not-a-flag]") == result)
     }
+
+    it("does not alias a short flag to a long flag's name") {
+      // Args.java's class Javadoc used to read "--verbose / -v style" next to the
+      // flag("verbose") example, which reads as though -v sets flag("verbose").
+      // It doesn't: a short flag is registered under its own single-character
+      // name, independently of any long flag with a similar-sounding name.
+      val result = shell.run(
+        """
+          |class Test {
+          |public:
+          |  static def main(args: String[]): String {
+          |    val o = Args::parse(args)
+          |    return o.flag("verbose") + ":" + o.flag("v")
+          |  }
+          |}
+          |""".stripMargin,
+        "ArgsShortNotLongAlias.on",
+        Array("-v")
+      )
+      assert(Shell.Success("false:true") == result)
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `onion.Args`'s class-level Javadoc usage example read:
  ```
  if opts.flag("verbose") { ... }            // --verbose / -v style
  ```
  which reads as though a short flag like `-v` sets `flag("verbose")`. It doesn't — `Args.parse`'s short-flag handling (`-abc` → flags `a`, `b`, `c`) registers each short flag under its own single-character name, completely independent of any long flag with a similar-sounding name. After `-v` alone, `flag("verbose")` stays `false`; only `flag("v")` is `true`.
- Reworded the Javadoc to explicitly state that short flags are their own names, not aliases for a same-named long flag.
- `docs/reference/stdlib.md` already documented this correctly (`parsed.flag("verbose") // --verbose`, no `-v` claim), so no doc-site change was needed.

## Test plan

- [x] Added `ArgsSpec`: "does not alias a short flag to a long flag's name" — pins that `-v` sets `flag("v")` but not `flag("verbose")`.
- [x] `sbt -Duser.language=en 'testOnly *ArgsSpec'` — 11/11 passed.
- [x] Full suite: `SBT_OPTS="-Xmx4G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5457 succeeded, 0 failed, 1 canceled (pre-existing, unrelated distribution-packaging test), 0 ignored.
- [x] Added a `CHANGELOG.md` entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q8Vb8VhSJJ5djQGbr7kHW

---
_Generated by [Claude Code](https://claude.ai/code/session_013q8Vb8VhSJJ5djQGbr7kHW)_