### PR TITLE
fix: TCO self-call check ignored the receiver, hanging on same-signature calls to other instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Tail-call optimization could rewrite a call to the same method on a *different*
+  instance as self-recursion, producing an infinite loop.** `TailCallOptimization`'s
+  `isSelfCall` (`src/main/scala/onion/compiler/optimization/TailCallOptimization.scala`)
+  matched a tail call's target method purely by name, declaring class, and argument
+  types — it never checked that the call's receiver was `this`. A `final`/`private`/
+  `static` method walking a linked structure via same-signature calls on other
+  instances (e.g. `next.sumAcc(acc + value)` while traversing a `Node` chain) was
+  misidentified as self-recursion and rewritten into a `while(true)` loop that only
+  ever updated its own parameter slots, never advancing to the new receiver — the
+  loop's exit condition could then never become true, hanging at runtime instead of
+  returning a (wrong) value. Added a `call.target.isInstanceOf[This]` guard so only
+  true `this`-receiver calls are optimized, and added a regression case to
+  `TailCallOptimizationSpec` pinning correct behavior for a same-signature call on a
+  different receiver.
+
 - **The "Function Interfaces" intro in `docs/reference/stdlib.md` (and its Japanese
   translation) described `f(args)` as "a shorthand for `f(args)`"** — a tautology that
   explains nothing about what the sugar actually does. `Function0`..`Function10`

--- a/src/main/scala/onion/compiler/optimization/TailCallOptimization.scala
+++ b/src/main/scala/onion/compiler/optimization/TailCallOptimization.scala
@@ -178,7 +178,12 @@ class TailCallOptimization(config: CompilerConfig)
       case call: Call =>
         call.method match {
           case targetMethod: MethodDefinition =>
-            val isSelf = targetMethod.name == method.name &&
+            // The receiver must be `this`: a matching name/class/signature call on
+            // some other instance of the same class (e.g. `next.sumAcc(...)`) is not
+            // self-recursion, and rewriting it into a loop would keep updating this
+            // method's own locals while never advancing to the new receiver.
+            val isSelf = call.target.isInstanceOf[This] &&
+            targetMethod.name == method.name &&
             targetMethod.classType.name == method.classType.name &&
             argumentTypesMatch(targetMethod.arguments, method.arguments)
             if (config.verbose) {

--- a/src/test/scala/onion/compiler/tools/TailCallOptimizationSpec.scala
+++ b/src/test/scala/onion/compiler/tools/TailCallOptimizationSpec.scala
@@ -105,6 +105,39 @@ class TailCallOptimizationSpec extends AbstractShellSpec {
       assert(Shell.Success(true) == result)
     }
 
+    it("does not treat a same-signature call on a different instance as self-recursion") {
+      // Regression: isSelfCall matched name/class/argument-types only, so a tail call
+      // to the same method on a *different* receiver (e.g. next.sumAcc(...) while
+      // walking a linked structure) was misidentified as self-recursion. optimizeMethod
+      // then rewrote the body into a while(true) loop that only ever updated this
+      // method's own parameter slots, never advancing to the new receiver, so the
+      // loop's exit condition could never become true -- an infinite loop/hang.
+      val result = shell.run(
+        """
+          |class Node {
+          |  val value: Int
+          |  val next: Node?
+          |public:
+          |  def this(value: Int, next: Node?) { this.value = value; this.next = next }
+          |  final def sumAcc(acc: Int): Int {
+          |    if next == null { return acc + value }
+          |    return next.sumAcc(acc + value)
+          |  }
+          |}
+          |class Main {
+          |public:
+          |  static def main(args: String[]): Int {
+          |    val n1 = new Node(1, new Node(2, new Node(3, null)))
+          |    return n1.sumAcc(0)
+          |  }
+          |}
+          |""".stripMargin,
+        "TcoDifferentReceiverNotSelfCall.on",
+        Array()
+      )
+      assert(Shell.Success(6) == result)
+    }
+
     it("optimizes a zero-argument static method without crashing") {
       val result = shell.run(
         """


### PR DESCRIPTION
## Summary

- `TailCallOptimization.isSelfCall`'s `Call` case matched a tail call's target purely by method name, declaring class, and argument types — it never checked that the call's **receiver** was `this`.
- A `final`/`private`/`static` method that walks a linked structure via a same-signature call on a **different instance** of the same class (e.g. `next.sumAcc(acc + value)` while traversing a `Node` chain) was misidentified as self-recursion.
- `optimizeMethod` then rewrote the body into a `while(true)` loop that only ever updates this method's own parameter slots — it never advances to the new receiver — so the loop's exit condition can never become true. The result is a runtime hang instead of the correct return value.

## Fix

Added `call.target.isInstanceOf[This]` to the `Call` case's self-call predicate in `src/main/scala/onion/compiler/optimization/TailCallOptimization.scala`, so only calls that actually dispatch on `this` are treated as self-recursion. `CallStatic` is unaffected (static calls have no receiver).

## Verification

Reproduced before the fix with:
```onion
class Node {
  val value: Int
  val next: Node?
public:
  def this(value: Int, next: Node?) { this.value = value; this.next = next }
  final def sumAcc(acc: Int): Int {
    if next == null { return acc + value }
    return next.sumAcc(acc + value)
  }
}
```
`n1.sumAcc(0)` hung indefinitely before the fix; after the fix it returns `6` in a couple of seconds.

Added `TailCallOptimizationSpec`'s "does not treat a same-signature call on a different instance as self-recursion" regression case pinning this.

## Test plan

- [x] `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — 5460 succeeded, 0 failed, 1 canceled (pre-existing, opt-in `ProjectDistributionSpec` smoke test gated behind `-Donion.dist.path`, unrelated to this change)
- [x] Manual repro script hangs on `develop`, returns `6` after the fix

## CHANGELOG

Added an entry under `[Unreleased] / Fixed`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUH3bswjGF4LhQjW8889Ps

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUH3bswjGF4LhQjW8889Ps)_