### PR TITLE
fix: prevent I0000 crash when ASM can't resolve a same-unit class's superclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `select` used as a statement whose branches yielded unrelated concrete
+  reference types could crash the compiler with `[I0000] Internal compiler
+  error in BytecodeGeneration`** instead of compiling cleanly, even though
+  the select's own value is discarded in statement position. ASM's default
+  `ClassWriter.getCommonSuperClass` (used to compute the JVM stack-map frame
+  at the join point after the branches) resolves both sides via classloader
+  reflection to find a common ancestor; when one side was a class still
+  being compiled in the same unit, that reflective load failed with a
+  `ClassNotFoundException`, which escaped as the internal error instead of a
+  diagnostic. `ClassWriter` now falls back to `java/lang/Object` — always a
+  valid common ancestor for two reference types — when the default lookup
+  can't resolve a type. Found by `MutationFuzzSpec` mutating
+  `run/SpreadsheetEngine.on`.
+
 ## [0.66.0] - 2026-09-12
 
 ### Fixed

--- a/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
+++ b/src/main/scala/onion/compiler/backend/asm/AsmCodeGeneration.scala
@@ -132,7 +132,7 @@ class AsmCodeGeneration(config: CompilerConfig) extends BytecodeGenerator:
     }
 
   private def generateClass(classDef: ClassDefinition): CompiledClass =
-    val cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES)
+    val cw = new RobustClassWriter(ClassWriter.COMPUTE_FRAMES)
     
     // Generate class header
     // If class has no visibility modifiers, default to public

