### PR TITLE
fix: FileResource#read(Shape)'s Javadoc was orphaned above readLossless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own names, not aliases, and added `ArgsSpec`'s "does not alias a short flag to a long flag's
   name" regression test pinning the real behavior.
 
+- **`FileResource#read(Shape)`'s Javadoc was orphaned above `readLossless(Shape)` instead of
+  documenting `read`.** The two `/** ... */` blocks between the methods sat back-to-back; only
+  the second attached to a declaration under normal Javadoc adjacency, leaving the first block
+  (which explicitly says `` Named `read` rather than `as` `` and plainly describes `read`, not
+  `readLossless`) as dead text, and `read(Shape<T> shape)` itself undocumented. Moved the doc
+  block down to directly precede `read`, matching the sibling `HttpResource#read(Shape)`, and
+  added `FileResourceReadJavadocSpec` to pin the doc's placement so it can't silently re-drift.
+
 ## [0.62.0] - 2026-09-07
 
 ### Fixed

--- a/src/main/java/onion/FileResource.java
+++ b/src/main/java/onion/FileResource.java
@@ -56,17 +56,6 @@ public final class FileResource {
     }
 
     /**
-     * The file read through {@code shape}.
-     *
-     * <p>The fixed getters above close the set of things a file can be read as -- the
-     * parse step is chosen by which one you call, and a user cannot add to it. A shape
-     * opens that set, and carries this file's path into every defect, so a failure says
-     * *which file* rather than only what was wrong (issue #353). Named `read` rather than `as`, which is Onion's cast keyword.
-     *
-     * <p>An unreadable file is a defect too, not an exception: reading a file that might
-     * not be there is the ordinary case at a boundary.
-     */
-    /**
      * The file read through a lossless shape, keeping the residue — the read half of a
      * config lens: {@code file"app.conf".readLossless(Server::cfg())}, then
      * {@code .edit { ... }.render()} and write the result back.
@@ -85,6 +74,17 @@ public final class FileResource {
         }
     }
 
+    /**
+     * The file read through {@code shape}.
+     *
+     * <p>The fixed getters above close the set of things a file can be read as -- the
+     * parse step is chosen by which one you call, and a user cannot add to it. A shape
+     * opens that set, and carries this file's path into every defect, so a failure says
+     * *which file* rather than only what was wrong (issue #353). Named `read` rather than `as`, which is Onion's cast keyword.
+     *
+     * <p>An unreadable file is a defect too, not an exception: reading a file that might
+     * not be there is the ordinary case at a boundary.
+     */
     public <T> Outcome<T> read(Shape<T> shape) {
         String content;
         try {

--- a/src/test/scala/onion/compiler/tools/FileResourceReadJavadocSpec.scala
+++ b/src/test/scala/onion/compiler/tools/FileResourceReadJavadocSpec.scala
@@ -1,0 +1,53 @@
+package onion.compiler.tools
+
+import org.scalatest.funspec.AnyFunSpec
+
+/**
+ * Guards against `FileResource#read(Shape)`'s Javadoc being orphaned above
+ * `readLossless(Shape)` instead of directly documenting `read`. The two
+ * methods sit back-to-back with two `/** ... */` blocks between them; only
+ * the second block attaches to a declaration under normal Javadoc adjacency
+ * (the one right above `readLossless`), leaving `read` itself undocumented
+ * and the first block ("Named `read` rather than `as`...", which plainly
+ * describes `read`, not `readLossless`) dead text. Compare the sibling
+ * `HttpResource#read(Shape)`, which carries the same doc text correctly
+ * attached to its own declaration.
+ */
+class FileResourceReadJavadocSpec extends AnyFunSpec {
+
+  private def read(p: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(p))
+
+  describe("FileResource#read(Shape)'s Javadoc") {
+    it("sits directly above read(Shape<T> shape), not above readLossless(Shape<T> shape)") {
+      val src = read("src/main/java/onion/FileResource.java")
+
+      val docMarker = "Named `read` rather than `as`"
+      val docIdx = src.indexOf(docMarker)
+      assert(docIdx >= 0, "expected the 'Named `read`...' doc comment to exist in FileResource.java")
+
+      val readLosslessIdx = src.indexOf("public <T> Outcome<Lossless<T>> readLossless(Shape<T> shape)")
+      val readIdx = src.indexOf("public <T> Outcome<T> read(Shape<T> shape)")
+      assert(readLosslessIdx >= 0, "expected readLossless(Shape<T> shape) to exist in FileResource.java")
+      assert(readIdx >= 0, "expected read(Shape<T> shape) to exist in FileResource.java")
+
+      assert(
+        readLosslessIdx < docIdx,
+        "the 'Named `read`...' doc comment must come after readLossless's own signature, " +
+          "not sit above it"
+      )
+      assert(
+        docIdx < readIdx,
+        "the 'Named `read`...' doc comment must precede read(Shape<T> shape)"
+      )
+
+      val commentEndIdx = src.indexOf("*/", docIdx) + 2
+      val between = src.substring(commentEndIdx, readIdx)
+      assert(
+        between.trim.isEmpty,
+        "nothing but whitespace should separate the doc comment from read(Shape<T> shape) -- " +
+          s"found: ${between.trim}"
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `FileResource#read(Shape)` had no Javadoc: two `/** ... */` blocks sat back-to-back between `readLossless(Shape)` and `read(Shape)`, and under normal Javadoc adjacency only the second block attaches to a declaration (`readLossless`'s own doc). The first block — which explicitly says `` Named `read` rather than `as` `` and plainly describes `read`, not `readLossless` — was dead text, orphaned above the wrong method.
- Confirmed against the sibling `HttpResource#read(Shape)`, which carries the same doc text correctly attached to its own declaration.
- Moved the orphaned doc block down to directly precede `read(Shape<T> shape)`. No behavior change.
- Added `FileResourceReadJavadocSpec`, which reads the `.java` source as text and asserts the doc sits directly above `read`'s signature (and after `readLossless`'s), so this can't silently re-drift.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `FileResourceReadJavadocSpec` reproduces red before the fix, green after.
- [x] Full suite, English locale (`SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull`): 5458 succeeded, 0 failed, 1 canceled (pre-existing, unrelated `ProjectDistributionSpec` environment-dependent test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbVpgeLLeex921eSixeqeH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbVpgeLLeex921eSixeqeH)_