### PR TITLE
fix: Config::getBoolean now falls back to default for unconvertible values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Config::getBoolean` silently returned `false` instead of falling back to the
+  supplied default for a present-but-unconvertible value**, unlike every sibling typed
+  getter. `getInt`/`getLong`/`getDouble` (`src/main/java/onion/Config.java`) each catch
+  their parse failure and return `defaultValue`, matching the docs' claim that "a value
+  that can't convert to the requested type" falls back to the default instead of
+  throwing — but `getBoolean` delegated to `Boolean.parseBoolean`, which never throws
+  and instead silently returns `false` for any string other than a case-insensitive
+  `"true"`. A config value like `"ssl": "yes"` would silently disable SSL even when
+  `getBoolean(config, "database.ssl", true)` asked for a safe `true` default on failure.
+  `getBoolean` now returns `defaultValue` unless the value is a `Boolean` or a
+  case-insensitive `"true"`/`"false"` string, and `ConfigSpec` gained a regression case
+  pinning the fallback for a non-boolean string value.
+
 ## [0.63.0] - 2026-09-07
 
 ### Fixed

--- a/src/main/java/onion/Config.java
+++ b/src/main/java/onion/Config.java
@@ -118,13 +118,16 @@ public class Config {
     }
 
     /**
-     * Gets a boolean value at path, or returns default if not found.
+     * Gets a boolean value at path, or returns default if not found or not convertible.
      */
     public static boolean getBoolean(Object config, String path, boolean defaultValue) {
         Object value = get(config, path);
         if (value == null) return defaultValue;
         if (value instanceof Boolean) return (Boolean) value;
-        return Boolean.parseBoolean(value.toString());
+        String text = value.toString();
+        if ("true".equalsIgnoreCase(text)) return true;
+        if ("false".equalsIgnoreCase(text)) return false;
+        return defaultValue;
     }
 
     /**

--- a/src/test/scala/onion/compiler/tools/ConfigSpec.scala
+++ b/src/test/scala/onion/compiler/tools/ConfigSpec.scala
@@ -310,6 +310,25 @@ class ConfigSpec extends AbstractShellSpec {
         )
         assert(Shell.Success("true,false") == result)
       }
+
+      it("falls back to the default when getBoolean's value can't convert to boolean") {
+        val result = shell.run(
+          """
+            |class Test {
+            |public:
+            |  static def main(args: String[]): String {
+            |    val json = "{\"ssl\": \"yes\"}";
+            |    val config = Config::parseJson(json);
+            |    val ssl = Config::getBoolean(config, "ssl", true);
+            |    return "" + ssl;
+            |  }
+            |}
+            |""".stripMargin,
+          "None",
+          Array()
+        )
+        assert(Shell.Success("true") == result)
+      }
     }
 
     describe("environment variables") {


### PR DESCRIPTION
## Summary
- `Config::getBoolean` delegated to `Boolean.parseBoolean`, which never throws and silently returns `false` for any string other than a case-insensitive `"true"`, ignoring the caller's `defaultValue` entirely.
- This contradicted both `docs/reference/stdlib.md`'s documented behavior ("a value that can't convert to the requested type" falls back to the supplied default) and the pattern followed by every sibling getter (`getInt`/`getLong`/`getDouble` each catch their parse failure and return `defaultValue`).
- Concretely: `Config::getBoolean(config, "database.ssl", true)` with a malformed value like `"ssl": "yes"` would silently return `false`, flipping a safe `true` default to disabled SSL instead of falling back to it.
- `getBoolean` now returns `defaultValue` unless the value is a `Boolean` or a case-insensitive `"true"`/`"false"` string.

## Test plan
- [x] Added a regression case to `ConfigSpec` (`falls back to the default when getBoolean's value can't convert to boolean`) — confirmed it failed against the old implementation (returned `"false"` instead of the supplied `true` default), then confirmed it passes after the fix.
- [x] Full suite green in English locale: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` → 5461 succeeded, 0 failed, 1 canceled (pre-existing/environment-dependent), 760 suites.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdiegPBhoicSEZB8qpXjMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdiegPBhoicSEZB8qpXjMx)_