### PR TITLE
docs: fix Function Interfaces intro tautology (f(args) shorthand for f(args))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The "Function Interfaces" intro in `docs/reference/stdlib.md` (and its Japanese
+  translation) described `f(args)` as "a shorthand for `f(args)`"** — a tautology that
+  explains nothing about what the sugar actually does. `Function0`..`Function10`
+  (`src/main/java/onion/Function1.java` etc.) each declare a single abstract `call`
+  method, and the compiler's unqualified-call desugaring
+  (`CallableValueCallSupport.resolveCallableValue`) rewrites a bare `f(args)` call on a
+  callable value into `f.call(args)`. Corrected both doc copies to name `f.call(args)`
+  as the real desugaring target, and added a regression case to
+  `StdlibDocMathAndFunctionInterfacesParitySpec` pinning the corrected wording in both
+  languages.
+
 - **`Args`'s class Javadoc read `if opts.flag("verbose") { ... } // --verbose / -v style`**, which
   reads as though a short flag like `-v` sets `flag("verbose")`. It doesn't: `-v` registers under
   the literal single-character name `"v"`, independent of any long flag with a similar-sounding

--- a/docs/ja/reference/stdlib.md
+++ b/docs/ja/reference/stdlib.md
@@ -584,7 +584,7 @@ Scalars::coerce("Int", [1, 2], null, "port")      // defect: expected Int, found
 
 ## 関数インターフェース
 
-ラムダとクロージャのための組み込み関数型。`f(args)`の代わりに`f(args)`として呼び出せます。
+ラムダとクロージャのための組み込み関数型。`f.call(args)`の代わりに`f(args)`として呼び出せます。
 
 ### Function0
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -642,7 +642,7 @@ conversion table, so a `shape`/`from re"..."` derivation and hand-written code u
 
 ## Function Interfaces
 
-Built-in function types for lambdas and closures. You can call them with `f(args)` as a shorthand for `f(args)`.
+Built-in function types for lambdas and closures. You can call them with `f(args)` as a shorthand for `f.call(args)`.
 
 ### Function0
 

--- a/src/test/scala/onion/compiler/tools/StdlibDocMathAndFunctionInterfacesParitySpec.scala
+++ b/src/test/scala/onion/compiler/tools/StdlibDocMathAndFunctionInterfacesParitySpec.scala
@@ -38,4 +38,17 @@ class StdlibDocMathAndFunctionInterfacesParitySpec extends AnyFunSpec {
       s"docs/reference/stdlib.md has ${en.size} Function Interfaces subsections but " +
       s"docs/ja/reference/stdlib.md has ${ja.size} — the section is missing or incomplete in Japanese")
   }
+
+  it("describes f(args) as shorthand for the real call target f.call(args), not a tautology of itself") {
+    // Function0..Function10 (src/main/java/onion/Function1.java etc.) declare a single
+    // abstract `call` method, and CallableValueCallSupport.resolveCallableValue desugars
+    // an unqualified f(args) call into f.call(args) — so the intro sentence must name
+    // `call` as the desugaring target, not restate `f(args)` on both sides.
+    val en = read("docs/reference/stdlib.md")
+    val ja = read("docs/ja/reference/stdlib.md")
+    assert(en.contains("as a shorthand for `f.call(args)`"),
+      "docs/reference/stdlib.md's Function Interfaces intro no longer names f.call(args) as the desugaring target")
+    assert(ja.contains("`f.call(args)`の代わりに`f(args)`として呼び出せます"),
+      "docs/ja/reference/stdlib.md's Function Interfaces intro no longer names f.call(args) as the desugaring target")
+  }
 }


### PR DESCRIPTION
## Summary

- `docs/reference/stdlib.md`'s "Function Interfaces" section (and the Japanese translation in `docs/ja/reference/stdlib.md`) described `f(args)` as "a shorthand for `f(args)`" — a tautology that explains nothing about what the sugar actually does.
- `Function0`..`Function10` (`src/main/java/onion/Function1.java` etc.) each declare a single abstract `call` method, and the compiler's unqualified-call desugaring (`CallableValueCallSupport.resolveCallableValue` in `src/main/scala/onion/compiler/typing/CallableValueCallSupport.scala`) rewrites a bare `f(args)` call on a callable value into `f.call(args)`. That's the real desugaring target the doc should name.
- Corrected both doc copies to say `f(args)` is shorthand for `f.call(args)`.
- Added a regression case to `StdlibDocMathAndFunctionInterfacesParitySpec` (`src/test/scala/onion/compiler/tools/`) asserting the corrected wording in both languages, so this can't silently drift back to the tautology.

## Test plan

- [x] `sbt shutdown && sbt -Duser.language=en "testOnly *StdlibDocMathAndFunctionInterfacesParitySpec"` — 3/3 green (new case included)
- [x] `sbt shutdown && sbt -Duser.language=en testFull` — 5459 succeeded, 0 failed, 1 canceled (pre-existing, unrelated `ProjectDistributionSpec` environment-gated dist-build case)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2VYzH8mQzxESFB9mfEpuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2VYzH8mQzxESFB9mfEpuk)_