--- a/src/main/scala/onion/compiler/backend/asm/ClosureCodegen.scala
+++ b/src/main/scala/onion/compiler/backend/asm/ClosureCodegen.scala
@@ -127,7 +127,7 @@ final class ClosureCodegen(
     capturedVars: Seq[ClosureLocalBinding],
     outerThisType: Option[ClassType]
   ): Array[Byte] = {
-    val cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS)
+    val cw = new RobustClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS)
 
     cw.visit(
       Opcodes.V17,

--- a/src/main/scala/onion/compiler/backend/asm/RobustClassWriter.scala
+++ b/src/main/scala/onion/compiler/backend/asm/RobustClassWriter.scala
@@ -1,0 +1,27 @@
+package onion.compiler.backend.asm
+
+import org.objectweb.asm.ClassWriter
+
+/**
+ * A `ClassWriter` for `COMPUTE_FRAMES` mode that tolerates merging a stack-map-frame
+ * type against a class still being compiled in the same unit (or otherwise absent
+ * from the classpath). ASM's default `getCommonSuperClass` resolves both sides via
+ * `Class.forName` on the *thread's* classloader to walk their supertypes; a class this
+ * compilation is producing was never loaded that way; the reflective load fails as an
+ * `ClassNotFoundException` wrapped in `TypeNotPresentException`, escaping as an
+ * uncaught internal compiler error (I0000) instead of a diagnostic (crash reproducer:
+ * MutationFuzzSpec, a `select`/`if` used as a statement whose branches yield unrelated
+ * reference types -- the merge point's stack-map frame needs a common ancestor of
+ * both even though the value itself is discarded right after).
+ *
+ * `java.lang.Object` is always a legal common ancestor for two reference types, so
+ * falling back to it on failure keeps the emitted frame verifier-safe -- it can only
+ * widen the inferred merge type, never narrow it, and any narrower type actually
+ * needed at a use site is already made concrete there via an explicit checkcast
+ * inserted by the type checker, independent of this frame computation.
+ */
+private[asm] class RobustClassWriter(flags: Int) extends ClassWriter(flags) {
+  override def getCommonSuperClass(type1: String, type2: String): String =
+    try super.getCommonSuperClass(type1, type2)
+    catch case _: TypeNotPresentException => "java/lang/Object"
+}

--- a/src/test/resources/crash-corpus/033-select-statement-unrelated-branch-types.on
+++ b/src/test/resources/crash-corpus/033-select-statement-unrelated-branch-types.on
@@ -1,0 +1,32 @@
+// A `select` used as a plain statement whose branches yield unrelated concrete
+// reference types (here: the primitive Boolean returned by List.add, and a
+// record type). The value is discarded either way, but ASM's default
+// ClassWriter.getCommonSuperClass -- used to compute the stack-map frame at
+// the join point after the branches -- tried to resolve the record's class
+// via classloader reflection to find a common ancestor, which fails because
+// the class is still being compiled in this same unit. That crashed with an
+// escaped ClassNotFoundException wrapped as [I0000] Internal compiler error
+// in BytecodeGeneration, instead of compiling cleanly (found by
+// MutationFuzzSpec mutating run/SpreadsheetEngine.on's Evaluator.evaluateAll).
+record R(v: Int)
+
+class Foo {
+public:
+  def run(): List[R] {
+    val results: List[R] = []
+    select 1 {
+      case 1:
+        (new R(2))
+      else:
+        results.add(new R(9))
+    }
+    return results
+  }
+}
+
+class Test {
+public:
+  static def main(args: String[]): void {
+    IO::println(new Foo().run().size)
+  }
+}


### PR DESCRIPTION
## Summary

`MutationFuzzSpec` (deterministic, fixed-seed mutation fuzzing over `run/*.on`) found a mutant of `run/SpreadsheetEngine.on` that crashed the compiler:

```
[I0000] Internal compiler error in BytecodeGeneration: java.lang.RuntimeException: Bytecode generation failed at Evaluator.evaluateAll()Ljava/util/List;
Caused by: java.lang.TypeNotPresentException: Type EvalResult not present
Caused by: java.lang.ClassNotFoundException: EvalResult
```

This violates the project's absolute quality bar (the compiler must never crash — no `I0000`), and was blocking the test suite (`sbt -Duser.language=en testFull` was red on `develop`), which in turn blocks every other PR from merging.

## Root cause

The mutation replaced `results.add(EvalResult::ok(id, v))` with a bare `(EvalResult::ok(id, v))` inside one branch of an `if`/`else`, itself inside the `else:` case of a `select` used purely as a **statement** (its overall value discarded). The two branches (`.add(...)` and the bare record expression) yield unrelated concrete reference types, so the JVM stack-map frame at the join point after the branches needs a common ancestor for the two — even though the value is immediately discarded afterward.

ASM's default `ClassWriter.getCommonSuperClass` resolves both sides via `Class.forName` on the classloader to walk their supertypes. That fails with `ClassNotFoundException` when one side (here, `EvalResult`) is a class still being compiled in the *same compilation unit* — it was never loaded via that classloader. The exception escaped `AsmCodeGeneration.codeMethod`'s catch as a generic `NonFatal`, which `PipelineRunner` reports as `I0000` instead of a diagnostic.

## Fix

Added `RobustClassWriter`, a `ClassWriter` subclass used everywhere the backend emits `COMPUTE_FRAMES` bytecode (`AsmCodeGeneration.generateClass`, `ClosureCodegen.generateClosureClass`). It falls back to `java/lang/Object` when the default reflection-based lookup fails — always a legal common ancestor for two reference types, so the emitted frame stays verifier-safe (it can only widen the inferred merge type, never narrow it; any narrower type actually needed at a use site is already made concrete there via an explicit `checkcast` inserted by the type checker, independent of this frame computation).

This is the standard technique other JVM-language compilers use for the same ASM limitation when generating mutually-referencing classes in one compilation unit.

## Testing

- Added `src/test/resources/crash-corpus/033-select-statement-unrelated-branch-types.on`, a minimized reproducer (`CompilerCrashRegressionSpec` auto-discovers every file in that directory).
- Verified the original fuzzer-found mutant (`SpreadsheetEngine-8.on`) and several hand-reduced variants (bare `select`, `select` with a nested `if`/`else`, enum-scrutinee `select`) all now compile cleanly.
- Full suite: `SBT_OPTS="-Xmx10G -XX:+UseG1GC -Xss16m" sbt -Duser.language=en testFull` — **5529 passed, 0 failed, 1 cancelled** (the cancelled test is the known distribution smoke test, gated behind `-Donion.dist.path`).

## Test plan

- [x] `sbt -Duser.language=en testFull` green locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqspmvdAU4AgFnt3igRqhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspmvdAU4AgFnt3igRqhh)_